### PR TITLE
Refactor: replace Set with es-toolkit uniq for better code readability

### DIFF
--- a/src/session-blocks.internal.ts
+++ b/src/session-blocks.internal.ts
@@ -1,3 +1,5 @@
+import { uniq } from 'es-toolkit';
+
 /**
  * Default session duration in hours (Claude's billing block duration)
  */
@@ -163,7 +165,7 @@ function createBlock(startTime: Date, entries: LoadedUsageEntry[], now: Date, se
 	};
 
 	let costUSD = 0;
-	const modelsSet = new Set<string>();
+	const models: string[] = [];
 
 	for (const entry of entries) {
 		tokenCounts.inputTokens += entry.usage.inputTokens;
@@ -171,7 +173,7 @@ function createBlock(startTime: Date, entries: LoadedUsageEntry[], now: Date, se
 		tokenCounts.cacheCreationInputTokens += entry.usage.cacheCreationInputTokens;
 		tokenCounts.cacheReadInputTokens += entry.usage.cacheReadInputTokens;
 		costUSD += entry.costUSD ?? 0;
-		modelsSet.add(entry.model);
+		models.push(entry.model);
 	}
 
 	return {
@@ -183,7 +185,7 @@ function createBlock(startTime: Date, entries: LoadedUsageEntry[], now: Date, se
 		entries,
 		tokenCounts,
 		costUSD,
-		models: Array.from(modelsSet),
+		models: uniq(models),
 	};
 }
 

--- a/src/utils.internal.ts
+++ b/src/utils.internal.ts
@@ -1,5 +1,6 @@
 import process from 'node:process';
 import Table from 'cli-table3';
+import { uniq } from 'es-toolkit';
 import pc from 'picocolors';
 import stringWidth from 'string-width';
 
@@ -243,7 +244,7 @@ function formatModelName(modelName: string): string {
  */
 export function formatModelsDisplay(models: string[]): string {
 	// Format array of models for display
-	const uniqueModels = [...new Set(models.map(formatModelName))];
+	const uniqueModels = uniq(models.map(formatModelName));
 	return uniqueModels.sort().join(', ');
 }
 


### PR DESCRIPTION
## Summary

Replace JavaScript Set usage with es-toolkit uniq function for better code readability and consistency throughout the codebase.

### Changes Made

- **utils.internal.ts**: Replace [...new Set(models.map(formatModelName))] with uniq(models.map(formatModelName))
- **session-blocks.internal.ts**: Replace Set-based model collection with array + uniq()
- **data-loader.ts**: Replace Set usage in three locations:
  - extractUniqueModels function
  - Session data version collection
  - Monthly data model collection

### Key Benefits

- **Improved readability**: uniq() is more explicit about the intent than Set construction
- **Consistency**: Aligns with existing es-toolkit usage patterns in the codebase
- **Simpler code**: Eliminates need for Array.from() conversions
- **Maintained functionality**: All unique collection behavior preserved

### What Was Preserved

Set instances used for deduplication checking (via has()/add() methods) were intentionally kept unchanged as they serve a different purpose than unique collection.

## Test Plan

- [x] All existing tests pass (182/182)
- [x] TypeScript compilation succeeds
- [x] ESLint formatting applied
- [x] Functionality verified through test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal logic for extracting unique values by utilizing a standardized utility function, ensuring consistent and reliable uniqueness filtering across various features. No changes to visible features or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->