### PR TITLE
Fix block start time flooring to nearest hour

### DIFF
--- a/src/_session-blocks.ts
+++ b/src/_session-blocks.ts
@@ -7,6 +7,17 @@ import { DEFAULT_RECENT_DAYS } from './_consts.ts';
 export const DEFAULT_SESSION_DURATION_HOURS = 5;
 
 /**
+ * Floors a timestamp to the beginning of the hour
+ * @param timestamp - The timestamp to floor
+ * @returns New Date object floored to the hour
+ */
+function floorToHour(timestamp: Date): Date {
+	const floored = new Date(timestamp);
+	floored.setMinutes(0, 0, 0);
+	return floored;
+}
+
+/**
  * Represents a single usage data entry loaded from JSONL files
  */
 export type LoadedUsageEntry = {
@@ -92,8 +103,8 @@ export function identifySessionBlocks(
 		const entryTime = entry.timestamp;
 
 		if (currentBlockStart == null) {
-			// First entry - start a new block
-			currentBlockStart = entryTime;
+			// First entry - start a new block (floored to the hour)
+			currentBlockStart = floorToHour(entryTime);
 			currentBlockEntries = [entry];
 		}
 		else {
@@ -118,8 +129,8 @@ export function identifySessionBlocks(
 					}
 				}
 
-				// Start new block
-				currentBlockStart = entryTime;
+				// Start new block (floored to the hour)
+				currentBlockStart = floorToHour(entryTime);
 				currentBlockEntries = [entry];
 			}
 			else {
@@ -451,6 +462,17 @@ if (import.meta.vitest != null) {
 			const blocks = identifySessionBlocks([entry]);
 			expect(blocks[0]?.tokenCounts.cacheCreationInputTokens).toBe(100);
 			expect(blocks[0]?.tokenCounts.cacheReadInputTokens).toBe(200);
+		});
+
+		it('floors block start time to nearest hour', () => {
+			const entryTime = new Date('2024-01-01T10:55:30Z'); // 10:55:30 AM
+			const expectedStartTime = new Date('2024-01-01T10:00:00Z'); // Should floor to 10:00:00 AM
+			const entries: LoadedUsageEntry[] = [createMockEntry(entryTime)];
+
+			const blocks = identifySessionBlocks(entries);
+			expect(blocks).toHaveLength(1);
+			expect(blocks[0]?.startTime).toEqual(expectedStartTime);
+			expect(blocks[0]?.id).toBe(expectedStartTime.toISOString());
 		});
 	});
 

--- a/src/_session-blocks.ts
+++ b/src/_session-blocks.ts
@@ -7,13 +7,13 @@ import { DEFAULT_RECENT_DAYS } from './_consts.ts';
 export const DEFAULT_SESSION_DURATION_HOURS = 5;
 
 /**
- * Floors a timestamp to the beginning of the hour
+ * Floors a timestamp to the beginning of the hour in UTC
  * @param timestamp - The timestamp to floor
- * @returns New Date object floored to the hour
+ * @returns New Date object floored to the UTC hour
  */
 function floorToHour(timestamp: Date): Date {
 	const floored = new Date(timestamp);
-	floored.setMinutes(0, 0, 0);
+	floored.setUTCMinutes(0, 0, 0);
 	return floored;
 }
 


### PR DESCRIPTION
- Fixes issue where blocks would start at exact session times instead of hour boundaries
- Add test to verify block start times are correctly floored

Fixes https://github.com/ryoppippi/ccusage/issues/133

| Before | After |
| ------  | ----  |
|<img width="676" alt="Screenshot 2025-06-21 at 7 19 09 PM" src="https://github.com/user-attachments/assets/775b9afd-47cf-456d-be4e-f7b8557392a1" />|<img width="678" alt="Screenshot 2025-06-21 at 7 19 16 PM" src="https://github.com/user-attachments/assets/84f27547-aa7a-4ba8-a0d6-8c7989e86343" />
<img width="674" alt="Screenshot 2025-06-21 at 7 19 34 PM" src="https://github.com/user-attachments/assets/c7940047-4560-4781-9140-accf0e4ba5fc" />

These screenshots were taken at 7:19 PM so the correct remaining time, considering Claude says it resets at 9:00 PM, is 1h 41m.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Session block start times are now consistently aligned to the beginning of the hour, improving accuracy in session grouping.
- **Tests**
  - Added a test case to verify correct alignment of session block start times to the nearest hour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->