### PR TITLE
feat: count and display the number of calls made to each model

### DIFF
--- a/src/calculate-cost.test.ts
+++ b/src/calculate-cost.test.ts
@@ -16,6 +16,7 @@ describe('Token aggregation utilities', () => {
 				cacheCreationTokens: 25,
 				cacheReadTokens: 10,
 				totalCost: 0.01,
+				totalCalls: 5,
 				modelsUsed: ['claude-sonnet-4-20250514'],
 				modelBreakdowns: [],
 			},
@@ -26,6 +27,7 @@ describe('Token aggregation utilities', () => {
 				cacheCreationTokens: 50,
 				cacheReadTokens: 20,
 				totalCost: 0.02,
+				totalCalls: 3,
 				modelsUsed: ['claude-opus-4-20250514'],
 				modelBreakdowns: [],
 			},
@@ -37,6 +39,7 @@ describe('Token aggregation utilities', () => {
 		expect(totals.cacheCreationTokens).toBe(75);
 		expect(totals.cacheReadTokens).toBe(30);
 		expect(totals.totalCost).toBeCloseTo(0.03);
+		expect(totals.totalCalls).toBe(8);
 	});
 
 	test('calculateTotals should aggregate session usage data', () => {
@@ -49,6 +52,7 @@ describe('Token aggregation utilities', () => {
 				cacheCreationTokens: 25,
 				cacheReadTokens: 10,
 				totalCost: 0.01,
+				totalCalls: 5,
 				lastActivity: '2024-01-01',
 				versions: ['1.0.3'],
 				modelsUsed: ['claude-sonnet-4-20250514'],
@@ -62,6 +66,7 @@ describe('Token aggregation utilities', () => {
 				cacheCreationTokens: 50,
 				cacheReadTokens: 20,
 				totalCost: 0.02,
+				totalCalls: 3,
 				lastActivity: '2024-01-02',
 				versions: ['1.0.3', '1.0.4'],
 				modelsUsed: ['claude-opus-4-20250514'],
@@ -75,6 +80,7 @@ describe('Token aggregation utilities', () => {
 		expect(totals.cacheCreationTokens).toBe(75);
 		expect(totals.cacheReadTokens).toBe(30);
 		expect(totals.totalCost).toBeCloseTo(0.03);
+		expect(totals.totalCalls).toBe(8);
 	});
 
 	test('getTotalTokens should sum all token types', () => {
@@ -108,6 +114,7 @@ describe('Token aggregation utilities', () => {
 			cacheCreationTokens: 25,
 			cacheReadTokens: 10,
 			totalCost: 0.01,
+			totalCalls: 5,
 		};
 
 		const totalsObject = createTotalsObject(totals);
@@ -118,6 +125,7 @@ describe('Token aggregation utilities', () => {
 			cacheReadTokens: 10,
 			totalTokens: 185,
 			totalCost: 0.01,
+			totalCalls: 5,
 		});
 	});
 
@@ -129,6 +137,7 @@ describe('Token aggregation utilities', () => {
 			cacheCreationTokens: 0,
 			cacheReadTokens: 0,
 			totalCost: 0,
+			totalCalls: 0,
 		});
 	});
 });

--- a/src/calculate-cost.ts
+++ b/src/calculate-cost.ts
@@ -9,6 +9,7 @@ type TokenData = {
 
 type TokenTotals = TokenData & {
 	totalCost: number;
+	totalCalls: number;
 };
 
 type TotalsObject = TokenTotals & {
@@ -25,6 +26,7 @@ export function calculateTotals(
 			cacheCreationTokens: acc.cacheCreationTokens + item.cacheCreationTokens,
 			cacheReadTokens: acc.cacheReadTokens + item.cacheReadTokens,
 			totalCost: acc.totalCost + item.totalCost,
+			totalCalls: acc.totalCalls + item.totalCalls,
 		}),
 		{
 			inputTokens: 0,
@@ -32,6 +34,7 @@ export function calculateTotals(
 			cacheCreationTokens: 0,
 			cacheReadTokens: 0,
 			totalCost: 0,
+			totalCalls: 0,
 		},
 	);
 }
@@ -53,5 +56,6 @@ export function createTotalsObject(totals: TokenTotals): TotalsObject {
 		cacheReadTokens: totals.cacheReadTokens,
 		totalTokens: getTotalTokens(totals),
 		totalCost: totals.totalCost,
+		totalCalls: totals.totalCalls,
 	};
 }

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -60,6 +60,7 @@ export const dailyCommand = define({
 					cacheReadTokens: data.cacheReadTokens,
 					totalTokens: getTotalTokens(data),
 					totalCost: data.totalCost,
+					totalCalls: data.totalCalls,
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
 				})),
@@ -76,6 +77,7 @@ export const dailyCommand = define({
 				head: [
 					'Date',
 					'Models',
+					'Calls',
 					'Input',
 					'Output',
 					'Cache Create',
@@ -95,6 +97,7 @@ export const dailyCommand = define({
 					'right',
 					'right',
 					'right',
+					'right',
 				],
 			});
 
@@ -104,6 +107,7 @@ export const dailyCommand = define({
 				table.push([
 					data.date,
 					formatModelsDisplay(data.modelsUsed),
+					formatNumber(data.totalCalls),
 					formatNumber(data.inputTokens),
 					formatNumber(data.outputTokens),
 					formatNumber(data.cacheCreationTokens),
@@ -127,6 +131,7 @@ export const dailyCommand = define({
 				'─'.repeat(12),
 				'─'.repeat(12),
 				'─'.repeat(12),
+				'─'.repeat(12),
 				'─'.repeat(10),
 			]);
 
@@ -134,6 +139,7 @@ export const dailyCommand = define({
 			table.push([
 				pc.yellow('Total'),
 				'', // Empty for Models column in totals
+				pc.yellow(formatNumber(totals.totalCalls)),
 				pc.yellow(formatNumber(totals.inputTokens)),
 				pc.yellow(formatNumber(totals.outputTokens)),
 				pc.yellow(formatNumber(totals.cacheCreationTokens)),

--- a/src/commands/monthly.ts
+++ b/src/commands/monthly.ts
@@ -41,6 +41,7 @@ export const monthlyCommand = define({
 						cacheReadTokens: 0,
 						totalTokens: 0,
 						totalCost: 0,
+						totalCalls: 0,
 					},
 				};
 				log(JSON.stringify(emptyOutput, null, 2));
@@ -71,6 +72,7 @@ export const monthlyCommand = define({
 					cacheReadTokens: data.cacheReadTokens,
 					totalTokens: getTotalTokens(data),
 					totalCost: data.totalCost,
+					totalCalls: data.totalCalls,
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
 				})),
@@ -87,6 +89,7 @@ export const monthlyCommand = define({
 				head: [
 					'Month',
 					'Models',
+					'Calls',
 					'Input',
 					'Output',
 					'Cache Create',
@@ -106,6 +109,7 @@ export const monthlyCommand = define({
 					'right',
 					'right',
 					'right',
+					'right',
 				],
 			});
 
@@ -115,6 +119,7 @@ export const monthlyCommand = define({
 				table.push([
 					data.month,
 					formatModelsDisplay(data.modelsUsed),
+					formatNumber(data.totalCalls),
 					formatNumber(data.inputTokens),
 					formatNumber(data.outputTokens),
 					formatNumber(data.cacheCreationTokens),
@@ -138,6 +143,7 @@ export const monthlyCommand = define({
 				'─'.repeat(12),
 				'─'.repeat(12),
 				'─'.repeat(12),
+				'─'.repeat(12),
 				'─'.repeat(10),
 			]);
 
@@ -145,6 +151,7 @@ export const monthlyCommand = define({
 			table.push([
 				pc.yellow('Total'),
 				'', // Empty for Models column in totals
+				pc.yellow(formatNumber(totals.totalCalls)),
 				pc.yellow(formatNumber(totals.inputTokens)),
 				pc.yellow(formatNumber(totals.outputTokens)),
 				pc.yellow(formatNumber(totals.cacheCreationTokens)),

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -60,6 +60,7 @@ export const sessionCommand = define({
 					cacheReadTokens: data.cacheReadTokens,
 					totalTokens: getTotalTokens(data),
 					totalCost: data.totalCost,
+					totalCalls: data.totalCalls,
 					lastActivity: data.lastActivity,
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
@@ -77,6 +78,7 @@ export const sessionCommand = define({
 				head: [
 					'Session',
 					'Models',
+					'Calls',
 					'Input',
 					'Output',
 					'Cache Create',
@@ -97,6 +99,7 @@ export const sessionCommand = define({
 					'right',
 					'right',
 					'right',
+					'right',
 					'left',
 				],
 			});
@@ -111,6 +114,7 @@ export const sessionCommand = define({
 				table.push([
 					sessionDisplay,
 					formatModelsDisplay(data.modelsUsed),
+					formatNumber(data.totalCalls),
 					formatNumber(data.inputTokens),
 					formatNumber(data.outputTokens),
 					formatNumber(data.cacheCreationTokens),
@@ -131,6 +135,7 @@ export const sessionCommand = define({
 			table.push([
 				'─'.repeat(maxSessionLength), // For Session
 				'─'.repeat(12), // For Models
+				'─'.repeat(12), // For Calls
 				'─'.repeat(12), // For Input Tokens
 				'─'.repeat(12), // For Output Tokens
 				'─'.repeat(12), // For Cache Create
@@ -144,6 +149,7 @@ export const sessionCommand = define({
 			table.push([
 				pc.yellow('Total'),
 				'', // Empty for Models column in totals
+				pc.yellow(formatNumber(totals.totalCalls)),
 				pc.yellow(formatNumber(totals.inputTokens)),
 				pc.yellow(formatNumber(totals.outputTokens)),
 				pc.yellow(formatNumber(totals.cacheCreationTokens)),

--- a/src/data-loader.test.ts
+++ b/src/data-loader.test.ts
@@ -364,6 +364,7 @@ describe('loadMonthlyUsageData', () => {
 			cacheCreationTokens: 0,
 			cacheReadTokens: 0,
 			totalCost: 0.015,
+			totalCalls: 1,
 			modelsUsed: [],
 			modelBreakdowns: [{
 				modelName: 'unknown',
@@ -372,6 +373,7 @@ describe('loadMonthlyUsageData', () => {
 				cacheCreationTokens: 0,
 				cacheReadTokens: 0,
 				cost: 0.015,
+				calls: 1,
 			}],
 		});
 		expect(result[1]).toEqual({
@@ -381,6 +383,7 @@ describe('loadMonthlyUsageData', () => {
 			cacheCreationTokens: 0,
 			cacheReadTokens: 0,
 			totalCost: 0.03,
+			totalCalls: 2,
 			modelsUsed: [],
 			modelBreakdowns: [{
 				modelName: 'unknown',
@@ -389,6 +392,7 @@ describe('loadMonthlyUsageData', () => {
 				cacheCreationTokens: 0,
 				cacheReadTokens: 0,
 				cost: 0.03,
+				calls: 2,
 			}],
 		});
 	});
@@ -436,6 +440,7 @@ describe('loadMonthlyUsageData', () => {
 			cacheCreationTokens: 0,
 			cacheReadTokens: 0,
 			totalCost: 0.03,
+			totalCalls: 2,
 			modelsUsed: [],
 			modelBreakdowns: [{
 				modelName: 'unknown',
@@ -444,6 +449,7 @@ describe('loadMonthlyUsageData', () => {
 				cacheCreationTokens: 0,
 				cacheReadTokens: 0,
 				cost: 0.03,
+				calls: 2,
 			}],
 		});
 	});

--- a/src/utils.internal.ts
+++ b/src/utils.internal.ts
@@ -62,6 +62,7 @@ export function pushBreakdownRows(
 		cacheCreationTokens: number;
 		cacheReadTokens: number;
 		cost: number;
+		calls: number;
 	}>,
 	extraColumns = 1,
 	trailingColumns = 0,
@@ -79,6 +80,7 @@ export function pushBreakdownRows(
 			+ breakdown.cacheCreationTokens + breakdown.cacheReadTokens;
 
 		row.push(
+			pc.gray(formatNumber(breakdown.calls)),
 			pc.gray(formatNumber(breakdown.inputTokens)),
 			pc.gray(formatNumber(breakdown.outputTokens)),
 			pc.gray(formatNumber(breakdown.cacheCreationTokens)),


### PR DESCRIPTION
This updates the command output to show the number of model calls that Claude Code made, alongside the input and output tokens count, cost, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Usage reports now display the total number of calls in daily, monthly, and session summaries, both in JSON and CLI table formats.
  - Model breakdowns include the number of calls per model.

- **Bug Fixes**
  - Tests updated to verify the accuracy of call counts in usage aggregation and reporting.

- **Style**
  - CLI tables updated to include a new "Calls" column for improved visibility of call metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->