### PR TITLE
docs: add statusline integration link to navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -77,6 +77,7 @@ export default withMermaid(defineConfig({
 						{ text: 'Library Usage', link: '/guide/library-usage' },
 						{ text: 'MCP Server', link: '/guide/mcp-server' },
 						{ text: 'JSON Output', link: '/guide/json-output' },
+						{ text: 'Statusline Integration', link: '/guide/statusline' },
 					],
 				},
 				{


### PR DESCRIPTION
## Summary
- Added a navigation link for the statusline integration documentation page in the VitePress configuration

## Test plan
- [ ] Verify the navigation link appears correctly in the documentation site
- [ ] Ensure the link points to the correct documentation page
- [ ] Check that the navigation structure remains consistent

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a “Statusline Integration” entry to the Guide → Integration sidebar, positioned after “JSON Output,” linking directly to the new statusline guide for easier discovery and navigation.
  - This update affects documentation navigation only; no other sidebar items were modified. No functional or API changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->