### PR TITLE
feat(docs): add sponsor section to homepage

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -80,6 +80,7 @@ export default withMermaid(defineConfig({
 					text: 'Community',
 					items: [
 						{ text: 'Related Projects', link: '/guide/related-projects' },
+						{ text: 'Sponsors', link: '/guide/sponsors' },
 					],
 				},
 			],

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,3 +55,11 @@ features:
     title: MCP Integration
     details: Built-in Model Context Protocol server for tool integration
 ---
+
+<div style="text-align: center; margin: 2rem 0;">
+  <h2 style="margin-bottom: 1rem;">Support ccusage</h2>
+  <p style="margin-bottom: 1.5rem;">If you find ccusage helpful, please consider sponsoring the development!</p>
+  <a href="https://github.com/sponsors/ryoppippi" target="_blank">
+    <img src="https://cdn.jsdelivr.net/gh/ryoppippi/sponsors@main/sponsors.svg" alt="Sponsors" style="max-width: 100%; height: auto;">
+  </a>
+</div>


### PR DESCRIPTION
## Summary

- Added a sponsor section to the documentation homepage
- Placed at the bottom of the page after the features section to maintain clean layout
- Includes GitHub Sponsors badge with link to sponsorship page

## Test plan

- [x] Verified the homepage layout renders correctly
- [x] Confirmed sponsor badge displays properly
- [x] Checked that the link to GitHub Sponsors works
- [x] Ensured the section is responsive and looks good on different screen sizes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a "Sponsors" link under the "Community" section in the documentation sidebar.
  - Included a new section on the homepage encouraging users to support development via GitHub Sponsors, featuring a sponsor badge and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->