### PR TITLE
feat: add configurable session length to blocks command

### DIFF
--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -5,6 +5,7 @@ import { getDefaultClaudePath, loadSessionBlockData } from '../data-loader.ts';
 import { log, logger } from '../logger.ts';
 import {
 	calculateBurnRate,
+	DEFAULT_SESSION_DURATION_HOURS,
 	filterRecentBlocks,
 	projectBlockUsage,
 	type SessionBlock,
@@ -111,11 +112,23 @@ export const blocksCommand = define({
 			short: 't',
 			description: 'Token limit for quota warnings (e.g., 500000 or "max" for highest previous block)',
 		},
+		sessionLength: {
+			type: 'number',
+			short: 'l',
+			description: `Session block duration in hours (default: ${DEFAULT_SESSION_DURATION_HOURS})`,
+			default: DEFAULT_SESSION_DURATION_HOURS,
+		},
 	},
 	toKebab: true,
 	async run(ctx) {
 		if (ctx.values.json) {
 			logger.level = 0;
+		}
+
+		// Validate session length
+		if (ctx.values.sessionLength <= 0) {
+			logger.error('Session length must be a positive number');
+			process.exit(1);
 		}
 
 		let blocks = await loadSessionBlockData({
@@ -124,6 +137,7 @@ export const blocksCommand = define({
 			claudePath: getDefaultClaudePath(),
 			mode: ctx.values.mode,
 			order: ctx.values.order,
+			sessionDurationHours: ctx.values.sessionLength,
 		});
 
 		if (blocks.length === 0) {

--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -478,6 +478,7 @@ export type LoadOptions = {
 	mode?: CostMode; // Cost calculation mode
 	order?: SortOrder; // Sort order for dates
 	offline?: boolean; // Use offline mode for pricing
+	sessionDurationHours?: number; // Session block duration in hours
 } & DateFilter;
 
 export async function loadDailyUsageData(
@@ -900,7 +901,7 @@ export async function loadSessionBlockData(
 	}
 
 	// Identify session blocks
-	const blocks = identifySessionBlocks(allEntries);
+	const blocks = identifySessionBlocks(allEntries, options?.sessionDurationHours);
 
 	// Filter by date range if specified
 	const filtered = (options?.since != null && options.since !== '') || (options?.until != null && options.until !== '')


### PR DESCRIPTION
## Summary
- Added --session-length (-l) option to customize session block duration in hours
- Default remains 5 hours for backward compatibility  
- Supports any positive number of hours (including decimals like 2.5)
- Added validation to ensure session length is positive
- Comprehensive test coverage for various duration scenarios

## Changes Made

### Core Implementation
- session-blocks.internal.ts: Made session duration configurable by updating identifySessionBlocks() to accept optional sessionDurationHours parameter
- data-loader.ts: Added sessionDurationHours to LoadOptions and passed through to session block identification
- blocks.ts: Added CLI option with validation and help text

### Testing
- Added 9 comprehensive tests covering custom durations (1h, 2h, 2.5h, 3h, 24h, 0.5h)
- Tests verify correct block creation, gap detection, and timing
- Edge cases covered: fractional hours, exactly equal durations, backward compatibility

### Validation
- Input validation ensures positive session lengths
- All existing functionality preserved (164 tests pass)
- Code formatted and type-checked

## Usage Examples

Default 5-hour sessions (backward compatible):
bun run start blocks

Custom 3-hour sessions:
bun run start blocks --session-length 3

Short 1-hour sessions for fine-grained tracking:
bun run start blocks -l 1

Fractional hours:
bun run start blocks --session-length 2.5

Works with all existing options:
bun run start blocks --session-length 8 --recent --json

## Test Plan
- ✅ Run bun test - all 164 tests pass
- ✅ Test blocks command with default duration
- ✅ Test with custom duration and fractional hours
- ✅ Verify gap detection works with custom durations
- ✅ Test edge cases (very small/large durations)
- ✅ Run linting and type checking
- ✅ Test validation with invalid values
- ✅ Verify JSON output includes correct timing
- ✅ Test table display shows correct durations

## Implementation Notes

The feature correctly handles:
- Gap Detection: Gaps created only when time between entries exceeds custom session duration
- Block Timing: End times are exactly sessionDurationHours after start times  
- Active Blocks: Properly calculates remaining time based on custom duration
- JSON Output: Includes correct timing information in API responses
- Table Display: Shows correct durations and remaining time in CLI tables

Full backward compatibility maintained while providing flexibility for different use cases.