### PR TITLE
fix: change OGP image from SVG to PNG for better social media compatibility

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -18,7 +18,7 @@ export default withMermaid(defineConfig({
 		['meta', { property: 'og:locale', content: 'en' }],
 		['meta', { property: 'og:title', content: 'ccusage | Claude Code Usage Analysis' }],
 		['meta', { property: 'og:site_name', content: 'ccusage' }],
-		['meta', { property: 'og:image', content: 'https://cdn.jsdelivr.net/gh/ryoppippi/ccusage@main/docs/public/logo.svg' }],
+		['meta', { property: 'og:image', content: 'https://cdn.jsdelivr.net/gh/ryoppippi/ccusage@main/docs/public/logo.png' }],
 		['meta', { property: 'og:url', content: 'https://github.com/ryoppippi/ccusage' }],
 	],
 


### PR DESCRIPTION
## Summary
- Changed OGP image format from SVG to PNG in VitePress config
- This ensures the logo displays correctly on social media platforms

## Problem
Many social platforms (Twitter, Facebook, LinkedIn) do not support SVG format for Open Graph Protocol previews, causing the logo to not display properly when sharing links.

## Solution
Updated the og:image meta tag to use logo.png instead of logo.svg. The PNG format is universally supported by all major social media platforms.

## Test plan
- [ ] Deploy changes to production
- [ ] Test URL preview on Twitter Card Validator
- [ ] Test URL preview on Facebook Sharing Debugger
- [ ] Test URL preview on LinkedIn Post Inspector
- [ ] Verify logo displays correctly in all platforms