### PR TITLE
fix: use getClaudePaths for multi-directory support

### DIFF
--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -11,7 +11,7 @@ import {
 } from '../_session-blocks.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
 import { formatCurrency, formatModelsDisplayMultiline, formatNumber, ResponsiveTable } from '../_utils.ts';
-import { getDefaultClaudePath, loadSessionBlockData } from '../data-loader.ts';
+import { loadSessionBlockData } from '../data-loader.ts';
 import { log, logger } from '../logger.ts';
 
 /**
@@ -145,7 +145,6 @@ export const blocksCommand = define({
 		let blocks = await loadSessionBlockData({
 			since: ctx.values.since,
 			until: ctx.values.until,
-			claudePath: getDefaultClaudePath(),
 			mode: ctx.values.mode,
 			order: ctx.values.order,
 			offline: ctx.values.offline,

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -8,7 +8,7 @@ import {
 	createTotalsObject,
 	getTotalTokens,
 } from '../calculate-cost.ts';
-import { formatDateCompact, getDefaultClaudePath, loadDailyUsageData } from '../data-loader.ts';
+import { formatDateCompact, loadDailyUsageData } from '../data-loader.ts';
 import { detectMismatches, printMismatchReport } from '../debug.ts';
 import { log, logger } from '../logger.ts';
 
@@ -24,7 +24,6 @@ export const dailyCommand = define({
 		const dailyData = await loadDailyUsageData({
 			since: ctx.values.since,
 			until: ctx.values.until,
-			claudePath: getDefaultClaudePath(),
 			mode: ctx.values.mode,
 			order: ctx.values.order,
 			offline: ctx.values.offline,
@@ -45,7 +44,7 @@ export const dailyCommand = define({
 
 		// Show debug information if requested
 		if (ctx.values.debug && !ctx.values.json) {
-			const mismatchStats = await detectMismatches(getDefaultClaudePath());
+			const mismatchStats = await detectMismatches(undefined);
 			printMismatchReport(mismatchStats, ctx.values.debugSamples);
 		}
 

--- a/src/commands/monthly.ts
+++ b/src/commands/monthly.ts
@@ -8,7 +8,7 @@ import {
 	createTotalsObject,
 	getTotalTokens,
 } from '../calculate-cost.ts';
-import { formatDateCompact, getDefaultClaudePath, loadMonthlyUsageData } from '../data-loader.ts';
+import { formatDateCompact, loadMonthlyUsageData } from '../data-loader.ts';
 import { detectMismatches, printMismatchReport } from '../debug.ts';
 import { log, logger } from '../logger.ts';
 
@@ -24,7 +24,6 @@ export const monthlyCommand = define({
 		const monthlyData = await loadMonthlyUsageData({
 			since: ctx.values.since,
 			until: ctx.values.until,
-			claudePath: getDefaultClaudePath(),
 			mode: ctx.values.mode,
 			order: ctx.values.order,
 			offline: ctx.values.offline,
@@ -56,7 +55,7 @@ export const monthlyCommand = define({
 
 		// Show debug information if requested
 		if (ctx.values.debug && !ctx.values.json) {
-			const mismatchStats = await detectMismatches(getDefaultClaudePath());
+			const mismatchStats = await detectMismatches(undefined);
 			printMismatchReport(mismatchStats, ctx.values.debugSamples);
 		}
 

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -8,7 +8,7 @@ import {
 	createTotalsObject,
 	getTotalTokens,
 } from '../calculate-cost.ts';
-import { formatDateCompact, getDefaultClaudePath, loadSessionData } from '../data-loader.ts';
+import { formatDateCompact, loadSessionData } from '../data-loader.ts';
 import { detectMismatches, printMismatchReport } from '../debug.ts';
 import { log, logger } from '../logger.ts';
 
@@ -24,7 +24,6 @@ export const sessionCommand = define({
 		const sessionData = await loadSessionData({
 			since: ctx.values.since,
 			until: ctx.values.until,
-			claudePath: getDefaultClaudePath(),
 			mode: ctx.values.mode,
 			order: ctx.values.order,
 			offline: ctx.values.offline,
@@ -45,7 +44,7 @@ export const sessionCommand = define({
 
 		// Show debug information if requested
 		if (ctx.values.debug && !ctx.values.json) {
-			const mismatchStats = await detectMismatches(getDefaultClaudePath());
+			const mismatchStats = await detectMismatches(undefined);
 			printMismatchReport(mismatchStats, ctx.values.debugSamples);
 		}
 


### PR DESCRIPTION
- Remove claudePath parameter from data loading functions in all commands
- This allows the data loader to check multiple Claude directories automatically
- Supports both ~/.config/claude and ~/.claude paths
- Fixes 'No Claude usage data found' error when data exists in alternate locations