### PR TITLE
fix(blocks-json): Fix total token count calculation to include cache

### DIFF
--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -266,9 +266,7 @@ export const blocksCommand = define({
 						isGap: block.isGap ?? false,
 						entries: block.entries.length,
 						tokenCounts: block.tokenCounts,
-						totalTokens:
-							block.tokenCounts.inputTokens
-							+ block.tokenCounts.outputTokens,
+						totalTokens: getTotalTokens(block.tokenCounts),
 						costUSD: block.costUSD,
 						models: block.models,
 						burnRate,


### PR DESCRIPTION
Fixes #274 

Total token count was being calculated incorrectly, and has now been updated to use the correct function.