### PR TITLE
feat: add comprehensive MCP server tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,11 @@ This ensures code quality and catches issues immediately after changes.
 
 **Testing Guidelines:**
 
+- **In-Source Testing Pattern**: This project uses in-source testing with `if (import.meta.vitest != null)` blocks
+- Tests are written directly in the same files as the source code, not in separate test files
+- Vitest globals (`describe`, `it`, `expect`) are available automatically without imports
+- Dynamic imports using `await import()` should only be used within test blocks to avoid tree-shaking issues
+- Mock data is created using `fs-fixture` with `createFixture()` for Claude data directory simulation
 - All test files must use current Claude 4 models, not outdated Claude 3 models
 - Test coverage should include both Sonnet and Opus models for comprehensive validation
 - Model names in tests must exactly match LiteLLM's pricing database entries

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -207,6 +207,7 @@ export function createMcpHttpApp(options: LoadOptions = defaultOptions): Hono {
 }
 
 if (import.meta.vitest != null) {
+	/* eslint-disable ts/no-unsafe-assignment, ts/no-unsafe-member-access, ts/no-unsafe-call */
 	describe('MCP Server', () => {
 		describe('createMcpServer', () => {
 			it('should create MCP server with default options', () => {
@@ -288,12 +289,11 @@ if (import.meta.vitest != null) {
 				expect(result).toHaveProperty('content');
 				expect(Array.isArray(result.content)).toBe(true);
 				expect(result.content).toHaveLength(1);
-				// eslint-disable-next-line ts/no-unsafe-call, ts/no-unsafe-member-access
+
 				expect((result.content as any).at(0)).toHaveProperty('type', 'text');
-				// eslint-disable-next-line ts/no-unsafe-call, ts/no-unsafe-member-access
+
 				expect((result.content as any).at(0)).toHaveProperty('text');
 
-				// eslint-disable-next-line ts/no-unsafe-assignment, ts/no-unsafe-call, ts/no-unsafe-member-access
 				const data = JSON.parse((result.content as any).at(0).text as string);
 				expect(Array.isArray(data)).toBe(true);
 
@@ -331,11 +331,10 @@ if (import.meta.vitest != null) {
 
 				expect(result).toHaveProperty('content');
 				expect(result.content).toHaveLength(1);
-				expect(result.content[0]).toHaveProperty('type', 'text');
-				expect(result.content[0]).toHaveProperty('text');
+				expect((result.content as any)[0]).toHaveProperty('type', 'text');
+				expect((result.content as any)[0]).toHaveProperty('text');
 
-				// eslint-disable-next-line ts/no-unsafe-assignment, ts/no-unsafe-member-access
-				const data = JSON.parse(result.content[0].text as string);
+				const data = JSON.parse((result.content as any)[0].text as string);
 				expect(Array.isArray(data)).toBe(true);
 
 				await client.close();
@@ -372,11 +371,10 @@ if (import.meta.vitest != null) {
 
 				expect(result).toHaveProperty('content');
 				expect(result.content).toHaveLength(1);
-				expect(result.content[0]).toHaveProperty('type', 'text');
-				expect(result.content[0]).toHaveProperty('text');
+				expect((result.content as any)[0]).toHaveProperty('type', 'text');
+				expect((result.content as any)[0]).toHaveProperty('text');
 
-				// eslint-disable-next-line ts/no-unsafe-assignment, ts/no-unsafe-member-access
-				const data = JSON.parse(result.content[0].text as string);
+				const data = JSON.parse((result.content as any)[0].text as string);
 				expect(Array.isArray(data)).toBe(true);
 
 				await client.close();
@@ -413,11 +411,10 @@ if (import.meta.vitest != null) {
 
 				expect(result).toHaveProperty('content');
 				expect(result.content).toHaveLength(1);
-				expect(result.content[0]).toHaveProperty('type', 'text');
-				expect(result.content[0]).toHaveProperty('text');
+				expect((result.content as any)[0]).toHaveProperty('type', 'text');
+				expect((result.content as any)[0]).toHaveProperty('text');
 
-				// eslint-disable-next-line ts/no-unsafe-assignment, ts/no-unsafe-member-access
-				const data = JSON.parse(result.content[0].text as string);
+				const data = JSON.parse((result.content as any)[0].text as string);
 				expect(Array.isArray(data)).toBe(true);
 
 				await client.close();


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for the MCP (Model Context Protocol) server functionality, covering both stdio and HTTP transport modes.

## ⚠️ BREAKING CHANGES

🚨 **Migration from valibot to zod**: Schema validation now uses zod instead of valibot for better type safety and ecosystem compatibility

🚨 **Migration from fastmcp to @modelcontextprotocol/sdk + Hono by @yusukebe**: 
- Replaced fastmcp with official MCP SDK for better compatibility and future-proofing
- HTTP transport now uses Hono framework by @yusukebe for improved performance and developer experience
- This provides more robust MCP protocol support and better HTTP handling

### Changes Made

- **In-Source Testing**: Added tests using the if (import.meta.vitest \!= null) pattern directly in src/mcp.ts
- **Stdio Transport Tests**: Test server creation, tool listing, and individual tool calls with mock Claude data  
- **HTTP Transport Tests**: Test Hono app creation, HTTP request handling, and error responses
- **Mock Data**: Use fs-fixture with createFixture() to simulate Claude data directory structure
- **Documentation**: Updated CLAUDE.md with in-source testing guidelines and patterns

### Test Coverage

- MCP server creation with default/custom options
- Stdio transport connection and tool listing (4 tools: daily, session, monthly, blocks)
- All MCP tools execute successfully and return valid JSON data
- HTTP transport handles valid POST requests and returns proper error codes
- Error handling for malformed JSON and invalid HTTP methods

### Testing Pattern

This follows the project in-source testing pattern with vitest globals and fs-fixture for mocking.

The tests ensure the MCP server works correctly for external integrations.