### PR TITLE
feat: add --fetch CLI argument for custom model pricing data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ All commands support the following options:
 - `-m, --mode <mode>`: Cost calculation mode: `auto` (default), `calculate`, or `display`
 - `-o, --order <order>`: Sort order: `desc` (newest first, default) or `asc` (oldest first).
 - `-b, --breakdown`: Show per-model cost breakdown (splits usage by Opus, Sonnet, etc.)
+- `-f, --fetch <source>`: Custom URL or local file path for model pricing data (supports HTTPS URLs and local filesystem paths)
 - `-d, --debug`: Show pricing mismatch information for debugging
 - `--debug-samples <number>`: Number of sample discrepancies to show in debug output (default: 5)
 - `-h, --help`: Display help message
@@ -231,6 +232,41 @@ All commands support the following options:
 - **`auto`** (default): Uses pre-calculated `costUSD` values when available, falls back to calculating costs from token counts using model pricing
 - **`calculate`**: Always calculates costs from token counts using model pricing, ignores any pre-calculated `costUSD` values
 - **`display`**: Always uses pre-calculated `costUSD` values only, shows $0.00 for entries without pre-calculated costs
+
+#### Custom Pricing Data Source
+
+The `--fetch` option allows you to specify a custom source for model pricing data instead of using the default LiteLLM pricing database:
+
+- **HTTPS URLs**: Use `--fetch https://example.com/pricing.json` to fetch pricing data from a remote endpoint
+- **Local files**: Use `--fetch /path/to/pricing.json` to load pricing data from a local JSON file
+
+The pricing data should be in the same format as LiteLLM's pricing database:
+
+```json
+{
+	"model-name": {
+		"input_cost_per_token": 0.00001,
+		"output_cost_per_token": 0.00003,
+		"cache_creation_input_token_cost": 0.000015,
+		"cache_read_input_token_cost": 0.0000015
+	}
+}
+```
+
+**Examples:**
+
+```bash
+# Use a custom pricing file
+ccusage daily --fetch ./custom-pricing.json --mode calculate
+
+# Fetch pricing from a custom URL
+ccusage session --fetch https://my-company.com/api/pricing --mode calculate
+
+# Works with all commands
+ccusage monthly --since 20240101 --fetch ./pricing.json
+```
+
+**Note:** The `--fetch` option only affects cost calculations when using `calculate` or `auto` modes. In `display` mode, only pre-calculated `costUSD` values are used.
 
 ### MCP (Model Context Protocol) Support
 

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -10,6 +10,7 @@ import {
 import { loadDailyUsageData } from '../data-loader.ts';
 import { detectMismatches, printMismatchReport } from '../debug.ts';
 import { log, logger } from '../logger.ts';
+import { PricingFetcher } from '../pricing-fetcher.ts';
 import { sharedCommandConfig } from '../shared-args.internal.ts';
 import { formatCurrency, formatModelsDisplay, formatNumber, pushBreakdownRows } from '../utils.internal.ts';
 
@@ -22,12 +23,17 @@ export const dailyCommand = define({
 			logger.level = 0;
 		}
 
+		// Create a single PricingFetcher instance to reuse across functions
+		using pricingFetcher = ctx.values.mode === 'display' ? undefined : new PricingFetcher(ctx.values.fetch);
+
 		const dailyData = await loadDailyUsageData({
 			since: ctx.values.since,
 			until: ctx.values.until,
 			claudePath: ctx.values.path,
 			mode: ctx.values.mode,
 			order: ctx.values.order,
+			fetch: ctx.values.fetch,
+			pricingFetcher,
 		});
 
 		if (dailyData.length === 0) {
@@ -45,7 +51,7 @@ export const dailyCommand = define({
 
 		// Show debug information if requested
 		if (ctx.values.debug && !ctx.values.json) {
-			const mismatchStats = await detectMismatches(ctx.values.path);
+			const mismatchStats = await detectMismatches(ctx.values.path, ctx.values.fetch, pricingFetcher);
 			printMismatchReport(mismatchStats, ctx.values.debugSamples);
 		}
 

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -10,6 +10,7 @@ import {
 import { loadSessionData } from '../data-loader.ts';
 import { detectMismatches, printMismatchReport } from '../debug.ts';
 import { log, logger } from '../logger.ts';
+import { PricingFetcher } from '../pricing-fetcher.ts';
 import { sharedCommandConfig } from '../shared-args.internal.ts';
 import { formatCurrency, formatModelsDisplay, formatNumber, pushBreakdownRows } from '../utils.internal.ts';
 
@@ -22,12 +23,17 @@ export const sessionCommand = define({
 			logger.level = 0;
 		}
 
+		// Create a single PricingFetcher instance to reuse across functions
+		using pricingFetcher = ctx.values.mode === 'display' ? undefined : new PricingFetcher(ctx.values.fetch);
+
 		const sessionData = await loadSessionData({
 			since: ctx.values.since,
 			until: ctx.values.until,
 			claudePath: ctx.values.path,
 			mode: ctx.values.mode,
 			order: ctx.values.order,
+			fetch: ctx.values.fetch,
+			pricingFetcher,
 		});
 
 		if (sessionData.length === 0) {
@@ -45,7 +51,7 @@ export const sessionCommand = define({
 
 		// Show debug information if requested
 		if (ctx.values.debug && !ctx.values.json) {
-			const mismatchStats = await detectMismatches(ctx.values.path);
+			const mismatchStats = await detectMismatches(ctx.values.path, ctx.values.fetch, pricingFetcher);
 			printMismatchReport(mismatchStats, ctx.values.debugSamples);
 		}
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -52,6 +52,8 @@ type MismatchStats = {
 
 export async function detectMismatches(
 	claudePath?: string,
+	fetch?: string,
+	pricingFetcher?: PricingFetcher,
 ): Promise<MismatchStats> {
 	const claudeDir = claudePath ?? path.join(homedir(), '.claude', 'projects');
 	const files = await glob(['**/*.jsonl'], {
@@ -59,8 +61,8 @@ export async function detectMismatches(
 		absolute: true,
 	});
 
-	// Use PricingFetcher with using statement for automatic cleanup
-	using fetcher = new PricingFetcher();
+	// Use provided PricingFetcher or create new one with using statement for automatic cleanup
+	using fetcher = pricingFetcher ?? new PricingFetcher(fetch);
 
 	const stats: MismatchStats = {
 		totalEntries: 0,

--- a/src/fetch-cli.test.ts
+++ b/src/fetch-cli.test.ts
@@ -1,0 +1,375 @@
+import { unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test';
+import { createFixture } from 'fs-fixture';
+import { loadDailyUsageData, loadSessionData } from './data-loader.ts';
+import { PricingFetcher } from './pricing-fetcher.ts';
+
+describe('--fetch CLI argument functionality', () => {
+	describe('PricingFetcher reuse prevents multiple fetch attempts', () => {
+		it('should demonstrate the fix prevents multiple URL fetch attempts', async () => {
+			// This test demonstrates that the issue is fixed by showing
+			// that PricingFetcher instances cache their results
+
+			const mockFetch = jest.fn()
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => Promise.resolve({
+						'test-model': {
+							input_cost_per_token: 0.00001,
+							output_cost_per_token: 0.00003,
+						},
+					}),
+				});
+
+			const originalFetch = globalThis.fetch;
+			// eslint-disable-next-line ts/no-unsafe-assignment
+			globalThis.fetch = mockFetch as any;
+
+			try {
+				// Create a shared PricingFetcher instance
+				using pricingFetcher = new PricingFetcher('https://test-url.com/pricing.json');
+
+				// First call should trigger fetch
+				await pricingFetcher.fetchModelPricing();
+				expect(mockFetch).toHaveBeenCalledTimes(1);
+
+				// Second call should use cached result
+				await pricingFetcher.fetchModelPricing();
+				expect(mockFetch).toHaveBeenCalledTimes(1); // Still 1, not 2
+
+				// Third call should also use cached result
+				await pricingFetcher.getModelPricing('test-model');
+				expect(mockFetch).toHaveBeenCalledTimes(1); // Still 1, not 2
+			}
+			finally {
+				globalThis.fetch = originalFetch;
+			}
+		});
+
+		it('should verify that separate PricingFetcher instances fetch independently', async () => {
+			const mockFetch = jest.fn()
+				.mockResolvedValue({
+					ok: true,
+					json: async () => Promise.resolve({
+						'test-model': {
+							input_cost_per_token: 0.00001,
+							output_cost_per_token: 0.00003,
+						},
+					}),
+				});
+
+			const originalFetch = globalThis.fetch;
+			// eslint-disable-next-line ts/no-unsafe-assignment
+			globalThis.fetch = mockFetch as any;
+
+			try {
+				// First PricingFetcher instance
+				using fetcher1 = new PricingFetcher('https://test-url.com/pricing.json');
+				await fetcher1.fetchModelPricing();
+				expect(mockFetch).toHaveBeenCalledTimes(1);
+
+				// Second PricingFetcher instance (separate from first)
+				using fetcher2 = new PricingFetcher('https://test-url.com/pricing.json');
+				await fetcher2.fetchModelPricing();
+				expect(mockFetch).toHaveBeenCalledTimes(2); // Now 2 fetches
+			}
+			finally {
+				globalThis.fetch = originalFetch;
+			}
+		});
+	});
+
+	describe('Custom pricing source integration', () => {
+		let tempDir: string;
+		let testPricingFile: string;
+
+		beforeEach(async () => {
+			tempDir = tmpdir();
+			testPricingFile = join(tempDir, 'test-pricing.json');
+		});
+
+		afterEach(async () => {
+			try {
+				await unlink(testPricingFile);
+			}
+			catch {
+				// Ignore cleanup errors
+			}
+		});
+
+		it('should use custom local pricing file for cost calculations', async () => {
+			const customPricing = {
+				'claude-sonnet-4-custom': {
+					input_cost_per_token: 0.00005,
+					output_cost_per_token: 0.00015,
+				},
+			};
+
+			await writeFile(testPricingFile, JSON.stringify(customPricing));
+
+			await using fixture = await createFixture({
+				projects: {
+					'test-project': {
+						'session-1': {
+							'usage1.jsonl': JSON.stringify({
+								timestamp: '2024-01-01T00:00:00Z',
+								message: {
+									usage: { input_tokens: 1000, output_tokens: 500 },
+									model: 'claude-sonnet-4-custom',
+								},
+							}),
+						},
+					},
+				},
+			});
+
+			const dailyData = await loadDailyUsageData({
+				claudePath: fixture.path,
+				mode: 'calculate',
+				fetch: testPricingFile,
+			});
+
+			expect(dailyData).toHaveLength(1);
+
+			// Cost should be calculated using custom pricing: 1000 * 0.00005 + 500 * 0.00015 = 0.125
+			expect(dailyData[0]?.totalCost).toBeCloseTo(0.125);
+		});
+
+		it('should handle session data with custom pricing file', async () => {
+			const customPricing = {
+				'test-model': {
+					input_cost_per_token: 0.00001,
+					output_cost_per_token: 0.00003,
+				},
+			};
+
+			await writeFile(testPricingFile, JSON.stringify(customPricing));
+
+			await using fixture = await createFixture({
+				projects: {
+					'my-project': {
+						'session-abc': {
+							'conversation.jsonl': JSON.stringify({
+								timestamp: '2024-01-01T00:00:00Z',
+								message: {
+									usage: { input_tokens: 2000, output_tokens: 1000 },
+									model: 'test-model',
+								},
+							}),
+						},
+					},
+				},
+			});
+
+			const sessionData = await loadSessionData({
+				claudePath: fixture.path,
+				mode: 'calculate',
+				fetch: testPricingFile,
+			});
+
+			expect(sessionData).toHaveLength(1);
+
+			// Cost should be: 2000 * 0.00001 + 1000 * 0.00003 = 0.05
+			expect(sessionData[0]?.totalCost).toBeCloseTo(0.05);
+			expect(sessionData[0]?.sessionId).toBe('session-abc');
+		});
+
+		it('should work with display mode and ignore custom pricing file', async () => {
+			const customPricing = {
+				'some-model': {
+					input_cost_per_token: 999,
+					output_cost_per_token: 999,
+				},
+			};
+
+			await writeFile(testPricingFile, JSON.stringify(customPricing));
+
+			await using fixture = await createFixture({
+				projects: {
+					'test-project': {
+						'session-1': {
+							'usage1.jsonl': JSON.stringify({
+								timestamp: '2024-01-01T00:00:00Z',
+								message: {
+									usage: { input_tokens: 1000, output_tokens: 500 },
+									model: 'some-model',
+								},
+								costUSD: 0.02,
+							}),
+						},
+					},
+				},
+			});
+
+			const dailyData = await loadDailyUsageData({
+				claudePath: fixture.path,
+				mode: 'display',
+				fetch: testPricingFile,
+			});
+
+			expect(dailyData).toHaveLength(1);
+
+			// Should use pre-calculated costUSD, not custom pricing
+			expect(dailyData[0]?.totalCost).toBe(0.02);
+		});
+
+		it('should throw error for malformed custom pricing JSON', async () => {
+			await writeFile(testPricingFile, 'invalid json content');
+
+			// Test with PricingFetcher directly - should throw PricingSourceError
+			using fetcher = new PricingFetcher(testPricingFile);
+			expect(fetcher.fetchModelPricing()).rejects.toThrow('Failed to load custom pricing data');
+		});
+
+		it('should throw error for non-existent custom pricing file', async () => {
+			const nonExistentFile = join(tempDir, 'does-not-exist.json');
+
+			// Test with PricingFetcher directly - should throw PricingSourceError
+			using fetcher = new PricingFetcher(nonExistentFile);
+			expect(fetcher.fetchModelPricing()).rejects.toThrow('Failed to load custom pricing data');
+		});
+	});
+
+	describe('Custom HTTPS URL support', () => {
+		it('should detect HTTPS URLs correctly and throw error on failure', async () => {
+			const httpsUrl = 'https://example.com/pricing.json';
+			using fetcher = new PricingFetcher(httpsUrl);
+
+			// Mock fetch to fail with network error
+			const mockFetch = jest.fn().mockRejectedValue(new Error('Network error'));
+			const originalFetch = globalThis.fetch;
+			// eslint-disable-next-line ts/no-unsafe-assignment
+			globalThis.fetch = mockFetch as any;
+
+			try {
+				// Should throw error for custom URL failure
+				expect(fetcher.fetchModelPricing()).rejects.toThrow('Failed to load custom pricing data');
+				expect(mockFetch).toHaveBeenCalledWith(httpsUrl);
+			}
+			finally {
+				globalThis.fetch = originalFetch;
+			}
+		});
+
+		it('should reject non-HTTPS URLs and throw error', async () => {
+			// eslint-disable-next-line ryoppippi/no-http-url
+			const httpUrl = 'http://example.com/pricing.json';
+			using fetcher = new PricingFetcher(httpUrl);
+
+			// Should not try to fetch HTTP URLs (only HTTPS supported)
+			const mockFetch = jest.fn();
+			const originalFetch = globalThis.fetch;
+			// eslint-disable-next-line ts/no-unsafe-assignment
+			globalThis.fetch = mockFetch as any;
+
+			try {
+				// Should throw error when trying to load non-HTTPS URL as file
+				expect(fetcher.fetchModelPricing()).rejects.toThrow('Failed to load custom pricing data');
+				// Should not have called fetch since it's not HTTPS
+				expect(mockFetch).not.toHaveBeenCalled();
+			}
+			finally {
+				globalThis.fetch = originalFetch;
+			}
+		});
+	});
+
+	describe('Auto mode with custom pricing', () => {
+		let tempDir: string;
+		let testPricingFile: string;
+
+		beforeEach(async () => {
+			tempDir = tmpdir();
+			testPricingFile = join(tempDir, 'test-pricing.json');
+		});
+
+		afterEach(async () => {
+			try {
+				await unlink(testPricingFile);
+			}
+			catch {
+				// Ignore cleanup errors
+			}
+		});
+
+		it('should prefer costUSD over custom pricing in auto mode', async () => {
+			const customPricing = {
+				'claude-sonnet-4-20250514': {
+					input_cost_per_token: 999,
+					output_cost_per_token: 999,
+				},
+			};
+
+			await writeFile(testPricingFile, JSON.stringify(customPricing));
+
+			await using fixture = await createFixture({
+				projects: {
+					'test-project': {
+						'session-1': {
+							'usage1.jsonl': JSON.stringify({
+								timestamp: '2024-01-01T00:00:00Z',
+								message: {
+									usage: { input_tokens: 1000, output_tokens: 500 },
+									model: 'claude-sonnet-4-20250514',
+								},
+								costUSD: 0.025,
+							}),
+						},
+					},
+				},
+			});
+
+			const dailyData = await loadDailyUsageData({
+				claudePath: fixture.path,
+				mode: 'auto',
+				fetch: testPricingFile,
+			});
+
+			expect(dailyData).toHaveLength(1);
+
+			// Should use costUSD (0.025) instead of calculating with custom pricing (would be ~1500)
+			expect(dailyData[0]?.totalCost).toBe(0.025);
+		});
+
+		it('should fall back to custom pricing when costUSD is missing in auto mode', async () => {
+			const customPricing = {
+				'claude-sonnet-4-custom': {
+					input_cost_per_token: 0.00002,
+					output_cost_per_token: 0.00006,
+				},
+			};
+
+			await writeFile(testPricingFile, JSON.stringify(customPricing));
+
+			await using fixture = await createFixture({
+				projects: {
+					'test-project': {
+						'session-1': {
+							'usage1.jsonl': JSON.stringify({
+								timestamp: '2024-01-01T00:00:00Z',
+								message: {
+									usage: { input_tokens: 1000, output_tokens: 500 },
+									model: 'claude-sonnet-4-custom',
+								},
+								// No costUSD field
+							}),
+						},
+					},
+				},
+			});
+
+			const dailyData = await loadDailyUsageData({
+				claudePath: fixture.path,
+				mode: 'auto',
+				fetch: testPricingFile,
+			});
+
+			expect(dailyData).toHaveLength(1);
+
+			// Should calculate using custom pricing: 1000 * 0.00002 + 500 * 0.00006 = 0.05
+			expect(dailyData[0]?.totalCost).toBeCloseTo(0.05);
+		});
+	});
+});

--- a/src/shared-args.internal.ts
+++ b/src/shared-args.internal.ts
@@ -70,6 +70,11 @@ export const sharedArgs = {
 		description: 'Show per-model cost breakdown',
 		default: false,
 	},
+	fetch: {
+		type: 'string',
+		short: 'f',
+		description: 'Custom URL or local file path for model pricing data (supports HTTPS URLs and local filesystem paths)',
+	},
 } as const satisfies Args;
 
 export const sharedCommandConfig = {


### PR DESCRIPTION
## Summary
- Implements the `--fetch` CLI argument requested in issue #12
- Allows users to specify custom URLs or local file paths for model pricing data
- Enables users behind corporate proxies to access pricing information

## Changes
- Added `--fetch` argument to shared CLI arguments with support for both HTTPS URLs and local filesystem paths
- Updated `PricingFetcher` class to accept custom data sources in constructor
- Modified all commands (daily, monthly, session) to pass the fetch parameter
- Updated debug functionality to use custom pricing sources
- Maintained full backward compatibility with default LiteLLM pricing

## Test plan
- [x] Build succeeds without errors
- [x] All existing tests pass (106/106)
- [x] Linting passes
- [x] Manual testing with both local file and HTTPS URL works correctly
- [x] Default behavior unchanged when --fetch is not specified
- [x] Help text displays the new option correctly

## Examples

Using a local file:
```bash
ccusage daily --fetch /path/to/pricing.json
```

Using a custom HTTPS URL:
```bash
ccusage daily --fetch https://example.com/custom-pricing.json
```

Resolves #12

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new command-line option to specify a custom source (URL or local file) for model pricing data in all commands.
  - Enhanced flexibility for cost calculations by allowing the use of external or local pricing databases.

- **Documentation**
  - Updated documentation to explain the new option, its usage, and its effect on different calculation modes, including usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->