### PR TITLE
fix: reduce screen flickering in live monitoring using alternate screen buffer

### DIFF
--- a/src/_terminal-utils.ts
+++ b/src/_terminal-utils.ts
@@ -40,6 +40,24 @@ export class TerminalManager {
 	}
 
 	/**
+	 * Enters alternate screen buffer (like vim/less)
+	 */
+	enterAlternateScreen(): void {
+		if (this.stream.isTTY) {
+			this.stream.write('\u001B[?1049h');
+		}
+	}
+
+	/**
+	 * Exits alternate screen buffer and restores original screen
+	 */
+	exitAlternateScreen(): void {
+		if (this.stream.isTTY) {
+			this.stream.write('\u001B[?1049l');
+		}
+	}
+
+	/**
 	 * Clears the entire screen and moves cursor to top-left corner
 	 * Essential for live monitoring displays that need to refresh completely
 	 */
@@ -89,6 +107,7 @@ export class TerminalManager {
 	 */
 	cleanup(): void {
 		this.showCursor();
+		this.exitAlternateScreen();
 	}
 }
 

--- a/src/commands/_blocks.live.ts
+++ b/src/commands/_blocks.live.ts
@@ -80,7 +80,8 @@ export async function startLiveMonitoring(config: LiveMonitoringConfig): Promise
 	process.on('SIGINT', cleanup);
 	process.on('SIGTERM', cleanup);
 
-	// Hide cursor for cleaner display
+	// Setup terminal for live updates
+	terminal.enterAlternateScreen();
 	terminal.hideCursor();
 
 	// Create live monitor with efficient data loading
@@ -111,8 +112,7 @@ export async function startLiveMonitoring(config: LiveMonitoringConfig): Promise
 				continue;
 			}
 
-			// Clear screen and render
-			terminal.clearScreen();
+			// Render display - alternate screen buffer reduces flicker
 			renderLiveDisplay(terminal, activeBlock, config);
 
 			// Wait before next refresh


### PR DESCRIPTION
## Summary
- Implement alternate screen buffer for live monitoring display to eliminate screen flickering
- Remove redundant screen clearing operations in the render loop
- Add proper cleanup to restore terminal state on exit

## Problem
The current implementation clears the entire screen on every refresh cycle, which causes visible flickering on slower terminals or when refresh rates are high. This creates a poor user experience, especially during extended monitoring sessions.

## Solution
This PR introduces alternate screen buffer support (similar to how \`vim\` or \`less\` work):
- Uses ANSI escape sequences to switch to an alternate screen buffer when monitoring starts
- The alternate buffer handles screen updates more efficiently, reducing flicker
- Automatically restores the original terminal content when monitoring ends

## Changes
1. **TerminalManager enhancements**:
   - Added \`enterAlternateScreen()\` method to switch to alternate buffer
   - Added \`exitAlternateScreen()\` method to restore original screen
   - Updated \`cleanup()\` to properly exit alternate screen

2. **Live monitoring improvements**:
   - Enter alternate screen when starting live monitoring
   - Removed redundant \`clearScreen()\` call before each render
   - The alternate buffer handles clearing automatically

## Test Plan
- [x] Tested live monitoring with \`bun run start blocks --active\`
- [x] Verified no flickering on terminal refresh
- [x] Confirmed terminal properly restores on exit (Ctrl+C)
- [x] Ensured all tests pass (\`bun run test\`)
- [x] Code formatting and linting pass (\`bun run format\` and ESLint)
- [x] TypeScript checks pass (\`bun typecheck\`)

## Impact
This change significantly improves the user experience for live monitoring features without affecting any other functionality. The alternate screen buffer is a standard terminal feature supported by all modern terminal emulators.