### PR TITLE
chore: stop exporting shared args

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"./logger": "./dist/logger.js",
 		"./mcp": "./dist/mcp.js",
 		"./pricing-fetcher": "./dist/pricing-fetcher.js",
-		"./shared-args": "./dist/shared-args.js",
 		"./utils": "./dist/utils.js",
 		"./package.json": "./package.json"
 	},

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	entry: [
 		'./src/*.ts',
 		'!./src/types.ts',
+		'!./src/shared-args.ts',
 		'!./src/**/*.test.ts',
 	],
 	outDir: 'dist',


### PR DESCRIPTION
This pull request removes references to the `shared-args` module from the project configuration files. The changes ensure that the module is no longer included in the build process or exported.

Configuration updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25): Removed the export entry for `./shared-args`, which previously pointed to `./dist/shared-args.js`.
* [`tsdown.config.ts`](diffhunk://#diff-c105f99c241d6d60e41561e663ee096629894e9b2a773c82283655b323f59485R7): Excluded `shared-args.ts` from the entry configuration, preventing it from being included in the build output.