### PR TITLE
feat: add --compact flag for explicit compact mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ ccusage daily --locale ja-JP  # Use Japanese locale for date/time formatting
 ccusage daily --instances  # Group by project/instance
 ccusage daily --project myproject  # Filter to specific project
 ccusage daily --instances --project myproject --json  # Combined usage
+
+# Compact mode for screenshots/sharing
+ccusage --compact  # Force compact table mode
+ccusage monthly --compact  # Compact monthly report
 ```
 
 ## Features
@@ -87,6 +91,7 @@ ccusage daily --instances --project myproject --json  # Combined usage
 - 📁 **Custom Path**: Support for custom Claude data directory locations
 - 🎨 **Beautiful Output**: Colorful table-formatted display with automatic responsive layout
 - 📱 **Smart Tables**: Automatic compact mode for narrow terminals (< 100 characters) with essential columns
+- 📸 **Compact Mode**: Use `--compact` flag to force compact table layout, perfect for screenshots and sharing
 - 📋 **Enhanced Model Display**: Model names shown as bulleted lists for better readability
 - 📄 **JSON Output**: Export data in structured JSON format with `--json`
 - 💰 **Cost Tracking**: Shows costs in USD for each day/month/session

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -105,6 +105,17 @@ ccusage blocks --live
 
 ccusage automatically colors the output based on the terminal's capabilities. If you want to disable colors, you can use the `--no-color` flag. Or you can use the `--color` flag to force colors on.
 
+## Compact Mode
+
+ccusage automatically adjusts its table layout based on terminal width. For narrow terminals (< 100 characters), it shows a compact view with essential columns. You can also force compact mode for better screenshots:
+
+```bash
+ccusage --compact            # Force compact mode
+ccusage monthly --compact    # Compact monthly report
+```
+
+This is particularly useful when sharing screenshots or working in constrained terminals.
+
 ## Troubleshooting
 
 ### No Data Found

--- a/src/_shared-args.ts
+++ b/src/_shared-args.ts
@@ -102,6 +102,11 @@ export const sharedArgs = {
 		short: 'q',
 		description: 'Process JSON output with jq command (requires jq binary, implies --json)',
 	},
+	compact: {
+		type: 'boolean',
+		description: 'Force compact mode for narrow displays (better for screenshots)',
+		default: false,
+	},
 } as const satisfies Args;
 
 /**

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -24,6 +24,7 @@ type TableOptions = {
 	compactHead?: string[];
 	compactColAligns?: ('left' | 'right' | 'center')[];
 	compactThreshold?: number;
+	forceCompact?: boolean;
 };
 
 /**
@@ -40,6 +41,7 @@ export class ResponsiveTable {
 	private compactColAligns?: ('left' | 'right' | 'center')[];
 	private compactThreshold: number;
 	private compactMode = false;
+	private forceCompact: boolean;
 
 	/**
 	 * Creates a new responsive table instance
@@ -53,6 +55,7 @@ export class ResponsiveTable {
 		this.compactHead = options.compactHead;
 		this.compactColAligns = options.compactColAligns;
 		this.compactThreshold = options.compactThreshold ?? 100;
+		this.forceCompact = options.forceCompact ?? false;
 	}
 
 	/**
@@ -123,7 +126,7 @@ export class ResponsiveTable {
 		const terminalWidth = Number.parseInt(process.env.COLUMNS ?? '', 10) || process.stdout.columns || 120;
 
 		// Determine if we should use compact mode
-		this.compactMode = terminalWidth < this.compactThreshold && this.compactHead != null;
+		this.compactMode = this.forceCompact || (terminalWidth < this.compactThreshold && this.compactHead != null);
 
 		// Get current table configuration
 		const { head, colAligns } = this.getCurrentTableConfig();

--- a/src/commands/blocks.ts
+++ b/src/commands/blocks.ts
@@ -396,8 +396,12 @@ export const blocksCommand = define({
 				});
 
 				// Detect if we need compact formatting
+				// Use compact format if:
+				// 1. User explicitly requested it with --compact flag
+				// 2. Terminal width is below threshold
 				const terminalWidth = process.stdout.columns || BLOCKS_DEFAULT_TERMINAL_WIDTH;
-				const useCompactFormat = terminalWidth < BLOCKS_COMPACT_WIDTH_THRESHOLD;
+				const isNarrowTerminal = terminalWidth < BLOCKS_COMPACT_WIDTH_THRESHOLD;
+				const useCompactFormat = ctx.values.compact || isNarrowTerminal;
 
 				for (const block of blocks) {
 					if (block.isGap ?? false) {

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -153,6 +153,7 @@ export const dailyCommand = define({
 					'right',
 				],
 				compactThreshold: 100,
+				forceCompact: ctx.values.compact,
 			});
 
 			// Add daily data - group by project if instances flag is used

--- a/src/commands/monthly.ts
+++ b/src/commands/monthly.ts
@@ -140,6 +140,7 @@ export const monthlyCommand = define({
 					'right',
 				],
 				compactThreshold: 100,
+				forceCompact: ctx.values.compact,
 			});
 
 			// Add monthly data

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -163,6 +163,7 @@ export const sessionCommand = define({
 					'left',
 				],
 				compactThreshold: 100,
+				forceCompact: ctx.values.compact,
 			});
 
 			// Add session data

--- a/src/commands/weekly.ts
+++ b/src/commands/weekly.ts
@@ -152,6 +152,7 @@ export const weeklyCommand = define({
 					'right',
 				],
 				compactThreshold: 100,
+				forceCompact: ctx.values.compact,
 			});
 
 			// Add weekly data


### PR DESCRIPTION
## Summary
- Added a new `--compact` flag to force compact table layout
- Users can now explicitly enable compact mode for better screenshots and sharing
- The flag works with all commands (daily, monthly, weekly, session)

## Implementation Details
- Added `compact` boolean flag to shared arguments (without short flag as requested)
- Extended `ResponsiveTable` class with `forceCompact` option
- Updated all command implementations to pass the compact flag from CLI context
- Documentation updated with examples and feature description

## Testing
- All existing tests pass
- Manually tested with various commands:
  - `ccusage --compact`
  - `ccusage daily --compact`
  - `ccusage monthly --compact`
  - `ccusage weekly --compact`
  - `ccusage session --compact`

Closes #502