### PR TITLE
Add viberank to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ Check out these [47 Claude Code ProTips from Greg Baugues.](https://www.youtube.
 
 - **[viberank](https://viberank.app)** — A community-driven leaderboard for Claude Code usage. Uses **ccusage** data to let developers track, compare, and showcase their Claude token stats and coding habits. ([GitHub](https://github.com/sculptdotfun/viberank))
 
-
 ## Claude Code Resources
 
 [`ClaudeLog`](https://claudelog.com) &nbsp; by &nbsp; [InventorBlack](https://www.reddit.com/user/inventor_black/)

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ Check out these [47 Claude Code ProTips from Greg Baugues.](https://www.youtube.
     </a>
 </p>
 
+### Projects Using `ccusage`
+
+- **[viberank](https://viberank.app)** — A community-driven leaderboard for Claude Code usage. Uses **ccusage** data to let developers track, compare, and showcase their Claude token stats and coding habits. ([GitHub](https://github.com/sculptdotfun/viberank))
+
+
 ## Claude Code Resources
 
 [`ClaudeLog`](https://claudelog.com) &nbsp; by &nbsp; [InventorBlack](https://www.reddit.com/user/inventor_black/)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Check out these [47 Claude Code ProTips from Greg Baugues.](https://www.youtube.
     </a>
 </p>
 
-### Projects Using `ccusage`
+## Projects Using `ccusage`
 
 - **[viberank](https://viberank.app)** — A community-driven leaderboard for Claude Code usage. Uses **ccusage** data to let developers track, compare, and showcase their Claude token stats and coding habits. ([GitHub](https://github.com/sculptdotfun/viberank))
 


### PR DESCRIPTION
I've updated viberank so that it now has:

1. a new CLI (npx viberank)
2. profile pages for stats
3. better validation logic
4. better submission merge logic

would love to showcase this as a project that uses ccusage, viberank has already been featured in quite a few articles and blogs (example: https://x.com/nikshepsvn/status/1952423566835941851, https://x.com/nikshepsvn/status/1951664318417662132, https://x.com/nikshepsvn/status/1950964313205727456 etc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Projects Using ccusage" section to the README, featuring viberank with a description and links to its website and GitHub repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->