### PR TITLE
refactor: replace Result with R import from @praha/byethrow

### DIFF
--- a/src/_jq-processor.ts
+++ b/src/_jq-processor.ts
@@ -1,4 +1,4 @@
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import spawn from 'nano-spawn';
 
 /**
@@ -7,12 +7,12 @@ import spawn from 'nano-spawn';
  * @param jqCommand - The jq command/filter to apply
  * @returns The processed output from jq
  */
-export async function processWithJq(jsonData: unknown, jqCommand: string): Result.ResultAsync<string, Error> {
+export async function processWithJq(jsonData: unknown, jqCommand: string): R.ResultAsync<string, Error> {
 	// Convert JSON data to string
 	const jsonString = JSON.stringify(jsonData);
 
-	// Use Result.try with object form to wrap spawn call
-	const result = Result.try({
+	// Use R.try with object form to wrap spawn call
+	const result = R.try({
 		try: async () => {
 			const spawnResult = await spawn('jq', [jqCommand], {
 				stdin: { string: jsonString },
@@ -41,7 +41,7 @@ if (import.meta.vitest != null) {
 		it('should process JSON with simple filter', async () => {
 			const data = { name: 'test', value: 42 };
 			const result = await processWithJq(data, '.name');
-			const unwrapped = Result.unwrap(result);
+			const unwrapped = R.unwrap(result);
 			expect(unwrapped).toBe('"test"');
 		});
 
@@ -53,7 +53,7 @@ if (import.meta.vitest != null) {
 				],
 			};
 			const result = await processWithJq(data, '.items | map(.name)');
-			const unwrapped = Result.unwrap(result);
+			const unwrapped = R.unwrap(result);
 			const parsed = JSON.parse(unwrapped) as string[];
 			expect(parsed).toEqual(['apple', 'banana']);
 		});
@@ -61,14 +61,14 @@ if (import.meta.vitest != null) {
 		it('should handle raw output', async () => {
 			const data = { message: 'hello world' };
 			const result = await processWithJq(data, '.message | @text');
-			const unwrapped = Result.unwrap(result);
+			const unwrapped = R.unwrap(result);
 			expect(unwrapped).toBe('"hello world"');
 		});
 
 		it('should return error for invalid jq syntax', async () => {
 			const data = { test: 'value' };
 			const result = await processWithJq(data, 'invalid syntax {');
-			const error = Result.unwrapError(result);
+			const error = R.unwrapError(result);
 			expect(error.message).toContain('jq processing failed');
 		});
 
@@ -81,14 +81,14 @@ if (import.meta.vitest != null) {
 				],
 			};
 			const result = await processWithJq(data, '.users | sort_by(.age) | .[0].name');
-			const unwrapped = Result.unwrap(result);
+			const unwrapped = R.unwrap(result);
 			expect(unwrapped).toBe('"Bob"');
 		});
 
 		it('should handle numeric output', async () => {
 			const data = { values: [1, 2, 3, 4, 5] };
 			const result = await processWithJq(data, '.values | add');
-			const unwrapped = Result.unwrap(result);
+			const unwrapped = R.unwrap(result);
 			expect(unwrapped).toBe('15');
 		});
 	});

--- a/src/commands/_blocks.live.ts
+++ b/src/commands/_blocks.live.ts
@@ -8,7 +8,7 @@
 
 import type { LiveMonitoringConfig } from '../_live-rendering.ts';
 import process from 'node:process';
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import pc from 'picocolors';
 import { MIN_RENDER_INTERVAL_MS } from '../_consts.ts';
 import { LiveMonitor } from '../_live-monitor.ts';
@@ -53,7 +53,7 @@ export async function startLiveMonitoring(config: LiveMonitoringConfig): Promise
 		order: config.order,
 	});
 
-	const monitoringResult = await Result.try({
+	const monitoringResult = await R.try({
 		try: async () => {
 			while (!abortController.signal.aborted) {
 				const now = Date.now();
@@ -100,7 +100,7 @@ export async function startLiveMonitoring(config: LiveMonitoringConfig): Promise
 		catch: error => error,
 	})();
 
-	if (Result.isFailure(monitoringResult)) {
+	if (R.isFailure(monitoringResult)) {
 		const error = monitoringResult.error;
 		if ((error instanceof DOMException || error instanceof Error) && error.name === 'AbortError') {
 			return; // Normal graceful shutdown

--- a/src/commands/_session_id.ts
+++ b/src/commands/_session_id.ts
@@ -1,7 +1,7 @@
 import type { CostMode } from '../_types.ts';
 import type { UsageData } from '../data-loader.ts';
 import process from 'node:process';
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import { processWithJq } from '../_jq-processor.ts';
 import { formatCurrency, formatNumber, ResponsiveTable } from '../_utils.ts';
 import { formatDateCompact, loadSessionUsageById } from '../data-loader.ts';
@@ -55,7 +55,7 @@ export async function handleSessionIdLookup(ctx: SessionIdContext, useJson: bool
 
 		if (ctx.values.jq != null) {
 			const jqResult = await processWithJq(jsonOutput, ctx.values.jq);
-			if (Result.isFailure(jqResult)) {
+			if (R.isFailure(jqResult)) {
 				logger.error(jqResult.error.message);
 				process.exit(1);
 			}

--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -1,6 +1,6 @@
 import type { SessionBlock } from '../_session-blocks.ts';
 import process from 'node:process';
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { BLOCKS_COMPACT_WIDTH_THRESHOLD, BLOCKS_DEFAULT_TERMINAL_WIDTH, BLOCKS_WARNING_THRESHOLD, DEFAULT_RECENT_DAYS, DEFAULT_REFRESH_INTERVAL_SECONDS, MAX_REFRESH_INTERVAL_SECONDS, MIN_REFRESH_INTERVAL_SECONDS } from '../_consts.ts';
@@ -297,7 +297,7 @@ export const blocksCommand = define({
 			// Process with jq if specified
 			if (ctx.values.jq != null) {
 				const jqResult = await processWithJq(jsonOutput, ctx.values.jq);
-				if (Result.isFailure(jqResult)) {
+				if (R.isFailure(jqResult)) {
 					logger.error((jqResult.error).message);
 					process.exit(1);
 				}

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { groupByProject, groupDataByProject } from '../_daily-grouping.ts';
@@ -98,7 +98,7 @@ export const dailyCommand = define({
 			// Process with jq if specified
 			if (ctx.values.jq != null) {
 				const jqResult = await processWithJq(jsonOutput, ctx.values.jq);
-				if (Result.isFailure(jqResult)) {
+				if (R.isFailure(jqResult)) {
 					logger.error((jqResult.error).message);
 					process.exit(1);
 				}

--- a/src/commands/monthly.ts
+++ b/src/commands/monthly.ts
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { processWithJq } from '../_jq-processor.ts';
@@ -85,7 +85,7 @@ export const monthlyCommand = define({
 			// Process with jq if specified
 			if (ctx.values.jq != null) {
 				const jqResult = await processWithJq(jsonOutput, ctx.values.jq);
-				if (Result.isFailure(jqResult)) {
+				if (R.isFailure(jqResult)) {
 					logger.error((jqResult.error).message);
 					process.exit(1);
 				}

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -1,6 +1,6 @@
 // Types not needed here after extracting --id logic
 import process from 'node:process';
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { processWithJq } from '../_jq-processor.ts';
@@ -104,7 +104,7 @@ export const sessionCommand = define({
 			// Process with jq if specified
 			if (ctx.values.jq != null) {
 				const jqResult = await processWithJq(jsonOutput, ctx.values.jq);
-				if (Result.isFailure(jqResult)) {
+				if (R.isFailure(jqResult)) {
 					logger.error((jqResult.error).message);
 					process.exit(1);
 				}

--- a/src/commands/weekly.ts
+++ b/src/commands/weekly.ts
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { WEEK_DAYS } from '../_consts.ts';
@@ -97,7 +97,7 @@ export const weeklyCommand = define({
 			// Process with jq if specified
 			if (ctx.values.jq != null) {
 				const jqResult = await processWithJq(jsonOutput, ctx.values.jq);
-				if (Result.isFailure(jqResult)) {
+				if (R.isFailure(jqResult)) {
 					logger.error((jqResult.error).message);
 					process.exit(1);
 				}

--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -25,7 +25,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { toArray } from '@antfu/utils';
 import { unreachable } from '@core/errorutil';
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import { groupBy, uniq } from 'es-toolkit'; // TODO: after node20 is deprecated, switch to native Object.groupBy
 import { sort } from 'fast-sort';
 import { createFixture } from 'fs-fixture';
@@ -778,7 +778,7 @@ export async function calculateCostForEntry(
 	if (mode === 'calculate') {
 		// Always calculate from tokens
 		if (data.message.model != null) {
-			return Result.unwrap(fetcher.calculateCostFromTokens(data.message.usage, data.message.model), 0);
+			return R.unwrap(fetcher.calculateCostFromTokens(data.message.usage, data.message.model), 0);
 		}
 		return 0;
 	}
@@ -790,7 +790,7 @@ export async function calculateCostForEntry(
 		}
 
 		if (data.message.model != null) {
-			return Result.unwrap(fetcher.calculateCostFromTokens(data.message.usage, data.message.model), 0);
+			return R.unwrap(fetcher.calculateCostFromTokens(data.message.usage, data.message.model), 0);
 		}
 
 		return 0;

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -9,7 +9,7 @@
 
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import { createFixture } from 'fs-fixture';
 import { glob } from 'tinyglobby';
 import { CLAUDE_PROJECTS_DIR_NAME, DEBUG_MATCH_THRESHOLD_PERCENT, USAGE_DATA_GLOB_PATTERN } from './_consts.ts';
@@ -111,13 +111,13 @@ export async function detectMismatches(
 			.filter(line => line.length > 0);
 
 		for (const line of lines) {
-			const parseParser = Result.try({
+			const parseParser = R.try({
 				try: () => JSON.parse(line) as unknown,
 				catch: () => new Error('Invalid JSON'),
 			});
 
 			const parseResult = parseParser();
-			if (Result.isFailure(parseResult)) {
+			if (R.isFailure(parseResult)) {
 				continue;
 			}
 
@@ -139,7 +139,7 @@ export async function detectMismatches(
 				stats.entriesWithBoth++;
 
 				const model = data.message.model;
-				const calculatedCost = await Result.unwrap(fetcher.calculateCostFromTokens(
+				const calculatedCost = await R.unwrap(fetcher.calculateCostFromTokens(
 					data.message.usage,
 					model,
 				));

--- a/src/pricing-fetcher.ts
+++ b/src/pricing-fetcher.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ModelPricing } from './_types.ts';
-import { Result } from '@praha/byethrow';
+import { R } from '@praha/byethrow';
 import { LITELLM_PRICING_URL } from './_consts.ts';
 import { prefetchClaudePricing } from './_macro.ts' with { type: 'macro' };
 import { modelPricingSchema } from './_types.ts';
@@ -49,7 +49,7 @@ export class PricingFetcher implements Disposable {
 	 * Loads offline pricing data from pre-fetched cache
 	 * @returns Map of model names to pricing information
 	 */
-	private loadOfflinePricing = Result.try({
+	private loadOfflinePricing = R.try({
 		try: async () => {
 			const pricing = new Map(Object.entries(await prefetchClaudePricing()));
 			this.cachedPricing = pricing;
@@ -64,15 +64,15 @@ export class PricingFetcher implements Disposable {
 	 * @returns Map of model names to pricing information
 	 * @throws Error if both network fetch and fallback fail
 	 */
-	private async handleFallbackToCachedPricing(originalError: unknown): Result.ResultAsync<Map<string, ModelPricing>, Error> {
+	private async handleFallbackToCachedPricing(originalError: unknown): R.ResultAsync<Map<string, ModelPricing>, Error> {
 		logger.warn('Failed to fetch model pricing from LiteLLM, falling back to cached pricing data');
 		logger.debug('Fetch error details:', originalError);
-		return Result.pipe(
+		return R.pipe(
 			this.loadOfflinePricing(),
-			Result.inspect((pricing) => {
+			R.inspect((pricing) => {
 				logger.info(`Using cached pricing data for ${pricing.size} models`);
 			}),
-			Result.inspectError((error) => {
+			R.inspectError((error) => {
 				logger.error('Failed to load cached pricing data as fallback:', error);
 				logger.error('Original fetch error:', originalError);
 			}),
@@ -84,32 +84,32 @@ export class PricingFetcher implements Disposable {
 	 * Automatically falls back to offline mode if network fetch fails
 	 * @returns Map of model names to pricing information
 	 */
-	private async ensurePricingLoaded(): Result.ResultAsync<Map<string, ModelPricing>, Error> {
-		return Result.pipe(
-			this.cachedPricing != null ? Result.succeed(this.cachedPricing) : Result.fail(new Error('Cached pricing not available')),
-			Result.orElse(async () => {
+	private async ensurePricingLoaded(): R.ResultAsync<Map<string, ModelPricing>, Error> {
+		return R.pipe(
+			this.cachedPricing != null ? R.succeed(this.cachedPricing) : R.fail(new Error('Cached pricing not available')),
+			R.orElse(async () => {
 				// If we're in offline mode, return pre-fetched data
 				if (this.offline) {
 					return this.loadOfflinePricing();
 				}
 
 				logger.warn('Fetching latest model pricing from LiteLLM...');
-				return Result.pipe(
-					Result.try({
+				return R.pipe(
+					R.try({
 						try: fetch(LITELLM_PRICING_URL),
 						catch: error => new Error('Failed to fetch model pricing from LiteLLM', { cause: error }),
 					}),
-					Result.andThrough((response) => {
+					R.andThrough((response) => {
 						if (!response.ok) {
-							return Result.fail(new Error(`Failed to fetch pricing data: ${response.statusText}`));
+							return R.fail(new Error(`Failed to fetch pricing data: ${response.statusText}`));
 						}
-						return Result.succeed();
+						return R.succeed();
 					}),
-					Result.andThen(async response => Result.try({
+					R.andThen(async response => R.try({
 						try: response.json() as Promise<Record<string, unknown>>,
 						catch: error => new Error('Failed to parse pricing data', { cause: error }),
 					})),
-					Result.map((data) => {
+					R.map((data) => {
 						const pricing = new Map<string, ModelPricing>();
 						for (const [modelName, modelData] of Object.entries(data)) {
 							if (typeof modelData === 'object' && modelData !== null) {
@@ -122,11 +122,11 @@ export class PricingFetcher implements Disposable {
 						}
 						return pricing;
 					}),
-					Result.inspect((pricing) => {
+					R.inspect((pricing) => {
 						this.cachedPricing = pricing;
 						logger.info(`Loaded pricing for ${pricing.size} models`);
 					}),
-					Result.orElse(async error => this.handleFallbackToCachedPricing(error)),
+					R.orElse(async error => this.handleFallbackToCachedPricing(error)),
 				);
 			}),
 		);
@@ -136,7 +136,7 @@ export class PricingFetcher implements Disposable {
 	 * Fetches all available model pricing data
 	 * @returns Map of model names to pricing information
 	 */
-	async fetchModelPricing(): Result.ResultAsync<Map<string, ModelPricing>, Error> {
+	async fetchModelPricing(): R.ResultAsync<Map<string, ModelPricing>, Error> {
 		return this.ensurePricingLoaded();
 	}
 
@@ -146,10 +146,10 @@ export class PricingFetcher implements Disposable {
 	 * @param modelName - Name of the model to get pricing for
 	 * @returns Model pricing information or null if not found
 	 */
-	async getModelPricing(modelName: string): Result.ResultAsync<ModelPricing | null, Error> {
-		return Result.pipe(
+	async getModelPricing(modelName: string): R.ResultAsync<ModelPricing | null, Error> {
+		return R.pipe(
 			this.ensurePricingLoaded(),
-			Result.map((pricing) => {
+			R.map((pricing) => {
 				// Direct match
 				const directMatch = pricing.get(modelName);
 				if (directMatch != null) {
@@ -206,10 +206,10 @@ export class PricingFetcher implements Disposable {
 			cache_read_input_tokens?: number;
 		},
 		modelName: string,
-	): Result.ResultAsync<number, Error> {
-		return Result.pipe(
+	): R.ResultAsync<number, Error> {
+		return R.pipe(
 			this.getModelPricing(modelName),
-			Result.map(pricing => pricing == null ? 0 : this.calculateCostFromPricing(tokens, pricing)),
+			R.map(pricing => pricing == null ? 0 : this.calculateCostFromPricing(tokens, pricing)),
 		);
 	}
 
@@ -279,7 +279,7 @@ if (import.meta.vitest != null) {
 
 				{
 					using fetcher = new TestPricingFetcher();
-					const pricing = await Result.unwrap(fetcher.fetchModelPricing());
+					const pricing = await R.unwrap(fetcher.fetchModelPricing());
 					expect(pricing.size).toBeGreaterThan(0);
 				}
 
@@ -289,7 +289,7 @@ if (import.meta.vitest != null) {
 			it('should calculate costs directly with model name', async () => {
 				using fetcher = new PricingFetcher();
 
-				const cost = await Result.unwrap(fetcher.calculateCostFromTokens(
+				const cost = await R.unwrap(fetcher.calculateCostFromTokens(
 					{
 						input_tokens: 1000,
 						output_tokens: 500,
@@ -304,7 +304,7 @@ if (import.meta.vitest != null) {
 		describe('fetchModelPricing', () => {
 			it('should fetch and parse pricing data from LiteLLM', async () => {
 				using fetcher = new PricingFetcher();
-				const pricing = await Result.unwrap(fetcher.fetchModelPricing());
+				const pricing = await R.unwrap(fetcher.fetchModelPricing());
 
 				// Should have pricing data
 				expect(pricing.size).toBeGreaterThan(0);
@@ -319,12 +319,12 @@ if (import.meta.vitest != null) {
 			it('should cache pricing data', async () => {
 				using fetcher = new PricingFetcher();
 				// First call should fetch from network
-				const firstResult = await Result.unwrap(fetcher.fetchModelPricing());
+				const firstResult = await R.unwrap(fetcher.fetchModelPricing());
 				const firstKeys = Array.from(firstResult.keys());
 
 				// Second call should use cache (and be instant)
 				const startTime = Date.now();
-				const secondResult = await Result.unwrap(fetcher.fetchModelPricing());
+				const secondResult = await R.unwrap(fetcher.fetchModelPricing());
 				const endTime = Date.now();
 
 				// Should be very fast (< 5ms) if cached
@@ -340,7 +340,7 @@ if (import.meta.vitest != null) {
 				using fetcher = new PricingFetcher();
 
 				// Test with a known Claude model from LiteLLM
-				const pricing = await Result.unwrap(fetcher.getModelPricing('claude-sonnet-4-20250514'));
+				const pricing = await R.unwrap(fetcher.getModelPricing('claude-sonnet-4-20250514'));
 				expect(pricing).not.toBeNull();
 			});
 
@@ -348,14 +348,14 @@ if (import.meta.vitest != null) {
 				using fetcher = new PricingFetcher();
 
 				// Test partial matching
-				const pricing = await Result.unwrap(fetcher.getModelPricing('claude-sonnet-4'));
+				const pricing = await R.unwrap(fetcher.getModelPricing('claude-sonnet-4'));
 				expect(pricing).not.toBeNull();
 			});
 
 			it('should return null for unknown models', async () => {
 				using fetcher = new PricingFetcher();
 
-				const pricing = await Result.unwrap(fetcher.getModelPricing(
+				const pricing = await R.unwrap(fetcher.getModelPricing(
 					'definitely-not-a-real-model-xyz',
 				));
 				expect(pricing).toBeNull();
@@ -366,7 +366,7 @@ if (import.meta.vitest != null) {
 			it('should calculate cost for claude-sonnet-4-20250514', async () => {
 				using fetcher = new PricingFetcher();
 				const modelName = 'claude-4-sonnet-20250514';
-				const pricing = await Result.unwrap(fetcher.getModelPricing(modelName));
+				const pricing = await R.unwrap(fetcher.getModelPricing(modelName));
 
 				// This model should exist in LiteLLM
 				expect(pricing).not.toBeNull();
@@ -387,7 +387,7 @@ if (import.meta.vitest != null) {
 			it('should calculate cost including cache tokens for claude-sonnet-4-20250514', async () => {
 				using fetcher = new PricingFetcher();
 				const modelName = 'claude-4-sonnet-20250514';
-				const pricing = await Result.unwrap(fetcher.getModelPricing(modelName));
+				const pricing = await R.unwrap(fetcher.getModelPricing(modelName));
 
 				// We need to check that pricing is not null before using it
 				expect(pricing).not.toBeNull();
@@ -414,7 +414,7 @@ if (import.meta.vitest != null) {
 			it('should calculate cost for claude-opus-4-20250514', async () => {
 				using fetcher = new PricingFetcher();
 				const modelName = 'claude-4-opus-20250514';
-				const pricing = await Result.unwrap(fetcher.getModelPricing(modelName));
+				const pricing = await R.unwrap(fetcher.getModelPricing(modelName));
 
 				// This model should exist in LiteLLM
 				expect(pricing).not.toBeNull();
@@ -435,7 +435,7 @@ if (import.meta.vitest != null) {
 			it('should calculate cost including cache tokens for claude-opus-4-20250514', async () => {
 				using fetcher = new PricingFetcher();
 				const modelName = 'claude-4-opus-20250514';
-				const pricing = await Result.unwrap(fetcher.getModelPricing(modelName));
+				const pricing = await R.unwrap(fetcher.getModelPricing(modelName));
 
 				// We need to check that pricing is not null before using it
 				expect(pricing).not.toBeNull();
@@ -498,7 +498,7 @@ if (import.meta.vitest != null) {
 			it('should use pre-fetched data in offline mode when available', async () => {
 				using fetcher = new PricingFetcher(true); // offline mode
 
-				const pricing = await Result.unwrap(fetcher.fetchModelPricing());
+				const pricing = await R.unwrap(fetcher.fetchModelPricing());
 
 				// Should have Claude models from pre-fetched data
 				expect(pricing.size).toBeGreaterThan(0);
@@ -513,7 +513,7 @@ if (import.meta.vitest != null) {
 			it('should calculate costs in offline mode when data available', async () => {
 				using fetcher = new PricingFetcher(true); // offline mode
 
-				const cost = await Result.unwrap(fetcher.calculateCostFromTokens(
+				const cost = await R.unwrap(fetcher.calculateCostFromTokens(
 					{
 						input_tokens: 1000,
 						output_tokens: 500,
@@ -545,7 +545,7 @@ if (import.meta.vitest != null) {
 				vi.stubGlobal('fetch', fetchMock);
 
 				using fetcher = new PricingFetcher(false); // Start in online mode
-				const pricing = await Result.unwrap(fetcher.fetchModelPricing());
+				const pricing = await R.unwrap(fetcher.fetchModelPricing());
 
 				// Verify that fetch was called (attempting online mode first)
 				expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('litellm'));
@@ -572,7 +572,7 @@ if (import.meta.vitest != null) {
 
 				using fetcher = new PricingFetcher(false); // Start in online mode, will fallback
 
-				const cost = await Result.unwrap(fetcher.calculateCostFromTokens(
+				const cost = await R.unwrap(fetcher.calculateCostFromTokens(
 					{
 						input_tokens: 1000,
 						output_tokens: 500,
@@ -602,7 +602,7 @@ if (import.meta.vitest != null) {
 				vi.stubGlobal('fetch', fetchMock);
 
 				using fetcher = new PricingFetcher(false); // Start in online mode
-				const pricing = await Result.unwrap(fetcher.fetchModelPricing());
+				const pricing = await R.unwrap(fetcher.fetchModelPricing());
 
 				// Verify that fetch was attempted
 				expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('litellm'));


### PR DESCRIPTION
## Summary\n• Replace all imports of \`Result\` with \`R\` for more concise code\n• Update all \`Result.*\` method calls to \`R.*\` throughout codebase\n• Fix variable naming issues caused by regex replacement\n• Maintain functionality while improving code readability\n\n## Test plan\n- [x] Run ESLint formatting and linting - all checks pass\n- [x] Verify no breaking changes to existing functionality\n- [x] All variable references correctly updated