### PR TITLE
fix!: add offline mode support to statusline command

### DIFF
--- a/docs/guide/statusline.md
+++ b/docs/guide/statusline.md
@@ -28,6 +28,20 @@ Add this to your `~/.claude/settings.json` or `~/.config/claude/settings.json`:
 }
 ```
 
+### Offline Mode (Optional)
+
+For faster performance and to avoid network calls to LiteLLM API, you can enable offline mode which uses cached pricing data:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bun x ccusage statusline --offline", // Uses cached pricing data
+    "padding": 0
+  }
+}
+```
+
 ## Output Format
 
 The statusline displays a compact, single-line summary:
@@ -59,6 +73,7 @@ The statusline command:
 - Identifies the active 5-hour billing block
 - Calculates real-time burn rates and projections
 - Outputs a single line suitable for status bar display
+- Supports offline mode for faster performance without network dependencies
 
 ## Beta Notice
 

--- a/docs/guide/statusline.md
+++ b/docs/guide/statusline.md
@@ -28,15 +28,17 @@ Add this to your `~/.claude/settings.json` or `~/.config/claude/settings.json`:
 }
 ```
 
-### Offline Mode (Optional)
+By default, statusline uses **offline mode** with cached pricing data for optimal performance.
 
-For faster performance and to avoid network calls to LiteLLM API, you can enable offline mode which uses cached pricing data:
+### Online Mode (Optional)
+
+If you need the latest pricing data from LiteLLM API, you can explicitly enable online mode:
 
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "bun x ccusage statusline --offline", // Uses cached pricing data
+    "command": "bun x ccusage statusline --no-offline", // Fetches latest pricing from API
     "padding": 0
   }
 }
@@ -73,7 +75,8 @@ The statusline command:
 - Identifies the active 5-hour billing block
 - Calculates real-time burn rates and projections
 - Outputs a single line suitable for status bar display
-- Supports offline mode for faster performance without network dependencies
+- **Uses offline mode by default** for instant response times without network dependencies
+- Can be configured to use online mode with `--no-offline` for latest pricing data
 
 ## Beta Notice
 

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
 		"release": "bun lint && bun typecheck && vitest run && bun run build && bumpp",
 		"start": "bun run ./src/index.ts",
 		"test": "TZ=UTC vitest",
-		"test:statusline": "cat test/statusline-test.json | bun run ./src/index.ts statusline",
-		"test:statusline:dev": "cat test/statusline-test.json | bun run start statusline",
+		"test:statusline": "cat test/statusline-test.json | bun run start statusline",
 		"typecheck": "tsgo --noEmit"
 	},
 	"devDependencies": {

--- a/src/commands/statusline.ts
+++ b/src/commands/statusline.ts
@@ -30,7 +30,10 @@ export const statuslineCommand = define({
 	name: 'statusline',
 	description: 'Display compact status line for Claude Code hooks (Beta)',
 	args: {
-		offline: sharedArgs.offline,
+		offline: {
+			...sharedArgs.offline,
+			default: true, // Default to offline mode for faster performance
+		},
 	},
 	async run(ctx) {
 		// Set logger to silent for statusline output

--- a/src/commands/statusline.ts
+++ b/src/commands/statusline.ts
@@ -3,6 +3,7 @@ import getStdin from 'get-stdin';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { calculateBurnRate } from '../_session-blocks.ts';
+import { sharedArgs } from '../_shared-args.ts';
 import { statuslineHookJsonSchema } from '../_types.ts';
 import { formatCurrency } from '../_utils.ts';
 import { calculateTotals } from '../calculate-cost.ts';
@@ -28,8 +29,10 @@ function formatRemainingTime(remaining: number): string {
 export const statuslineCommand = define({
 	name: 'statusline',
 	description: 'Display compact status line for Claude Code hooks (Beta)',
-	args: {},
-	async run() {
+	args: {
+		offline: sharedArgs.offline,
+	},
+	async run(ctx) {
 		// Set logger to silent for statusline output
 		logger.level = 0;
 
@@ -61,7 +64,7 @@ export const statuslineCommand = define({
 		// Load current session's cost by finding the specific JSONL file
 		let sessionCost: number | null = null;
 		try {
-			const sessionData = await loadSessionUsageById(sessionId, { mode: 'auto' });
+			const sessionData = await loadSessionUsageById(sessionId, { mode: 'auto', offline: ctx.values.offline });
 			if (sessionData != null) {
 				sessionCost = sessionData.totalCost;
 			}
@@ -80,6 +83,7 @@ export const statuslineCommand = define({
 				since: todayStr,
 				until: todayStr,
 				mode: 'auto',
+				offline: ctx.values.offline,
 			});
 
 			if (dailyData.length > 0) {
@@ -97,6 +101,7 @@ export const statuslineCommand = define({
 		try {
 			const blocks = await loadSessionBlockData({
 				mode: 'auto',
+				offline: ctx.values.offline,
 			});
 
 			// Only identify blocks if we have data


### PR DESCRIPTION
## Summary

This PR adds offline mode support to the statusline command and **makes it the default** for optimal performance. The statusline now uses cached pricing data by default, eliminating network latency.

## Breaking Change

⚠️ **BREAKING**: 
1. The statusline command now accepts CLI arguments (specifically `--offline`/`--no-offline`)
2. **Offline mode is now the default behavior** (previously required network access)

While this changes the command signature and default behavior, existing configurations will continue to work without modification.

## Changes

- ✨ Add `--offline` flag to statusline command arguments
- 🚀 **Set offline mode as default** for instant response times
- 🔧 Pass offline flag to all data loading functions:
  - `loadSessionUsageById()`
  - `loadDailyUsageData()`
  - `loadSessionBlockData()`
- 📚 Update documentation to reflect offline as default behavior
- 🌐 Add `--no-offline` flag for users who need latest pricing from API

## Benefits

- **Instant Response**: No network latency - critical for status line updates
- **Offline Support**: Works without internet connection
- **Better UX**: Status line updates immediately without waiting for API calls
- **Reduced API Load**: Fewer requests to external pricing service
- **Consistent Pricing**: Uses stable, cached pricing data

## Usage

### Default Mode (Offline - Recommended)
```json
{
  "statusLine": {
    "type": "command",
    "command": "bun x ccusage statusline"  // Uses cached pricing (fast)
  }
}
```

### Online Mode (Optional)
```json
{
  "statusLine": {
    "type": "command",
    "command": "bun x ccusage statusline --no-offline"  // Fetches from API (slower)
  }
}
```

## Testing

- ✅ All tests pass
- ✅ Tested with sample statusline hook JSON
- ✅ Verified backward compatibility (existing configs work)
- ✅ Confirmed offline mode is now default
- ✅ Verified `--no-offline` flag enables online mode

## Migration

No migration required. Existing configurations will continue to work but will now use offline mode by default for better performance. Users who need the latest pricing data can explicitly add `--no-offline` to their command.