### PR TITLE
feat(mcp): add monthly and blocks tools to MCP server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,13 +21,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `bun run start daily` - Show daily usage report
 - `bun run start monthly` - Show monthly usage report
 - `bun run start session` - Show session-based usage report
+- `bun run start blocks` - Show 5-hour billing blocks usage report
 - `bun run start daily --json` - Show daily usage report in JSON format
 - `bun run start monthly --json` - Show monthly usage report in JSON format
 - `bun run start session --json` - Show session usage report in JSON format
+- `bun run start blocks --json` - Show blocks usage report in JSON format
 - `bun run start daily --mode <mode>` - Control cost calculation mode (auto/calculate/display)
 - `bun run start monthly --mode <mode>` - Control cost calculation mode (auto/calculate/display)
 - `bun run start session --mode <mode>` - Control cost calculation mode (auto/calculate/display)
+- `bun run start blocks --mode <mode>` - Control cost calculation mode (auto/calculate/display)
+- `bun run start blocks --active` - Show only active block with projections
+- `bun run start blocks --recent` - Show blocks from last 3 days (including active)
+- `bun run start blocks --token-limit <limit>` - Token limit for quota warnings (number or "max")
 - `bun run ./src/index.ts` - Direct execution for development
+
+**MCP Server Usage:**
+
+- `bun run start mcp` - Start MCP server with stdio transport (default)
+- `bun run start mcp --type http --port 8080` - Start MCP server with HTTP transport
 
 **Cost Calculation Modes:**
 
@@ -54,8 +65,9 @@ This is a CLI tool that analyzes Claude Code usage data from local JSONL files s
 **Key Data Structures:**
 
 - Raw usage data is parsed from JSONL with timestamp, token counts, and pre-calculated costs
-- Data is aggregated into daily summaries, monthly summaries, or session summaries
+- Data is aggregated into daily summaries, monthly summaries, session summaries, or 5-hour billing blocks
 - Sessions are identified by directory structure: `projects/{project}/{session}/{file}.jsonl`
+- 5-hour blocks group usage data by Claude's billing cycles with active block tracking
 
 **External Dependencies:**
 
@@ -63,11 +75,17 @@ This is a CLI tool that analyzes Claude Code usage data from local JSONL files s
 - CLI built with `gunshi` framework, tables with `cli-table3`
 - **LiteLLM Integration**: Cost calculations depend on LiteLLM's pricing database for model pricing data
 
-**MCP Servers Available:**
+**MCP Integration:**
 
-- **ESLint MCP**: Lint TypeScript/JavaScript files directly through Claude Code tools
-- **Context7 MCP**: Look up documentation for libraries and frameworks
-- **Gunshi MCP**: Access gunshi.dev documentation and examples
+- **Built-in MCP Server**: Exposes usage data through MCP protocol with tools:
+  - `daily` - Daily usage reports
+  - `session` - Session-based usage reports
+  - `monthly` - Monthly usage reports
+  - `blocks` - 5-hour billing blocks usage reports
+- **External MCP Servers Available:**
+  - **ESLint MCP**: Lint TypeScript/JavaScript files directly through Claude Code tools
+  - **Context7 MCP**: Look up documentation for libraries and frameworks
+  - **Gunshi MCP**: Access gunshi.dev documentation and examples
 
 ## Code Style Notes
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,8 @@ Available MCP tools:
 
 - `daily`: Returns daily usage reports (accepts `since`, `until`, `mode` parameters)
 - `session`: Returns session usage reports (accepts `since`, `until`, `mode` parameters)
+- `monthly`: Returns monthly usage reports (accepts `since`, `until`, `mode` parameters)
+- `blocks`: Returns 5-hour billing blocks usage reports (accepts `since`, `until`, `mode` parameters)
 
 #### Claude Desktop Configuration Example
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This tool helps you understand the value you're getting from your subscription b
 - 🔄 **Cache Token Support**: Tracks and displays cache creation and cache read tokens separately
 - 🌐 **Offline Mode**: Use pre-cached pricing data without network connectivity with `--offline` (Claude models only)
 - 📏 **Responsive Tables**: Automatic table width adjustment for narrow terminals with intelligent word wrapping
+- 🔌 **MCP Integration**: Built-in Model Context Protocol server for integration with other tools
 
 ## Important Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This tool helps you understand the value you're getting from your subscription b
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
+- ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
 - 🤖 **Model Tracking**: See which Claude models you're using (Opus, Sonnet, etc.)
 - 📊 **Model Breakdown**: View per-model cost breakdown with `--breakdown` flag
 - 📅 **Date Filtering**: Filter reports by date range using `--since` and `--until`

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -7,6 +7,7 @@ import { name, version } from '../package.json';
 import {
 	getDefaultClaudePath,
 	loadDailyUsageData,
+	loadFiveHourBlockData,
 	loadMonthlyUsageData,
 	loadSessionData,
 } from './data-loader.ts';
@@ -82,6 +83,16 @@ export function createMcpServer({
 		execute: async (args) => {
 			const monthlyData = await loadMonthlyUsageData({ ...args, claudePath });
 			return JSON.stringify(monthlyData);
+		},
+	});
+
+	server.addTool({
+		name: 'blocks',
+		description: 'Show usage report grouped by 5-hour billing blocks',
+		parameters: parametersSchema,
+		execute: async (args) => {
+			const blocksData = await loadFiveHourBlockData({ ...args, claudePath });
+			return JSON.stringify(blocksData);
 		},
 	});
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -7,6 +7,7 @@ import { name, version } from '../package.json';
 import {
 	getDefaultClaudePath,
 	loadDailyUsageData,
+	loadMonthlyUsageData,
 	loadSessionData,
 } from './data-loader.ts';
 import { CostModes, dateSchema } from './types.internal.ts';
@@ -71,6 +72,16 @@ export function createMcpServer({
 		execute: async (args) => {
 			const sessionData = await loadSessionData({ ...args, claudePath });
 			return JSON.stringify(sessionData);
+		},
+	});
+
+	server.addTool({
+		name: 'monthly',
+		description: 'Show usage report grouped by month',
+		parameters: parametersSchema,
+		execute: async (args) => {
+			const monthlyData = await loadMonthlyUsageData({ ...args, claudePath });
+			return JSON.stringify(monthlyData);
 		},
 	});
 


### PR DESCRIPTION
## Summary

• Add monthly usage report tool to MCP server
• Add 5-hour billing blocks usage report tool to MCP server  
• Update documentation for new MCP tools and blocks command

## MCP Server Enhancements

**New Tools Added:**
- \`monthly\` - Returns monthly usage reports with same parameters as existing tools
- \`blocks\` - Returns 5-hour billing blocks usage reports with billing cycle tracking

**API Consistency:**
- Both tools accept standard parameters: \`since\`, \`until\`, \`mode\`
- JSON output format consistent with existing \`daily\` and \`session\` tools
- Seamless integration with existing MCP client implementations

## Documentation Updates

**CLAUDE.md:**
- Added comprehensive blocks command usage examples
- Updated MCP integration section with all 4 available tools
- Enhanced development commands with MCP server options
- Updated data structures documentation for 5-hour billing blocks

**README.md:**
- Added 5-Hour Blocks Report feature documentation
- Added MCP Integration feature highlighting
- Updated MCP tools list with complete tool descriptions
- Maintained consistency with existing documentation patterns

## Test Plan

- [x] Verify monthly tool returns valid JSON with monthly aggregated data
- [x] Verify blocks tool returns valid JSON with 5-hour block data
- [x] Confirm MCP server starts successfully with new tools
- [x] Validate parameter passing works correctly for new tools
- [x] Check documentation accuracy and completeness
- [x] Ensure consistent API interface across all MCP tools
- [x] All tests pass
- [x] Lint and typecheck pass