### PR TITLE
feat: add currency conversion support with --currency option

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
 	"exports": {
 		".": "./dist/index.js",
 		"./calculate-cost": "./dist/calculate-cost.js",
+		"./currency-converter": "./dist/currency-converter.js",
 		"./data-loader": "./dist/data-loader.js",
 		"./debug": "./dist/debug.js",
+		"./exchange-rate-fetcher": "./dist/exchange-rate-fetcher.js",
 		"./logger": "./dist/logger.js",
 		"./mcp": "./dist/mcp.js",
 		"./pricing-fetcher": "./dist/pricing-fetcher.js",

--- a/src/_shared-args.ts
+++ b/src/_shared-args.ts
@@ -78,6 +78,12 @@ export const sharedArgs = {
 		description: 'Use cached pricing data for Claude models instead of fetching from API',
 		default: false,
 	},
+	currency: {
+		type: 'string',
+		short: 'c',
+		description: 'Currency to display costs in (default: USD). Examples: JPY, EUR, GBP',
+		default: 'USD',
+	},
 } as const satisfies Args;
 
 /**

--- a/src/currency-converter.ts
+++ b/src/currency-converter.ts
@@ -1,0 +1,296 @@
+/**
+ * @fileoverview Currency conversion utilities for ccusage
+ *
+ * This module provides currency conversion functionality, combining
+ * exchange rate fetching with currency formatting to convert and display
+ * USD amounts in different currencies.
+ *
+ * @module currency-converter
+ */
+
+import { formatCurrency } from './_utils.ts';
+import { ExchangeRateFetcher } from './exchange-rate-fetcher.ts';
+import { logger } from './logger.ts';
+
+/**
+ * Currency converter class that combines exchange rate fetching with formatting
+ * Implements Disposable pattern for automatic resource cleanup
+ */
+export class CurrencyConverter implements Disposable {
+	private exchangeRateFetcher: ExchangeRateFetcher;
+
+	/**
+	 * Creates a new CurrencyConverter instance
+	 */
+	constructor() {
+		this.exchangeRateFetcher = new ExchangeRateFetcher();
+	}
+
+	/**
+	 * Implements Disposable interface for automatic cleanup
+	 */
+	[Symbol.dispose](): void {
+		this.exchangeRateFetcher[Symbol.dispose]();
+	}
+
+	/**
+	 * Converts USD amount to target currency and formats it
+	 * @param usdAmount - Amount in USD to convert
+	 * @param targetCurrency - Target currency code (e.g., 'JPY', 'EUR')
+	 * @returns Formatted currency string or null if conversion fails
+	 */
+	async convertAndFormat(usdAmount: number, targetCurrency: string): Promise<string | null> {
+		const upperCurrency = targetCurrency.toUpperCase();
+
+		// No conversion needed for USD
+		if (upperCurrency === 'USD') {
+			return formatCurrency(usdAmount, 'USD');
+		}
+
+		try {
+			const convertedAmount = await this.exchangeRateFetcher.convertFromUsd(usdAmount, upperCurrency);
+
+			if (convertedAmount == null) {
+				logger.warn(`Currency conversion failed: ${upperCurrency} not supported`);
+				return null;
+			}
+
+			return formatCurrency(convertedAmount, upperCurrency);
+		}
+		catch (error) {
+			logger.error(`Failed to convert currency to ${upperCurrency}:`, error);
+			return null;
+		}
+	}
+
+	/**
+	 * Converts USD amount to target currency without formatting
+	 * @param usdAmount - Amount in USD to convert
+	 * @param targetCurrency - Target currency code
+	 * @returns Converted amount or null if conversion fails
+	 */
+	async convertAmount(usdAmount: number, targetCurrency: string): Promise<number | null> {
+		const upperCurrency = targetCurrency.toUpperCase();
+
+		// No conversion needed for USD
+		if (upperCurrency === 'USD') {
+			return usdAmount;
+		}
+
+		try {
+			return await this.exchangeRateFetcher.convertFromUsd(usdAmount, upperCurrency);
+		}
+		catch (error) {
+			logger.error(`Failed to convert currency to ${upperCurrency}:`, error);
+			return null;
+		}
+	}
+
+	/**
+	 * Gets the list of supported currencies
+	 * @returns Array of supported currency codes
+	 */
+	async getSupportedCurrencies(): Promise<string[]> {
+		try {
+			return await this.exchangeRateFetcher.getSupportedCurrencies();
+		}
+		catch (error) {
+			logger.error('Failed to get supported currencies:', error);
+			return ['USD']; // Fallback to USD only
+		}
+	}
+
+	/**
+	 * Validates if a currency is supported
+	 * @param currencyCode - Currency code to validate
+	 * @returns True if currency is supported
+	 */
+	async isCurrencySupported(currencyCode: string): Promise<boolean> {
+		const upperCode = currencyCode.toUpperCase();
+
+		// USD is always supported
+		if (upperCode === 'USD') {
+			return true;
+		}
+
+		try {
+			const rate = await this.exchangeRateFetcher.getExchangeRate(upperCode);
+			return rate != null;
+		}
+		catch (error) {
+			logger.debug(`Currency validation failed for ${upperCode}:`, error);
+			return false;
+		}
+	}
+
+	/**
+	 * Gets cache information for debugging
+	 * @returns Exchange rate cache information
+	 */
+	async getCacheInfo(): Promise<{
+		hasCachedData: boolean;
+		cacheDate?: string;
+		lastUpdate?: Date;
+		currencyCount?: number;
+	}> {
+		return this.exchangeRateFetcher.getCacheInfo();
+	}
+
+	/**
+	 * Gets the appropriate currency column header
+	 * @param currencyCode - Currency code for the header
+	 * @returns Formatted column header string
+	 */
+	getCurrencyColumnHeader(currencyCode: string): string {
+		const upperCode = currencyCode.toUpperCase();
+		return upperCode === 'USD' ? 'Cost (USD)' : `Cost (${upperCode})`;
+	}
+}
+
+/**
+ * Convenience function to create and use a currency converter with automatic disposal
+ * @param currencyCode - Target currency code
+ * @param callback - Function to execute with the converter
+ * @returns Result of the callback function
+ */
+export async function withCurrencyConverter<T>(
+	currencyCode: string,
+	callback: (converter: CurrencyConverter) => Promise<T>,
+): Promise<T> {
+	using converter = new CurrencyConverter();
+	return await callback(converter);
+}
+
+if (import.meta.vitest != null) {
+	describe('currency-converter', () => {
+		describe('CurrencyConverter', () => {
+			it('should support using statement for automatic cleanup', async () => {
+				let converterDisposed = false;
+
+				class TestCurrencyConverter extends CurrencyConverter {
+					override [Symbol.dispose](): void {
+						super[Symbol.dispose]();
+						converterDisposed = true;
+					}
+				}
+
+				{
+					using converter = new TestCurrencyConverter();
+					const result = await converter.convertAndFormat(1, 'USD');
+					expect(result).toBe('$1.00');
+				}
+
+				expect(converterDisposed).toBe(true);
+			});
+
+			it('should convert and format USD amounts correctly', async () => {
+				using converter = new CurrencyConverter();
+
+				const usdResult = await converter.convertAndFormat(10.50, 'USD');
+				expect(usdResult).toBe('$10.50');
+			});
+
+			it('should convert to other currencies', async () => {
+				using converter = new CurrencyConverter();
+
+				const jpyResult = await converter.convertAndFormat(1, 'JPY');
+				expect(jpyResult).toMatch(/^¥\d+$/); // Should be formatted JPY without decimals
+
+				const eurResult = await converter.convertAndFormat(1, 'EUR');
+				expect(eurResult).toMatch(/^\d+\.\d{2}€$/); // Should be formatted EUR with decimals
+			});
+
+			it('should handle case insensitive currency codes', async () => {
+				using converter = new CurrencyConverter();
+
+				const result = await converter.convertAndFormat(1, 'usd');
+				expect(result).toBe('$1.00');
+			});
+
+			it('should return null for unsupported currencies', async () => {
+				using converter = new CurrencyConverter();
+
+				const result = await converter.convertAndFormat(1, 'FAKE');
+				expect(result).toBeNull();
+			});
+
+			it('should convert amounts without formatting', async () => {
+				using converter = new CurrencyConverter();
+
+				const usdAmount = await converter.convertAmount(10, 'USD');
+				expect(usdAmount).toBe(10);
+
+				const jpyAmount = await converter.convertAmount(1, 'JPY');
+				expect(jpyAmount).toBeGreaterThan(100); // JPY should be > 100 per USD
+			});
+
+			it('should validate currency support', async () => {
+				using converter = new CurrencyConverter();
+
+				const usdSupported = await converter.isCurrencySupported('USD');
+				expect(usdSupported).toBe(true);
+
+				const jpySupported = await converter.isCurrencySupported('JPY');
+				expect(jpySupported).toBe(true);
+
+				const fakeSupported = await converter.isCurrencySupported('FAKE');
+				expect(fakeSupported).toBe(false);
+			});
+
+			it('should get supported currencies list', async () => {
+				using converter = new CurrencyConverter();
+
+				const currencies = await converter.getSupportedCurrencies();
+				expect(currencies).toContain('USD');
+				expect(currencies).toContain('JPY');
+				expect(currencies).toContain('EUR');
+				expect(currencies.length).toBeGreaterThan(100);
+			});
+
+			it('should provide currency column headers', () => {
+				using converter = new CurrencyConverter();
+
+				expect(converter.getCurrencyColumnHeader('USD')).toBe('Cost (USD)');
+				expect(converter.getCurrencyColumnHeader('JPY')).toBe('Cost (JPY)');
+				expect(converter.getCurrencyColumnHeader('eur')).toBe('Cost (EUR)');
+			});
+
+			it('should provide cache information', async () => {
+				using converter = new CurrencyConverter();
+
+				// Force a fetch to ensure cache exists
+				await converter.convertAndFormat(1, 'JPY');
+
+				const cacheInfo = await converter.getCacheInfo();
+				expect(cacheInfo.hasCachedData).toBe(true);
+				expect(cacheInfo.cacheDate).toBeDefined();
+				expect(cacheInfo.lastUpdate).toBeInstanceOf(Date);
+				expect(cacheInfo.currencyCount).toBeGreaterThan(100);
+			});
+		});
+
+		describe('withCurrencyConverter', () => {
+			it('should automatically dispose converter after use', async () => {
+				let disposed = false;
+
+				// Mock the converter disposal to track it
+				const originalDispose = CurrencyConverter.prototype[Symbol.dispose];
+				CurrencyConverter.prototype[Symbol.dispose] = function () {
+					disposed = true;
+					originalDispose.call(this);
+				};
+
+				const result = await withCurrencyConverter('USD', async (converter) => {
+					const formatted = await converter.convertAndFormat(1, 'USD');
+					return formatted;
+				});
+
+				expect(result).toBe('$1.00');
+				expect(disposed).toBe(true);
+
+				// Restore original dispose method
+				CurrencyConverter.prototype[Symbol.dispose] = originalDispose;
+			});
+		});
+	});
+}

--- a/src/currency-validator.ts
+++ b/src/currency-validator.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Currency validation utilities
+ *
+ * This module provides currency validation functionality to validate
+ * and normalize currency codes before conversion.
+ *
+ * @module currency-validator
+ */
+
+import type { CurrencyConverter } from './currency-converter.ts';
+import { logger } from './logger.ts';
+
+/**
+ * Validates and normalizes a currency code
+ * @param currencyCode - Currency code to validate
+ * @param converter - CurrencyConverter instance for validation
+ * @returns Promise<string> - Normalized currency code
+ * @throws Error if currency is not supported
+ */
+export async function validateCurrency(
+	currencyCode: string,
+	converter: CurrencyConverter,
+): Promise<string> {
+	const normalizedCurrency = currencyCode.toUpperCase();
+
+	// USD is always valid
+	if (normalizedCurrency === 'USD') {
+		return normalizedCurrency;
+	}
+
+	// Check if currency is supported
+	const isSupported = await converter.isCurrencySupported(normalizedCurrency);
+	if (!isSupported) {
+		logger.error(`Currency '${normalizedCurrency}' is not supported. Use 'USD' or check available currencies.`);
+		throw new Error(`Currency '${normalizedCurrency}' is not supported`);
+	}
+
+	return normalizedCurrency;
+}
+
+if (import.meta.vitest != null) {
+	describe('currency-validator', () => {
+		describe('validateCurrency', () => {
+			it('should validate USD currency', async () => {
+				const mockIsCurrencySupported = vi.fn().mockResolvedValue(true);
+				const mockConverter = {
+					isCurrencySupported: mockIsCurrencySupported,
+				} as unknown as CurrencyConverter;
+
+				const result = await validateCurrency('USD', mockConverter);
+				expect(result).toBe('USD');
+				expect(mockIsCurrencySupported).not.toHaveBeenCalled();
+			});
+
+			it('should validate and normalize case', async () => {
+				const mockIsCurrencySupported = vi.fn().mockResolvedValue(true);
+				const mockConverter = {
+					isCurrencySupported: mockIsCurrencySupported,
+				} as unknown as CurrencyConverter;
+
+				const result = await validateCurrency('jpy', mockConverter);
+				expect(result).toBe('JPY');
+				expect(mockIsCurrencySupported).toHaveBeenCalledWith('JPY');
+			});
+
+			it('should throw error for unsupported currency', async () => {
+				const mockIsCurrencySupported = vi.fn().mockResolvedValue(false);
+				const mockConverter = {
+					isCurrencySupported: mockIsCurrencySupported,
+				} as unknown as CurrencyConverter;
+
+				await expect(validateCurrency('FAKE', mockConverter))
+					.rejects
+					.toThrow('Currency \'FAKE\' is not supported');
+			});
+
+			it('should handle supported currencies', async () => {
+				const mockIsCurrencySupported = vi.fn().mockResolvedValue(true);
+				const mockConverter = {
+					isCurrencySupported: mockIsCurrencySupported,
+				} as unknown as CurrencyConverter;
+
+				const result = await validateCurrency('EUR', mockConverter);
+				expect(result).toBe('EUR');
+				expect(mockIsCurrencySupported).toHaveBeenCalledWith('EUR');
+			});
+		});
+	});
+}

--- a/src/exchange-rate-fetcher.ts
+++ b/src/exchange-rate-fetcher.ts
@@ -85,7 +85,7 @@ export class ExchangeRateFetcher implements Disposable {
 	 * @returns Current date string
 	 */
 	private getCurrentDateString(): string {
-		return new Date().toISOString().split('T')[0]!;
+		return new Date().toISOString().slice(0, 10);
 	}
 
 	/**

--- a/src/exchange-rate-fetcher.ts
+++ b/src/exchange-rate-fetcher.ts
@@ -1,0 +1,365 @@
+/**
+ * @fileoverview Currency exchange rate fetcher with daily caching
+ *
+ * This module provides an ExchangeRateFetcher class that retrieves and caches
+ * currency exchange rates from exchangerate-api.com with daily cache limits
+ * to respect the free tier API limitations (1 request per day).
+ *
+ * @module exchange-rate-fetcher
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { logger } from './logger.ts';
+
+/**
+ * Exchange rate data structure
+ */
+export type ExchangeRateData = {
+	/** Base currency (always USD) */
+	base_code: string;
+	/** Exchange rates mapping */
+	rates: Record<string, number>;
+	/** Last update timestamp */
+	time_last_update_unix: number;
+	/** Cache timestamp when data was fetched */
+	cached_at: number;
+};
+
+/**
+ * Cache file structure for exchange rates
+ */
+type ExchangeRateCache = {
+	data: ExchangeRateData;
+	fetched_date: string; // YYYY-MM-DD format
+};
+
+/**
+ * Exchange rate API response structure
+ */
+type ExchangeRateApiResponse = {
+	result: string;
+	base_code: string;
+	rates: Record<string, number>;
+	time_last_update_unix: number;
+};
+
+/**
+ * Fetches and caches currency exchange rates with daily limits
+ * Implements daily caching to respect API rate limits (1 request per day for free tier)
+ */
+export class ExchangeRateFetcher implements Disposable {
+	private static readonly API_URL = 'https://open.er-api.com/v6/latest/USD';
+	private static readonly CACHE_DIR = join(homedir(), '.claude', 'ccusage-cache');
+	private static readonly CACHE_FILE = join(ExchangeRateFetcher.CACHE_DIR, 'exchange-rates.json');
+
+	private cachedRates: ExchangeRateData | null = null;
+
+	/**
+	 * Creates a new ExchangeRateFetcher instance
+	 */
+	constructor() {
+		// Ensure cache directory exists
+		if (!existsSync(ExchangeRateFetcher.CACHE_DIR)) {
+			mkdirSync(ExchangeRateFetcher.CACHE_DIR, { recursive: true });
+		}
+	}
+
+	/**
+	 * Implements Disposable interface for automatic cleanup
+	 */
+	[Symbol.dispose](): void {
+		this.clearCache();
+	}
+
+	/**
+	 * Clears the cached exchange rate data
+	 */
+	clearCache(): void {
+		this.cachedRates = null;
+	}
+
+	/**
+	 * Gets current date in YYYY-MM-DD format
+	 * @returns Current date string
+	 */
+	private getCurrentDateString(): string {
+		return new Date().toISOString().split('T')[0]!;
+	}
+
+	/**
+	 * Loads exchange rates from local cache file
+	 * @returns Cached exchange rate data or null if not valid
+	 */
+	private loadFromCache(): ExchangeRateData | null {
+		try {
+			if (!existsSync(ExchangeRateFetcher.CACHE_FILE)) {
+				logger.debug('Exchange rate cache file does not exist');
+				return null;
+			}
+
+			const cacheContent = readFileSync(ExchangeRateFetcher.CACHE_FILE, 'utf-8');
+			const cache = JSON.parse(cacheContent) as ExchangeRateCache;
+
+			// Check if cache is from today
+			const today = this.getCurrentDateString();
+			if (cache.fetched_date !== today) {
+				logger.debug(`Exchange rate cache is from ${cache.fetched_date}, today is ${today}. Cache expired.`);
+				return null;
+			}
+
+			logger.debug('Using cached exchange rates from today');
+			return cache.data;
+		}
+		catch (error) {
+			logger.warn('Failed to load exchange rate cache:', error);
+			return null;
+		}
+	}
+
+	/**
+	 * Saves exchange rate data to local cache file
+	 * @param data - Exchange rate data to cache
+	 */
+	private saveToCache(data: ExchangeRateData): void {
+		try {
+			const cache: ExchangeRateCache = {
+				data,
+				fetched_date: this.getCurrentDateString(),
+			};
+
+			writeFileSync(ExchangeRateFetcher.CACHE_FILE, JSON.stringify(cache, null, 2));
+			logger.debug('Exchange rates cached successfully');
+		}
+		catch (error) {
+			logger.warn('Failed to save exchange rate cache:', error);
+		}
+	}
+
+	/**
+	 * Fetches exchange rates from the API
+	 * @returns Exchange rate data from API
+	 */
+	private async fetchFromApi(): Promise<ExchangeRateData> {
+		logger.info('Fetching latest exchange rates from API (1 daily request limit)...');
+
+		const response = await fetch(ExchangeRateFetcher.API_URL);
+		if (!response.ok) {
+			throw new Error(`Failed to fetch exchange rates: ${response.status} ${response.statusText}`);
+		}
+
+		const apiData = await response.json() as ExchangeRateApiResponse;
+
+		if (apiData.result !== 'success') {
+			throw new Error('Exchange rate API returned unsuccessful result');
+		}
+
+		const data: ExchangeRateData = {
+			base_code: apiData.base_code,
+			rates: apiData.rates,
+			time_last_update_unix: apiData.time_last_update_unix,
+			cached_at: Date.now(),
+		};
+
+		// Save to cache for future use
+		this.saveToCache(data);
+
+		logger.info(`Fetched exchange rates for ${Object.keys(data.rates).length} currencies`);
+		return data;
+	}
+
+	/**
+	 * Gets exchange rate data, using cache if available and valid, otherwise fetching from API
+	 * @returns Exchange rate data
+	 */
+	private async ensureExchangeRatesLoaded(): Promise<ExchangeRateData> {
+		// Return cached data if already loaded
+		if (this.cachedRates != null) {
+			return this.cachedRates;
+		}
+
+		// Try to load from cache first
+		const cachedData = this.loadFromCache();
+		if (cachedData != null) {
+			this.cachedRates = cachedData;
+			return cachedData;
+		}
+
+		// Cache miss or expired, fetch from API
+		try {
+			const freshData = await this.fetchFromApi();
+			this.cachedRates = freshData;
+			return freshData;
+		}
+		catch (error) {
+			logger.error('Failed to fetch exchange rates from API:', error);
+			throw new Error('Unable to fetch current exchange rates. Please check your internet connection or try again later.');
+		}
+	}
+
+	/**
+	 * Gets the exchange rate for a specific currency relative to USD
+	 * @param currencyCode - Three-letter currency code (e.g., 'JPY', 'EUR')
+	 * @returns Exchange rate or null if currency not found
+	 */
+	async getExchangeRate(currencyCode: string): Promise<number | null> {
+		const upperCode = currencyCode.toUpperCase();
+
+		// USD to USD is always 1
+		if (upperCode === 'USD') {
+			return 1;
+		}
+
+		const rates = await this.ensureExchangeRatesLoaded();
+		const rate = rates.rates[upperCode];
+
+		if (rate == null) {
+			logger.warn(`Exchange rate not found for currency: ${upperCode}`);
+			return null;
+		}
+
+		return rate;
+	}
+
+	/**
+	 * Converts USD amount to target currency
+	 * @param usdAmount - Amount in USD
+	 * @param targetCurrency - Target currency code
+	 * @returns Converted amount or null if currency not supported
+	 */
+	async convertFromUsd(usdAmount: number, targetCurrency: string): Promise<number | null> {
+		const rate = await this.getExchangeRate(targetCurrency);
+		if (rate == null) {
+			return null;
+		}
+
+		return usdAmount * rate;
+	}
+
+	/**
+	 * Gets all available currency codes
+	 * @returns Array of supported currency codes
+	 */
+	async getSupportedCurrencies(): Promise<string[]> {
+		const rates = await this.ensureExchangeRatesLoaded();
+		return Object.keys(rates.rates).sort();
+	}
+
+	/**
+	 * Gets cache information for debugging
+	 * @returns Cache status information
+	 */
+	async getCacheInfo(): Promise<{
+		hasCachedData: boolean;
+		cacheDate?: string;
+		lastUpdate?: Date;
+		currencyCount?: number;
+	}> {
+		try {
+			if (existsSync(ExchangeRateFetcher.CACHE_FILE)) {
+				const cacheContent = readFileSync(ExchangeRateFetcher.CACHE_FILE, 'utf-8');
+				const cache = JSON.parse(cacheContent) as ExchangeRateCache;
+
+				return {
+					hasCachedData: true,
+					cacheDate: cache.fetched_date,
+					lastUpdate: new Date(cache.data.time_last_update_unix * 1000),
+					currencyCount: Object.keys(cache.data.rates).length,
+				};
+			}
+		}
+		catch (error) {
+			logger.debug('Error reading cache info:', error);
+		}
+
+		return { hasCachedData: false };
+	}
+}
+
+if (import.meta.vitest != null) {
+	describe('exchange-rate-fetcher', () => {
+		describe('ExchangeRateFetcher', () => {
+			it('should support using statement for automatic cleanup', async () => {
+				let fetcherDisposed = false;
+
+				class TestExchangeRateFetcher extends ExchangeRateFetcher {
+					override [Symbol.dispose](): void {
+						super[Symbol.dispose]();
+						fetcherDisposed = true;
+					}
+				}
+
+				{
+					using fetcher = new TestExchangeRateFetcher();
+					const rate = await fetcher.getExchangeRate('JPY');
+					expect(rate).toBeGreaterThan(0);
+				}
+
+				expect(fetcherDisposed).toBe(true);
+			});
+
+			it('should return 1 for USD to USD conversion', async () => {
+				using fetcher = new ExchangeRateFetcher();
+				const rate = await fetcher.getExchangeRate('USD');
+				expect(rate).toBe(1);
+			});
+
+			it('should fetch and return exchange rates', async () => {
+				using fetcher = new ExchangeRateFetcher();
+
+				const jpyRate = await fetcher.getExchangeRate('JPY');
+				expect(jpyRate).toBeGreaterThan(0);
+				expect(jpyRate).toBeGreaterThan(100); // JPY should be > 100 per USD
+
+				const eurRate = await fetcher.getExchangeRate('EUR');
+				expect(eurRate).toBeGreaterThan(0);
+				expect(eurRate).toBeLessThan(2); // EUR should be < 2 per USD
+			});
+
+			it('should convert USD amounts correctly', async () => {
+				using fetcher = new ExchangeRateFetcher();
+
+				const jpyAmount = await fetcher.convertFromUsd(1, 'JPY');
+				expect(jpyAmount).toBeGreaterThan(100);
+
+				const eurAmount = await fetcher.convertFromUsd(1, 'EUR');
+				expect(eurAmount).toBeGreaterThan(0);
+				expect(eurAmount).toBeLessThan(2);
+			});
+
+			it('should return null for unsupported currencies', async () => {
+				using fetcher = new ExchangeRateFetcher();
+
+				const rate = await fetcher.getExchangeRate('FAKE');
+				expect(rate).toBeNull();
+
+				const amount = await fetcher.convertFromUsd(100, 'FAKE');
+				expect(amount).toBeNull();
+			});
+
+			it('should return list of supported currencies', async () => {
+				using fetcher = new ExchangeRateFetcher();
+
+				const currencies = await fetcher.getSupportedCurrencies();
+				expect(currencies).toContain('JPY');
+				expect(currencies).toContain('EUR');
+				expect(currencies).toContain('USD');
+				expect(currencies.length).toBeGreaterThan(100);
+			});
+
+			it('should provide cache information', async () => {
+				using fetcher = new ExchangeRateFetcher();
+
+				// Force a fetch to ensure cache exists
+				await fetcher.getExchangeRate('JPY');
+
+				const cacheInfo = await fetcher.getCacheInfo();
+				expect(cacheInfo.hasCachedData).toBe(true);
+				expect(cacheInfo.cacheDate).toBeDefined();
+				expect(cacheInfo.lastUpdate).toBeInstanceOf(Date);
+				expect(cacheInfo.currencyCount).toBeGreaterThan(100);
+			});
+		});
+	});
+}


### PR DESCRIPTION
  Hi! I really love ccusage's minimalist design philosophy, so I'm a bit hesitant to propose this
  feature addition.

  My personal use case: I wanted to quickly see my Claude costs in JPY without leaving the terminal or
  doing manual conversion. So I implemented currency conversion as an optional feature.

  Design considerations:
  - Non-breaking: Defaults to USD, existing behavior unchanged
  - Opt-in only: Requires explicit ```--currency```  flag
  - Self-contained: New functionality in separate modules
  - Daily rate limits: Uses free exchange rate API (open.er-api.com) with 1 request/day limit, cached
  locally

  Example usage:
  ```bash
  ccusage daily --currency JPY  # ¥4,881 instead of $33.35
  ccusage monthly --currency EUR # €1,520 instead of $1,755
 ```

  Implementation scope: This adds comprehensive currency support (25+ currencies with proper
  formatting) through two new modules for exchange rate fetching and currency conversion, plus minimal
  changes to existing commands to integrate the ```--currency``` option.

  I understand if this feels too heavy for your core mission.
  What do you think?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for displaying costs in multiple currencies, not just USD.
  - Introduced a command-line option to select the desired currency for cost reports.
  - Daily usage reports now convert and display costs in the selected currency, with appropriate symbols and formatting.
  - Currency conversion uses up-to-date exchange rates and supports a wide range of international currencies.
  - Added currency validation to ensure selected currencies are supported.

- **Bug Fixes**
  - Improved handling and formatting for unknown or unsupported currencies.

- **Tests**
  - Expanded unit tests to cover currency formatting, conversion accuracy, validation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->