### PR TITLE
Replace Object.groupBy with manual implementation for Node.js 20 compatibility

### DIFF
--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -11,6 +11,7 @@ import {
 	getModelPricing,
 	type ModelPricing,
 } from './pricing-fetcher.ts';
+import { groupBy } from './utils.internal.ts';
 
 export function getDefaultClaudePath(): string {
 	return path.join(homedir(), '.claude');
@@ -175,7 +176,7 @@ export async function loadDailyUsageData(
 	}
 
 	// Group by date using Object.groupBy
-	const groupedByDate = Object.groupBy(allEntries, entry => entry.date);
+	const groupedByDate = groupBy(allEntries, entry => entry.date);
 
 	// Aggregate each group
 	const results = Object.entries(groupedByDate)
@@ -305,7 +306,7 @@ export async function loadSessionData(
 	}
 
 	// Group by session using Object.groupBy
-	const groupedBySessions = Object.groupBy(
+	const groupedBySessions = groupBy(
 		allEntries,
 		entry => entry.sessionKey,
 	);
@@ -393,7 +394,7 @@ export async function loadMonthlyUsageData(
 	const dailyData = await loadDailyUsageData(options);
 
 	// Group daily data by month using Object.groupBy
-	const groupedByMonth = Object.groupBy(dailyData, data =>
+	const groupedByMonth = groupBy(dailyData, data =>
 		data.date.substring(0, 7));
 
 	// Aggregate each month group

--- a/src/utils.internal.test.ts
+++ b/src/utils.internal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { formatCurrency, formatNumber } from './utils.internal.ts';
+import { formatCurrency, formatNumber, groupBy } from './utils.internal.ts';
 
 describe('formatNumber', () => {
 	test('formats positive numbers with comma separators', () => {
@@ -63,5 +63,36 @@ describe('formatCurrency', () => {
 	test('handles large numbers', () => {
 		expect(formatCurrency(1000000)).toBe('$1000000.00');
 		expect(formatCurrency(9999999.99)).toBe('$9999999.99');
+	});
+});
+
+describe('groupBy', () => {
+	test('groups elements by key function', () => {
+		const data = [
+			{ type: 'fruit', name: 'apple' },
+			{ type: 'fruit', name: 'banana' },
+			{ type: 'vegetable', name: 'carrot' },
+		];
+
+		const result = groupBy(data, item => item.type);
+
+		expect(result.fruit).toEqual([
+			{ type: 'fruit', name: 'apple' },
+			{ type: 'fruit', name: 'banana' },
+		]);
+		expect(result.vegetable).toEqual([
+			{ type: 'vegetable', name: 'carrot' },
+		]);
+	});
+
+	test('handles empty array', () => {
+		const result = groupBy([], () => 'key');
+		expect(Object.keys(result)).toEqual([]);
+	});
+
+	test('handles single element', () => {
+		const data = [{ name: 'test' }];
+		const result = groupBy(data, () => 'single');
+		expect(result.single).toEqual([{ name: 'test' }]);
 	});
 });

--- a/src/utils.internal.ts
+++ b/src/utils.internal.ts
@@ -5,3 +5,23 @@ export function formatNumber(num: number): string {
 export function formatCurrency(amount: number): string {
 	return `$${amount.toFixed(2)}`;
 }
+
+/**
+ * WHY: Object.groupBy requires Node.js 21+. tsdown doesn't support runtime polyfills, only syntax transforms.
+ */
+export function groupBy<T, K extends PropertyKey>(
+	array: readonly T[],
+	keyFn: (item: T) => K,
+): Record<K, T[] | undefined> {
+	return array.reduce(
+		(groups, item) => {
+			const key = keyFn(item);
+			if (groups[key] == null) {
+				groups[key] = [];
+			}
+			groups[key]!.push(item);
+			return groups;
+		},
+		{} as Record<K, T[] | undefined>,
+	);
+}


### PR DESCRIPTION
Close #46

## Summary
- Replace Object.groupBy usage with manual groupBy implementation
- Add tests for groupBy utility function
- Maintains Node.js 20 compatibility without external polyfill dependencies

## Test plan
- [x] All tests pass
- [x] Verified with Node.js 20