### PR TITLE
fix: replace own groupBy implementation with es-toolkit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "clean-pkg-json": "^1.3.0",
         "cli-table3": "^0.6.5",
         "consola": "^3.4.2",
+        "es-toolkit": "^1.39.3",
         "eslint": "^9.28.0",
         "eslint-plugin-format": "^1.0.1",
         "fast-sort": "^3.4.1",
@@ -410,6 +411,8 @@
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-toolkit": ["es-toolkit@1.39.3", "", {}, "sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"clean-pkg-json": "^1.3.0",
 		"cli-table3": "^0.6.5",
 		"consola": "^3.4.2",
+		"es-toolkit": "^1.39.3",
 		"eslint": "^9.28.0",
 		"eslint-plugin-format": "^1.0.1",
 		"fast-sort": "^3.4.1",

--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { unreachable } from '@core/errorutil';
+import { groupBy } from 'es-toolkit'; // TODO: after node20 is deprecated, switch to native Object.groupBy
 import { sort } from 'fast-sort';
 import { glob } from 'tinyglobby';
 import * as v from 'valibot';
@@ -10,7 +11,6 @@ import { logger } from './logger.ts';
 import {
 	PricingFetcher,
 } from './pricing-fetcher.ts';
-import { groupBy } from './utils.internal.ts';
 
 export function getDefaultClaudePath(): string {
 	return path.join(homedir(), '.claude');

--- a/src/utils.internal.test.ts
+++ b/src/utils.internal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { formatCurrency, formatNumber, groupBy } from './utils.internal.ts';
+import { formatCurrency, formatNumber } from './utils.internal.ts';
 
 describe('formatNumber', () => {
 	test('formats positive numbers with comma separators', () => {
@@ -63,36 +63,5 @@ describe('formatCurrency', () => {
 	test('handles large numbers', () => {
 		expect(formatCurrency(1000000)).toBe('$1000000.00');
 		expect(formatCurrency(9999999.99)).toBe('$9999999.99');
-	});
-});
-
-describe('groupBy', () => {
-	test('groups elements by key function', () => {
-		const data = [
-			{ type: 'fruit', name: 'apple' },
-			{ type: 'fruit', name: 'banana' },
-			{ type: 'vegetable', name: 'carrot' },
-		];
-
-		const result = groupBy(data, item => item.type);
-
-		expect(result.fruit).toEqual([
-			{ type: 'fruit', name: 'apple' },
-			{ type: 'fruit', name: 'banana' },
-		]);
-		expect(result.vegetable).toEqual([
-			{ type: 'vegetable', name: 'carrot' },
-		]);
-	});
-
-	test('handles empty array', () => {
-		const result = groupBy([], () => 'key');
-		expect(Object.keys(result)).toEqual([]);
-	});
-
-	test('handles single element', () => {
-		const data = [{ name: 'test' }];
-		const result = groupBy(data, () => 'single');
-		expect(result.single).toEqual([{ name: 'test' }]);
 	});
 });

--- a/src/utils.internal.ts
+++ b/src/utils.internal.ts
@@ -8,26 +8,6 @@ export function formatCurrency(amount: number): string {
 	return `$${amount.toFixed(2)}`;
 }
 
-/**
- * WHY: Object.groupBy requires Node.js 21+. tsdown doesn't support runtime polyfills, only syntax transforms.
- */
-export function groupBy<T, K extends PropertyKey>(
-	array: readonly T[],
-	keyFn: (item: T) => K,
-): Record<K, T[] | undefined> {
-	return array.reduce(
-		(groups, item) => {
-			const key = keyFn(item);
-			if (groups[key] == null) {
-				groups[key] = [];
-			}
-			groups[key]!.push(item);
-			return groups;
-		},
-		{} as Record<K, T[] | undefined>,
-	);
-}
-
 export function formatModelName(modelName: string): string {
 	// Extract model type from full model name
 	// e.g., "claude-sonnet-4-20250514" -> "sonnet-4"


### PR DESCRIPTION
This pull request refactors the `groupBy` utility function by replacing the custom implementation with the version from the `es-toolkit` library. It also includes cleanup of related imports and tests.

### Dependency Updates:
* Added `es-toolkit` as a new dependency in `package.json`. This library provides the `groupBy` function used to replace the custom implementation.

### Code Refactoring:
* Replaced the custom `groupBy` function in `src/utils.internal.ts` with the `groupBy` function from `es-toolkit`. The custom implementation was removed entirely.
* Updated the import in `src/data-loader.ts` to use `groupBy` from `es-toolkit` instead of the local `utils.internal.ts` file.

### Test Cleanup:
* Removed the test suite for the custom `groupBy` function in `src/utils.internal.test.ts`, as the function is no longer part of the codebase.
* Cleaned up the `groupBy` import in `src/utils.internal.test.ts` to reflect the removal of the function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development dependencies to include "es-toolkit".
- **Refactor**
  - Switched to using the external "es-toolkit" package for grouping functionality.
  - Removed the internal implementation and related tests for the groupBy utility function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->