### PR TITLE
Add Node.js/Bun version requirement documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ After adding this configuration, restart Claude Desktop. You'll then be able to 
 
 ## Requirements
 
+- Node.js 21.0.0 or higher, or Bun 1.0.20 or higher
 - Claude Code usage history files (`~/.claude/projects/**/*.jsonl`)
 
 ## License


### PR DESCRIPTION
## Summary

- Update README Requirements section to specify Node.js 21.0.0+ or Bun 1.0.20+
- Addresses `TypeError: Object.groupBy is not a function` on Node.js 20.x environments

## Problem

The application uses `Object.groupBy()` which was introduced in:
- **Node.js 21.0.0**: https://nodejs.org/en/blog/announcements/v21-release-announce#v8-118
- **Bun 1.0.20**: https://github.com/oven-sh/bun/issues/7855#issuecomment-1870556296

Users running Node.js 20.x encounter this error:
```
TypeError: Object.groupBy is not a function
```

## Solution

Updated README.md Requirements section to clearly document the minimum runtime versions needed for Object.groupBy support.

🤖 Generated with [Claude Code](https://claude.ai/code)