### PR TITLE
fix(live-monitor): borders are misaligned in some terminal environments

### DIFF
--- a/src/_live-rendering.ts
+++ b/src/_live-rendering.ts
@@ -16,20 +16,9 @@ import prettyMs from 'pretty-ms';
 import stringWidth from 'string-width';
 import { BURN_RATE_THRESHOLDS } from './_consts.ts';
 import { calculateBurnRate, projectBlockUsage } from './_session-blocks.ts';
-import { centerText, createProgressBar } from './_terminal-utils.ts';
+import { centerText, createProgressBar, drawEmoji } from './_terminal-utils.ts';
 import { getTotalTokens } from './_token-utils.ts';
 import { formatCurrency, formatModelsDisplay, formatNumber } from './_utils.ts';
-
-/**
- * Draws an emoji with consistent 2-character width regardless of terminal behavior
- * @param emoji The emoji to draw
- * @returns A string containing ANSI escape sequences and the emoji
- */
-function drawEmoji(emoji: string): string {
-	// Save position, draw emoji, restore position, then move forward 2 characters
-	// This ensures the emoji always takes up 2 character spaces regardless of how the terminal renders it
-	return `${ansiEscapes.cursorSavePosition}${emoji}${ansiEscapes.cursorRestorePosition}${ansiEscapes.cursorForward(2)}`;
-}
 
 /**
  * Get rate indicator (HIGH/MODERATE/NORMAL) based on burn rate

--- a/src/_live-rendering.ts
+++ b/src/_live-rendering.ts
@@ -21,6 +21,17 @@ import { getTotalTokens } from './_token-utils.ts';
 import { formatCurrency, formatModelsDisplay, formatNumber } from './_utils.ts';
 
 /**
+ * Draws an emoji with consistent 2-character width regardless of terminal behavior
+ * @param emoji The emoji to draw
+ * @returns A string containing ANSI escape sequences and the emoji
+ */
+function drawEmoji(emoji: string): string {
+	// Save position, draw emoji, restore position, then move forward 2 characters
+	// This ensures the emoji always takes up 2 character spaces regardless of how the terminal renders it
+	return `${ansiEscapes.cursorSavePosition}${emoji}${ansiEscapes.cursorRestorePosition}${ansiEscapes.cursorForward(2)}`;
+}
+
+/**
  * Get rate indicator (HIGH/MODERATE/NORMAL) based on burn rate
  */
 function getRateIndicator(burnRate: ReturnType<typeof calculateBurnRate>): string {
@@ -194,7 +205,7 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 	terminal.write(`${marginStr}│${' '.repeat(boxWidth - 2)}│\n`);
 
 	// Session section
-	const sessionLabel = pc.bold('⏱️ SESSION');
+	const sessionLabel = `${drawEmoji('⏱️')}${pc.bold(' SESSION')}`;
 	const sessionLabelWidth = stringWidth(sessionLabel);
 	const sessionBarStr = `${sessionLabel}${''.padEnd(Math.max(0, labelWidth - sessionLabelWidth))} ${sessionProgressBar} ${sessionRightText}`;
 	const sessionBarPadded = sessionBarStr + ' '.repeat(Math.max(0, boxWidth - 3 - stringWidth(sessionBarStr)));
@@ -273,7 +284,7 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 	};
 
 	// Usage section
-	const usageLabel = pc.bold('🔥 USAGE');
+	const usageLabel = `${drawEmoji('🔥')}${pc.bold(' USAGE')}`;
 	const usageLabelWidth = stringWidth(usageLabel);
 
 	// Create usage bar string with pre-generated text
@@ -386,7 +397,7 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 			: pc.green('✓ ON TRACK');
 
 		// Projection section
-		const projLabel = pc.bold('📈 PROJECTION');
+		const projLabel = `${drawEmoji('📈')}${pc.bold(' PROJECTION')}`;
 		const projLabelWidth = stringWidth(projLabel);
 
 		// Create projection bar string with pre-generated text
@@ -435,7 +446,7 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 	// Models section
 	if (block.models.length > 0) {
 		terminal.write(`${marginStr}├${'─'.repeat(boxWidth - 2)}┤\n`);
-		const modelsLine = `⚙️  Models: ${formatModelsDisplay(block.models)}`;
+		const modelsLine = `${drawEmoji('⚙️')}  Models: ${formatModelsDisplay(block.models)}`;
 		const modelsLinePadded = modelsLine + ' '.repeat(Math.max(0, boxWidth - 3 - stringWidth(modelsLine)));
 		terminal.write(`${marginStr}│ ${modelsLinePadded}│\n`);
 	}

--- a/src/_live-rendering.ts
+++ b/src/_live-rendering.ts
@@ -35,7 +35,7 @@ function getRateIndicator(burnRate: ReturnType<typeof calculateBurnRate>): strin
 		case burnRate.tokensPerMinuteForIndicator > BURN_RATE_THRESHOLDS.MODERATE:
 			return pc.yellow('⚡ MODERATE');
 		default:
-			return pc.green('✓ NORMAL');
+			return pc.green(`${drawEmoji('✓')} NORMAL`);
 	}
 }
 
@@ -221,7 +221,7 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 	let usageLimitResetTimePadded: string | null = null;
 	if (block.usageLimitResetTime !== undefined && now < block.usageLimitResetTime) {
 		const resetTime = block.usageLimitResetTime?.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: true }) ?? null;
-		const usageLimitResetTime = resetTime !== null ? pc.red(`❌ USAGE LIMIT. RESET AT ${resetTime}`) : '';
+		const usageLimitResetTime = resetTime !== null ? pc.red(`${drawEmoji('❌')} USAGE LIMIT. RESET AT ${resetTime}`) : '';
 		usageLimitResetTimePadded = resetTime !== null ? usageLimitResetTime + ' '.repeat(Math.max(0, boxWidth - 3 - stringWidth(usageLimitResetTime))) : null;
 	}
 	terminal.write(`${marginStr}│ ${sessionDetailsPadded}│\n`);
@@ -379,11 +379,11 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 
 		const limitStatus = config.tokenLimit != null && config.tokenLimit > 0
 			? (projectedPercent > 100
-					? pc.red('❌ WILL EXCEED LIMIT')
+					? pc.red(`${drawEmoji('❌')} WILL EXCEED LIMIT`)
 					: projectedPercent > 80
-						? pc.yellow('⚠️  APPROACHING LIMIT')
-						: pc.green('✓ WITHIN LIMIT'))
-			: pc.green('✓ ON TRACK');
+						? pc.yellow(`${drawEmoji('⚠️')} APPROACHING LIMIT`)
+						: pc.green(`${drawEmoji('✓')} WITHIN LIMIT`))
+			: pc.green(`${drawEmoji('✓')} ON TRACK`);
 
 		// Projection section
 		const projLabel = `${drawEmoji('📈')}${pc.bold(' PROJECTION')}`;
@@ -442,7 +442,7 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 
 	// Footer
 	terminal.write(`${marginStr}├${'─'.repeat(boxWidth - 2)}┤\n`);
-	const refreshText = `↻ Refreshing every ${config.refreshInterval / 1000}s  •  Press Ctrl+C to stop`;
+	const refreshText = `${drawEmoji('↻')} Refreshing every ${config.refreshInterval / 1000}s  •  Press Ctrl+C to stop`;
 	terminal.write(`${marginStr}│${pc.gray(centerText(refreshText, boxWidth - 2))}│\n`);
 	terminal.write(`${marginStr}└${'─'.repeat(boxWidth - 2)}┘\n`);
 }

--- a/src/_terminal-utils.ts
+++ b/src/_terminal-utils.ts
@@ -308,7 +308,21 @@ export function centerText(text: string, width: number): string {
 export function drawEmoji(emoji: string): string {
 	const emojiWidth = stringWidth(emoji);
 	const content = emojiWidth === 1 ? `${emoji} ` : emoji;
-	return `${ansiEscapes.cursorSavePosition}${content}${ansiEscapes.cursorRestorePosition}${ansiEscapes.cursorForward(2)}`;
+
+	// Using below sequences instead causes issues in some terminals such as NeoVim.
+	// - ansiEscapes.cursorSavePosition (\u001B[s = Save Cursor)
+	// - ansiEscapes.cursorRestorePosition (\u001B[u = Unsave Cursor)
+	//
+	// Instead, we use:
+	// - \u001B7 = Save Cursor & Attrs
+	// - \u001B8 = Restore Cursor & Attrs
+	//
+	// see: https://www2.ccs.neu.edu/research/gpc/VonaUtils/vona/terminal/vtansi.htm
+
+	const SAVE_CUROSR = '\u001B7';
+	const RESTORE_CURSOR = '\u001B8';
+
+	return `${SAVE_CUROSR}${content}${RESTORE_CURSOR}${ansiEscapes.cursorForward(2)}`;
 }
 
 // In-source testing

--- a/src/_terminal-utils.ts
+++ b/src/_terminal-utils.ts
@@ -299,3 +299,33 @@ export function centerText(text: string, width: number): string {
 
 	return ' '.repeat(leftPadding) + text + ' '.repeat(rightPadding);
 }
+
+/**
+ * Draws an emoji with consistent 2-character width regardless of terminal behavior
+ * @param emoji The emoji to draw
+ * @returns A string containing ANSI escape sequences and the emoji
+ */
+export function drawEmoji(emoji: string): string {
+	const emojiWidth = stringWidth(emoji);
+	const content = emojiWidth === 1 ? `${emoji} ` : emoji;
+	return `${ansiEscapes.cursorSavePosition}${content}${ansiEscapes.cursorRestorePosition}${ansiEscapes.cursorForward(2)}`;
+}
+
+// In-source testing
+if (import.meta.vitest != null) {
+	describe('drawEmoji', () => {
+		it('should always return a string with width 2', () => {
+			// 2-width emojis
+			expect(stringWidth(drawEmoji('⏱️'))).toBe(2);
+			expect(stringWidth(drawEmoji('🔥'))).toBe(2);
+			expect(stringWidth(drawEmoji('📈'))).toBe(2);
+			expect(stringWidth(drawEmoji('⚙️'))).toBe(2);
+			expect(stringWidth(drawEmoji('❌'))).toBe(2);
+			expect(stringWidth(drawEmoji('⚠️'))).toBe(2);
+
+			// 1-width emojis (should be padded to 2)
+			expect(stringWidth(drawEmoji('✓'))).toBe(2);
+			expect(stringWidth(drawEmoji('↻'))).toBe(2);
+		});
+	});
+}


### PR DESCRIPTION
This PR implemented the drawEmoji function, which draws all emojis using two half-width characters,
and used it for all emoji drawing parts in the code.
- close #172 

