### PR TITLE
feat(blocks): add cost-based and model based live monitoring support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,311 @@
+# Building and Installing ccusage Locally
+
+This guide explains how to build and install a custom version of ccusage for local development and testing.
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) runtime (latest version)
+- Node.js (for global installation via npm)
+- Git (for version control)
+
+## Quick Start
+
+```bash
+# 1. Clone and navigate to the project
+git clone <your-fork-url>
+cd ccusage
+
+# 2. Install dependencies
+bun install
+
+# 3. Build the project
+bun run build
+
+# 4. Install globally with custom name
+npm install -g .
+```
+
+## Building Options
+
+### Option 1: Development Link (Recommended for Active Development)
+
+Use this when actively developing and want changes to be immediately available:
+
+```bash
+# Link for development (changes reflect immediately)
+bun link
+
+# Use the original command name
+ccusage blocks --help
+
+# Unlink when done
+bun unlink
+```
+
+**Pros:**
+
+- ✅ No build step needed
+- ✅ Changes reflect immediately
+- ✅ Easy to remove
+
+**Cons:**
+
+- ❌ Uses development code (not production build)
+- ❌ Requires project directory to remain intact
+
+### Option 2: Custom Named Global Install (Recommended for Testing)
+
+Use this when you want a separate command alongside the official ccusage:
+
+```bash
+# 1. Modify package.json name field
+# Change "name": "ccusage" to "name": "your-custom-name"
+
+# 2. Build the project
+bun run build
+
+# 3. Install globally
+npm install -g .
+
+# 4. Use your custom command
+your-custom-name blocks --help
+```
+
+**Pros:**
+
+- ✅ Separate from official ccusage
+- ✅ Production build
+- ✅ Works from any directory
+
+**Cons:**
+
+- ❌ Requires rebuild for changes
+- ❌ Need to manage package name
+
+### Option 3: Shell Alias (Simplest)
+
+Use this for quick testing without global installation:
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+alias ccusage-local='bun --cwd /path/to/your/ccusage run start'
+
+# Reload shell
+source ~/.zshrc
+
+# Use the alias
+ccusage-local blocks --help
+```
+
+## Custom Package Name Setup
+
+### Step 1: Modify Package Name
+
+Edit `package.json`:
+
+```json
+{
+	"name": "your-custom-name",
+	"version": "15.2.0"
+	// ... rest of configuration
+}
+```
+
+Common naming patterns:
+
+- `ccusage-dev` - for development version
+- `ccusage-local` - for local testing
+- `hg-ccusage` - with your initials
+- `ccusage-fork` - for forked version
+
+### Step 2: Build and Install
+
+```bash
+# Clean any previous builds
+rm -rf dist/
+
+# Build the project
+bun run build
+
+# Install globally
+npm install -g .
+```
+
+### Step 3: Verify Installation
+
+```bash
+# Check version
+your-custom-name --version
+
+# Test functionality
+your-custom-name blocks --help
+
+# Test new cost limit feature
+your-custom-name blocks --live --cost-limit max
+```
+
+## Build Scripts
+
+The project includes these build-related scripts:
+
+```bash
+# Core build commands
+bun run build          # Build distribution files
+bun run typecheck       # Type check TypeScript
+bun run format          # Format and lint code
+bun run test            # Run test suite
+
+# Quality assurance
+bun run release         # Full release workflow (lint + typecheck + test + build)
+
+# Development
+bun run start           # Run from source
+```
+
+## Troubleshooting
+
+### Build Fails
+
+```bash
+# Clean and rebuild
+rm -rf dist/ node_modules/
+bun install
+bun run build
+```
+
+### Global Install Fails
+
+```bash
+# Try with npm instead of bun
+npm install -g .
+
+# Or try with sudo (macOS/Linux)
+sudo npm install -g .
+```
+
+### Command Not Found
+
+```bash
+# Check if it's in your PATH
+which your-custom-name
+
+# Check npm global packages
+npm list -g --depth=0
+
+# Verify npm global bin directory
+npm config get prefix
+```
+
+### Permission Issues
+
+```bash
+# Fix npm permissions (macOS/Linux)
+mkdir ~/.npm-global
+npm config set prefix '~/.npm-global'
+
+# Add to ~/.bashrc or ~/.zshrc
+export PATH=~/.npm-global/bin:$PATH
+```
+
+## Uninstalling
+
+### Remove Global Package
+
+```bash
+# Remove globally installed package
+npm uninstall -g your-custom-name
+
+# Or if using original name
+npm uninstall -g ccusage
+```
+
+### Remove Development Link
+
+```bash
+# In project directory
+bun unlink
+```
+
+### Remove Shell Alias
+
+```bash
+# Edit ~/.bashrc or ~/.zshrc and remove the alias line
+# Then reload shell
+source ~/.zshrc
+```
+
+## Development Workflow
+
+### For Active Development
+
+```bash
+# 1. Use development link
+bun link
+
+# 2. Make changes to source files
+# 3. Test immediately (no rebuild needed)
+ccusage blocks --live --cost-limit max
+
+# 4. When satisfied, create production build
+bun unlink
+bun run build
+npm install -g .
+```
+
+### For Testing Builds
+
+```bash
+# 1. Make changes
+# 2. Build and install
+bun run build && npm install -g .
+
+# 3. Test
+your-custom-name blocks --help
+
+# 4. Iterate
+```
+
+## New Features Added
+
+This build includes the new cost-based live monitoring feature:
+
+```bash
+# Cost limit with numeric value
+your-custom-name blocks --live --cost-limit 10.0
+
+# Cost limit with max from previous sessions
+your-custom-name blocks --live --cost-limit max
+
+# Mutual exclusivity validation (shows error)
+your-custom-name blocks --live --token-limit 1000 --cost-limit 5.0
+```
+
+## Contributing Back
+
+When ready to contribute your changes:
+
+```bash
+# 1. Ensure tests pass
+bun run test
+
+# 2. Format code
+bun run format
+
+# 3. Type check
+bun typecheck
+
+# 4. Create commit
+git add .
+git commit -m "feat: add cost-based live monitoring"
+
+# 5. Push and create PR
+git push origin your-branch-name
+```
+
+## Notes
+
+- Always test both development and production builds
+- Keep the original ccusage functionality intact
+- Document any breaking changes
+- Consider backwards compatibility
+- Test on different terminal sizes for live monitoring

--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,10 @@
   "workspaces": {
     "": {
       "name": "ccusage",
+      "dependencies": {
+        "hg-ccusage": ".",
+        "g": "^2.0.1",
+      },
       "devDependencies": {
         "@antfu/utils": "^9.2.0",
         "@core/errorutil": "npm:@jsr/core__errorutil",
@@ -1071,6 +1075,8 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "g": ["g@2.0.1", "", {}, "sha512-Fi6Ng5fZ/ANLQ15H11hCe+09sgUoNvDEBevVgx3KoYOhsH5iLNPn54hx0jPZ+3oSWr+xajnp2Qau9VmPsc7hTA=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.3.0", "", {}, "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ=="],
@@ -1116,6 +1122,8 @@
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hg-ccusage": ["hg-ccusage@file:", { "devDependencies": { "@antfu/utils": "^9.2.0", "@core/errorutil": "npm:@jsr/core__errorutil", "@hono/mcp": "^0.1.0", "@hono/node-server": "^1.14.4", "@jsr/std__async": "1", "@modelcontextprotocol/sdk": "^1.13.0", "@oxc-project/runtime": "^0.73.2", "@ryoppippi/eslint-config": "^0.3.7", "@types/bun": "^1.2.16", "@typescript/native-preview": "^7.0.0-dev.20250619.1", "ansi-escapes": "^7.0.0", "bumpp": "^10.2.0", "clean-pkg-json": "^1.3.0", "cli-table3": "^0.6.5", "consola": "^3.4.2", "es-toolkit": "^1.39.3", "eslint": "^9.29.0", "eslint-plugin-format": "^1.0.1", "fast-sort": "^3.4.1", "fs-fixture": "^2.8.1", "gunshi": "^0.26.3", "hono": "^4.8.0", "lint-staged": "^16.1.2", "path-type": "^6.0.0", "picocolors": "^1.1.1", "pretty-ms": "^9.2.0", "publint": "^0.3.12", "rollup-plugin-node-externals": "^8.0.1", "simple-git-hooks": "^2.13.0", "sort-package-json": "^3.2.1", "string-width": "^7.2.0", "tinyglobby": "^0.2.14", "tsdown": "^0.12.8", "type-fest": "^4.41.0", "unplugin-macros": "^0.17.0", "unplugin-unused": "^0.5.1", "vitest": "^3.2.4", "xdg-basedir": "^5.1.0", "zod": "^3.25.67" }, "bin": "./dist/index.js" }],
 
     "hono": ["hono@4.8.2", "", {}, "sha512-hM+1RIn9PK1I6SiTNS6/y7O1mvg88awYLFEuEtoiMtRyT3SD2iu9pSFgbBXT3b1Ua4IwzvSTLvwO0SEhDxCi4w=="],
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ccusage",
+	"name": "hg-ccusage",
 	"type": "module",
 	"version": "15.2.0",
 	"description": "Usage analysis tool for Claude Code",

--- a/src/_live-monitor.ts
+++ b/src/_live-monitor.ts
@@ -32,6 +32,7 @@ export type LiveMonitorConfig = {
 	sessionDurationHours: number;
 	mode: CostMode;
 	order: SortOrder;
+	models?: string[];
 };
 
 /**
@@ -145,9 +146,22 @@ export class LiveMonitor implements Disposable {
 			}
 		}
 
+		// Filter by models if specified
+		const filteredEntries = this.config.models != null && this.config.models.length > 0
+			? this.allEntries.filter((entry) => {
+					// Check if the entry's model matches any of the specified models
+					// Support partial matching (e.g., "sonnet" matches "claude-sonnet-4-20250514")
+					const entryModel = entry.model.toLowerCase();
+					return this.config.models!.some((filterModel) => {
+						const lowerFilterModel = filterModel.toLowerCase();
+						return entryModel.includes(lowerFilterModel) || lowerFilterModel.includes(entryModel);
+					});
+				})
+			: this.allEntries;
+
 		// Generate blocks and find active one
 		const blocks = identifySessionBlocks(
-			this.allEntries,
+			filteredEntries,
 			this.config.sessionDurationHours,
 		);
 

--- a/src/_live-rendering.ts
+++ b/src/_live-rendering.ts
@@ -498,12 +498,12 @@ if (import.meta.vitest != null) {
 		it('should display cost limit when provided', () => {
 			// Mock terminal with buffer to capture output
 			const buffer: string[] = [];
-			const mockTerminal: TerminalManager = {
+			const mockTerminal = {
 				width: 50,
 				height: 20,
 				write: (str: string) => buffer.push(str),
 				startBuffering: () => {},
-				flushBuffer: () => {},
+				flush: () => {},
 			};
 
 			const mockBlock: SessionBlock = {
@@ -511,7 +511,7 @@ if (import.meta.vitest != null) {
 				startTime: new Date(),
 				endTime: new Date(),
 				costUSD: 2.5,
-				tokenCounts: { inputTokens: 5000, outputTokens: 3000, cacheCreationTokens: 0, cacheReadTokens: 0 },
+				tokenCounts: { inputTokens: 5000, outputTokens: 3000, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
 				entries: [], // Required by calculateBurnRate
 				isActive: false,
 				models: [],
@@ -527,7 +527,8 @@ if (import.meta.vitest != null) {
 				order: 'desc',
 			};
 
-			renderCompactLiveDisplay(mockTerminal, mockBlock, config, 8000, 120, 60);
+			// eslint-disable-next-line ts/no-unsafe-argument
+			renderCompactLiveDisplay(mockTerminal as any, mockBlock, config, 8000, 120, 60);
 
 			const output = buffer.join('');
 			expect(output).toContain('Cost: $2.50/$5.00');
@@ -537,12 +538,12 @@ if (import.meta.vitest != null) {
 
 		it('should display token limit when provided', () => {
 			const buffer: string[] = [];
-			const mockTerminal: TerminalManager = {
+			const mockTerminal = {
 				width: 50,
 				height: 20,
 				write: (str: string) => buffer.push(str),
 				startBuffering: () => {},
-				flushBuffer: () => {},
+				flush: () => {},
 			};
 
 			const mockBlock: SessionBlock = {
@@ -550,7 +551,7 @@ if (import.meta.vitest != null) {
 				startTime: new Date(),
 				endTime: new Date(),
 				costUSD: 2.5,
-				tokenCounts: { inputTokens: 5000, outputTokens: 3500, cacheCreationTokens: 0, cacheReadTokens: 0 },
+				tokenCounts: { inputTokens: 5000, outputTokens: 3500, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
 				entries: [], // Required by calculateBurnRate
 				isActive: false,
 				models: [],
@@ -566,7 +567,8 @@ if (import.meta.vitest != null) {
 				order: 'desc',
 			};
 
-			renderCompactLiveDisplay(mockTerminal, mockBlock, config, 8500, 120, 60);
+			// eslint-disable-next-line ts/no-unsafe-argument
+			renderCompactLiveDisplay(mockTerminal as any, mockBlock, config, 8500, 120, 60);
 
 			const output = buffer.join('');
 			expect(output).toContain('Tokens: 8,500/10,000');
@@ -576,12 +578,12 @@ if (import.meta.vitest != null) {
 
 		it('should prefer cost limit over token limit when both provided', () => {
 			const buffer: string[] = [];
-			const mockTerminal: TerminalManager = {
+			const mockTerminal = {
 				width: 50,
 				height: 20,
 				write: (str: string) => buffer.push(str),
 				startBuffering: () => {},
-				flushBuffer: () => {},
+				flush: () => {},
 			};
 
 			const mockBlock: SessionBlock = {
@@ -589,7 +591,7 @@ if (import.meta.vitest != null) {
 				startTime: new Date(),
 				endTime: new Date(),
 				costUSD: 4.5,
-				tokenCounts: { inputTokens: 5000, outputTokens: 3000, cacheCreationTokens: 0, cacheReadTokens: 0 },
+				tokenCounts: { inputTokens: 5000, outputTokens: 3000, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
 				entries: [], // Required by calculateBurnRate
 				isActive: false,
 				models: [],
@@ -605,7 +607,8 @@ if (import.meta.vitest != null) {
 				order: 'desc',
 			};
 
-			renderCompactLiveDisplay(mockTerminal, mockBlock, config, 8000, 120, 60);
+			// eslint-disable-next-line ts/no-unsafe-argument
+			renderCompactLiveDisplay(mockTerminal as any, mockBlock, config, 8000, 120, 60);
 
 			const output = buffer.join('');
 			expect(output).toContain('Cost: $4.50/$5.00');

--- a/src/_live-rendering.ts
+++ b/src/_live-rendering.ts
@@ -29,6 +29,7 @@ export type LiveMonitoringConfig = {
 	sessionDurationHours: number;
 	mode: CostMode;
 	order: SortOrder;
+	models?: string[];
 };
 
 /**

--- a/src/commands/_blocks.live.ts
+++ b/src/commands/_blocks.live.ts
@@ -50,6 +50,7 @@ export async function startLiveMonitoring(config: LiveMonitoringConfig): Promise
 		sessionDurationHours: config.sessionDurationHours,
 		mode: config.mode,
 		order: config.order,
+		models: config.models,
 	});
 
 	try {

--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -124,6 +124,20 @@ function parseCostLimit(value: string | undefined, maxFromAll: number): number |
 	return Number.isNaN(limit) ? undefined : limit;
 }
 
+/**
+ * Parses model filter argument
+ * @param value - Model filter string value (comma-separated or single model)
+ * @returns Array of model names or undefined if not specified
+ */
+function parseModelFilter(value: string | undefined): string[] | undefined {
+	if (value == null || value === '') {
+		return undefined;
+	}
+
+	// Split by comma and trim whitespace
+	return value.split(',').map(model => model.trim()).filter(model => model !== '');
+}
+
 export const blocksCommand = define({
 	name: 'blocks',
 	description: 'Show usage report grouped by session billing blocks',
@@ -167,6 +181,11 @@ export const blocksCommand = define({
 			description: `Refresh interval in seconds for live mode (default: ${DEFAULT_REFRESH_INTERVAL_SECONDS})`,
 			default: DEFAULT_REFRESH_INTERVAL_SECONDS,
 		},
+		model: {
+			type: 'string',
+			short: 'm',
+			description: 'Filter by specific model(s) - comma-separated or single model name',
+		},
 	},
 	toKebab: true,
 	async run(ctx) {
@@ -187,6 +206,7 @@ export const blocksCommand = define({
 			order: ctx.values.order,
 			offline: ctx.values.offline,
 			sessionDurationHours: ctx.values.sessionLength,
+			models: parseModelFilter(ctx.values.model),
 		});
 
 		if (blocks.length === 0) {
@@ -304,6 +324,7 @@ export const blocksCommand = define({
 				sessionDurationHours: ctx.values.sessionLength,
 				mode: ctx.values.mode,
 				order: ctx.values.order,
+				models: parseModelFilter(ctx.values.model),
 			});
 			return; // Exit early, don't show table
 		}

--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -105,6 +105,25 @@ function parseTokenLimit(value: string | undefined, maxFromAll: number): number 
 	return Number.isNaN(limit) ? undefined : limit;
 }
 
+/**
+ * Parses cost limit argument, supporting 'max' keyword
+ * @param value - Cost limit string value
+ * @param maxFromAll - Maximum cost found in all blocks
+ * @returns Parsed cost limit or undefined if invalid
+ */
+function parseCostLimit(value: string | undefined, maxFromAll: number): number | undefined {
+	if (value == null || value === '') {
+		return undefined;
+	}
+
+	if (value === 'max') {
+		return maxFromAll > 0 ? maxFromAll : undefined;
+	}
+
+	const limit = Number.parseFloat(value);
+	return Number.isNaN(limit) ? undefined : limit;
+}
+
 export const blocksCommand = define({
 	name: 'blocks',
 	description: 'Show usage report grouped by session billing blocks',
@@ -126,6 +145,11 @@ export const blocksCommand = define({
 			type: 'string',
 			short: 't',
 			description: 'Token limit for quota warnings (e.g., 500000 or "max")',
+		},
+		costLimit: {
+			type: 'string',
+			short: 'c',
+			description: 'Cost limit for quota warnings (e.g., 5.50 or "max")',
 		},
 		sessionLength: {
 			type: 'number',
@@ -191,6 +215,21 @@ export const blocksCommand = define({
 			}
 		}
 
+		// Calculate max cost from ALL blocks before applying filters
+		let maxCostFromAll = 0;
+		if (ctx.values.costLimit === 'max') {
+			for (const block of blocks) {
+				if (!(block.isGap ?? false) && !block.isActive) {
+					if (block.costUSD > maxCostFromAll) {
+						maxCostFromAll = block.costUSD;
+					}
+				}
+			}
+			if (!ctx.values.json && maxCostFromAll > 0) {
+				logger.info(`Using max cost from previous sessions: $${maxCostFromAll.toFixed(2)}`);
+			}
+		}
+
 		// Apply filters
 		if (ctx.values.recent) {
 			blocks = filterRecentBlocks(blocks, DEFAULT_RECENT_DAYS);
@@ -216,12 +255,31 @@ export const blocksCommand = define({
 				logger.info('Live mode automatically shows only active blocks.');
 			}
 
+			// Validate mutual exclusivity of token and cost limits
+			if (ctx.values.tokenLimit != null && ctx.values.costLimit != null) {
+				logger.error('Cannot specify both --token-limit and --cost-limit at the same time');
+				process.exit(1);
+			}
+
 			// Default to 'max' if no token limit specified in live mode
 			let tokenLimitValue = ctx.values.tokenLimit;
-			if (tokenLimitValue == null || tokenLimitValue === '') {
+			const costLimitValue = ctx.values.costLimit;
+
+			if (tokenLimitValue == null && costLimitValue == null) {
 				tokenLimitValue = 'max';
 				if (maxTokensFromAll > 0) {
-					logger.info(`No token limit specified, using max from previous sessions: ${formatNumber(maxTokensFromAll)}`);
+					logger.info(`No limit specified, using token limit max from previous sessions: ${formatNumber(maxTokensFromAll)}`);
+				}
+			}
+			else if (tokenLimitValue == null || tokenLimitValue === '') {
+				if (costLimitValue != null) {
+					// Cost limit is specified, don't default token limit
+				}
+				else {
+					tokenLimitValue = 'max';
+					if (maxTokensFromAll > 0) {
+						logger.info(`No token limit specified, using max from previous sessions: ${formatNumber(maxTokensFromAll)}`);
+					}
 				}
 			}
 
@@ -241,6 +299,7 @@ export const blocksCommand = define({
 			await startLiveMonitoring({
 				claudePath: paths[0]!,
 				tokenLimit: parseTokenLimit(tokenLimitValue, maxTokensFromAll),
+				costLimit: parseCostLimit(costLimitValue, maxCostFromAll),
 				refreshInterval: refreshInterval * 1000, // Convert to milliseconds
 				sessionDurationHours: ctx.values.sessionLength,
 				mode: ctx.values.mode,

--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -610,6 +610,7 @@ export type LoadOptions = {
 	order?: SortOrder; // Sort order for dates
 	offline?: boolean; // Use offline mode for pricing
 	sessionDurationHours?: number; // Session block duration in hours
+	models?: string[]; // Filter by specific models
 } & DateFilter;
 
 /**
@@ -1088,8 +1089,21 @@ export async function loadSessionBlockData(
 		}
 	}
 
+	// Filter by models if specified
+	const filteredEntries = options?.models != null && options.models.length > 0
+		? allEntries.filter((entry) => {
+				// Check if the entry's model matches any of the specified models
+				// Support partial matching (e.g., "sonnet" matches "claude-sonnet-4-20250514")
+				const entryModel = entry.model.toLowerCase();
+				return options.models!.some((filterModel) => {
+					const lowerFilterModel = filterModel.toLowerCase();
+					return entryModel.includes(lowerFilterModel) || lowerFilterModel.includes(entryModel);
+				});
+			})
+		: allEntries;
+
 	// Identify session blocks
-	const blocks = identifySessionBlocks(allEntries, options?.sessionDurationHours);
+	const blocks = identifySessionBlocks(filteredEntries, options?.sessionDurationHours);
 
 	// Filter by date range if specified
 	const filtered = (options?.since != null && options.since !== '') || (options?.until != null && options.until !== '')


### PR DESCRIPTION
### feat(blocks): add cost-based live monitoring with -c/--cost-limit option
Add new cost limit functionality for live monitoring mode:
- Add -c/--cost-limit argument supporting numeric values and "max" keyword
- Implement cost-based progress bars and projections in live display
- Add mutual exclusivity validation between token and cost limits
- Support cost burn rate display ($X.XX/hour) instead of tokens/min
- Add maxCostFromAll calculation to find highest cost from previous sessions
- Update live rendering to show cost-focused displays when cost limit is active
- Maintain backward compatibility with existing token-based monitoring

Technical changes:
- Add parseCostLimit() function mirroring parseTokenLimit() logic
- Extend LiveMonitoringConfig type with costLimit field
- Update compact display mode to support cost limits
- Add comprehensive test coverage for cost limit scenarios
- Create BUILD.md with local installation and development instructions

Breaking changes: None - fully backward compatible

### feat(blocks): add model filtering support with -m/--model option

Add CLI support for filtering usage data by specific Claude models in blocks command.
Supports both static and live monitoring modes with partial model name matching.

Changes:
- Add -m/--model CLI argument accepting comma-separated model names
- Update LoadOptions interface to include models filter
- Implement model filtering in loadSessionBlockData with partial matching
- Add model filtering to LiveMonitor for live mode support
- Update LiveMonitoringConfig interface to pass model filter
- Support partial matching (e.g., "sonnet" matches "claude-sonnet-4-20250514")

Usage examples:
- ccusage blocks --model sonnet
- ccusage blocks --model sonnet,opus
- ccusage blocks --live --model sonnet
