### PR TITLE
test: disable watch mode in vitest config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Testing and Quality:**
 
-- `bun run test` - Run all tests (using vitest via bun)
+- `bun run test` - Run all tests (using vitest via bun, watch mode disabled)
 - Lint code using ESLint MCP server (available via Claude Code tools)
 - `bun run format` - Format code with ESLint (writes changes)
 - `bun typecheck` - Type check with TypeScript

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		watch: false,
 		includeSource: ['src/**/*.{js,ts}'],
 		globals: true,
 	},


### PR DESCRIPTION
## Summary
- Disabled watch mode in vitest configuration by setting `watch: false`
- Updated CLAUDE.md documentation to reflect this change

## Test plan
- [ ] Run `bun run test` to verify tests still work correctly
- [ ] Confirm that tests do not automatically re-run when files change