### PR TITLE
fix!: order is now asc instead of desc

### DIFF
--- a/src/shared-args.ts
+++ b/src/shared-args.ts
@@ -61,7 +61,7 @@ export const sharedArgs = {
 		type: "enum",
 		short: "o",
 		description: "Sort order: desc (newest first) or asc (oldest first)",
-		default: "desc" as const satisfies SortOrder,
+		default: "asc" as const satisfies SortOrder,
 		choices: SortOrders,
 	},
 } as const satisfies Args;


### PR DESCRIPTION
This pull request includes a small change to the `src/shared-args.ts` file. The default sort order for the `sharedArgs` configuration has been updated from "desc" (newest first) to "asc" (oldest first).