### PR TITLE
chore: set Node.js engine requirement to >=20 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,6 @@
 		"simple-git-hooks"
 	],
 	"engines": {
-		"node": ">=18.18.0"
-	}
+        "node": ">=20.0.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -108,5 +108,8 @@
 	},
 	"trustedDependencies": [
 		"simple-git-hooks"
-	]
+	],
+	"engines": {
+		"node": ">=18.18.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
 		".",
 		"docs"
 	],
+	"engines": {
+		"node": ">=20.0.0"
+	},
 	"scripts": {
 		"build": "tsdown",
 		"docs:build": "cd docs && bun run build",
@@ -108,8 +111,5 @@
 	},
 	"trustedDependencies": [
 		"simple-git-hooks"
-	],
-	"engines": {
-        "node": ">=20.0.0"
-    }
+	]
 }


### PR DESCRIPTION
Symbol.dispose and Symbol.asyncDispose were shipped in 18.18 and required to run ccusage. See #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated requirements to ensure the app runs on Node.js version 20.0.0 or higher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->