### PR TITLE
Fix off-by-one compact date formatting

### DIFF
--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -567,7 +567,12 @@ export function formatDate(dateStr: string, timezone?: string, locale?: string):
  * @returns Formatted date string with newline separator (YYYY\nMM-DD)
  */
 export function formatDateCompact(dateStr: string, timezone: string | undefined, locale: string): string {
-	const date = new Date(dateStr);
+	// For YYYY-MM-DD format, append T00:00:00 to parse as local date
+	// Without this, new Date('YYYY-MM-DD') interprets as UTC midnight
+	const localDateStr = /^\d{4}-\d{2}-\d{2}$/.test(dateStr)
+		? `${dateStr}T00:00:00`
+		: dateStr;
+	const date = new Date(localDateStr);
 	const formatter = createDatePartsFormatter(timezone, locale);
 	const parts = formatter.formatToParts(date);
 	const year = parts.find(p => p.type === 'year')?.value ?? '';


### PR DESCRIPTION
Suggested fix for issue #433.

formatDateCompact is being given a date in YYYY-MM-DD format that has already been converted to the local time zone. Constructing a new Date from that string interprets it as UTC, which causes an off-by-one error for users at a negative offset from UTC.