### PR TITLE
feat: add 5-hour session window tracking (closes #23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `bun run start daily` - Show daily usage report
 - `bun run start monthly` - Show monthly usage report
 - `bun run start session` - Show session-based usage report
+- `bun run start session --windows` - Show 5-hour session window statistics
 - `bun run start daily --json` - Show daily usage report in JSON format
 - `bun run start monthly --json` - Show monthly usage report in JSON format
 - `bun run start session --json` - Show session usage report in JSON format
@@ -56,6 +57,8 @@ This is a CLI tool that analyzes Claude Code usage data from local JSONL files s
 - Raw usage data is parsed from JSONL with timestamp, token counts, and pre-calculated costs
 - Data is aggregated into daily summaries, monthly summaries, or session summaries
 - Sessions are identified by directory structure: `projects/{project}/{session}/{file}.jsonl`
+- 5-hour window tracking: Usage is grouped into UTC-based 5-hour windows (00:00, 05:00, 10:00, 15:00, 20:00)
+- Session limits: Monthly session usage is tracked and compared against plan limits (e.g., 50 for Max plan)
 
 **External Dependencies:**
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This tool helps you understand the value you're getting from your subscription b
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
+- ⏰ **5-Hour Window Tracking**: Track usage in Claude's 5-hour session windows with `--windows` flag
 - 🤖 **Model Tracking**: See which Claude models you're using (Opus, Sonnet, etc.)
 - 📊 **Model Breakdown**: View per-model cost breakdown with `--breakdown` flag
 - 📅 **Date Filtering**: Filter reports by date range using `--since` and `--until`
@@ -51,6 +52,7 @@ This tool helps you understand the value you're getting from your subscription b
 - 🔄 **Cache Token Support**: Tracks and displays cache creation and cache read tokens separately
 - 🌐 **Offline Mode**: Use pre-cached pricing data without network connectivity with `--offline` (Claude models only)
 - 📏 **Responsive Tables**: Automatic table width adjustment for narrow terminals with intelligent word wrapping
+- 🚨 **Session Limit Warnings**: Monitor your monthly session usage against plan limits
 
 ## Important Disclaimer
 
@@ -228,6 +230,10 @@ ccusage session --breakdown       # Show cost breakdown by model
 # Use offline mode (no network required)
 ccusage session --offline         # Use pre-cached pricing data
 ccusage session -O                # Short alias for --offline
+
+# Show 5-hour session window statistics
+ccusage session --windows         # Show usage grouped by 5-hour windows with monthly limits
+ccusage session --windows --session-limit 100  # Specify custom session limit (default: 50)
 ```
 
 ### Options
@@ -245,6 +251,13 @@ All commands support the following options:
 - `--debug-samples <number>`: Number of sample discrepancies to show in debug output (default: 5)
 - `-h, --help`: Display help message
 - `-v, --version`: Display version
+
+#### Session-specific Options
+
+The `session` command has additional options for 5-hour window tracking:
+
+- `-w, --windows`: Show 5-hour session window statistics instead of regular session report
+- `-l, --session-limit <number>`: Session limit for your plan (default: 50 for Claude Max plan)
 
 #### Cost Calculation Modes
 

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -1,3 +1,4 @@
+import type { CostMode } from '../types.internal.ts';
 import process from 'node:process';
 import { define } from 'gunshi';
 import pc from 'picocolors';
@@ -6,17 +7,47 @@ import {
 	createTotalsObject,
 	getTotalTokens,
 } from '../calculate-cost.ts';
-import { formatDateCompact, getDefaultClaudePath, loadSessionData } from '../data-loader.ts';
+import {
+	calculateWindowStatistics,
+	formatDateCompact,
+	getDefaultClaudePath,
+	groupWindowsByMonth,
+	loadSessionData,
+	type SessionUsage,
+	type UsageData,
+} from '../data-loader.ts';
 import { detectMismatches, printMismatchReport } from '../debug.ts';
 import { log, logger } from '../logger.ts';
 import { sharedCommandConfig } from '../shared-args.internal.ts';
-import { formatCurrency, formatModelsDisplay, formatNumber, pushBreakdownRows } from '../utils.internal.ts';
+import {
+	formatCurrency,
+	formatDuration,
+	formatModelsDisplay,
+	formatNumber,
+	getWindowStartTime,
+	pushBreakdownRows,
+} from '../utils.internal.ts';
 import { ResponsiveTable } from '../utils.table.ts';
 
 export const sessionCommand = define({
 	name: 'session',
 	description: 'Show usage report grouped by conversation session',
 	...sharedCommandConfig,
+	args: {
+		...sharedCommandConfig.args,
+		windows: {
+			type: 'boolean',
+			short: 'w',
+			description: 'Show 5-hour session window statistics',
+			default: false,
+		},
+		sessionLimit: {
+			type: 'number',
+			short: 'l',
+			description: 'Session limit for your plan (e.g., 50 for Max plan)',
+			default: 50,
+		},
+	},
 	async run(ctx) {
 		if (ctx.values.json) {
 			logger.level = 0;
@@ -41,6 +72,14 @@ export const sessionCommand = define({
 			process.exit(0);
 		}
 
+		// Check if windows mode is requested
+		if (ctx.values.windows) {
+			// Window statistics mode
+			await displayWindowStatistics(sessionData, ctx.values);
+			return;
+		}
+
+		// Regular session mode continues below
 		// Calculate totals
 		const totals = calculateTotals(sessionData);
 
@@ -159,3 +198,258 @@ export const sessionCommand = define({
 		}
 	},
 });
+
+/**
+ * Display 5-hour window statistics
+ */
+async function displayWindowStatistics(
+	sessionData: SessionUsage[],
+	options: {
+		json?: boolean;
+		sessionLimit?: number;
+		order?: string;
+		mode?: string;
+		since?: string;
+		until?: string;
+		debug?: boolean;
+		debugSamples?: number;
+	},
+): Promise<void> {
+	// Extract all entries from session data to calculate windows
+	// We need to reconstruct the raw entries since sessionData is already aggregated
+	// For now, we'll load the data again with raw entries
+	const allEntries: Array<{
+		data: UsageData;
+		timestamp: string;
+		cost: number;
+		sessionKey: string;
+		model: string | undefined;
+	}> = [];
+
+	// Load raw data to get all entries
+	// This is a temporary solution - ideally we'd refactor loadSessionData to return raw entries
+	const claudePath = getDefaultClaudePath();
+	const path = await import('node:path');
+	const claudeDir = path.join(claudePath, 'projects');
+	const { glob } = await import('tinyglobby');
+	const files = await glob(['**/*.jsonl'], {
+		cwd: claudeDir,
+		absolute: true,
+	});
+
+	// Load and parse all entries
+	const { readFile } = await import('node:fs/promises');
+	const v = await import('valibot');
+	const { PricingFetcher } = await import('../pricing-fetcher.ts');
+	const { UsageDataSchema, calculateCostForEntry } = await import('../data-loader.ts');
+
+	const mode = options.mode ?? 'auto';
+	using fetcher = mode === 'display' ? null : new PricingFetcher();
+
+	for (const file of files) {
+		const content = await readFile(file, 'utf-8');
+		const lines = content
+			.trim()
+			.split('\n')
+			.filter(line => line.length > 0);
+
+		// Extract session info from file path
+		const relativePath = path.relative(claudeDir, file);
+		const parts = relativePath.split(path.sep);
+		const sessionId = parts[parts.length - 2] ?? 'unknown';
+		const joinedPath = parts.slice(0, -2).join(path.sep);
+		const projectPath = joinedPath.length > 0 ? joinedPath : 'Unknown Project';
+		const sessionKey = `${projectPath}/${sessionId}`;
+
+		for (const line of lines) {
+			try {
+				const parsed = JSON.parse(line) as unknown;
+				const result = v.safeParse(UsageDataSchema, parsed);
+				if (!result.success) {
+					continue;
+				}
+				const data = result.output;
+
+				const cost = fetcher != null
+					? await calculateCostForEntry(data, mode as CostMode, fetcher)
+					: data.costUSD ?? 0;
+
+				allEntries.push({
+					data,
+					timestamp: data.timestamp,
+					cost,
+					sessionKey,
+					model: data.message.model,
+				});
+			}
+			catch {
+				// Skip invalid lines
+			}
+		}
+	}
+
+	// Calculate window statistics
+	const windowMap = calculateWindowStatistics(allEntries);
+	const monthlySummaries = groupWindowsByMonth(windowMap, {
+		sessionLimit: options.sessionLimit,
+	});
+
+	// Filter by date range if specified
+	const filteredSummaries = monthlySummaries.filter((summary) => {
+		if ((options.since !== undefined && options.since !== '') || (options.until !== undefined && options.until !== '')) {
+			const monthNum = summary.month.replace('-', '');
+			if (options.since !== undefined && options.since !== '' && monthNum < options.since.substring(0, 6)) {
+				return false;
+			}
+			if (options.until !== undefined && options.until !== '' && monthNum > options.until.substring(0, 6)) {
+				return false;
+			}
+		}
+		return true;
+	});
+
+	if (options.json === true) {
+		// JSON output
+		const jsonOutput = {
+			monthlySummaries: filteredSummaries.map(summary => ({
+				month: summary.month,
+				windowCount: summary.windowCount,
+				sessionLimit: summary.sessionLimit,
+				remainingSessions: summary.remainingSessions,
+				utilizationPercent: summary.utilizationPercent,
+				totalCost: summary.totalCost,
+				totalTokens: summary.totalTokens,
+				windows: summary.windows.map(window => ({
+					windowId: window.windowId,
+					startTime: window.startTimestamp,
+					endTime: window.endTimestamp,
+					duration: window.duration,
+					messageCount: window.messageCount,
+					sessionCount: window.sessionCount,
+					inputTokens: window.inputTokens,
+					outputTokens: window.outputTokens,
+					cacheCreationTokens: window.cacheCreationTokens,
+					cacheReadTokens: window.cacheReadTokens,
+					totalCost: window.totalCost,
+					modelsUsed: window.modelsUsed,
+				})),
+			})),
+		};
+		log(JSON.stringify(jsonOutput, null, 2));
+		return;
+	}
+
+	// Table output
+	logger.box('Claude Code 5-Hour Session Windows');
+
+	for (const summary of filteredSummaries) {
+		// Monthly header
+		let header = `\n${pc.bold(summary.month)}: ${summary.windowCount} sessions`;
+
+		if (summary.sessionLimit != null) {
+			const utilPercent = summary.utilizationPercent ?? 0;
+			const utilColor = utilPercent >= 90
+				? pc.red
+				: utilPercent >= 80
+					? pc.yellow
+					: pc.green;
+
+			header += ` used (${utilColor(`${summary.utilizationPercent?.toFixed(1)}%`)} of ${summary.sessionLimit} limit)`;
+
+			log(header);
+
+			const remaining = summary.remainingSessions ?? 0;
+			if (remaining <= 5 && remaining > 0) {
+				log(pc.yellow(`[WARNING] Only ${summary.remainingSessions} sessions remaining`));
+			}
+			else if (summary.remainingSessions === 0) {
+				log(pc.red('[LIMIT REACHED] Session limit reached'));
+			}
+			else {
+				log(pc.green(`[OK] ${summary.remainingSessions} sessions remaining`));
+			}
+		}
+		else {
+			log(header);
+		}
+
+		log(pc.dim('Note: Sessions are counted per calendar month (UTC).'));
+		log(pc.dim('Your actual billing cycle may differ.\n'));
+
+		// Create window table
+		const table = new ResponsiveTable({
+			head: [
+				'Window Start',
+				'Duration',
+				'Messages',
+				'Sessions',
+				'Tokens',
+				'Cost',
+			],
+			style: {
+				head: ['cyan'],
+			},
+			colAligns: [
+				'left',
+				'right',
+				'right',
+				'right',
+				'right',
+				'right',
+			],
+			dateFormatter: formatDateCompact,
+		});
+
+		// Show top 10 windows
+		const windowsToShow = summary.windows.slice(0, 10);
+
+		for (const window of windowsToShow) {
+			const startTime = getWindowStartTime(window.windowId);
+			const localTime = startTime.toLocaleString();
+			const duration = formatDuration(window.duration);
+			const totalTokens = window.inputTokens + window.outputTokens
+				+ window.cacheCreationTokens + window.cacheReadTokens;
+
+			table.push([
+				localTime,
+				duration,
+				formatNumber(window.messageCount),
+				formatNumber(window.sessionCount),
+				formatNumber(totalTokens),
+				formatCurrency(window.totalCost),
+			]);
+		}
+
+		if (summary.windows.length > 10) {
+			table.push([
+				pc.dim(`... and ${summary.windows.length - 10} more windows`),
+				'',
+				'',
+				'',
+				'',
+				'',
+			]);
+		}
+
+		// Add totals row
+		table.push([
+			'─'.repeat(19),
+			'─'.repeat(8),
+			'─'.repeat(8),
+			'─'.repeat(8),
+			'─'.repeat(12),
+			'─'.repeat(10),
+		]);
+
+		table.push([
+			pc.yellow('Total'),
+			'',
+			'',
+			formatNumber(summary.windowCount),
+			formatNumber(summary.totalTokens),
+			formatCurrency(summary.totalCost),
+		]);
+
+		log(table.toString());
+	}
+}

--- a/src/utils.internal.test.ts
+++ b/src/utils.internal.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { formatCurrency, formatNumber } from './utils.internal.ts';
+import {
+	formatCurrency,
+	formatDuration,
+	formatNumber,
+	get5HourWindowId,
+	getWindowStartTime,
+} from './utils.internal.ts';
 
 describe('formatNumber', () => {
 	test('formats positive numbers with comma separators', () => {
@@ -63,5 +69,48 @@ describe('formatCurrency', () => {
 	test('handles large numbers', () => {
 		expect(formatCurrency(1000000)).toBe('$1000000.00');
 		expect(formatCurrency(9999999.99)).toBe('$9999999.99');
+	});
+});
+
+describe('get5HourWindowId', () => {
+	test('calculates correct window IDs for UTC timestamps', () => {
+		expect(get5HourWindowId('2025-06-16T00:30:00Z')).toBe('2025-06-16-00');
+		expect(get5HourWindowId('2025-06-16T05:00:00Z')).toBe('2025-06-16-05');
+		expect(get5HourWindowId('2025-06-16T10:00:00Z')).toBe('2025-06-16-10');
+		expect(get5HourWindowId('2025-06-16T15:00:00Z')).toBe('2025-06-16-15');
+		expect(get5HourWindowId('2025-06-16T20:00:00Z')).toBe('2025-06-16-20');
+	});
+
+	test('handles window boundaries correctly', () => {
+		expect(get5HourWindowId('2025-06-16T04:59:59Z')).toBe('2025-06-16-00');
+		expect(get5HourWindowId('2025-06-16T05:00:00Z')).toBe('2025-06-16-05');
+	});
+
+	test('handles day boundaries correctly', () => {
+		expect(get5HourWindowId('2025-06-16T23:30:00Z')).toBe('2025-06-16-20');
+		expect(get5HourWindowId('2025-06-17T00:30:00Z')).toBe('2025-06-17-00');
+	});
+});
+
+describe('getWindowStartTime', () => {
+	test('correctly parses window ID to Date', () => {
+		const windowId = '2025-06-16-15';
+		const startTime = getWindowStartTime(windowId);
+		expect(startTime.toISOString()).toBe('2025-06-16T15:00:00.000Z');
+	});
+});
+
+describe('formatDuration', () => {
+	test('formats durations correctly', () => {
+		expect(formatDuration(0)).toBe('0m');
+		expect(formatDuration(60000)).toBe('1m'); // 1 minute
+		expect(formatDuration(3600000)).toBe('1h 0m'); // 1 hour
+		expect(formatDuration(5400000)).toBe('1h 30m'); // 1.5 hours
+		expect(formatDuration(18000000)).toBe('5h 0m'); // 5 hours
+	});
+
+	test('rounds down to nearest minute', () => {
+		expect(formatDuration(61000)).toBe('1m'); // 1 minute 1 second
+		expect(formatDuration(119999)).toBe('1m'); // 1 minute 59.999 seconds
 	});
 });

--- a/src/utils.internal.ts
+++ b/src/utils.internal.ts
@@ -8,6 +8,17 @@ export function formatCurrency(amount: number): string {
 	return `$${amount.toFixed(2)}`;
 }
 
+export function formatDuration(milliseconds: number): string {
+	const totalMinutes = Math.floor(milliseconds / 60000);
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+
+	if (hours === 0) {
+		return `${minutes}m`;
+	}
+	return `${hours}h ${minutes}m`;
+}
+
 export function formatModelName(modelName: string): string {
 	// Extract model type from full model name
 	// e.g., "claude-sonnet-4-20250514" -> "sonnet-4"
@@ -26,6 +37,33 @@ export function formatModelsDisplay(models: string[]): string {
 	return uniqueModels.sort().join(', ');
 }
 
+// Window calculation utilities
+/**
+ * Calculate the 5-hour window ID for a given timestamp
+ * Windows start at: 00:00, 05:00, 10:00, 15:00, 20:00 UTC
+ */
+export function get5HourWindowId(timestamp: string): string {
+	const dt = new Date(timestamp);
+	const utcHour = dt.getUTCHours();
+	const windowStartHour = Math.floor(utcHour / 5) * 5;
+	const windowDate = dt.toISOString().split('T')[0];
+	return `${windowDate}-${windowStartHour.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Get window start time for display
+ */
+export function getWindowStartTime(windowId: string): Date {
+	// windowId format: YYYY-MM-DD-HH
+	const parts = windowId.split('-');
+	const year = parts[0];
+	const month = parts[1];
+	const day = parts[2];
+	const hour = parts[3];
+	return new Date(`${year}-${month}-${day}T${hour}:00:00Z`);
+}
+
+// Complex display utilities
 /**
  * Pushes model breakdown rows to a table
  * @param table - The table to push rows to


### PR DESCRIPTION
## Summary
- Implements 5-hour session window tracking to help users monitor their Claude Max plan usage
- Adds `--windows` flag to show detailed session window statistics
- Adds `--session-limit` flag (default: 50) to calculate remaining sessions

## Key Changes

### New Features
- **Window Calculation**: Added utilities to calculate 5-hour UTC-based session windows (00:00, 05:00, 10:00, 15:00, 20:00)
- **Enhanced Session Command**: 
  - `--windows` flag displays 5-hour session window statistics
  - `--session-limit` flag sets plan limit for utilization tracking (default: 50)
- **Calendar Month Tracking**: Sessions are counted per calendar month (UTC) with clear documentation about billing cycle differences

### Implementation Details
- Added window calculation utilities in `utils.internal.ts`
- Added window aggregation functions in `data-loader.ts`
- Enhanced session command with new display mode for window statistics
- Added comprehensive tests for window calculations and aggregation
- Updated documentation in README.md and CLAUDE.md

### User Experience
- Shows session utilization percentage with color coding (green/yellow/red)
- Displays warnings when approaching session limits
- Provides clear indication when session limit is reached
- Shows top 10 most recent windows with usage details

## Test Plan
- [x] All existing tests pass
- [x] Added unit tests for window calculation utilities
- [x] Added integration tests for window aggregation
- [x] Manual testing with various date ranges and session limits
- [x] Verified calendar month counting behavior
- [x] Tested JSON output format

## Example Usage
```bash
# Show 5-hour session windows with default limit (50)
ccusage session --windows

# Show windows with custom session limit
ccusage session --windows --session-limit 30

# JSON output for programmatic use
ccusage session --windows --json
```

## Notes
- Sessions are counted per calendar month in UTC timezone
- Actual billing cycles may differ from calendar months
- The 50 session default is based on Claude Max plan documentation

Fixes #23

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced 5-hour session window tracking for usage statistics, allowing users to view and analyze usage grouped by UTC-based 5-hour intervals.
	- Added options to specify session limits and receive warnings when approaching or exceeding plan limits.
- **Documentation**
	- Updated user guides and feature descriptions to explain the new 5-hour window tracking, session limit warnings, and related command-line options.
	- Expanded usage examples and detailed option explanations for enhanced clarity.
- **Tests**
	- Added comprehensive tests for window-based aggregation, monthly summaries, and new utility functions.
- **Style**
	- Improved formatting for duration outputs and window statistics displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->