### PR TITLE
feat: add CSV output support with refactored shared handlers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `bun run start monthly --json` - Show monthly usage report in JSON format
 - `bun run start session --json` - Show session usage report in JSON format
 - `bun run start blocks --json` - Show blocks usage report in JSON format
+- `bun run start daily --csv` - Show daily usage report in CSV format
+- `bun run start monthly --csv` - Show monthly usage report in CSV format
+- `bun run start session --csv` - Show session usage report in CSV format
+- `bun run start blocks --csv` - Show blocks usage report in CSV format
 - `bun run start daily --mode <mode>` - Control cost calculation mode (auto/calculate/display)
 - `bun run start monthly --mode <mode>` - Control cost calculation mode (auto/calculate/display)
 - `bun run start session --mode <mode>` - Control cost calculation mode (auto/calculate/display)
@@ -74,6 +78,7 @@ This is a CLI tool that analyzes Claude Code usage data from local JSONL files s
 
 - Table format (default): Pretty-printed tables with colors for terminal display
 - JSON format (`--json`): Structured JSON output for programmatic consumption
+- CSV format (`--csv`): Comma-separated values for spreadsheet analysis (cannot be used with `--json`)
 
 **Key Data Structures:**
 

--- a/src/_csv-output.ts
+++ b/src/_csv-output.ts
@@ -1,0 +1,277 @@
+// Shared CSV output utilities for ccusage commands
+import { arrayToCsv, formatDecimal } from './_csv-utils.ts';
+import { calculateTotals, getTotalTokens } from './calculate-cost.ts';
+import { log } from './logger.ts';
+
+/**
+ * Common data structure for CSV output
+ */
+type CsvRowData = {
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationTokens: number;
+	cacheReadTokens: number;
+	totalCost: number;
+	modelsUsed: string[];
+};
+
+/**
+ * Configuration for CSV output
+ */
+type CsvOutputConfig = {
+	/** Headers for the CSV file */
+	headers: string[];
+	/** Empty headers template when no data */
+	emptyHeaders: string;
+	/** Function to extract row data from each item */
+	rowMapper: (item: any) => Record<string, unknown>;
+	/** Whether to include totals row */
+	includeTotals?: boolean;
+};
+
+/**
+ * Validates that values can be used together
+ */
+function validateCsvJsonExclusive(hasJson: boolean, hasCsv: boolean): void {
+	if (hasJson && hasCsv) {
+		throw new Error('Cannot use both --json and --csv options together');
+	}
+}
+
+/**
+ * Outputs data in CSV format with optional totals
+ */
+function outputCsvData<T extends CsvRowData>(
+	data: T[],
+	config: CsvOutputConfig,
+): void {
+	if (data.length === 0) {
+		log(config.emptyHeaders);
+		return;
+	}
+
+	// Convert data to CSV format
+	const csvData = data.map(config.rowMapper);
+	log(arrayToCsv(csvData, config.headers));
+
+	// Add totals row if requested
+	if (config.includeTotals && data.length > 0) {
+		const totals = calculateTotals(data);
+		log(''); // Empty line before totals
+
+		// Create totals row with appropriate number of empty columns
+		const totalValues = [
+			totals.inputTokens,
+			totals.outputTokens,
+			totals.cacheCreationTokens,
+			totals.cacheReadTokens,
+			getTotalTokens(totals),
+			formatDecimal(totals.totalCost),
+		];
+
+		// Calculate number of columns before token data
+		const columnsBeforeTokens = config.headers.length - totalValues.length;
+		const emptyColumns = new Array(columnsBeforeTokens).fill('').join(',');
+		const totalRow = emptyColumns ? `Total,${emptyColumns.slice(1)},${totalValues.join(',')}` : `Total,${totalValues.join(',')}`;
+
+		log(totalRow);
+	}
+}
+
+/**
+ * Daily/Monthly CSV output handler
+ */
+export function handleUsageDataCsv<T extends CsvRowData & { date?: string; month?: string }>(
+	data: T[],
+	hasJson: boolean,
+	hasCsv: boolean,
+	type: 'daily' | 'monthly',
+): void {
+	validateCsvJsonExclusive(hasJson, hasCsv);
+
+	if (!hasCsv) { return; }
+
+	const timeField = type === 'daily' ? 'Date' : 'Month';
+	const timeKey = type === 'daily' ? 'date' : 'month';
+
+	outputCsvData(data as any, {
+		headers: [timeField, 'Models', 'InputTokens', 'OutputTokens', 'CacheCreationTokens', 'CacheReadTokens', 'TotalTokens', 'Cost'],
+		emptyHeaders: `${timeField},Models,InputTokens,OutputTokens,CacheCreationTokens,CacheReadTokens,TotalTokens,Cost`,
+		includeTotals: true,
+		rowMapper: item => ({
+			[timeField]: item[timeKey],
+			Models: item.modelsUsed.join(';'),
+			InputTokens: item.inputTokens,
+			OutputTokens: item.outputTokens,
+			CacheCreationTokens: item.cacheCreationTokens,
+			CacheReadTokens: item.cacheReadTokens,
+			TotalTokens: getTotalTokens(item),
+			Cost: formatDecimal(item.totalCost),
+		}),
+	});
+}
+
+/**
+ * Session CSV output handler
+ */
+export function handleSessionCsv<T extends CsvRowData & { sessionId: string; lastActivity: string }>(
+	data: T[],
+	hasJson: boolean,
+	hasCsv: boolean,
+): void {
+	validateCsvJsonExclusive(hasJson, hasCsv);
+
+	if (!hasCsv) { return; }
+
+	outputCsvData(data as any, {
+		headers: ['SessionID', 'Models', 'InputTokens', 'OutputTokens', 'CacheCreationTokens', 'CacheReadTokens', 'TotalTokens', 'Cost', 'LastActivity'],
+		emptyHeaders: 'SessionID,Models,InputTokens,OutputTokens,CacheCreationTokens,CacheReadTokens,TotalTokens,Cost,LastActivity',
+		includeTotals: true,
+		rowMapper: item => ({
+			SessionID: item.sessionId.split('-').slice(-2).join('-'), // Display last two parts
+			Models: item.modelsUsed.join(';'),
+			InputTokens: item.inputTokens,
+			OutputTokens: item.outputTokens,
+			CacheCreationTokens: item.cacheCreationTokens,
+			CacheReadTokens: item.cacheReadTokens,
+			TotalTokens: getTotalTokens(item),
+			Cost: formatDecimal(item.totalCost),
+			LastActivity: item.lastActivity,
+		}),
+	});
+}
+
+/**
+ * Blocks CSV output handler
+ */
+export function handleBlocksCsv<T extends {
+	startTime: Date;
+	endTime: Date;
+	actualEndTime?: Date;
+	isActive: boolean;
+	isGap?: boolean;
+	models: string[];
+	tokenCounts: { inputTokens: number; outputTokens: number };
+	costUSD: number;
+}>(
+	data: T[],
+	hasJson: boolean,
+	hasCsv: boolean,
+	tokenLimit?: string,
+	maxTokensFromAll?: number,
+): void {
+	validateCsvJsonExclusive(hasJson, hasCsv);
+
+	if (!hasCsv) { return; }
+
+	outputCsvData(data as any, {
+		headers: ['BlockStart', 'Duration', 'Models', 'Tokens', 'Percentage', 'Cost'],
+		emptyHeaders: 'BlockStart,Duration,Models,Tokens,Percentage,Cost',
+		includeTotals: false, // Blocks don't have traditional totals
+		rowMapper: (block) => {
+			if (block.isGap) {
+				const duration = Math.round((block.endTime.getTime() - block.startTime.getTime()) / (1000 * 60 * 60));
+				return {
+					BlockStart: block.startTime.toISOString(),
+					Duration: `${duration}h gap`,
+					Models: '-',
+					Tokens: 0,
+					Percentage: '',
+					Cost: 0,
+				};
+			}
+
+			const totalTokens = block.tokenCounts.inputTokens + block.tokenCounts.outputTokens;
+			let duration: string;
+
+			if (block.isActive) {
+				duration = 'ACTIVE';
+			}
+			else if (block.actualEndTime) {
+				const durationMins = Math.round((block.actualEndTime.getTime() - block.startTime.getTime()) / (1000 * 60));
+				const hours = Math.floor(durationMins / 60);
+				const mins = durationMins % 60;
+				duration = hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+			}
+			else {
+				duration = '-';
+			}
+
+			// Calculate percentage if token limit is set
+			const parseTokenLimit = (value?: string, max?: number): number | undefined => {
+				if (!value) { return undefined; }
+				if (value === 'max') { return max && max > 0 ? max : undefined; }
+				const limit = Number.parseInt(value, 10);
+				return Number.isNaN(limit) ? undefined : limit;
+			};
+
+			const actualTokenLimit = parseTokenLimit(tokenLimit, maxTokensFromAll);
+			const percentage = actualTokenLimit && actualTokenLimit > 0
+				? ((totalTokens / actualTokenLimit) * 100).toFixed(1)
+				: '';
+
+			return {
+				BlockStart: block.startTime.toISOString(),
+				Duration: duration,
+				Models: block.models.join(';'),
+				Tokens: totalTokens,
+				Percentage: percentage,
+				Cost: formatDecimal(block.costUSD),
+			};
+		},
+	});
+}
+
+if (import.meta.vitest != null) {
+	const { describe, it, expect, vi } = import.meta.vitest;
+
+	// Mock logger
+	vi.mock('./logger.ts', () => ({
+		log: vi.fn(),
+	}));
+
+	describe('CSV output handlers', () => {
+		it('should validate json/csv exclusivity', () => {
+			expect(() => validateCsvJsonExclusive(true, true)).toThrow('Cannot use both --json and --csv options together');
+			expect(() => validateCsvJsonExclusive(true, false)).not.toThrow();
+			expect(() => validateCsvJsonExclusive(false, true)).not.toThrow();
+		});
+
+		it('should handle daily CSV output', async () => {
+			const data = [{
+				date: '2024-01-15',
+				modelsUsed: ['claude-sonnet-4'],
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheCreationTokens: 10,
+				cacheReadTokens: 5,
+				totalCost: 0.01,
+			}];
+
+			handleUsageDataCsv(data, false, true, 'daily');
+
+			const { log } = vi.mocked(await import('./logger.ts'));
+			expect(log).toHaveBeenCalledWith(expect.stringContaining('Date,Models,InputTokens'));
+			expect(log).toHaveBeenCalledWith(expect.stringContaining('2024-01-15,claude-sonnet-4,100,50'));
+		});
+
+		it('should handle session CSV output', async () => {
+			const data = [{
+				sessionId: 'project-session-12345',
+				modelsUsed: ['claude-opus-4'],
+				inputTokens: 200,
+				outputTokens: 100,
+				cacheCreationTokens: 20,
+				cacheReadTokens: 10,
+				totalCost: 0.02,
+				lastActivity: '2024-01-15T10:00:00Z',
+			}];
+
+			handleSessionCsv(data, false, true);
+
+			const { log } = vi.mocked(await import('./logger.ts'));
+			expect(log).toHaveBeenCalledWith(expect.stringContaining('SessionID,Models,InputTokens'));
+			expect(log).toHaveBeenCalledWith(expect.stringContaining('session-12345,claude-opus-4,200,100'));
+		});
+	});
+}

--- a/src/_csv-utils.ts
+++ b/src/_csv-utils.ts
@@ -1,0 +1,184 @@
+/**
+ * Escapes a value for CSV format
+ * @param value - The value to escape
+ * @returns Escaped value suitable for CSV
+ */
+export function escapeCsvValue(value: string | number | boolean | null | undefined): string {
+	if (value == null) {
+		return '';
+	}
+
+	const stringValue = String(value);
+
+	// Check if the value needs to be quoted
+	if (
+		stringValue.includes(',')
+		|| stringValue.includes('"')
+		|| stringValue.includes('\n')
+		|| stringValue.includes('\r')
+	) {
+		// Escape double quotes by doubling them
+		const escaped = stringValue.replace(/"/g, '""');
+		return `"${escaped}"`;
+	}
+
+	return stringValue;
+}
+
+/**
+ * Converts an array of objects to CSV format
+ * @param data - Array of objects to convert
+ * @param headers - Optional custom headers (defaults to object keys)
+ * @returns CSV string with headers and data
+ */
+export function arrayToCsv<T extends Record<string, unknown>>(
+	data: readonly T[],
+	headers?: readonly string[],
+): string {
+	if (data.length === 0) {
+		return headers ? headers.join(',') : '';
+	}
+
+	// Use provided headers or extract from first object
+	const firstItem = data[0];
+	if (!firstItem) {
+		return headers != null ? headers.join(',') : '';
+	}
+	const columnHeaders = headers ?? Object.keys(firstItem);
+
+	// Create header row
+	const headerRow = columnHeaders.map(escapeCsvValue).join(',');
+
+	// Create data rows
+	const dataRows = data.map((row) => {
+		return columnHeaders
+			.map((header) => {
+				// If using custom headers, need to map them to object keys
+				const key = headers != null ? Object.keys(firstItem)[columnHeaders.indexOf(header)] : header;
+				const value = key != null ? row[key] : undefined;
+				// Handle arrays by joining with semicolons
+				if (Array.isArray(value)) {
+					return escapeCsvValue(value.join(';'));
+				}
+				return escapeCsvValue(value as string | number | boolean | null | undefined);
+			})
+			.join(',');
+	});
+
+	return [headerRow, ...dataRows].join('\n');
+}
+
+/**
+ * Formats a number as a decimal string with specified precision
+ * @param value - Number to format
+ * @param precision - Number of decimal places (default: 6)
+ * @returns Formatted decimal string
+ */
+export function formatDecimal(value: number, precision = 6): string {
+	return value.toFixed(precision);
+}
+
+/**
+ * Formats a date for CSV output (ISO 8601 format)
+ * @param date - Date to format
+ * @returns ISO 8601 date string
+ */
+export function formatDateForCsv(date: Date): string {
+	return date.toISOString().split('T')[0] ?? '';
+}
+
+if (import.meta.vitest != null) {
+	const { describe, it, expect } = import.meta.vitest;
+
+	describe('escapeCsvValue', () => {
+		it('should return empty string for null/undefined', () => {
+			expect(escapeCsvValue(null)).toBe('');
+			expect(escapeCsvValue(undefined)).toBe('');
+		});
+
+		it('should convert numbers and booleans to strings', () => {
+			expect(escapeCsvValue(123)).toBe('123');
+			expect(escapeCsvValue(true)).toBe('true');
+			expect(escapeCsvValue(false)).toBe('false');
+		});
+
+		it('should not quote simple strings', () => {
+			expect(escapeCsvValue('hello')).toBe('hello');
+			expect(escapeCsvValue('test123')).toBe('test123');
+		});
+
+		it('should quote and escape strings with commas', () => {
+			expect(escapeCsvValue('hello,world')).toBe('"hello,world"');
+		});
+
+		it('should quote and escape strings with quotes', () => {
+			expect(escapeCsvValue('say "hello"')).toBe('"say ""hello"""');
+		});
+
+		it('should quote strings with newlines', () => {
+			expect(escapeCsvValue('line1\nline2')).toBe('"line1\nline2"');
+			expect(escapeCsvValue('line1\r\nline2')).toBe('"line1\r\nline2"');
+		});
+	});
+
+	describe('arrayToCsv', () => {
+		it('should handle empty array', () => {
+			expect(arrayToCsv([])).toBe('');
+			expect(arrayToCsv([], ['col1', 'col2'])).toBe('col1,col2');
+		});
+
+		it('should convert simple objects', () => {
+			const data = [
+				{ name: 'Alice', age: 30 },
+				{ name: 'Bob', age: 25 },
+			];
+			const expected = 'name,age\nAlice,30\nBob,25';
+			expect(arrayToCsv(data)).toBe(expected);
+		});
+
+		it('should use custom headers', () => {
+			const data = [
+				{ name: 'Alice', age: 30 },
+				{ name: 'Bob', age: 25 },
+			];
+			const expected = 'Name,Age\nAlice,30\nBob,25';
+			expect(arrayToCsv(data, ['Name', 'Age'])).toBe(expected);
+		});
+
+		it('should handle arrays in values', () => {
+			const data = [
+				{ id: 1, tags: ['a', 'b', 'c'] },
+				{ id: 2, tags: ['x', 'y'] },
+			];
+			const expected = 'id,tags\n1,a;b;c\n2,x;y';
+			expect(arrayToCsv(data)).toBe(expected);
+		});
+
+		it('should handle special characters', () => {
+			const data = [
+				{ text: 'Hello, "world"', value: 'line1\nline2' },
+			];
+			const expected = 'text,value\n"Hello, ""world""","line1\nline2"';
+			expect(arrayToCsv(data)).toBe(expected);
+		});
+	});
+
+	describe('formatDecimal', () => {
+		it('should format with default precision', () => {
+			expect(formatDecimal(1.234567890)).toBe('1.234568');
+			expect(formatDecimal(0.1)).toBe('0.100000');
+		});
+
+		it('should format with custom precision', () => {
+			expect(formatDecimal(1.234567890, 2)).toBe('1.23');
+			expect(formatDecimal(1.234567890, 8)).toBe('1.23456789');
+		});
+	});
+
+	describe('formatDateForCsv', () => {
+		it('should format date as ISO 8601', () => {
+			const date = new Date('2024-01-15T12:34:56Z');
+			expect(formatDateForCsv(date)).toBe('2024-01-15');
+		});
+	});
+}

--- a/src/_shared-args.ts
+++ b/src/_shared-args.ts
@@ -38,6 +38,11 @@ export const sharedArgs = {
 		description: 'Output in JSON format',
 		default: false,
 	},
+	csv: {
+		type: 'boolean',
+		description: 'Output in CSV format',
+		default: false,
+	},
 	mode: {
 		type: 'enum',
 		short: 'm',

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -1,6 +1,7 @@
 import process from 'node:process';
 import { define } from 'gunshi';
 import pc from 'picocolors';
+import { handleUsageDataCsv } from '../_csv-output.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
 import { formatCurrency, formatModelsDisplayMultiline, formatNumber, pushBreakdownRows, ResponsiveTable } from '../_utils.ts';
 import {
@@ -17,8 +18,19 @@ export const dailyCommand = define({
 	description: 'Show usage report grouped by date',
 	...sharedCommandConfig,
 	async run(ctx) {
-		if (ctx.values.json) {
+		if (ctx.values.json || ctx.values.csv) {
 			logger.level = 0;
+		}
+
+		// Validate CSV/JSON options early
+		try {
+			if (ctx.values.json && ctx.values.csv) {
+				throw new Error('Cannot use both --json and --csv options together');
+			}
+		}
+		catch (error: any) {
+			logger.error(error.message);
+			process.exit(1);
 		}
 
 		const dailyData = await loadDailyUsageData({
@@ -33,6 +45,9 @@ export const dailyCommand = define({
 			if (ctx.values.json) {
 				log(JSON.stringify([]));
 			}
+			else if (ctx.values.csv) {
+				handleUsageDataCsv([], ctx.values.json, ctx.values.csv, 'daily');
+			}
 			else {
 				logger.warn('No Claude usage data found.');
 			}
@@ -43,12 +58,15 @@ export const dailyCommand = define({
 		const totals = calculateTotals(dailyData);
 
 		// Show debug information if requested
-		if (ctx.values.debug && !ctx.values.json) {
+		if (ctx.values.debug && !ctx.values.json && !ctx.values.csv) {
 			const mismatchStats = await detectMismatches(undefined);
 			printMismatchReport(mismatchStats, ctx.values.debugSamples);
 		}
 
-		if (ctx.values.json) {
+		if (ctx.values.csv) {
+			handleUsageDataCsv(dailyData, ctx.values.json, ctx.values.csv, 'daily');
+		}
+		else if (ctx.values.json) {
 			// Output JSON format
 			const jsonOutput = {
 				daily: dailyData.map(data => ({

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -1,6 +1,7 @@
 import process from 'node:process';
 import { define } from 'gunshi';
 import pc from 'picocolors';
+import { handleSessionCsv } from '../_csv-output.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
 import { formatCurrency, formatModelsDisplayMultiline, formatNumber, pushBreakdownRows, ResponsiveTable } from '../_utils.ts';
 import {
@@ -17,8 +18,19 @@ export const sessionCommand = define({
 	description: 'Show usage report grouped by conversation session',
 	...sharedCommandConfig,
 	async run(ctx) {
-		if (ctx.values.json) {
+		if (ctx.values.json || ctx.values.csv) {
 			logger.level = 0;
+		}
+
+		// Validate CSV/JSON options early
+		try {
+			if (ctx.values.json && ctx.values.csv) {
+				throw new Error('Cannot use both --json and --csv options together');
+			}
+		}
+		catch (error: any) {
+			logger.error(error.message);
+			process.exit(1);
 		}
 
 		const sessionData = await loadSessionData({
@@ -33,6 +45,9 @@ export const sessionCommand = define({
 			if (ctx.values.json) {
 				log(JSON.stringify([]));
 			}
+			else if (ctx.values.csv) {
+				handleSessionCsv([], ctx.values.json, ctx.values.csv);
+			}
 			else {
 				logger.warn('No Claude usage data found.');
 			}
@@ -43,12 +58,15 @@ export const sessionCommand = define({
 		const totals = calculateTotals(sessionData);
 
 		// Show debug information if requested
-		if (ctx.values.debug && !ctx.values.json) {
+		if (ctx.values.debug && !ctx.values.json && !ctx.values.csv) {
 			const mismatchStats = await detectMismatches(undefined);
 			printMismatchReport(mismatchStats, ctx.values.debugSamples);
 		}
 
-		if (ctx.values.json) {
+		if (ctx.values.csv) {
+			handleSessionCsv(sessionData, ctx.values.json, ctx.values.csv);
+		}
+		else if (ctx.values.json) {
 			// Output JSON format
 			const jsonOutput = {
 				sessions: sessionData.map(data => ({


### PR DESCRIPTION
## Function 
 The `--csv` option allows csv output. This is an option that works well with other system integration and spreadsheets such as excel.

## Caution.

You may choose not to implement this in ccusage because it is the same as this.
```bash 
npx ccusage --json | jq -r ' 
 ["date", "inputTokens", "outputTokens", "cacheCreationTokens", "cacheReadTokens", "totalTokens", "totalCost ", "modelsUsed"], 
 (.daily[] | [ 
.date, 
.inputTokens, 
.outputTokens, 
.cacheCreationTokens, 
.cacheReadTokens, 
.totalTokens, 
.totalCost, 
 (. modelsUsed | join(";")) 
 ]) 
 | @csv 
' 
```