### PR TITLE
fix(live-monitor): exclude cache tokens from burn rate indicators

### DIFF
--- a/src/_consts.ts
+++ b/src/_consts.ts
@@ -108,3 +108,11 @@ export const MAX_REFRESH_INTERVAL_SECONDS = 60;
  * Prevents terminal flickering and excessive CPU usage during rapid updates
  */
 export const MIN_RENDER_INTERVAL_MS = 16;
+
+/**
+ * Burn rate thresholds for indicator display (tokens per minute)
+ */
+export const BURN_RATE_THRESHOLDS = {
+	HIGH: 1000,
+	MODERATE: 500,
+} as const;

--- a/src/_live-rendering.ts
+++ b/src/_live-rendering.ts
@@ -14,9 +14,29 @@ import * as ansiEscapes from 'ansi-escapes';
 import pc from 'picocolors';
 import prettyMs from 'pretty-ms';
 import stringWidth from 'string-width';
+import { BURN_RATE_THRESHOLDS } from './_consts.ts';
 import { calculateBurnRate, projectBlockUsage } from './_session-blocks.ts';
 import { centerText, createProgressBar } from './_terminal-utils.ts';
 import { formatCurrency, formatModelsDisplay, formatNumber } from './_utils.ts';
+
+/**
+ * Get rate indicator (HIGH/MODERATE/NORMAL) based on burn rate
+ */
+function getRateIndicator(burnRate: ReturnType<typeof calculateBurnRate>): string {
+	if (burnRate == null) {
+		return '';
+	}
+
+	// eslint-disable-next-line ts/switch-exhaustiveness-check
+	switch (true) {
+		case burnRate.tokensPerMinuteForIndicator > BURN_RATE_THRESHOLDS.HIGH:
+			return pc.red('⚡ HIGH');
+		case burnRate.tokensPerMinuteForIndicator > BURN_RATE_THRESHOLDS.MODERATE:
+			return pc.yellow('⚡ MODERATE');
+		default:
+			return pc.green('✓ NORMAL');
+	}
+}
 
 /**
  * Live monitoring configuration
@@ -206,9 +226,7 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 
 	// Burn rate with better formatting
 	const burnRate = calculateBurnRate(block);
-	const rateIndicator = burnRate != null
-		? (burnRate.tokensPerMinute > 1000 ? pc.red('⚡ HIGH') : burnRate.tokensPerMinute > 500 ? pc.yellow('⚡ MODERATE') : pc.green('✓ NORMAL'))
-		: '';
+	const rateIndicator = getRateIndicator(burnRate);
 	const rateDisplay = burnRate != null
 		? `${pc.bold('Burn Rate:')} ${Math.round(burnRate.tokensPerMinute)} token/min ${rateIndicator}`
 		: `${pc.bold('Burn Rate:')} N/A`;
@@ -408,6 +426,93 @@ if (import.meta.vitest != null) {
 			expect(formatTokensShort(1000)).toBe('1.0k');
 			expect(formatTokensShort(1234)).toBe('1.2k');
 			expect(formatTokensShort(15678)).toBe('15.7k');
+		});
+	});
+
+	describe('getRateIndicator', () => {
+		it('returns empty string for null burn rate', () => {
+			const result = getRateIndicator(null);
+			expect(result).toBe('');
+		});
+
+		it('returns HIGH for rates above 1000', () => {
+			const burnRate = {
+				tokensPerMinute: 2000,
+				tokensPerMinuteForIndicator: 1500,
+				costPerHour: 10,
+			};
+			const result = getRateIndicator(burnRate);
+			expect(result).toContain('HIGH');
+		});
+
+		it('returns MODERATE for rates between 500 and 1000', () => {
+			const burnRate = {
+				tokensPerMinute: 1000,
+				tokensPerMinuteForIndicator: 750,
+				costPerHour: 5,
+			};
+			const result = getRateIndicator(burnRate);
+			expect(result).toContain('MODERATE');
+		});
+
+		it('returns NORMAL for rates 500 and below', () => {
+			const burnRate = {
+				tokensPerMinute: 800,
+				tokensPerMinuteForIndicator: 400,
+				costPerHour: 2,
+			};
+			const result = getRateIndicator(burnRate);
+			expect(result).toContain('NORMAL');
+		});
+
+		it('returns NORMAL for exactly 500 tokens per minute', () => {
+			const burnRate = {
+				tokensPerMinute: 1000,
+				tokensPerMinuteForIndicator: 500,
+				costPerHour: 3,
+			};
+			const result = getRateIndicator(burnRate);
+			expect(result).toContain('NORMAL');
+		});
+
+		it('returns MODERATE for exactly 1000 tokens per minute (boundary)', () => {
+			const burnRate = {
+				tokensPerMinute: 2000,
+				tokensPerMinuteForIndicator: 1000,
+				costPerHour: 5,
+			};
+			const result = getRateIndicator(burnRate);
+			expect(result).toContain('MODERATE'); // 1000 is not greater than 1000, but is greater than 500
+		});
+
+		it('returns HIGH for just above 1000 tokens per minute', () => {
+			const burnRate = {
+				tokensPerMinute: 2000,
+				tokensPerMinuteForIndicator: 1001,
+				costPerHour: 5,
+			};
+			const result = getRateIndicator(burnRate);
+			expect(result).toContain('HIGH');
+		});
+
+		it('returns NORMAL for just below 500 tokens per minute', () => {
+			const burnRate = {
+				tokensPerMinute: 800,
+				tokensPerMinuteForIndicator: 499,
+				costPerHour: 2,
+			};
+			const result = getRateIndicator(burnRate);
+			expect(result).toContain('NORMAL');
+		});
+
+		it('returns MODERATE for just above 500 tokens per minute', () => {
+			const burnRate = {
+				tokensPerMinute: 1000,
+				tokensPerMinuteForIndicator: 501,
+				costPerHour: 3,
+			};
+			const result = getRateIndicator(burnRate);
+			expect(result).toContain('MODERATE');
 		});
 	});
 

--- a/src/_session-blocks.ts
+++ b/src/_session-blocks.ts
@@ -67,6 +67,7 @@ export type SessionBlock = {
  */
 type BurnRate = {
 	tokensPerMinute: number;
+	tokensPerMinuteForIndicator: number;
 	costPerHour: number;
 };
 
@@ -263,10 +264,17 @@ export function calculateBurnRate(block: SessionBlock): BurnRate | null {
 
 	const totalTokens = getTotalTokens(block.tokenCounts);
 	const tokensPerMinute = totalTokens / durationMinutes;
+
+	// For burn rate indicator (HIGH/MODERATE/NORMAL), use only input and output tokens
+	// to maintain consistent thresholds with pre-cache behavior
+	const nonCacheTokens = (block.tokenCounts.inputTokens ?? 0) + (block.tokenCounts.outputTokens ?? 0);
+	const tokensPerMinuteForIndicator = nonCacheTokens / durationMinutes;
+
 	const costPerHour = (block.costUSD / durationMinutes) * 60;
 
 	return {
 		tokensPerMinute,
+		tokensPerMinuteForIndicator,
 		costPerHour,
 	};
 }
@@ -575,7 +583,46 @@ if (import.meta.vitest != null) {
 
 			const result = calculateBurnRate(block);
 			expect(result).not.toBeNull();
-			expect(result?.tokensPerMinute).toBe(4500); // 4500 tokens / 1 minute
+			expect(result?.tokensPerMinute).toBe(4500); // 4500 tokens / 1 minute (includes all tokens)
+			expect(result?.tokensPerMinuteForIndicator).toBe(4500); // 4500 tokens / 1 minute (non-cache only)
+			expect(result?.costPerHour).toBeCloseTo(1.8, 2); // 0.03 / 1 minute * 60 minutes
+		});
+
+		it('correctly separates cache and non-cache tokens in burn rate calculation', () => {
+			const baseTime = new Date('2024-01-01T10:00:00Z');
+			const block: SessionBlock = {
+				id: baseTime.toISOString(),
+				startTime: baseTime,
+				endTime: new Date(baseTime.getTime() + SESSION_DURATION_MS),
+				isActive: true,
+				entries: [
+					{
+						timestamp: baseTime,
+						usage: { inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+						costUSD: 0.01,
+						model: 'claude-sonnet-4-20250514',
+					},
+					{
+						timestamp: new Date(baseTime.getTime() + 60 * 1000),
+						usage: { inputTokens: 500, outputTokens: 200, cacheCreationInputTokens: 2000, cacheReadInputTokens: 8000 },
+						costUSD: 0.02,
+						model: 'claude-sonnet-4-20250514',
+					},
+				],
+				tokenCounts: {
+					inputTokens: 1500,
+					outputTokens: 700,
+					cacheCreationInputTokens: 2000,
+					cacheReadInputTokens: 8000,
+				},
+				costUSD: 0.03,
+				models: ['claude-sonnet-4-20250514'],
+			};
+
+			const result = calculateBurnRate(block);
+			expect(result).not.toBeNull();
+			expect(result?.tokensPerMinute).toBe(12200); // 1500 + 700 + 2000 + 8000 = 12200 tokens / 1 minute
+			expect(result?.tokensPerMinuteForIndicator).toBe(2200); // 1500 + 700 = 2200 tokens / 1 minute (non-cache only)
 			expect(result?.costPerHour).toBeCloseTo(1.8, 2); // 0.03 / 1 minute * 60 minutes
 		});
 	});


### PR DESCRIPTION
## Summary

- Fixes burn rate indicator display issue introduced in PR #193
- Burn rate display shows total tokens (including cache), but HIGH/MODERATE/NORMAL indicators use only input+output tokens to maintain consistent thresholds
- Extracts rate indicator logic to testable function with comprehensive boundary value test coverage
- Moves burn rate thresholds to _consts.ts for centralized configuration

## Changes

- Add \`tokensPerMinuteForIndicator\` field to BurnRate type for separate threshold calculation
- Extract \`getRateIndicator()\` function with switch(true) pattern for better readability
- Add \`BURN_RATE_THRESHOLDS\` constants to _consts.ts
- Comprehensive test coverage including all boundary values (499, 500, 501, 1000, 1001)
- Update existing burn rate calculation test to verify cache token separation

## Test plan

- [x] All existing tests pass
- [x] New rate indicator function has 100% branch coverage
- [x] Burn rate calculation correctly separates cache and non-cache tokens
- [x] Live monitor displays consistent HIGH/MODERATE/NORMAL indicators

Fixes: https://github.com/ryoppippi/ccusage/issues/267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer burn rate indicators ("HIGH", "MODERATE", "NORMAL") based on predefined thresholds for tokens used per minute.
  * Burn rate calculation now distinguishes between total tokens and tokens used specifically for indicator purposes, improving indicator accuracy.

* **Tests**
  * Introduced comprehensive tests to ensure correct burn rate indicator behavior and calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->