### PR TITLE
feat: add message count column to blocks table display

### DIFF
--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -315,6 +315,7 @@ export const blocksCommand = define({
 				log(`Time Remaining: ${pc.green(`${Math.floor(remaining / 60)}h ${remaining % 60}m`)}\n`);
 
 				log(pc.bold('Current Usage:'));
+				log(`  Messages:         ${formatNumber(block.entries.length)}`);
 				log(`  Input Tokens:     ${formatNumber(block.tokenCounts.inputTokens)}`);
 				log(`  Output Tokens:    ${formatNumber(block.tokenCounts.outputTokens)}`);
 				log(`  Total Cost:       ${formatCurrency(block.costUSD)}\n`);
@@ -359,8 +360,8 @@ export const blocksCommand = define({
 				// Calculate token limit if "max" is specified
 				const actualTokenLimit = parseTokenLimit(ctx.values.tokenLimit, maxTokensFromAll);
 
-				const tableHeaders = ['Block Start', 'Duration/Status', 'Models', 'Tokens'];
-				const tableAligns: ('left' | 'right' | 'center')[] = ['left', 'left', 'left', 'right'];
+				const tableHeaders = ['Block Start', 'Duration/Status', 'Models', 'Messages', 'Tokens'];
+				const tableAligns: ('left' | 'right' | 'center')[] = ['left', 'left', 'left', 'right', 'right'];
 
 				// Add % column if token limit is set
 				if (actualTokenLimit != null && actualTokenLimit > 0) {
@@ -389,6 +390,7 @@ export const blocksCommand = define({
 							pc.gray('(inactive)'),
 							pc.gray('-'),
 							pc.gray('-'),
+							pc.gray('-'),
 						];
 						if (actualTokenLimit != null && actualTokenLimit > 0) {
 							gapRow.push(pc.gray('-'));
@@ -405,6 +407,7 @@ export const blocksCommand = define({
 							formatBlockTime(block, useCompactFormat),
 							status,
 							formatModels(block.models),
+							formatNumber(block.entries.length),
 							formatNumber(totalTokens),
 						];
 
@@ -438,6 +441,7 @@ export const blocksCommand = define({
 									{ content: pc.gray(`(assuming ${formatNumber(actualTokenLimit)} token limit)`), hAlign: 'right' as const },
 									pc.blue('REMAINING'),
 									'',
+									'',
 									remainingText,
 									remainingPercentText,
 									'', // No cost for remaining - it's about token limit, not cost
@@ -456,6 +460,7 @@ export const blocksCommand = define({
 								const projectedRow = [
 									{ content: pc.gray('(assuming current burn rate)'), hAlign: 'right' as const },
 									pc.yellow('PROJECTED'),
+									'',
 									'',
 									projectedText,
 								];


### PR DESCRIPTION
## Summary
- Add a new 'Messages' column to the blocks table display showing the count of entries in each block
- Update the detailed active block view to show message count
- Ensure all table rows (including gap, remaining, and projected rows) align properly with the new column

## Motivation
Claude's billing model includes message-based limits in addition to token limits. For example, the Max 20x plan has a limit of ~900 messages per 5-hour session. Without visibility into message counts in the blocks report, users cannot track their usage against these limits effectively.

## Changes
- Added 'Messages' to table headers in `src/commands/blocks.ts`
- Added `block.entries.length` as message count in regular block rows
- Updated gap rows, remaining rows, and projected rows to include empty placeholders for proper column alignment
- Added message count display in the detailed active block view
- The MCP server already includes entries count in JSON output, so this change only affects the table display

## Testing
- Tested locally with `bun run start blocks` to verify the new column displays correctly
- Ran `bun run test` to ensure no existing tests were broken
- Ran `bun run format` and `bun typecheck` to ensure code quality

## Example Output

The blocks table now shows:
```
Block Start                Duration/Status  Models             Messages  Tokens      %        Cost
12/09/24, 3:54:29 PM      (28m)            claude-sonnet-4       42      12,345    2.5%    $0.0370
12/09/24, 4:25:00 PM      ACTIVE           claude-sonnet-4      204      45,678    9.1%    $0.1370
```

The detailed active block view (`--active` flag) now includes:
```
Current Usage:
  Messages:         204
  Input Tokens:     35,678
  Output Tokens:    10,000
  Total Cost:       $0.1370
```