### PR TITLE
fix: add offline flag support to blocks command

### DIFF
--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -148,6 +148,7 @@ export const blocksCommand = define({
 			claudePath: getDefaultClaudePath(),
 			mode: ctx.values.mode,
 			order: ctx.values.order,
+			offline: ctx.values.offline,
 			sessionDurationHours: ctx.values.sessionLength,
 		});
 

--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -1056,7 +1056,7 @@ export async function loadSessionBlockData(
 	const mode = options?.mode ?? 'auto';
 
 	// Use PricingFetcher with using statement for automatic cleanup
-	using fetcher = mode === 'display' ? null : new PricingFetcher();
+	using fetcher = mode === 'display' ? null : new PricingFetcher(options?.offline);
 
 	// Track processed message+request combinations for deduplication
 	const processedHashes = new Set<string>();


### PR DESCRIPTION
## Description

This PR fixes the `--offline` flag not working for the `blocks` command.

## Problem

The `--offline` flag works correctly for commands like `monthly` but does not work for the `blocks` command. When running `ccusage blocks --offline`, the command still attempts to fetch pricing data from the API instead of using cached data.

## Root Cause

The issue occurs in two places:

1. In `src/commands/blocks.ts`, the `offline` parameter was not being passed to `loadSessionBlockData()`
2. In `src/data-loader.ts`, the `loadSessionBlockData()` function was not passing the `offline` parameter to the `PricingFetcher` constructor

## Solution

1. Added `offline: ctx.values.offline` to the options object passed to `loadSessionBlockData()` in `src/commands/blocks.ts`
2. Changed `new PricingFetcher()` to `new PricingFetcher(options?.offline)` in `src/data-loader.ts`

This matches the implementation in other commands like `monthly` which correctly handle the offline flag.

## Testing

After this fix:
- `ccusage blocks --offline` now correctly uses cached pricing data
- `ccusage blocks --no-offline` (or without the flag) fetches fresh pricing data
- Behavior is now consistent with other commands

Fixes #127

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for offline mode during session block data loading, enabling better handling of pricing data when offline functionality is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->