### PR TITLE
feat: add timezone option for date grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ ccusage blocks --live  # Real-time usage dashboard
 ccusage daily --since 20250525 --until 20250530
 ccusage daily --json  # JSON output
 ccusage daily --breakdown  # Per-model cost breakdown
+ccusage daily --timezone UTC  # Use UTC timezone
 
 # Project analysis
 ccusage daily --instances  # Group by project/instance
@@ -90,6 +91,7 @@ ccusage daily --instances --project myproject --json  # Combined usage
 - 🌐 **Offline Mode**: Use pre-cached pricing data without network connectivity with `--offline` (Claude models only)
 - 🔌 **MCP Integration**: Built-in Model Context Protocol server for integration with other tools
 - 🏗️ **Multi-Instance Support**: Group usage by project with `--instances` flag and filter by specific projects
+- 🌍 **Timezone Support**: Configure timezone for date grouping with `--timezone` option
 - 🚀 **Ultra-Small Bundle**: Unlike other CLI tools, we pay extreme attention to bundle size - incredibly small even without minification!
 
 ## Documentation

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -6,7 +6,7 @@ ccusage supports various configuration options to customize its behavior and ada
 
 ### CLAUDE_CONFIG_DIR
 
-The primary configuration option is the `CLAUDE_CONFIG_DIR` environment variable, which specifies where ccusage should look for Claude Code data.
+The `CLAUDE_CONFIG_DIR` environment variable specifies where ccusage should look for Claude Code data.
 
 #### Single Directory
 
@@ -140,11 +140,46 @@ ccusage daily --order asc              # Oldest first
 ccusage daily --offline                # Use cached pricing data
 ccusage daily -O                       # Short alias
 
+# Timezone
+ccusage daily --timezone UTC           # Use UTC timezone
+ccusage daily -z America/New_York      # Use New York timezone
+ccusage daily --timezone Asia/Tokyo    # Use Tokyo timezone
+
 # Project analysis (daily command only)
 ccusage daily --instances              # Group by project
 ccusage daily --project myproject      # Filter to specific project
 ccusage daily --instances --project myproject  # Combined usage
 ```
+
+### Timezone Configuration
+
+The `--timezone` option controls how dates are calculated for grouping usage data:
+
+```bash
+# Use UTC timezone for consistent reports
+ccusage daily --timezone UTC
+
+# Use specific timezone
+ccusage daily --timezone America/New_York
+ccusage monthly -z Asia/Tokyo
+
+# Default behavior (no timezone specified)
+ccusage daily  # Uses system's local timezone
+```
+
+#### Timezone Effect
+
+The timezone affects how usage is grouped by date. For example, usage at 11 PM UTC on January 1st would appear on:
+- **January 1st** when `--timezone UTC`
+- **January 1st** when `--timezone America/New_York` (6 PM EST)
+- **January 2nd** when `--timezone Asia/Tokyo` (8 AM JST next day)
+
+#### Use Cases
+
+- **UTC Alignment**: Use `--timezone UTC` for consistent reports across different locations
+- **Remote Teams**: Align reports to team's primary timezone
+- **Cross-Timezone Analysis**: Compare usage patterns across different time zones
+- **CI/CD Environments**: Use UTC for consistent automated reports
 
 ### Debug Options
 

--- a/src/_shared-args.ts
+++ b/src/_shared-args.ts
@@ -86,6 +86,11 @@ export const sharedArgs = {
 		type: 'boolean',
 		description: 'Disable colored output (default: auto). NO_COLOR=1 has the same effect.',
 	},
+	timezone: {
+		type: 'string',
+		short: 'z',
+		description: 'Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone',
+	},
 } as const satisfies Args;
 
 /**

--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -160,6 +160,7 @@ export const blocksCommand = define({
 			order: ctx.values.order,
 			offline: ctx.values.offline,
 			sessionDurationHours: ctx.values.sessionLength,
+			timezone: ctx.values.timezone,
 		});
 
 		if (blocks.length === 0) {

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -45,6 +45,7 @@ export const dailyCommand = define({
 			offline: ctx.values.offline,
 			groupByProject: ctx.values.instances,
 			project: ctx.values.project,
+			timezone: ctx.values.timezone,
 		});
 
 		if (dailyData.length === 0) {
@@ -119,7 +120,7 @@ export const dailyCommand = define({
 					'right',
 					'right',
 				],
-				dateFormatter: formatDateCompact,
+				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, ctx.values.timezone),
 				compactHead: [
 					'Date',
 					'Models',

--- a/src/commands/monthly.ts
+++ b/src/commands/monthly.ts
@@ -27,6 +27,7 @@ export const monthlyCommand = define({
 			mode: ctx.values.mode,
 			order: ctx.values.order,
 			offline: ctx.values.offline,
+			timezone: ctx.values.timezone,
 		});
 
 		if (monthlyData.length === 0) {
@@ -106,7 +107,7 @@ export const monthlyCommand = define({
 					'right',
 					'right',
 				],
-				dateFormatter: formatDateCompact,
+				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, ctx.values.timezone),
 				compactHead: [
 					'Month',
 					'Models',

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -27,6 +27,7 @@ export const sessionCommand = define({
 			mode: ctx.values.mode,
 			order: ctx.values.order,
 			offline: ctx.values.offline,
+			timezone: ctx.values.timezone,
 		});
 
 		if (sessionData.length === 0) {
@@ -99,7 +100,7 @@ export const sessionCommand = define({
 					'right',
 					'left',
 				],
-				dateFormatter: formatDateCompact,
+				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, ctx.values.timezone),
 				compactHead: [
 					'Session',
 					'Models',

--- a/src/commands/weekly.ts
+++ b/src/commands/weekly.ts
@@ -35,6 +35,7 @@ export const weeklyCommand = define({
 		const weeklyData = await loadWeeklyUsageData({
 			since: ctx.values.since,
 			until: ctx.values.until,
+			timezone: ctx.values.timezone,
 			mode: ctx.values.mode,
 			order: ctx.values.order,
 			offline: ctx.values.offline,
@@ -118,7 +119,7 @@ export const weeklyCommand = define({
 					'right',
 					'right',
 				],
-				dateFormatter: formatDateCompact,
+				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, ctx.values.timezone),
 				compactHead: [
 					'Week',
 					'Models',

--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -516,43 +516,56 @@ function extractUniqueModels<T>(
 }
 
 /**
- * Date formatter using Intl.DateTimeFormat for consistent formatting
- * Uses local timezone for proper date grouping
+ * Creates a date formatter with the specified timezone
+ * @param timezone - Optional timezone to use (e.g., 'UTC', 'America/New_York')
+ * @returns Intl.DateTimeFormat instance
  */
-const dateFormatter = new Intl.DateTimeFormat('en-CA', {
-	year: 'numeric',
-	month: '2-digit',
-	day: '2-digit',
-});
+function createDateFormatter(timezone?: string): Intl.DateTimeFormat {
+	return new Intl.DateTimeFormat('en-CA', {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		timeZone: timezone,
+	});
+}
+
+/**
+ * Creates a date parts formatter with the specified timezone
+ * @param timezone - Optional timezone to use
+ * @returns Intl.DateTimeFormat instance
+ */
+function createDatePartsFormatter(timezone?: string): Intl.DateTimeFormat {
+	return new Intl.DateTimeFormat('en', {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		timeZone: timezone,
+	});
+}
 
 /**
  * Formats a date string to YYYY-MM-DD format
  * @param dateStr - Input date string
+ * @param timezone - Optional timezone to use for formatting
  * @returns Formatted date string in YYYY-MM-DD format
  */
-export function formatDate(dateStr: string): string {
+export function formatDate(dateStr: string, timezone?: string): string {
 	const date = new Date(dateStr);
+	const formatter = createDateFormatter(timezone);
 	// en-CA locale gives us YYYY-MM-DD format directly
-	return dateFormatter.format(date);
+	return formatter.format(date);
 }
-
-/**
- * Date parts formatter for extracting year, month, and day separately
- */
-const datePartsFormatter = new Intl.DateTimeFormat('en', {
-	year: 'numeric',
-	month: '2-digit',
-	day: '2-digit',
-});
 
 /**
  * Formats a date string to compact format with year on first line and month-day on second
  * @param dateStr - Input date string
+ * @param timezone - Optional timezone to use for formatting
  * @returns Formatted date string with newline separator (YYYY\nMM-DD)
  */
-export function formatDateCompact(dateStr: string): string {
+export function formatDateCompact(dateStr: string, timezone?: string): string {
 	const date = new Date(dateStr);
-	const parts = datePartsFormatter.formatToParts(date);
+	const formatter = createDatePartsFormatter(timezone);
+	const parts = formatter.formatToParts(date);
 	const year = parts.find(p => p.type === 'year')?.value ?? '';
 	const month = parts.find(p => p.type === 'month')?.value ?? '';
 	const day = parts.find(p => p.type === 'day')?.value ?? '';
@@ -783,6 +796,7 @@ export type LoadOptions = {
 	groupByProject?: boolean; // Group data by project instead of aggregating
 	project?: string; // Filter to specific project name
 	startOfWeek?: WeekDay; // Start of week for weekly aggregation
+	timezone?: string; // Timezone for date grouping (e.g., 'UTC', 'America/New_York'). Defaults to system timezone
 } & DateFilter;
 
 /**
@@ -853,7 +867,7 @@ export async function loadDailyUsageData(
 				// Mark this combination as processed
 				markAsProcessed(uniqueHash, processedHashes);
 
-				const date = formatDate(data.timestamp);
+				const date = formatDate(data.timestamp, options?.timezone);
 				// If fetcher is available, calculate cost based on mode and tokens
 				// If fetcher is null, use pre-calculated costUSD or default to 0
 				const cost = fetcher != null
@@ -1097,7 +1111,7 @@ export async function loadSessionData(
 				sessionId: createSessionId(latestEntry.sessionId),
 				projectPath: createProjectPath(latestEntry.projectPath),
 				...totals,
-				lastActivity: formatDate(latestEntry.timestamp) as ActivityDate,
+				lastActivity: formatDate(latestEntry.timestamp, options?.timezone) as ActivityDate,
 				versions: uniq(versions).sort() as Version[],
 				modelsUsed: modelsUsed as ModelName[],
 				modelBreakdowns,
@@ -1361,7 +1375,7 @@ export async function loadSessionBlockData(
 	// Filter by date range if specified
 	const dateFiltered = (options?.since != null && options.since !== '') || (options?.until != null && options.until !== '')
 		? blocks.filter((block) => {
-				const blockDateStr = formatDate(block.startTime.toISOString()).replace(/-/g, '');
+				const blockDateStr = formatDate(block.startTime.toISOString(), options?.timezone).replace(/-/g, '');
 				if (options.since != null && options.since !== '' && blockDateStr < options.since) {
 					return false;
 				}
@@ -1382,6 +1396,42 @@ if (import.meta.vitest != null) {
 		// Test with UTC timestamps - results depend on local timezone
 			expect(formatDate('2024-01-01T00:00:00Z')).toBe('2024-01-01');
 			expect(formatDate('2024-12-31T23:59:59Z')).toBe('2024-12-31');
+		});
+
+		it('respects timezone parameter', () => {
+			// Test date that crosses day boundary
+			const testTimestamp = '2024-01-01T15:00:00Z'; // 3 PM UTC = midnight JST next day
+
+			// Default behavior (no timezone) uses system timezone
+			expect(formatDate(testTimestamp)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+			// UTC timezone
+			expect(formatDate(testTimestamp, 'UTC')).toBe('2024-01-01');
+
+			// Asia/Tokyo timezone (crosses to next day)
+			expect(formatDate(testTimestamp, 'Asia/Tokyo')).toBe('2024-01-02');
+
+			// America/New_York timezone
+			expect(formatDate('2024-01-02T03:00:00Z', 'America/New_York')).toBe('2024-01-01'); // 3 AM UTC = 10 PM EST previous day
+
+			// Invalid timezone should throw or use default behavior
+			// Most browsers will throw, but some might fallback to UTC
+			try {
+				formatDate(testTimestamp, 'Invalid/Timezone');
+			}
+			catch (e) {
+				expect(e).toBeInstanceOf(RangeError);
+			}
+		});
+
+		it('formatDateCompact respects timezone parameter', () => {
+			const testTimestamp = '2024-01-01T15:00:00Z';
+
+			// UTC timezone
+			expect(formatDateCompact(testTimestamp, 'UTC')).toBe('2024\n01-01');
+
+			// Asia/Tokyo timezone (crosses to next day)
+			expect(formatDateCompact(testTimestamp, 'Asia/Tokyo')).toBe('2024\n01-02');
 		});
 
 		it('handles various date formats', () => {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -195,6 +195,7 @@ export function createMcpServer({
 		since: filterDateSchema.optional(),
 		until: filterDateSchema.optional(),
 		mode: z.enum(['auto', 'calculate', 'display']).default('auto').optional(),
+		timezone: z.string().optional(),
 	};
 
 	// Register daily tool


### PR DESCRIPTION
## Summary
- Added `--timezone`/`-z` option to all commands for configurable date grouping
- Users can now specify any valid IANA timezone (e.g., UTC, America/New_York, Asia/Tokyo)
- Default behavior remains unchanged - uses system timezone when not specified

## Why this change?
Following up on #414, this PR adds proper timezone support as a command-line option rather than relying on environment variables. This provides a more flexible and user-friendly way to control date grouping across different timezones.

## Changes
- Added `timezone` option to shared command arguments
- Updated `formatDate` and `formatDateCompact` functions to accept timezone parameter
- Modified all commands (daily, monthly, weekly, session, blocks) to pass timezone option
- Updated MCP server to accept timezone parameter
- Added comprehensive tests for timezone functionality
- Updated documentation with timezone usage examples

## Examples
```bash
# Use UTC timezone for consistent reports
ccusage daily --timezone UTC

# Use specific timezone
ccusage daily --timezone America/New_York
ccusage monthly -z Asia/Tokyo

# Default behavior (system timezone)
ccusage daily
```

## Test plan
- [x] All existing tests pass
- [x] Added new tests for timezone parameter functionality
- [x] Manual testing with different timezones
- [x] Documentation updated