### PR TITLE
Add --24hour flag to switch between 12-hour and 24-hour time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ ccusage blocks --live  # Real-time usage dashboard
 ccusage daily --since 20250525 --until 20250530
 ccusage daily --json  # JSON output
 ccusage daily --breakdown  # Per-model cost breakdown
+
+# Time format options
+ccusage blocks  # 24-hour time format (default): 14:30:45
+ccusage blocks --am-pm  # 12-hour AM/PM format: 2:30:45 PM
+ccusage blocks --live --am-pm  # Live monitoring with AM/PM format
 ```
 
 ## Features
@@ -71,6 +76,7 @@ ccusage daily --breakdown  # Per-model cost breakdown
 - 💰 **Cost Tracking**: Shows costs in USD for each day/month/session
 - 🔄 **Cache Token Support**: Tracks and displays cache creation and cache read tokens separately
 - 🌐 **Offline Mode**: Use pre-cached pricing data without network connectivity with `--offline` (Claude models only)
+- 🕐 **Time Format Options**: Choose between 24-hour format (default) or 12-hour AM/PM format with `--am-pm` flag
 - 🔌 **MCP Integration**: Built-in Model Context Protocol server for integration with other tools
 
 ## Documentation

--- a/src/_live-rendering.ts
+++ b/src/_live-rendering.ts
@@ -16,7 +16,7 @@ import prettyMs from 'pretty-ms';
 import stringWidth from 'string-width';
 import { calculateBurnRate, projectBlockUsage } from './_session-blocks.ts';
 import { centerText, createProgressBar } from './_terminal-utils.ts';
-import { formatCurrency, formatModelsDisplay, formatNumber } from './_utils.ts';
+import { formatCurrency, formatModelsDisplay, formatNumber, formatTime } from './_utils.ts';
 
 /**
  * Live monitoring configuration
@@ -28,6 +28,7 @@ export type LiveMonitoringConfig = {
 	sessionDurationHours: number;
 	mode: CostMode;
 	order: SortOrder;
+	useAmPm: boolean;
 };
 
 /**
@@ -130,9 +131,9 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 		},
 	);
 
-	// Format times with AM/PM
-	const startTime = block.startTime.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: true });
-	const endTime = block.endTime.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: true });
+	// Format times
+	const startTime = formatTime(block.startTime, config.useAmPm, true);
+	const endTime = formatTime(block.endTime, config.useAmPm, true);
 
 	// Draw header
 	terminal.write(`${marginStr}┌${'─'.repeat(boxWidth - 2)}┐\n`);

--- a/src/_shared-args.ts
+++ b/src/_shared-args.ts
@@ -78,6 +78,11 @@ export const sharedArgs = {
 		description: 'Use cached pricing data for Claude models instead of fetching from API',
 		default: false,
 	},
+	'am-pm': {
+		type: 'boolean',
+		description: 'Use 12-hour (AM/PM) time format instead of 24-hour',
+		default: false,
+	},
 } as const satisfies Args;
 
 /**

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -304,6 +304,64 @@ export function formatCurrency(amount: number): string {
 }
 
 /**
+ * Formats a date/time according to the specified time format preference
+ * @param date - The date to format
+ * @param useAmPm - Whether to use 12-hour AM/PM format (default: false for 24-hour format)
+ * @param options - Additional formatting options
+ * @returns Formatted date/time string
+ */
+export function formatDateTime(date: Date, useAmPm = false, options: {
+	includeDate?: boolean;
+	includeSeconds?: boolean;
+	compact?: boolean;
+} = {}): string {
+	const { includeDate = true, includeSeconds = false, compact = false } = options;
+	
+	const baseOptions: Intl.DateTimeFormatOptions = {
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: useAmPm,
+	};
+	
+	if (includeSeconds) {
+		baseOptions.second = '2-digit';
+	}
+	
+	if (includeDate) {
+		if (compact) {
+			baseOptions.month = '2-digit';
+			baseOptions.day = '2-digit';
+		} else {
+			// Use default full date format
+			return date.toLocaleString(undefined, { ...baseOptions });
+		}
+	}
+	
+	return date.toLocaleString(undefined, baseOptions);
+}
+
+/**
+ * Formats only the time portion of a date according to the specified time format preference
+ * @param date - The date to format
+ * @param useAmPm - Whether to use 12-hour AM/PM format (default: false for 24-hour format)
+ * @param includeSeconds - Whether to include seconds (default: false)
+ * @returns Formatted time string
+ */
+export function formatTime(date: Date, useAmPm = false, includeSeconds = false): string {
+	const options: Intl.DateTimeFormatOptions = {
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: useAmPm,
+	};
+	
+	if (includeSeconds) {
+		options.second = '2-digit';
+	}
+	
+	return date.toLocaleTimeString(undefined, options);
+}
+
+/**
  * Formats Claude model names into a shorter, more readable format
  * Extracts model type and generation from full model name
  * @param modelName - Full model name (e.g., "claude-sonnet-4-20250514")


### PR DESCRIPTION


📝 Usage Examples
Default 12-hour format:

ccusage blocks
# Output: Block Started: 1/15/2024, 2:30:45 PM (2h 15m ago)
24-hour format:

ccusage blocks --24hour
# Output: Block Started: 1/15/2024, 14:30:45 (2h 15m ago)
Live monitoring:

ccusage blocks --live --24hour
# Shows times like "Started: 14:30:45" instead of "Started: 02:30:45 PM"

Technical Details

Backwards Compatibility

✅ Flag is optional and defaults to 12-hour format
✅ All existing commands work unchanged
✅ Compatible with other flags like --json, --live, --breakdown

Implementation Approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying times in 24-hour format across relevant commands and displays. Users can now enable this option via a new command-line argument.
- **Enhancements**
  - Improved date and time formatting consistency with new utilities, ensuring uniform output for both 12-hour and 24-hour formats.
- **Tests**
  - Introduced comprehensive tests for the new date and time formatting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->