### PR TITLE
docs: add ccusage Raycast Extension to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ While the original approach uses DuckDB for analysis, this tool provides a more 
 some projects use `ccusage` internally and provide additional features:
 
 - [claude-usage-tracker-for-mac](https://github.com/penicillin0/claude-usage-tracker-for-mac) – macOS menu bar app to visualize Claude Code usage costs by [@penicillin0](https://github.com/penicillin0).
+- [ccusage Raycast Extension](https://www.raycast.com/nyatinte/ccusage) – Raycast extension to view Claude Code usage reports in Raycast by [@nyatinte](https://github.com/nyatinte).
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

- Add the ccusage Raycast Extension to the Related Projects section in README.md
- Provides users with easy access to a Raycast extension for viewing Claude Code usage reports

## Details

This PR adds a new entry to the Related Projects section for the ccusage Raycast Extension. The extension allows users to view Claude Code usage reports directly within Raycast, providing a convenient integration for Raycast users.

The addition follows the same format as the existing macOS menu bar app entry, maintaining consistency in the documentation.

## Related

- Extension URL: https://www.raycast.com/nyatinte/ccusage
- Extension created by: @nyatinte

Thank you @ryoppippi for creating such an awesome tool and for all your help and support during the Raycast extension development process\! 🙏