### PR TITLE
fix: correct session id identification from path

### DIFF
--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -917,10 +917,12 @@ export async function loadSessionData(
 		const relativePath = path.relative(baseDir, file);
 		const parts = relativePath.split(path.sep);
 
-		// Session ID is the directory name containing the JSONL file
-		const sessionId = parts[parts.length - 2] ?? 'unknown';
-		// Project path is everything before the session ID
-		const joinedPath = parts.slice(0, -2).join(path.sep);
+		// Session ID is the name of the jsonl file name containing the JSONL file
+		const sessionId = parts[parts.length - 1].replace(/.jsonl/g, '') ?? 'unknown';
+		// Project path is everything before the session ID. Since it is relative to the
+		// projects folder (.../dashed-path-project-name/uuid-for-session.jsonl)
+		// so 0,-2 would be empty since there's only 2 elements.
+		const joinedPath = parts.slice(0, -1).join(path.sep);
 		const projectPath = joinedPath.length > 0 ? joinedPath : 'Unknown Project';
 
 		const content = await readFile(file, 'utf-8');


### PR DESCRIPTION
The code claude implemented for fetching the session ID is incorrect.

Previously it looked in `~/.claude/projects/project-name/session-id/xxx.jsonl`, however the actual storage location is `~/.claude/projects/project-name/session-id.jsonl`

This change updates the path logic to identify the session by the UUID and properly detect the project name. Worth noting that the paths from the projects folder to the jsonl are relative, so the `projectPath` is really just the name of the folder, not the full absolute path. Since this isn't displayed at the moment, I figured that was fine.

This was done directly in github web editing, I expect there to be a CI failure or two. Right now this is untested, but I plan on using this in the `anthropics/claude-code-action` workflow to print out the costs at the end of the workflow.