### PR TITLE
chore: remove @praha/byethrow MCP server, use documentation URL

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -14,15 +14,6 @@
 				"--no-cache"
 			]
 		},
-		"@praha/byethrow": {
-			"type": "stdio",
-			"command": "bun",
-			"args": [
-				"x",
-				"@praha/byethrow-mcp"
-			],
-			"env": {}
-		},
 		"lsmcp": {
 			"command": "bun",
 			"args": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ This is a CLI tool that analyzes Claude Code usage data from local JSONL files s
 **Error Handling:**
 
 - **Prefer @praha/byethrow Result type** over traditional try-catch for functional error handling
+  - Documentation: https://praha-inc.github.io/byethrow/llms.txt
 - Use `Result.try()` for wrapping operations that may throw (JSON parsing, etc.)
 - Use `Result.isFailure()` for checking errors (more readable than `!Result.isSuccess()`)
 - Use early return pattern (`if (Result.isFailure(result)) continue;`) instead of ternary operators


### PR DESCRIPTION
## Summary

- Remove @praha/byethrow MCP server configuration from .mcp.json
- Update CLAUDE.md to reference https://praha-inc.github.io/byethrow/llms.txt for byethrow documentation
- Keep @praha/byethrow package dependency for Result type usage in the codebase

This change switches from using the MCP server for byethrow documentation to referencing the LLMs.txt URL directly in the documentation.

## Test plan

- [x] Removed MCP server configuration from .mcp.json
- [x] Updated documentation reference in CLAUDE.md
- [x] Preserved package dependency for Result type usage
- [ ] Verify byethrow Result type still works in codebase
- [ ] Test that documentation URL is accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference link under Error Handling for additional resources.
* **Chores**
  * Removed an unused MCP server configuration, reducing the number of configured servers.
  * Dropped a related development dependency to streamline the setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->