### PR TITLE
feat(mcp): add runtime detection for Bun and Deno HTTP servers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@praha/byethrow-mcp": "^0.0.10",
         "@ryoppippi/eslint-config": "^0.3.7",
         "@types/bun": "^1.2.17",
+        "@types/deno": "^2.3.0",
         "@typescript/native-preview": "^7.0.0-dev.20250702.1",
         "ansi-escapes": "^7.0.0",
         "bumpp": "^10.2.0",
@@ -479,6 +480,8 @@
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/deno": ["@types/deno@2.3.0", "", {}, "sha512-/4SyefQpKjwNKGkq9qG3Ln7MazfbWKvydyVFBnXzP5OQA4u1paoFtaOe1iHKycIWHHkhYag0lPxyheThV1ijzw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"@praha/byethrow-mcp": "^0.0.10",
 		"@ryoppippi/eslint-config": "^0.3.7",
 		"@types/bun": "^1.2.17",
+		"@types/deno": "^2.3.0",
 		"@typescript/native-preview": "^7.0.0-dev.20250702.1",
 		"ansi-escapes": "^7.0.0",
 		"bumpp": "^10.2.0",

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -53,26 +53,31 @@ export const mcpCommand = define({
 		else {
 			const app = createMcpHttpApp(options);
 			// Use the Hono app to handle requests
-			if (globalThis.Bun != null) {
-				logger.info('Detected Bun environment, starting Bun server');
-				Bun.serve({
-					fetch: app.fetch,
-					port,
-				});
-			}
-			else if (globalThis.Deno != null) {
-				logger.info('Detected Deno environment, starting Deno server');
-				Deno.serve(
-					{ port },
-					app.fetch,
-				);
-			}
-			else {
-				logger.warn('No Bun or Deno detected, falling back to Node.js server');
-				serve({
-					fetch: app.fetch,
-					port,
-				});
+			// eslint-disable-next-line ts/switch-exhaustiveness-check
+			switch (true) {
+				case globalThis.Bun != null: {
+					logger.info('Detected Bun environment, starting Bun server');
+					Bun.serve({
+						fetch: app.fetch,
+						port,
+					});
+					break;
+				}
+				case globalThis.Deno != null: {
+					logger.info('Detected Deno environment, starting Deno server');
+					Deno.serve(
+						{ port },
+						app.fetch,
+					);
+					break;
+				}
+				default: {
+					logger.warn('No Bun or Deno detected, falling back to Node.js server');
+					serve({
+						fetch: app.fetch,
+						port,
+					});
+				}
 			}
 			logger.info(`MCP server is running on http://localhost:${port}`);
 		}

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -53,10 +53,27 @@ export const mcpCommand = define({
 		else {
 			const app = createMcpHttpApp(options);
 			// Use the Hono app to handle requests
-			serve({
-				fetch: app.fetch,
-				port,
-			});
+			if (globalThis.Bun != null) {
+				logger.info('Detected Bun environment, starting Bun server');
+				Bun.serve({
+					fetch: app.fetch,
+					port,
+				});
+			}
+			else if (globalThis.Deno != null) {
+				logger.info('Detected Deno environment, starting Deno server');
+				Deno.serve(
+					{ port },
+					app.fetch,
+				);
+			}
+			else {
+				logger.warn('No Bun or Deno detected, falling back to Node.js server');
+				serve({
+					fetch: app.fetch,
+					port,
+				});
+			}
 			logger.info(`MCP server is running on http://localhost:${port}`);
 		}
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
 		"resolveJsonModule": true,
 		"types": [
 			"vitest/globals",
-			"vitest/importMeta"
+			"vitest/importMeta",
+			"@types/deno",
+			"@types/bun"
 		],
 		"allowImportingTsExtensions": true,
 		"allowJs": true,


### PR DESCRIPTION
## Summary\n- Added runtime detection to automatically use native server implementations\n- Uses Bun.serve() when running in Bun environment for better performance  \n- Uses Deno.serve() when running in Deno environment\n- Falls back to Node.js serve() for other environments\n\n## Changes\n- Added runtime detection logic in MCP HTTP server initialization using switch statement\n- Added @types/deno to devDependencies for proper type support\n- Maintains backward compatibility with existing Node.js deployments\n\n## Test plan\n- [ ] Test MCP server runs correctly in Bun environment\n- [ ] Test MCP server runs correctly in Deno environment  \n- [ ] Test MCP server falls back correctly in Node.js environment\n- [ ] Verify all existing functionality works as expected