### PR TITLE
fix: handle file read errors gracefully in live monitor

### DIFF
--- a/src/_live-monitor.ts
+++ b/src/_live-monitor.ts
@@ -91,7 +91,15 @@ export class LiveMonitor implements Disposable {
 			const sortedFiles = await sortFilesByTimestamp(filesToRead);
 
 			for (const file of sortedFiles) {
-				const content = await readFile(file, 'utf-8');
+				let content: string;
+				try {
+					content = await readFile(file, 'utf-8');
+				}
+				catch {
+					// Skip files that can't be read
+					continue;
+				}
+
 				const lines = content
 					.trim()
 					.split('\n')

--- a/src/_live-monitor.ts
+++ b/src/_live-monitor.ts
@@ -91,14 +91,11 @@ export class LiveMonitor implements Disposable {
 			const sortedFiles = await sortFilesByTimestamp(filesToRead);
 
 			for (const file of sortedFiles) {
-				let content: string;
-				try {
-					content = await readFile(file, 'utf-8');
-				}
-				catch {
-					// Skip files that can't be read
-					continue;
-				}
+				const content = await readFile(file, 'utf-8')
+					.catch(() => {
+						// Skip files that can't be read
+						return '';
+					});
 
 				const lines = content
 					.trim()


### PR DESCRIPTION
When Claude Code's `cleanupPeriodDays` option triggers automatic deletion of old usage logs, `ccusage blocks --live` crashes with ENOENT errors. This fix adds error handling to silently skip files that cannot be read, allowing live monitoring to continue uninterrupted.

<img width="786" alt="image" src="https://github.com/user-attachments/assets/3a225077-e542-47c4-bdb6-bdcca0595c1f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to ensure the application continues processing files even if some files are unreadable or inaccessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->