### PR TITLE
docs: update CLAUDE.md to reference byethrow MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -21,6 +21,16 @@
 				"-p",
 				"tsgo"
 			]
+		},
+		"byethrow": {
+			"command": "bun",
+			"args": [
+				"x",
+				"sitemcp",
+				"https://praha-inc.github.io/byethrow/",
+				"--concurrency 10",
+				"--no-cache"
+			]
 		}
 	}
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,7 @@ This is a CLI tool that analyzes Claude Code usage data from local JSONL files s
   - **ESLint MCP**: Lint TypeScript/JavaScript files directly through Claude Code tools
   - **Context7 MCP**: Look up documentation for libraries and frameworks
   - **Gunshi MCP**: Access gunshi.dev documentation and examples
+  - **Byethrow MCP**: Access @praha/byethrow documentation and examples for functional error handling
   - **TypeScript MCP (lsmcp)**: Search for TypeScript functions, types, and symbols across the codebase
 
 ## Code Style Notes
@@ -170,7 +171,7 @@ This is a CLI tool that analyzes Claude Code usage data from local JSONL files s
 **Error Handling:**
 
 - **Prefer @praha/byethrow Result type** over traditional try-catch for functional error handling
-  - Documentation: https://praha-inc.github.io/byethrow/llms.txt
+  - Documentation: Available via byethrow MCP server
 - Use `Result.try()` for wrapping operations that may throw (JSON parsing, etc.)
 - Use `Result.isFailure()` for checking errors (more readable than `!Result.isSuccess()`)
 - Use early return pattern (`if (Result.isFailure(result)) continue;`) instead of ternary operators
@@ -253,6 +254,7 @@ This ensures code quality and catches issues immediately after changes.
 # Tips for Claude Code
 
 - [gunshi](https://gunshi.dev/llms.txt) - Documentation available via Gunshi MCP server
+- [byethrow](https://praha-inc.github.io/byethrow/llms.txt) - Documentation available via Byethrow MCP server
 - Context7 MCP server available for library documentation lookup
 - do not use console.log. use logger.ts instead
 - **IMPORTANT**: When searching for TypeScript functions, types, or symbols in the codebase, ALWAYS use TypeScript MCP (lsmcp) tools like `get_definitions`, `find_references`, `get_hover`, etc. DO NOT use grep/rg for searching TypeScript code structures.


### PR DESCRIPTION
Replace direct llms.txt URL references with byethrow MCP server access in CLAUDE.md documentation.

## Summary
- Update Error Handling section to reference byethrow MCP server instead of direct URL
- Add Byethrow MCP to External MCP Servers list with description
- Add byethrow reference to Tips for Claude Code section

## Changes
- **Error Handling section**: Changed documentation reference from direct llms.txt URL to "Available via byethrow MCP server"
- **MCP Integration section**: Added "Byethrow MCP: Access @praha/byethrow documentation and examples for functional error handling" to the External MCP Servers list
- **Tips for Claude Code section**: Added byethrow entry with MCP server reference

This change ensures consistent access to byethrow documentation through the newly added MCP server integration.