### PR TITLE
chore(deps): add type-fest

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "sort-package-json": "^3.2.1",
         "tinyglobby": "^0.2.14",
         "tsdown": "^0.12.7",
+        "type-fest": "^4.41.0",
         "unplugin-unused": "^0.5.0",
         "valibot": "^1.1.0",
       },
@@ -1084,6 +1085,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"sort-package-json": "^3.2.1",
 		"tinyglobby": "^0.2.14",
 		"tsdown": "^0.12.7",
+		"type-fest": "^4.41.0",
 		"unplugin-unused": "^0.5.0",
 		"valibot": "^1.1.0"
 	},

--- a/src/types.internal.ts
+++ b/src/types.internal.ts
@@ -1,3 +1,4 @@
+import type { TupleToUnion } from 'type-fest';
 import * as v from 'valibot';
 
 export const dateSchema = v.pipe(
@@ -6,7 +7,7 @@ export const dateSchema = v.pipe(
 );
 
 export const CostModes = ['auto', 'calculate', 'display'] as const;
-export type CostMode = (typeof CostModes)[number];
+export type CostMode = TupleToUnion<typeof CostModes>;
 
 export const SortOrders = ['desc', 'asc'] as const;
-export type SortOrder = (typeof SortOrders)[number];
+export type SortOrder = TupleToUnion<typeof SortOrders>;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
 	clean: true,
 	sourcemap: false,
 	dts: {
-		resolve: ['valibot'],
+		resolve: ['valibot', 'type-fest'],
 	},
 	publint: true,
 	unused: true,


### PR DESCRIPTION
This pull request introduces the `type-fest` dependency and updates type definitions in the project to use its `TupleToUnion` utility. Additionally, the configuration for `tsdown` has been updated to include `type-fest` in the `dts.resolve` option.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R68): Added `type-fest` version `^4.41.0` as a new dependency.

### Type Definition Enhancements:
* [`src/types.internal.ts`](diffhunk://#diff-6c55920ed2c9214fb91c7138a3f6d2077113e89e8df51b3b5339e195a2713230R1): Updated type definitions for `CostMode` and `SortOrder` to use `TupleToUnion` from `type-fest`, simplifying the type derivation from constant arrays. [[1]](diffhunk://#diff-6c55920ed2c9214fb91c7138a3f6d2077113e89e8df51b3b5339e195a2713230R1) [[2]](diffhunk://#diff-6c55920ed2c9214fb91c7138a3f6d2077113e89e8df51b3b5339e195a2713230L9-R13)

### Configuration Updates:
* [`tsdown.config.ts`](diffhunk://#diff-c105f99c241d6d60e41561e663ee096629894e9b2a773c82283655b323f59485L15-R15): Modified the `dts.resolve` option to include `type-fest`, ensuring type definitions for `type-fest` are correctly resolved during build.