### PR TITLE
fix(statusline): correctly load session costs using actual session IDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,14 @@ This is a CLI tool that analyzes Claude Code usage data from local JSONL files s
 
 - Raw usage data is parsed from JSONL with timestamp, token counts, and pre-calculated costs
 - Data is aggregated into daily summaries, monthly summaries, session summaries, or 5-hour billing blocks
-- Sessions are identified by directory structure: `projects/{project}/{session}/{file}.jsonl`
+- **Important Note on Naming**: The term "session" in this codebase has two different meanings:
+  1. **Session Reports** (`bun run start session`): Groups usage by project directories. What we call "sessionId" in these reports is actually derived from the directory structure (project/directory)
+  2. **True Session ID**: The actual Claude Code session ID found in the `sessionId` field within JSONL entries and used as the filename ({sessionId}.jsonl)
+- File structure: `projects/{project}/{sessionId}.jsonl` where:
+  - `{project}` is the project directory name (used for grouping)
+  - `{sessionId}.jsonl` is the JSONL file named with the actual session ID from Claude Code
+  - Each JSONL file contains all usage entries for a single Claude Code session
+  - The sessionId in the filename matches the `sessionId` field inside the JSONL entries
 - 5-hour blocks group usage data by Claude's billing cycles with active block tracking
 
 **External Dependencies:**

--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -1195,6 +1195,66 @@ export async function loadWeeklyUsageData(
 		})));
 }
 
+/**
+ * Load usage data for a specific session by sessionId
+ * Searches for a JSONL file named {sessionId}.jsonl in all Claude project directories
+ * @param sessionId - The session ID to load data for (matches the JSONL filename)
+ * @param options - Options for loading data
+ * @param options.mode - Cost calculation mode (auto, calculate, display)
+ * @param options.offline - Whether to use offline pricing data
+ * @returns Usage data for the specific session or null if not found
+ */
+export async function loadSessionUsageById(
+	sessionId: string,
+	options?: { mode?: CostMode; offline?: boolean },
+): Promise<{ totalCost: number; entries: UsageData[] } | null> {
+	const claudePaths = getClaudePaths();
+
+	// Find the JSONL file for this session ID
+	const patterns = claudePaths.map(p => path.join(p, 'projects', '**', `${sessionId}.jsonl`));
+	const jsonlFiles = await glob(patterns);
+
+	if (jsonlFiles.length === 0) {
+		return null;
+	}
+
+	const file = jsonlFiles[0];
+	if (file == null) {
+		return null;
+	}
+	const content = await readFile(file, 'utf-8');
+	const lines = content.trim().split('\n').filter(line => line.length > 0);
+
+	const mode = options?.mode ?? 'auto';
+	using fetcher = mode === 'display' ? null : new PricingFetcher(options?.offline);
+
+	const entries: UsageData[] = [];
+	let totalCost = 0;
+
+	for (const line of lines) {
+		try {
+			const parsed = JSON.parse(line) as unknown;
+			const result = usageDataSchema.safeParse(parsed);
+			if (!result.success) {
+				continue;
+			}
+			const data = result.data;
+
+			const cost = fetcher != null
+				? await calculateCostForEntry(data, mode, fetcher)
+				: data.costUSD ?? 0;
+
+			totalCost += cost;
+			entries.push(data);
+		}
+		catch {
+			// Skip invalid JSON lines
+		}
+	}
+
+	return { totalCost, entries };
+}
+
 export async function loadBucketUsageData(
 	groupingFn: (data: DailyUsage) => Bucket,
 	options?: LoadOptions,
@@ -1458,6 +1518,89 @@ if (import.meta.vitest != null) {
 			expect(formatDate(testDate, 'UTC', 'en-CA')).toBe('2024-08-04');
 			expect(formatDate(testDate, 'UTC', 'ja-JP')).toBe('2024/08/04');
 			expect(formatDate(testDate, 'UTC', 'de-DE')).toBe('04.08.2024');
+		});
+	});
+
+	describe('loadSessionUsageById', async () => {
+		const { createFixture } = await import('fs-fixture');
+
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
+
+		it('loads usage data for a specific session', async () => {
+			await using fixture = await createFixture({
+				'.claude': {
+					projects: {
+						'test-project': {
+							'session-123.jsonl': `${JSON.stringify({
+								timestamp: '2024-01-01T00:00:00Z',
+								sessionId: 'session-123',
+								message: {
+									usage: {
+										input_tokens: 100,
+										output_tokens: 50,
+										cache_creation_input_tokens: 10,
+										cache_read_input_tokens: 20,
+									},
+									model: 'claude-sonnet-4-20250514',
+								},
+								costUSD: 0.5,
+							})}\n${JSON.stringify({
+								timestamp: '2024-01-01T01:00:00Z',
+								sessionId: 'session-123',
+								message: {
+									usage: {
+										input_tokens: 200,
+										output_tokens: 100,
+										cache_creation_input_tokens: 20,
+										cache_read_input_tokens: 40,
+									},
+									model: 'claude-sonnet-4-20250514',
+								},
+								costUSD: 1.0,
+							})}`,
+						},
+					},
+				},
+			});
+
+			vi.stubEnv('CLAUDE_CONFIG_DIR', path.join(fixture.path, '.claude'));
+
+			const result = await loadSessionUsageById('session-123', { mode: 'display' });
+
+			expect(result).not.toBeNull();
+			expect(result?.totalCost).toBe(1.5);
+			expect(result?.entries).toHaveLength(2);
+		});
+
+		it('returns null for non-existent session', async () => {
+			await using fixture = await createFixture({
+				'.claude': {
+					projects: {
+						'test-project': {
+							'other-session.jsonl': JSON.stringify({
+								timestamp: '2024-01-01T00:00:00Z',
+								sessionId: 'other-session',
+								message: {
+									usage: {
+										input_tokens: 100,
+										output_tokens: 50,
+									},
+									model: 'claude-sonnet-4-20250514',
+								},
+								costUSD: 0.5,
+							}),
+						},
+					},
+				},
+			});
+
+			vi.stubEnv('CLAUDE_CONFIG_DIR', path.join(fixture.path, '.claude'));
+
+			const result = await loadSessionUsageById('non-existent', { mode: 'display' });
+
+			expect(result).toBeNull();
 		});
 	});
 

--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -158,6 +158,8 @@ export function extractProjectFromPath(jsonlPath: string): string {
  * Zod schema for validating Claude usage data from JSONL files
  */
 export const usageDataSchema = z.object({
+	cwd: z.string().optional(), // Claude Code version, optional for compatibility
+	sessionId: sessionIdSchema.optional(), // Session ID for deduplication
 	timestamp: isoTimestampSchema,
 	version: versionSchema.optional(), // Claude Code version
 	message: z.object({


### PR DESCRIPTION
## Summary
- Fixed session cost calculation in statusline command to use actual session IDs from hook data
- Added new loadSessionUsageById() function to properly locate and load specific session JSONL files  
- Improved test coverage with vitest environment mocking

## Problem
The statusline command was incorrectly trying to extract session IDs from transcript paths instead of using the session_id field directly from hook data. This caused session costs to not be displayed correctly.

## Solution
- Created dedicated function loadSessionUsageById() that searches for JSONL files by their actual session ID (filename)
- Updated statusline command to use the session_id from hook data directly
- Added comprehensive tests with vitest environment mocking and proper cleanup
- Updated documentation to clarify the naming confusion between project directories and actual sessions

## Test Plan
- [x] Run bun run test - all tests pass
- [x] Run bun typecheck - no type errors
- [x] Run bun run format - code is properly formatted
- [ ] Test statusline command with actual Claude Code hooks