### PR TITLE
chore(docs): configure VitePress lastUpdated to use UTC timezone

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -150,7 +150,7 @@ export default withMermaid(
 					hour12: false,
 					timeZone: 'UTC',
 				},
-				
+
 			},
 		},
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,140 +1,169 @@
 import { defineConfig } from 'vitepress';
-import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons';
+import {
+  groupIconMdPlugin,
+  groupIconVitePlugin,
+} from 'vitepress-plugin-group-icons';
 import llmstxt from 'vitepress-plugin-llms';
 import { withMermaid } from 'vitepress-plugin-mermaid';
 import typedocSidebar from '../api/typedoc-sidebar.json';
 
-export default withMermaid(defineConfig({
-	title: 'ccusage',
-	description: 'Usage analysis tool for Claude Code',
-	base: '/',
-	cleanUrls: true,
-	ignoreDeadLinks: true,
+export default withMermaid(
+  defineConfig({
+    title: 'ccusage',
+    description: 'Usage analysis tool for Claude Code',
+    base: '/',
+    cleanUrls: true,
+    ignoreDeadLinks: true,
 
-	head: [
-		['link', { rel: 'icon', href: '/favicon.svg' }],
-		['meta', { name: 'theme-color', content: '#646cff' }],
-		['meta', { property: 'og:type', content: 'website' }],
-		['meta', { property: 'og:locale', content: 'en' }],
-		['meta', { property: 'og:title', content: 'ccusage | Claude Code Usage Analysis' }],
-		['meta', { property: 'og:site_name', content: 'ccusage' }],
-		['meta', { property: 'og:image', content: 'https://cdn.jsdelivr.net/gh/ryoppippi/ccusage@main/docs/public/logo.svg' }],
-		['meta', { property: 'og:url', content: 'https://github.com/ryoppippi/ccusage' }],
-	],
+    head: [
+      ['link', { rel: 'icon', href: '/favicon.svg' }],
+      ['meta', { name: 'theme-color', content: '#646cff' }],
+      ['meta', { property: 'og:type', content: 'website' }],
+      ['meta', { property: 'og:locale', content: 'en' }],
+      [
+        'meta',
+        {
+          property: 'og:title',
+          content: 'ccusage | Claude Code Usage Analysis',
+        },
+      ],
+      ['meta', { property: 'og:site_name', content: 'ccusage' }],
+      [
+        'meta',
+        {
+          property: 'og:image',
+          content:
+            'https://cdn.jsdelivr.net/gh/ryoppippi/ccusage@main/docs/public/logo.svg',
+        },
+      ],
+      [
+        'meta',
+        { property: 'og:url', content: 'https://github.com/ryoppippi/ccusage' },
+      ],
+    ],
 
-	themeConfig: {
-		logo: '/logo.svg',
+    themeConfig: {
+      logo: '/logo.svg',
 
-		nav: [
-			{ text: 'Guide', link: '/guide/' },
-			{ text: 'API Reference', link: '/api/' },
-			{
-				text: 'Links',
-				items: [
-					{ text: 'GitHub', link: 'https://github.com/ryoppippi/ccusage' },
-					{ text: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
-					{ text: 'Changelog', link: 'https://github.com/ryoppippi/ccusage/releases' },
-					{ text: 'DeepWiki', link: 'https://deepwiki.com/ryoppippi/ccusage' },
-					{ text: 'Package Stats', link: 'https://tanstack.com/ccusage?npmPackage=ccusage' },
-				],
-			},
-		],
+      nav: [
+        { text: 'Guide', link: '/guide/' },
+        { text: 'API Reference', link: '/api/' },
+        {
+          text: 'Links',
+          items: [
+            { text: 'GitHub', link: 'https://github.com/ryoppippi/ccusage' },
+            { text: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
+            {
+              text: 'Changelog',
+              link: 'https://github.com/ryoppippi/ccusage/releases',
+            },
+            {
+              text: 'DeepWiki',
+              link: 'https://deepwiki.com/ryoppippi/ccusage',
+            },
+            {
+              text: 'Package Stats',
+              link: 'https://tanstack.com/ccusage?npmPackage=ccusage',
+            },
+          ],
+        },
+      ],
 
-		sidebar: {
-			'/guide/': [
-				{
-					text: 'Introduction',
-					items: [
-						{ text: 'Introduction', link: '/guide/' },
-						{ text: 'Getting Started', link: '/guide/getting-started' },
-						{ text: 'Installation', link: '/guide/installation' },
-					],
-				},
-				{
-					text: 'Usage',
-					items: [
-						{ text: 'Daily Reports', link: '/guide/daily-reports' },
-						{ text: 'Monthly Reports', link: '/guide/monthly-reports' },
-						{ text: 'Session Reports', link: '/guide/session-reports' },
-						{ text: 'Blocks Reports', link: '/guide/blocks-reports' },
-						{ text: 'Live Monitoring', link: '/guide/live-monitoring' },
-					],
-				},
-				{
-					text: 'Configuration',
-					items: [
-						{ text: 'Environment Variables', link: '/guide/configuration' },
-						{ text: 'Custom Paths', link: '/guide/custom-paths' },
-						{ text: 'Cost Calculation Modes', link: '/guide/cost-modes' },
-					],
-				},
-				{
-					text: 'Integration',
-					items: [
-						{ text: 'Library Usage', link: '/guide/library-usage' },
-						{ text: 'MCP Server', link: '/guide/mcp-server' },
-						{ text: 'JSON Output', link: '/guide/json-output' },
-					],
-				},
-				{
-					text: 'Community',
-					items: [
-						{ text: 'Related Projects', link: '/guide/related-projects' },
-					],
-				},
-			],
-			'/api/': [
-				{
-					text: 'API Reference',
-					items: [
-						{ text: 'Overview', link: '/api/' },
-						...typedocSidebar,
-					],
-				},
-			],
-		},
+      sidebar: {
+        '/guide/': [
+          {
+            text: 'Introduction',
+            items: [
+              { text: 'Introduction', link: '/guide/' },
+              { text: 'Getting Started', link: '/guide/getting-started' },
+              { text: 'Installation', link: '/guide/installation' },
+            ],
+          },
+          {
+            text: 'Usage',
+            items: [
+              { text: 'Daily Reports', link: '/guide/daily-reports' },
+              { text: 'Monthly Reports', link: '/guide/monthly-reports' },
+              { text: 'Session Reports', link: '/guide/session-reports' },
+              { text: 'Blocks Reports', link: '/guide/blocks-reports' },
+              { text: 'Live Monitoring', link: '/guide/live-monitoring' },
+            ],
+          },
+          {
+            text: 'Configuration',
+            items: [
+              { text: 'Environment Variables', link: '/guide/configuration' },
+              { text: 'Custom Paths', link: '/guide/custom-paths' },
+              { text: 'Cost Calculation Modes', link: '/guide/cost-modes' },
+            ],
+          },
+          {
+            text: 'Integration',
+            items: [
+              { text: 'Library Usage', link: '/guide/library-usage' },
+              { text: 'MCP Server', link: '/guide/mcp-server' },
+              { text: 'JSON Output', link: '/guide/json-output' },
+            ],
+          },
+          {
+            text: 'Community',
+            items: [
+              { text: 'Related Projects', link: '/guide/related-projects' },
+            ],
+          },
+        ],
+        '/api/': [
+          {
+            text: 'API Reference',
+            items: [{ text: 'Overview', link: '/api/' }, ...typedocSidebar],
+          },
+        ],
+      },
 
-		socialLinks: [
-			{ icon: 'github', link: 'https://github.com/ryoppippi/ccusage' },
-			{ icon: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
-		],
+      socialLinks: [
+        { icon: 'github', link: 'https://github.com/ryoppippi/ccusage' },
+        { icon: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
+      ],
 
-		footer: {
-			message: 'Released under the MIT License.',
-			copyright: 'Copyright © 2024 ryoppippi',
-		},
+      footer: {
+        message: 'Released under the MIT License.',
+        copyright: 'Copyright © 2024 ryoppippi',
+      },
 
-		search: {
-			provider: 'local',
-		},
+      search: {
+        provider: 'local',
+      },
 
-		editLink: {
-			pattern: 'https://github.com/ryoppippi/ccusage/edit/main/docs/:path',
-			text: 'Edit this page on GitHub',
-		},
+      editLink: {
+        pattern: 'https://github.com/ryoppippi/ccusage/edit/main/docs/:path',
+        text: 'Edit this page on GitHub',
+      },
 
-		lastUpdated: {
-			text: 'Updated at',
-			formatOptions: {
-				dateStyle: 'full',
-				timeStyle: 'medium',
-			},
-		},
-	},
+      lastUpdated: {
+        text: 'Updated at',
+        formatOptions: {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false,
+          timeZone: 'UTC',
+        },
+      },
+    },
 
-	vite: {
-		plugins: [
-			groupIconVitePlugin(),
-			...llmstxt(),
-		],
-	},
+    vite: {
+      plugins: [groupIconVitePlugin(), ...llmstxt()],
+    },
 
-	markdown: {
-		config(md) {
-			md.use(groupIconMdPlugin);
-		},
-	},
-	mermaid: {
-		// Optional mermaid configuration
-	},
-}));
+    markdown: {
+      config(md) {
+        md.use(groupIconMdPlugin);
+      },
+    },
+    mermaid: {
+      // Optional mermaid configuration
+    },
+  })
+);

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,171 +1,145 @@
 import { defineConfig } from 'vitepress';
-import {
-	groupIconMdPlugin,
-	groupIconVitePlugin,
-} from 'vitepress-plugin-group-icons';
+import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons';
 import llmstxt from 'vitepress-plugin-llms';
 import { withMermaid } from 'vitepress-plugin-mermaid';
 import typedocSidebar from '../api/typedoc-sidebar.json';
 
-export default withMermaid(
-	defineConfig({
-		title: 'ccusage',
-		description: 'Usage analysis tool for Claude Code',
-		base: '/',
-		cleanUrls: true,
-		ignoreDeadLinks: true,
+export default withMermaid(defineConfig({
+	title: 'ccusage',
+	description: 'Usage analysis tool for Claude Code',
+	base: '/',
+	cleanUrls: true,
+	ignoreDeadLinks: true,
 
-		head: [
-			['link', { rel: 'icon', href: '/favicon.svg' }],
-			['meta', { name: 'theme-color', content: '#646cff' }],
-			['meta', { property: 'og:type', content: 'website' }],
-			['meta', { property: 'og:locale', content: 'en' }],
-			[
-				'meta',
-				{
-					property: 'og:title',
-					content: 'ccusage | Claude Code Usage Analysis',
-				},
-			],
-			['meta', { property: 'og:site_name', content: 'ccusage' }],
-			[
-				'meta',
-				{
-					property: 'og:image',
-					content:
-            'https://cdn.jsdelivr.net/gh/ryoppippi/ccusage@main/docs/public/logo.svg',
-				},
-			],
-			[
-				'meta',
-				{ property: 'og:url', content: 'https://github.com/ryoppippi/ccusage' },
-			],
+	head: [
+		['link', { rel: 'icon', href: '/favicon.svg' }],
+		['meta', { name: 'theme-color', content: '#646cff' }],
+		['meta', { property: 'og:type', content: 'website' }],
+		['meta', { property: 'og:locale', content: 'en' }],
+		['meta', { property: 'og:title', content: 'ccusage | Claude Code Usage Analysis' }],
+		['meta', { property: 'og:site_name', content: 'ccusage' }],
+		['meta', { property: 'og:image', content: 'https://cdn.jsdelivr.net/gh/ryoppippi/ccusage@main/docs/public/logo.svg' }],
+		['meta', { property: 'og:url', content: 'https://github.com/ryoppippi/ccusage' }],
+	],
+
+	themeConfig: {
+		logo: '/logo.svg',
+
+		nav: [
+			{ text: 'Guide', link: '/guide/' },
+			{ text: 'API Reference', link: '/api/' },
+			{
+				text: 'Links',
+				items: [
+					{ text: 'GitHub', link: 'https://github.com/ryoppippi/ccusage' },
+					{ text: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
+					{ text: 'Changelog', link: 'https://github.com/ryoppippi/ccusage/releases' },
+					{ text: 'DeepWiki', link: 'https://deepwiki.com/ryoppippi/ccusage' },
+					{ text: 'Package Stats', link: 'https://tanstack.com/ccusage?npmPackage=ccusage' },
+				],
+			},
 		],
 
-		themeConfig: {
-			logo: '/logo.svg',
-
-			nav: [
-				{ text: 'Guide', link: '/guide/' },
-				{ text: 'API Reference', link: '/api/' },
+		sidebar: {
+			'/guide/': [
 				{
-					text: 'Links',
+					text: 'Introduction',
 					items: [
-						{ text: 'GitHub', link: 'https://github.com/ryoppippi/ccusage' },
-						{ text: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
-						{
-							text: 'Changelog',
-							link: 'https://github.com/ryoppippi/ccusage/releases',
-						},
-						{
-							text: 'DeepWiki',
-							link: 'https://deepwiki.com/ryoppippi/ccusage',
-						},
-						{
-							text: 'Package Stats',
-							link: 'https://tanstack.com/ccusage?npmPackage=ccusage',
-						},
+						{ text: 'Introduction', link: '/guide/' },
+						{ text: 'Getting Started', link: '/guide/getting-started' },
+						{ text: 'Installation', link: '/guide/installation' },
+					],
+				},
+				{
+					text: 'Usage',
+					items: [
+						{ text: 'Daily Reports', link: '/guide/daily-reports' },
+						{ text: 'Monthly Reports', link: '/guide/monthly-reports' },
+						{ text: 'Session Reports', link: '/guide/session-reports' },
+						{ text: 'Blocks Reports', link: '/guide/blocks-reports' },
+						{ text: 'Live Monitoring', link: '/guide/live-monitoring' },
+					],
+				},
+				{
+					text: 'Configuration',
+					items: [
+						{ text: 'Environment Variables', link: '/guide/configuration' },
+						{ text: 'Custom Paths', link: '/guide/custom-paths' },
+						{ text: 'Cost Calculation Modes', link: '/guide/cost-modes' },
+					],
+				},
+				{
+					text: 'Integration',
+					items: [
+						{ text: 'Library Usage', link: '/guide/library-usage' },
+						{ text: 'MCP Server', link: '/guide/mcp-server' },
+						{ text: 'JSON Output', link: '/guide/json-output' },
+					],
+				},
+				{
+					text: 'Community',
+					items: [
+						{ text: 'Related Projects', link: '/guide/related-projects' },
 					],
 				},
 			],
-
-			sidebar: {
-				'/guide/': [
-					{
-						text: 'Introduction',
-						items: [
-							{ text: 'Introduction', link: '/guide/' },
-							{ text: 'Getting Started', link: '/guide/getting-started' },
-							{ text: 'Installation', link: '/guide/installation' },
-						],
-					},
-					{
-						text: 'Usage',
-						items: [
-							{ text: 'Daily Reports', link: '/guide/daily-reports' },
-							{ text: 'Monthly Reports', link: '/guide/monthly-reports' },
-							{ text: 'Session Reports', link: '/guide/session-reports' },
-							{ text: 'Blocks Reports', link: '/guide/blocks-reports' },
-							{ text: 'Live Monitoring', link: '/guide/live-monitoring' },
-						],
-					},
-					{
-						text: 'Configuration',
-						items: [
-							{ text: 'Environment Variables', link: '/guide/configuration' },
-							{ text: 'Custom Paths', link: '/guide/custom-paths' },
-							{ text: 'Cost Calculation Modes', link: '/guide/cost-modes' },
-						],
-					},
-					{
-						text: 'Integration',
-						items: [
-							{ text: 'Library Usage', link: '/guide/library-usage' },
-							{ text: 'MCP Server', link: '/guide/mcp-server' },
-							{ text: 'JSON Output', link: '/guide/json-output' },
-						],
-					},
-					{
-						text: 'Community',
-						items: [
-							{ text: 'Related Projects', link: '/guide/related-projects' },
-						],
-					},
-				],
-				'/api/': [
-					{
-						text: 'API Reference',
-						items: [{ text: 'Overview', link: '/api/' }, ...typedocSidebar],
-					},
-				],
-			},
-
-			socialLinks: [
-				{ icon: 'github', link: 'https://github.com/ryoppippi/ccusage' },
-				{ icon: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
-			],
-
-			footer: {
-				message: 'Released under the MIT License.',
-				copyright: 'Copyright © 2024 ryoppippi',
-			},
-
-			search: {
-				provider: 'local',
-			},
-
-			editLink: {
-				pattern: 'https://github.com/ryoppippi/ccusage/edit/main/docs/:path',
-				text: 'Edit this page on GitHub',
-			},
-
-			lastUpdated: {
-				text: 'Updated at',
-				formatOptions: {
-					year: 'numeric',
-					month: '2-digit',
-					day: '2-digit',
-					hour: '2-digit',
-					minute: '2-digit',
-					hour12: false,
-					timeZone: 'UTC',
+			'/api/': [
+				{
+					text: 'API Reference',
+					items: [
+						{ text: 'Overview', link: '/api/' },
+						...typedocSidebar,
+					],
 				},
+			],
+		},
 
+		socialLinks: [
+			{ icon: 'github', link: 'https://github.com/ryoppippi/ccusage' },
+			{ icon: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
+		],
+
+		footer: {
+			message: 'Released under the MIT License.',
+			copyright: 'Copyright © 2024 ryoppippi',
+		},
+
+		search: {
+			provider: 'local',
+		},
+
+		editLink: {
+			pattern: 'https://github.com/ryoppippi/ccusage/edit/main/docs/:path',
+			text: 'Edit this page on GitHub',
+		},
+
+		lastUpdated: {
+			text: 'Updated at',
+			formatOptions: {
+				year: 'numeric',
+				month: '2-digit',
+				day: '2-digit',
+				hour: '2-digit',
+				minute: '2-digit',
+				hour12: false,
+				timeZone: 'UTC',
 			},
 		},
+	},
 
-		vite: {
-			plugins: [groupIconVitePlugin(), ...llmstxt()],
-		},
+	vite: {
+		plugins: [
+			groupIconVitePlugin(),
+			...llmstxt(),
+		],
+	},
 
-		markdown: {
-			config(md) {
-				md.use(groupIconMdPlugin);
-			},
+	markdown: {
+		config(md) {
+			md.use(groupIconMdPlugin);
 		},
-
-		mermaid: {
-			// Optional mermaid configuration
-		},
-	}),
-);
+	},
+	mermaid: {
+		// Optional mermaid configuration
+	},
+}));

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,169 +1,171 @@
 import { defineConfig } from 'vitepress';
 import {
-  groupIconMdPlugin,
-  groupIconVitePlugin,
+	groupIconMdPlugin,
+	groupIconVitePlugin,
 } from 'vitepress-plugin-group-icons';
 import llmstxt from 'vitepress-plugin-llms';
 import { withMermaid } from 'vitepress-plugin-mermaid';
 import typedocSidebar from '../api/typedoc-sidebar.json';
 
 export default withMermaid(
-  defineConfig({
-    title: 'ccusage',
-    description: 'Usage analysis tool for Claude Code',
-    base: '/',
-    cleanUrls: true,
-    ignoreDeadLinks: true,
+	defineConfig({
+		title: 'ccusage',
+		description: 'Usage analysis tool for Claude Code',
+		base: '/',
+		cleanUrls: true,
+		ignoreDeadLinks: true,
 
-    head: [
-      ['link', { rel: 'icon', href: '/favicon.svg' }],
-      ['meta', { name: 'theme-color', content: '#646cff' }],
-      ['meta', { property: 'og:type', content: 'website' }],
-      ['meta', { property: 'og:locale', content: 'en' }],
-      [
-        'meta',
-        {
-          property: 'og:title',
-          content: 'ccusage | Claude Code Usage Analysis',
-        },
-      ],
-      ['meta', { property: 'og:site_name', content: 'ccusage' }],
-      [
-        'meta',
-        {
-          property: 'og:image',
-          content:
+		head: [
+			['link', { rel: 'icon', href: '/favicon.svg' }],
+			['meta', { name: 'theme-color', content: '#646cff' }],
+			['meta', { property: 'og:type', content: 'website' }],
+			['meta', { property: 'og:locale', content: 'en' }],
+			[
+				'meta',
+				{
+					property: 'og:title',
+					content: 'ccusage | Claude Code Usage Analysis',
+				},
+			],
+			['meta', { property: 'og:site_name', content: 'ccusage' }],
+			[
+				'meta',
+				{
+					property: 'og:image',
+					content:
             'https://cdn.jsdelivr.net/gh/ryoppippi/ccusage@main/docs/public/logo.svg',
-        },
-      ],
-      [
-        'meta',
-        { property: 'og:url', content: 'https://github.com/ryoppippi/ccusage' },
-      ],
-    ],
+				},
+			],
+			[
+				'meta',
+				{ property: 'og:url', content: 'https://github.com/ryoppippi/ccusage' },
+			],
+		],
 
-    themeConfig: {
-      logo: '/logo.svg',
+		themeConfig: {
+			logo: '/logo.svg',
 
-      nav: [
-        { text: 'Guide', link: '/guide/' },
-        { text: 'API Reference', link: '/api/' },
-        {
-          text: 'Links',
-          items: [
-            { text: 'GitHub', link: 'https://github.com/ryoppippi/ccusage' },
-            { text: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
-            {
-              text: 'Changelog',
-              link: 'https://github.com/ryoppippi/ccusage/releases',
-            },
-            {
-              text: 'DeepWiki',
-              link: 'https://deepwiki.com/ryoppippi/ccusage',
-            },
-            {
-              text: 'Package Stats',
-              link: 'https://tanstack.com/ccusage?npmPackage=ccusage',
-            },
-          ],
-        },
-      ],
+			nav: [
+				{ text: 'Guide', link: '/guide/' },
+				{ text: 'API Reference', link: '/api/' },
+				{
+					text: 'Links',
+					items: [
+						{ text: 'GitHub', link: 'https://github.com/ryoppippi/ccusage' },
+						{ text: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
+						{
+							text: 'Changelog',
+							link: 'https://github.com/ryoppippi/ccusage/releases',
+						},
+						{
+							text: 'DeepWiki',
+							link: 'https://deepwiki.com/ryoppippi/ccusage',
+						},
+						{
+							text: 'Package Stats',
+							link: 'https://tanstack.com/ccusage?npmPackage=ccusage',
+						},
+					],
+				},
+			],
 
-      sidebar: {
-        '/guide/': [
-          {
-            text: 'Introduction',
-            items: [
-              { text: 'Introduction', link: '/guide/' },
-              { text: 'Getting Started', link: '/guide/getting-started' },
-              { text: 'Installation', link: '/guide/installation' },
-            ],
-          },
-          {
-            text: 'Usage',
-            items: [
-              { text: 'Daily Reports', link: '/guide/daily-reports' },
-              { text: 'Monthly Reports', link: '/guide/monthly-reports' },
-              { text: 'Session Reports', link: '/guide/session-reports' },
-              { text: 'Blocks Reports', link: '/guide/blocks-reports' },
-              { text: 'Live Monitoring', link: '/guide/live-monitoring' },
-            ],
-          },
-          {
-            text: 'Configuration',
-            items: [
-              { text: 'Environment Variables', link: '/guide/configuration' },
-              { text: 'Custom Paths', link: '/guide/custom-paths' },
-              { text: 'Cost Calculation Modes', link: '/guide/cost-modes' },
-            ],
-          },
-          {
-            text: 'Integration',
-            items: [
-              { text: 'Library Usage', link: '/guide/library-usage' },
-              { text: 'MCP Server', link: '/guide/mcp-server' },
-              { text: 'JSON Output', link: '/guide/json-output' },
-            ],
-          },
-          {
-            text: 'Community',
-            items: [
-              { text: 'Related Projects', link: '/guide/related-projects' },
-            ],
-          },
-        ],
-        '/api/': [
-          {
-            text: 'API Reference',
-            items: [{ text: 'Overview', link: '/api/' }, ...typedocSidebar],
-          },
-        ],
-      },
+			sidebar: {
+				'/guide/': [
+					{
+						text: 'Introduction',
+						items: [
+							{ text: 'Introduction', link: '/guide/' },
+							{ text: 'Getting Started', link: '/guide/getting-started' },
+							{ text: 'Installation', link: '/guide/installation' },
+						],
+					},
+					{
+						text: 'Usage',
+						items: [
+							{ text: 'Daily Reports', link: '/guide/daily-reports' },
+							{ text: 'Monthly Reports', link: '/guide/monthly-reports' },
+							{ text: 'Session Reports', link: '/guide/session-reports' },
+							{ text: 'Blocks Reports', link: '/guide/blocks-reports' },
+							{ text: 'Live Monitoring', link: '/guide/live-monitoring' },
+						],
+					},
+					{
+						text: 'Configuration',
+						items: [
+							{ text: 'Environment Variables', link: '/guide/configuration' },
+							{ text: 'Custom Paths', link: '/guide/custom-paths' },
+							{ text: 'Cost Calculation Modes', link: '/guide/cost-modes' },
+						],
+					},
+					{
+						text: 'Integration',
+						items: [
+							{ text: 'Library Usage', link: '/guide/library-usage' },
+							{ text: 'MCP Server', link: '/guide/mcp-server' },
+							{ text: 'JSON Output', link: '/guide/json-output' },
+						],
+					},
+					{
+						text: 'Community',
+						items: [
+							{ text: 'Related Projects', link: '/guide/related-projects' },
+						],
+					},
+				],
+				'/api/': [
+					{
+						text: 'API Reference',
+						items: [{ text: 'Overview', link: '/api/' }, ...typedocSidebar],
+					},
+				],
+			},
 
-      socialLinks: [
-        { icon: 'github', link: 'https://github.com/ryoppippi/ccusage' },
-        { icon: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
-      ],
+			socialLinks: [
+				{ icon: 'github', link: 'https://github.com/ryoppippi/ccusage' },
+				{ icon: 'npm', link: 'https://www.npmjs.com/package/ccusage' },
+			],
 
-      footer: {
-        message: 'Released under the MIT License.',
-        copyright: 'Copyright © 2024 ryoppippi',
-      },
+			footer: {
+				message: 'Released under the MIT License.',
+				copyright: 'Copyright © 2024 ryoppippi',
+			},
 
-      search: {
-        provider: 'local',
-      },
+			search: {
+				provider: 'local',
+			},
 
-      editLink: {
-        pattern: 'https://github.com/ryoppippi/ccusage/edit/main/docs/:path',
-        text: 'Edit this page on GitHub',
-      },
+			editLink: {
+				pattern: 'https://github.com/ryoppippi/ccusage/edit/main/docs/:path',
+				text: 'Edit this page on GitHub',
+			},
 
-      lastUpdated: {
-        text: 'Updated at',
-        formatOptions: {
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-          hour: '2-digit',
-          minute: '2-digit',
-          hour12: false,
-          timeZone: 'UTC',
-        },
-      },
-    },
+			lastUpdated: {
+				text: 'Updated at',
+				formatOptions: {
+					year: 'numeric',
+					month: '2-digit',
+					day: '2-digit',
+					hour: '2-digit',
+					minute: '2-digit',
+					hour12: false,
+					timeZone: 'UTC',
+				},
+				
+			},
+		},
 
-    vite: {
-      plugins: [groupIconVitePlugin(), ...llmstxt()],
-    },
+		vite: {
+			plugins: [groupIconVitePlugin(), ...llmstxt()],
+		},
 
-    markdown: {
-      config(md) {
-        md.use(groupIconMdPlugin);
-      },
-    },
-    mermaid: {
-      // Optional mermaid configuration
-    },
-  })
+		markdown: {
+			config(md) {
+				md.use(groupIconMdPlugin);
+			},
+		},
+
+		mermaid: {
+			// Optional mermaid configuration
+		},
+	}),
 );


### PR DESCRIPTION
### Summary  
This PR configures the `lastUpdated` timestamp on the VitePress documentation site to display in UTC timezone.

### Changes  
- Added `timeZone: 'UTC'` to `lastUpdated.formatOptions` in `docs/.vitepress/config.ts`.  
- Ensures that all "Last Updated" timestamps are consistently displayed in UTC across the documentation.


### 📸 Before & After (Last Updated Timestamp in VitePress)

| Before (Local Time) | After (UTC Time) |
|---------------------|------------------|
| <img width="1582" alt="image" src="https://github.com/user-attachments/assets/03c79149-dfc4-4c93-98a8-67292c858999" /> | <img width="1582" alt="image" src="https://github.com/user-attachments/assets/48d55cb1-9a5d-4970-a448-93d0e6b4ec6f" /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the display format of last updated timestamps to a fixed, precise format with numeric year, two-digit month and day, two-digit hour and minute, 24-hour time, and UTC time zone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->