### PR TITLE
fix: use local timezone for date grouping instead of UTC

### DIFF
--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -517,10 +517,9 @@ function extractUniqueModels<T>(
 
 /**
  * Date formatter using Intl.DateTimeFormat for consistent formatting
- * Using UTC to avoid timezone issues
+ * Uses local timezone for proper date grouping
  */
 const dateFormatter = new Intl.DateTimeFormat('en-CA', {
-	timeZone: 'UTC',
 	year: 'numeric',
 	month: '2-digit',
 	day: '2-digit',
@@ -541,7 +540,6 @@ export function formatDate(dateStr: string): string {
  * Date parts formatter for extracting year, month, and day separately
  */
 const datePartsFormatter = new Intl.DateTimeFormat('en', {
-	timeZone: 'UTC',
 	year: 'numeric',
 	month: '2-digit',
 	day: '2-digit',


### PR DESCRIPTION
## Summary

This PR fixes an issue where usage data was being grouped by UTC date boundaries instead of the user's local timezone, causing data to appear on incorrect dates.

Fixes #413
Caused by #409 

## Problem

When using ccusage, usage data was being grouped incorrectly based on UTC time rather than the user's local timezone. This caused confusing results where:
- Usage at 20:00 local time (MDT) would appear on the next day's report
- Daily summaries didn't align with when users actually used Claude Code
- Users in timezones behind UTC would see their evening usage shifted to the following day

### Example
A user in MDT (UTC-6) using Claude Code at 8:00 PM on August 3rd would see that usage reported as August 4th, because 8:00 PM MDT is 2:00 AM UTC the next day.

## Solution

Removed the hardcoded `timeZone: 'UTC'` configuration from the `Intl.DateTimeFormat` instances in `data-loader.ts`. This allows the date formatters to:
1. Use the system's local timezone by default
2. Respect the `TZ` environment variable if users want to override it
3. Group usage data by local date boundaries as users would expect

## Changes

- Removed `timeZone: 'UTC'` from `dateFormatter` 
- Removed `timeZone: 'UTC'` from `datePartsFormatter`
- Updated comment to reflect local timezone usage

## Testing

- All 253 existing tests pass
- Verified that usage data now groups correctly by local date
- Confirmed that the `TZ` environment variable can still override timezone if needed
- Linting and type checking pass without issues

## Backward Compatibility

This change makes the date grouping more intuitive and correct for users. The data itself is unchanged - only the grouping/display is affected. Users who need UTC grouping can still achieve it by setting `TZ=UTC`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dates are now displayed and grouped according to your local timezone instead of UTC, providing a more intuitive experience for users in different regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->