### PR TITLE
fix(live-monitor): Fix live token count and align default token limit behaviour with docs

### DIFF
--- a/src/_live-rendering.ts
+++ b/src/_live-rendering.ts
@@ -17,6 +17,7 @@ import stringWidth from 'string-width';
 import { BURN_RATE_THRESHOLDS } from './_consts.ts';
 import { calculateBurnRate, projectBlockUsage } from './_session-blocks.ts';
 import { centerText, createProgressBar } from './_terminal-utils.ts';
+import { getTotalTokens } from './_token-utils.ts';
 import { formatCurrency, formatModelsDisplay, formatNumber } from './_utils.ts';
 
 /**
@@ -113,7 +114,7 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 	const now = new Date();
 
 	// Calculate key metrics
-	const totalTokens = block.tokenCounts.inputTokens + block.tokenCounts.outputTokens;
+	const totalTokens = getTotalTokens(block.tokenCounts);
 	const elapsed = (now.getTime() - block.startTime.getTime()) / (1000 * 60);
 	const remaining = (block.endTime.getTime() - now.getTime()) / (1000 * 60);
 

--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -94,11 +94,7 @@ function formatModels(models: string[]): string {
  * @returns Parsed token limit or undefined if invalid
  */
 function parseTokenLimit(value: string | undefined, maxFromAll: number): number | undefined {
-	if (value == null || value === '') {
-		return undefined;
-	}
-
-	if (value === 'max') {
+	if (value == null || value === '' || value === 'max') {
 		return maxFromAll > 0 ? maxFromAll : undefined;
 	}
 
@@ -178,7 +174,7 @@ export const blocksCommand = define({
 
 		// Calculate max tokens from ALL blocks before applying filters
 		let maxTokensFromAll = 0;
-		if (ctx.values.tokenLimit === 'max') {
+		if (ctx.values.tokenLimit === 'max' || ctx.values.tokenLimit == null || ctx.values.tokenLimit === '') {
 			for (const block of blocks) {
 				if (!(block.isGap ?? false) && !block.isActive) {
 					const blockTokens = getTotalTokens(block.tokenCounts);


### PR DESCRIPTION
Fixes #288 and #298.

For #288, the issue was simply that the `getTotalTokens` function was not being used in the live monitor; so the incorrect number was being displayed.

For #298, the issue was that the default behaviour specified in the docs is that the live monitor uses the `max` token limit from previous blocks. However, the _actual_ default behaviour was to specify no limit at all, and therefore fall back to just showing a 10% progress bar (L226, _live-rendering.ts) for usage and 15% progress bar (L303, _live-rendering.ts).

Before fix:
<img width="969" height="374" alt="image" src="https://github.com/user-attachments/assets/ff66bbbb-92df-4b8d-a2dd-c9c61e0b5657" />

After fix:
<img width="970" height="370" alt="image" src="https://github.com/user-attachments/assets/99e7ed42-5246-4f7c-9d2f-a43296ebd0bd" />

There are some alignment issues in the rendering around the progress bars. However, I do not feel that fixing that issue is necessary for this fix, as it is simply a result of the current formatting choices. 

The code for this PR was hand-written, not AI-generated. :-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in handling token limit inputs, so missing or empty values are now treated the same as specifying 'max'.
  * Enhanced reliability of token count calculations by using a centralized method for determining total tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->