### PR TITLE
docs: emphasize bunx usage and ultra-small bundle size advantage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,24 @@
 
 ### Quick Start (Recommended)
 
-Run directly without installation:
+Thanks to ccusage's incredibly small bundle size ([![install size](https://packagephobia.com/badge?p=ccusage)](https://packagephobia.com/result?p=ccusage)), you can run it directly without installation:
 
 ```bash
+# Using bunx (recommended for speed)
+bunx ccusage
+
+# Using npx
 npx ccusage@latest
+
+# Using deno (with security flags)
+deno run -E -R=$HOME/.claude/projects/ -S=homedir -N='raw.githubusercontent.com:443' npm:ccusage@latest
 ```
 
-### Local Installation
+> 💡 **Tip**: We recommend using `bunx` instead of `npx` for a massive speed improvement!
+
+### Local Installation (Optional)
+
+Since ccusage has such a small bundle size, installation is entirely optional:
 
 ```bash
 npm install -g ccusage
@@ -72,6 +83,7 @@ ccusage daily --breakdown  # Per-model cost breakdown
 - 🔄 **Cache Token Support**: Tracks and displays cache creation and cache read tokens separately
 - 🌐 **Offline Mode**: Use pre-cached pricing data without network connectivity with `--offline` (Claude models only)
 - 🔌 **MCP Integration**: Built-in Model Context Protocol server for integration with other tools
+- 🚀 **Ultra-Small Bundle**: Unlike other CLI tools, we pay extreme attention to bundle size - incredibly small even without minification!
 
 ## Documentation
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -41,6 +41,10 @@ graph LR
 
 ## Key Features
 
+### 🚀 Ultra-Small Bundle Size
+
+Unlike other CLI tools, we pay extreme attention to bundle size. ccusage achieves an incredibly small footprint even without minification, which means you can run it directly without installation using `bunx ccusage` for instant access.
+
 ### 📊 Multiple Report Types
 
 - **Daily Reports** - Usage aggregated by calendar date

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -2,18 +2,27 @@
 
 ccusage can be installed and used in several ways depending on your preferences and use case.
 
+## Why No Installation Needed?
+
+Thanks to ccusage's incredibly small bundle size, you don't need to install it globally. Unlike other CLI tools, we pay extreme attention to bundle size optimization, achieving an impressively small footprint even without minification. This means:
+
+- ✅ Near-instant startup times
+- ✅ Minimal download overhead
+- ✅ Always use the latest version
+- ✅ No global pollution of your system
+
 ## Quick Start (Recommended)
 
-The fastest way to try ccusage is to run it directly without installation:
+The fastest way to use ccusage is to run it directly:
 
 ::: code-group
 
-```bash [npx]
-npx ccusage@latest
+```bash [bunx (Recommended)]
+bunx ccusage
 ```
 
-```bash [bunx]
-bunx ccusage
+```bash [npx]
+npx ccusage@latest
 ```
 
 ```bash [pnpm]
@@ -26,16 +35,28 @@ deno run -E -R=$HOME/.claude/projects/ -S=homedir -N='raw.githubusercontent.com:
 
 :::
 
-This approach:
+::: tip Speed Recommendation
+We strongly recommend using `bunx` instead of `npx` due to the massive speed difference. Bunx caches packages more efficiently, resulting in near-instant startup times after the first run.
+:::
 
-- ✅ Always uses the latest version
-- ✅ No global installation required
-- ✅ Works across different systems
-- ✅ Perfect for occasional use
+::: info Deno Security
+Consider using `deno run` if you want additional security controls. Deno allows you to specify exact permissions, making it safer to run tools you haven't audited.
+:::
 
-## Global Installation
+### Performance Comparison
 
-If you use ccusage frequently, install it globally:
+Here's why runtime choice matters:
+
+| Runtime | First Run | Subsequent Runs | Notes |
+|---------|-----------|-----------------|-------|
+| bunx | Fast | **Instant** | Best overall choice |
+| npx | Slow | Moderate | Widely available |
+| pnpm dlx | Fast | Fast | Good alternative |
+| deno | Moderate | Fast | Best for security |
+
+## Global Installation (Optional)
+
+While not necessary due to our small bundle size, you can still install ccusage globally if you prefer:
 
 ::: code-group
 


### PR DESCRIPTION
## Summary

- Update installation documentation to emphasize using bunx over npx for speed
- Highlight that installation is optional due to incredibly small bundle size
- Add bundle size as a key differentiating feature

## Changes

### README.md
- Reorder installation methods to put bunx first as recommended option
- Add inline bundle size badge to emphasize small size
- Add tip about bunx speed advantage
- Mark local installation as optional
- Add feature bullet about ultra-small bundle size

### Documentation Site
- Add section explaining why no installation is needed
- Include performance comparison table for different runtimes
- Highlight bundle size optimization as first key feature
- Add tips and info boxes for better user guidance

## Context

Based on the creator's tweets about ccusage:
- Bundle size is quite small, so installation is not necessary
- bunx is recommended over npx for massive speed difference
- Deno is also an option for security-conscious users

This PR makes these advantages more visible to users discovering ccusage.