### PR TITLE
Fix: Windows hang when CWD contains symbolic links

### DIFF
--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -1280,9 +1280,9 @@ export async function loadSessionUsageById(
 	const claudePaths = getClaudePaths();
 
 	// Find the JSONL file for this session ID
-	// On Windows, replace backslashes from path.join with forward slashes for tinyglobby compatibility
+	// Use path.posix to ensure forward slashes in pattern for tinyglobby compatibility
 	const patterns = claudePaths.map(p => 
-		path.join(p, 'projects', '**', `${sessionId}.jsonl`).replace(/\\/g, '/')
+		path.posix.join(p, 'projects', '**', `${sessionId}.jsonl`)
 	);
 	const jsonlFiles = await glob(patterns);
 

--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -1280,7 +1280,10 @@ export async function loadSessionUsageById(
 	const claudePaths = getClaudePaths();
 
 	// Find the JSONL file for this session ID
-	const patterns = claudePaths.map(p => path.join(p, 'projects', '**', `${sessionId}.jsonl`));
+	// Convert backslashes to forward slashes to avoid tinyglobby bug with Windows paths in directories containing symlinks
+	const patterns = claudePaths.map(p => 
+		path.join(p, 'projects', '**', `${sessionId}.jsonl`).replace(/\\/g, '/')
+	);
 	const jsonlFiles = await glob(patterns);
 
 	if (jsonlFiles.length === 0) {

--- a/src/data-loader.ts
+++ b/src/data-loader.ts
@@ -1280,7 +1280,7 @@ export async function loadSessionUsageById(
 	const claudePaths = getClaudePaths();
 
 	// Find the JSONL file for this session ID
-	// Convert backslashes to forward slashes to avoid tinyglobby bug with Windows paths in directories containing symlinks
+	// On Windows, replace backslashes from path.join with forward slashes for tinyglobby compatibility
 	const patterns = claudePaths.map(p => 
 		path.join(p, 'projects', '**', `${sessionId}.jsonl`).replace(/\\/g, '/')
 	);


### PR DESCRIPTION
## Problem

ccusage would hang indefinitely on Windows when run from directories containing symbolic links (junction points) such as:
- `C:\Users\{username}\Documents` (contains My Music, My Pictures, My Videos junctions)
- `C:\Users\{username}` (contains My Documents, Application Data, etc.)

This issue was discovered through https://github.com/Owloops/claude-powerline which uses ccusage's `loadSessionUsageById()` function and would hang when run from these directories.

## Root Cause

The issue is ultimately caused by a bug in tinyglobby where Windows absolute paths with backslashes (e.g., `C:\Users\...\**\file.jsonl`) would cause the glob function to incorrectly process the path when the current working directory contained symbolic links.

## Solution

Convert backslashes to forward slashes in glob patterns. Forward slashes are cross-platform compatible and avoid the tinyglobby bug entirely.

## Changes

- Modified `loadSessionUsageById` in `src/data-loader.ts` to replace backslashes with forward slashes in the glob pattern

## Testing

Tested the following scenarios on Windows:
- ✅ Running from directories WITH symlinks (Documents, Home) - now works correctly
- ✅ Running from directories WITHOUT symlinks - continues to work
- ✅ Unix/Linux/macOS compatibility - unaffected (already use forward slashes)

## Technical Details

The bug manifests when:
1. Using Windows absolute paths with backslashes (`C:\...`)
2. Current working directory contains symbolic links/junction points
3. tinyglobby attempts to process the path

By converting to forward slashes, we maintain full cross-platform compatibility while avoiding the tinyglobby bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows path handling for session-usage discovery by normalizing glob patterns to use forward slashes; session usage data is now reliably found (including projects accessed via symlinked directories). No changes to commands, configuration, or outputs; behavior on macOS/Linux unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->