### PR TITLE
fix!: '-l' for locale alias

### DIFF
--- a/src/_shared-args.ts
+++ b/src/_shared-args.ts
@@ -93,6 +93,7 @@ export const sharedArgs = {
 	},
 	locale: {
 		type: 'string',
+		short: 'l',
 		description: 'Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)',
 		default: 'en-CA',
 	},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a short flag `-l` for the `locale` option in the CLI, allowing for quicker locale selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->