### PR TITLE
docs: added homepage links to specific guide sections

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,15 +24,19 @@ features:
   - icon: 📅
     title: Monthly Reports
     details: Analyze usage patterns over monthly periods with cost tracking
+    link: /guide/monthly-reports
   - icon: 💬
     title: Session Reports
     details: Group usage by conversation sessions for detailed analysis
+    link: /guide/session-reports
   - icon: ⏰
     title: 5-Hour Blocks
     details: Track usage within Claude's billing windows with active monitoring
+    link: /guide/blocks-reports
   - icon: 📈
     title: Live Monitoring
     details: Real-time dashboard with progress bars and cost projections
+    link: /guide/live-monitoring
   - icon: 🤖
     title: Model Tracking
     details: See which Claude models you're using (Opus, Sonnet, etc.)
@@ -42,6 +46,7 @@ features:
   - icon: 📄
     title: JSON Output
     details: Export data in structured JSON format for programmatic use
+    link: /guide/json-output
   - icon: 💰
     title: Cost Analysis
     details: Shows estimated costs in USD for each day/month/session
@@ -54,6 +59,7 @@ features:
   - icon: 🔌
     title: MCP Integration
     details: Built-in Model Context Protocol server for tool integration
+    link: /guide/mcp-server
 ---
 
 <div style="text-align: center; margin: 2rem 0;">


### PR DESCRIPTION
added homepage links to specific guide sections, they only existed for daily reports before, fixes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the feature list to include direct navigation links for Monthly Reports, Session Reports, 5-Hour Blocks, Live Monitoring, JSON Output, and MCP Integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->