### PR TITLE
Add Ccusage native app to related-projects.md

### DIFF
--- a/docs/guide/related-projects.md
+++ b/docs/guide/related-projects.md
@@ -6,6 +6,7 @@ Projects that use ccusage internally or extend its functionality:
 
 - [claude-usage-tracker-for-mac](https://github.com/penicillin0/claude-usage-tracker-for-mac) - macOS menu bar app for tracking Claude usage
 - [ClaudeCode_Dashboard](https://github.com/m-sigepon/ClaudeCode_Dashboard) - Web dashboard with charts and visualizations
+- [Ccusage App](https://github.com/EthanBarlo/ccusage-app) - Native application to display ccusage data in graphs and visualisations
 
 ## Extensions & Integrations
 


### PR DESCRIPTION
This `ccusage` project as inspired lots of people.
Who doesn't love to see how much value they are getting from a subscription.

So I decided to build a native app to visualise some of the data from ccusage, 
Because why not, and it kinda turned out really well so i've published it.
https://github.com/EthanBarlo/ccusage-app

Its very fresh and its only been tested so far on Macos. 
So feel free to test it out, and see if it works on other platforms.

Obviously open to contributions, 
And ideas for what charts would be useful.
And theres definitely room for improvement, but here is the first initial version.

Dashboard
![CleanShot 2025-06-22 at 13 29 42](https://github.com/user-attachments/assets/65391a29-1b89-435a-96a8-eda91430a8ec)

Projects
![CleanShot 2025-06-22 at 13 33 00@2x](https://github.com/user-attachments/assets/7d2c2b5f-33e9-4ade-8b77-5ee0d7fc78fe)

Sessions
![CleanShot 2025-06-22 at 13 30 29](https://github.com/user-attachments/assets/55675e9f-7750-4cb5-a60a-cf89136090c5)

It does also show a countdown and some stats on the currently active session as well.
But I don't have one started right now to screenshot.
![CleanShot 2025-06-22 at 13 33 27@2x](https://github.com/user-attachments/assets/47597049-9fde-486c-b4ff-ddd0de8bd8f5)

Settings
To configure the billling date / subscription reset.
![CleanShot 2025-06-22 at 13 30 42](https://github.com/user-attachments/assets/8f196580-fb9d-4a5f-8e0b-6b74fcf1cbf6)
