### PR TITLE
docs: reorganize configuration documentation into separate pages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -66,7 +66,11 @@ export default withMermaid(defineConfig({
 				{
 					text: 'Configuration',
 					items: [
-						{ text: 'Environment Variables', link: '/guide/configuration' },
+						{ text: 'Overview', link: '/guide/configuration' },
+						{ text: 'Command-Line Options', link: '/guide/cli-options' },
+						{ text: 'Environment Variables', link: '/guide/environment-variables' },
+						{ text: 'Configuration Files', link: '/guide/config-files' },
+						{ text: 'Directory Detection', link: '/guide/directory-detection' },
 						{ text: 'Custom Paths', link: '/guide/custom-paths' },
 						{ text: 'Cost Calculation Modes', link: '/guide/cost-modes' },
 					],

--- a/docs/guide/cli-options.md
+++ b/docs/guide/cli-options.md
@@ -1,0 +1,354 @@
+# Command-Line Options
+
+ccusage provides extensive command-line options to customize its behavior. These options take precedence over configuration files and environment variables.
+
+## Global Options
+
+All ccusage commands support these global options:
+
+### Date Filtering
+
+Filter usage data by date range:
+
+```bash
+# Filter by date range
+ccusage daily --since 20250101 --until 20250630
+
+# Show data from a specific date
+ccusage monthly --since 20250101
+
+# Show data up to a specific date
+ccusage session --until 20250630
+```
+
+### Output Format
+
+Control how data is displayed:
+
+```bash
+# JSON output for programmatic use
+ccusage daily --json
+ccusage daily -j
+
+# Show per-model breakdown
+ccusage daily --breakdown
+ccusage daily -b
+
+# Combine options
+ccusage daily --json --breakdown
+```
+
+### Cost Calculation Mode
+
+Choose how costs are calculated:
+
+```bash
+# Auto mode (default) - use costUSD when available
+ccusage daily --mode auto
+
+# Calculate mode - always calculate from tokens
+ccusage daily --mode calculate
+
+# Display mode - only show pre-calculated costUSD
+ccusage daily --mode display
+```
+
+### Sort Order
+
+Control the ordering of results:
+
+```bash
+# Newest first (default)
+ccusage daily --order desc
+
+# Oldest first
+ccusage daily --order asc
+```
+
+### Offline Mode
+
+Run without network connectivity:
+
+```bash
+# Use cached pricing data
+ccusage daily --offline
+ccusage daily -O
+```
+
+### Timezone
+
+Set the timezone for date calculations:
+
+```bash
+# Use UTC timezone
+ccusage daily --timezone UTC
+
+# Use specific timezone
+ccusage daily --timezone America/New_York
+ccusage daily -z Asia/Tokyo
+
+# Short alias
+ccusage monthly -z Europe/London
+```
+
+#### Timezone Effect
+
+The timezone affects how usage is grouped by date. For example, usage at 11 PM UTC on January 1st would appear on:
+- **January 1st** when `--timezone UTC`
+- **January 1st** when `--timezone America/New_York` (6 PM EST)
+- **January 2nd** when `--timezone Asia/Tokyo` (8 AM JST next day)
+
+### Locale
+
+Control date and time formatting:
+
+```bash
+# US English (12-hour time format)
+ccusage daily --locale en-US
+
+# Japanese (24-hour time format)
+ccusage blocks --locale ja-JP
+
+# German (24-hour time format)
+ccusage session -l de-DE
+
+# Short alias
+ccusage daily -l fr-FR
+```
+
+#### Locale Effects
+
+The locale affects display formatting:
+
+**Date Format:**
+- `en-US`: 08/04/2025
+- `en-CA`: 2025-08-04 (ISO format, default)
+- `ja-JP`: 2025/08/04
+- `de-DE`: 04.08.2025
+
+**Time Format:**
+- `en-US`: 3:30:00 PM (12-hour)
+- Others: 15:30:00 (24-hour)
+
+### Debug Options
+
+Get detailed debugging information:
+
+```bash
+# Debug mode - show pricing mismatches and config loading
+ccusage daily --debug
+
+# Show sample discrepancies
+ccusage daily --debug --debug-samples 10
+```
+
+### Configuration File
+
+Use a custom configuration file:
+
+```bash
+# Specify custom config file
+ccusage daily --config ./my-config.json
+ccusage monthly --config /path/to/team-config.json
+```
+
+## Command-Specific Options
+
+### Daily Command
+
+Additional options for daily reports:
+
+```bash
+# Group by project
+ccusage daily --instances
+ccusage daily -i
+
+# Filter to specific project
+ccusage daily --project myproject
+ccusage daily -p myproject
+
+# Combine project filtering
+ccusage daily --instances --project myproject
+```
+
+### Weekly Command
+
+Options for weekly reports:
+
+```bash
+# Set week start day
+ccusage weekly --start-of-week monday
+ccusage weekly --start-of-week sunday
+```
+
+### Session Command
+
+Options for session reports:
+
+```bash
+# Filter by session ID
+ccusage session --id abc123-session
+
+# Filter by project
+ccusage session --project myproject
+```
+
+### Blocks Command
+
+Options for 5-hour billing blocks:
+
+```bash
+# Show only active block
+ccusage blocks --active
+ccusage blocks -a
+
+# Show recent blocks (last 3 days)
+ccusage blocks --recent
+ccusage blocks -r
+
+# Set token limit for warnings
+ccusage blocks --token-limit 500000
+ccusage blocks --token-limit max
+
+# Live monitoring mode
+ccusage blocks --live
+ccusage blocks --live --refresh-interval 2
+
+# Customize session length
+ccusage blocks --session-length 5
+```
+
+### MCP Server
+
+Options for MCP server:
+
+```bash
+# Default stdio transport
+ccusage mcp
+
+# HTTP transport
+ccusage mcp --type http --port 8080
+
+# Custom cost mode
+ccusage mcp --mode calculate
+```
+
+### Statusline
+
+Options for statusline display:
+
+```bash
+# Basic statusline
+ccusage statusline
+
+# Force offline mode
+ccusage statusline --offline
+
+# Enable caching
+ccusage statusline --cache
+
+# Custom refresh interval
+ccusage statusline --refresh-interval 5
+```
+
+## JSON Output Options
+
+When using `--json` output, additional processing options are available:
+
+```bash
+# Apply jq filter to JSON output
+ccusage daily --json --jq ".data[]"
+
+# Filter high-cost days
+ccusage daily --json --jq ".data[] | select(.cost > 10)"
+
+# Extract specific fields
+ccusage session --json --jq ".data[] | {date, cost}"
+```
+
+## Option Precedence
+
+Options are applied in this order (highest to lowest priority):
+
+1. **Command-line arguments** - Direct CLI options
+2. **Custom config file** - Via `--config` flag
+3. **Local project config** - `.ccusage/ccusage.json`
+4. **User config** - `~/.config/claude/ccusage.json`
+5. **Legacy config** - `~/.claude/ccusage.json`
+6. **Built-in defaults**
+
+## Examples
+
+### Development Workflow
+
+```bash
+# Daily development check
+ccusage daily --instances --breakdown
+
+# Check specific project costs
+ccusage daily --project myapp --since 20250101
+
+# Export for reporting
+ccusage monthly --json > monthly-report.json
+```
+
+### Team Collaboration
+
+```bash
+# Use team configuration
+ccusage daily --config ./team-config.json
+
+# Consistent timezone for remote team
+ccusage daily --timezone UTC --locale en-CA
+
+# Generate shareable report
+ccusage weekly --json --jq ".summary"
+```
+
+### Cost Monitoring
+
+```bash
+# Monitor active usage
+ccusage blocks --active --live
+
+# Check if approaching limits
+ccusage blocks --token-limit 500000
+
+# Historical analysis
+ccusage monthly --mode calculate --breakdown
+```
+
+### Debugging Issues
+
+```bash
+# Debug configuration loading
+ccusage daily --debug --config ./test-config.json
+
+# Check pricing discrepancies
+ccusage daily --debug --debug-samples 20
+
+# Silent mode for scripts
+LOG_LEVEL=0 ccusage daily --json
+```
+
+## Short Aliases
+
+Many options have short aliases for convenience:
+
+| Long Option | Short | Description |
+|------------|-------|-------------|
+| `--json` | `-j` | JSON output |
+| `--breakdown` | `-b` | Per-model breakdown |
+| `--offline` | `-O` | Offline mode |
+| `--timezone` | `-z` | Set timezone |
+| `--locale` | `-l` | Set locale |
+| `--instances` | `-i` | Group by project |
+| `--project` | `-p` | Filter project |
+| `--active` | `-a` | Active block only |
+| `--recent` | `-r` | Recent blocks |
+
+## Related Documentation
+
+- [Environment Variables](/guide/environment-variables) - Configure via environment
+- [Configuration Files](/guide/config-files) - Persistent configuration
+- [Cost Calculation Modes](/guide/cost-modes) - Understanding cost modes

--- a/docs/guide/config-files.md
+++ b/docs/guide/config-files.md
@@ -1,0 +1,438 @@
+# Configuration Files
+
+ccusage supports JSON configuration files for persistent settings. Configuration files allow you to set default options for all commands or customize behavior for specific commands without repeating options every time.
+
+## Quick Start
+
+### 1. Use Schema for IDE Support
+
+Always include the schema for autocomplete and validation:
+
+```json
+{
+  "$schema": "https://ccusage.com/config-schema.json"
+}
+```
+
+### 2. Set Common Defaults
+
+Put frequently used options in `defaults`:
+
+```json
+{
+  "defaults": {
+    "timezone": "UTC",
+    "locale": "en-CA",
+    "breakdown": true
+  }
+}
+```
+
+### 3. Override for Specific Commands
+
+```json
+{
+  "defaults": {
+    "breakdown": false
+  },
+  "commands": {
+    "daily": {
+      "breakdown": true  // Only daily needs breakdown
+    }
+  }
+}
+```
+
+### 4. Convert CLI Arguments to Config
+
+If you find yourself repeating CLI arguments:
+
+```bash
+# Before (repeated CLI arguments)
+ccusage daily --breakdown --instances --timezone UTC
+ccusage monthly --breakdown --timezone UTC
+```
+
+Convert them to a config file:
+
+```json
+// ccusage.json
+{
+  "$schema": "https://ccusage.com/config-schema.json",
+  "defaults": {
+    "breakdown": true,
+    "timezone": "UTC"
+  },
+  "commands": {
+    "daily": {
+      "instances": true
+    }
+  }
+}
+```
+
+Now simpler commands:
+```bash
+ccusage daily
+ccusage monthly
+```
+
+## Configuration File Locations
+
+ccusage searches for configuration files in these locations (in priority order):
+
+1. **Local project**: `.ccusage/ccusage.json` (highest priority)
+2. **User config**: `~/.config/claude/ccusage.json`
+3. **Legacy location**: `~/.claude/ccusage.json` (lowest priority)
+
+Configuration files are merged in priority order, with local project settings overriding user settings.
+
+## Basic Configuration
+
+Create a `ccusage.json` file with your preferred defaults:
+
+```json
+{
+  "$schema": "https://ccusage.com/config-schema.json",
+  "defaults": {
+    "json": false,
+    "mode": "auto",
+    "offline": false,
+    "timezone": "Asia/Tokyo",
+    "locale": "ja-JP",
+    "breakdown": true
+  }
+}
+```
+
+## Configuration Structure
+
+### Schema Support
+
+Add the `$schema` property to get IntelliSense and validation in your IDE:
+
+```json
+{
+  "$schema": "https://ccusage.com/config-schema.json"
+}
+```
+
+You can also reference a local schema file after installing ccusage:
+
+```json
+{
+  "$schema": "./node_modules/ccusage/config-schema.json"
+}
+```
+
+### Global Defaults
+
+The `defaults` section sets default values for all commands:
+
+```json
+{
+  "$schema": "https://ccusage.com/config-schema.json",
+  "defaults": {
+    "since": "20250101",
+    "until": "20250630",
+    "json": false,
+    "mode": "auto",
+    "debug": false,
+    "debugSamples": 5,
+    "order": "asc",
+    "breakdown": false,
+    "offline": false,
+    "timezone": "UTC",
+    "locale": "en-CA",
+    "jq": ".data[]"
+  }
+}
+```
+
+### Command-Specific Configuration
+
+Override defaults for specific commands using the `commands` section:
+
+```json
+{
+  "$schema": "https://ccusage.com/config-schema.json",
+  "defaults": {
+    "mode": "auto",
+    "offline": false
+  },
+  "commands": {
+    "daily": {
+      "instances": true,
+      "breakdown": true
+    },
+    "blocks": {
+      "active": true,
+      "tokenLimit": "500000"
+    }
+  }
+}
+```
+
+## Command-Specific Options
+
+### Daily Command
+
+```json
+{
+  "commands": {
+    "daily": {
+      "instances": true,
+      "project": "my-project",
+      "breakdown": true,
+      "since": "20250101",
+      "until": "20250630"
+    }
+  }
+}
+```
+
+### Weekly Command
+
+```json
+{
+  "commands": {
+    "weekly": {
+      "startOfWeek": "monday",
+      "breakdown": true,
+      "timezone": "Europe/London"
+    }
+  }
+}
+```
+
+### Monthly Command
+
+```json
+{
+  "commands": {
+    "monthly": {
+      "breakdown": true,
+      "mode": "calculate",
+      "locale": "en-US"
+    }
+  }
+}
+```
+
+### Session Command
+
+```json
+{
+  "commands": {
+    "session": {
+      "id": "abc123-session",
+      "project": "my-project",
+      "json": true
+    }
+  }
+}
+```
+
+### Blocks Command
+
+```json
+{
+  "commands": {
+    "blocks": {
+      "active": true,
+      "recent": false,
+      "tokenLimit": "max",
+      "sessionLength": 5,
+      "live": false,
+      "refreshInterval": 1
+    }
+  }
+}
+```
+
+### MCP Server
+
+```json
+{
+  "commands": {
+    "mcp": {
+      "type": "stdio",
+      "port": 8080,
+      "mode": "auto"
+    }
+  }
+}
+```
+
+### Statusline
+
+```json
+{
+  "commands": {
+    "statusline": {
+      "offline": true,
+      "cache": true,
+      "refreshInterval": 2
+    }
+  }
+}
+```
+
+## Custom Configuration Files
+
+Use the `--config` option to specify a custom configuration file:
+
+```bash
+# Use a specific configuration file
+ccusage daily --config ./my-config.json
+
+# Works with all commands
+ccusage blocks --config /path/to/team-config.json
+```
+
+This is useful for:
+- **Team configurations** - Share configuration files across team members
+- **Environment-specific settings** - Different configs for development/production
+- **Project-specific overrides** - Use different settings for different projects
+
+## Configuration Example
+
+For a complete configuration example, see [`/ccusage.example.json`](/ccusage.example.json) in the repository root, which demonstrates:
+
+- Global defaults configuration
+- Command-specific overrides
+- All available options with proper types
+
+
+## Configuration Priority
+
+Settings are applied in this priority order (highest to lowest):
+
+1. **Command-line arguments** (e.g., `--json`, `--offline`)
+2. **Custom config file** (specified with `--config /path/to/config.json`)
+3. **Local project config** (`.ccusage/ccusage.json`)
+4. **User config** (`~/.config/claude/ccusage.json`)
+5. **Legacy config** (`~/.claude/ccusage.json`)
+6. **Built-in defaults**
+
+Example:
+```json
+// .ccusage/ccusage.json
+{
+  "defaults": {
+    "mode": "calculate"
+  }
+}
+```
+
+```bash
+# Config file sets mode to "calculate"
+ccusage daily  # Uses mode: calculate
+
+# But CLI argument overrides it
+ccusage daily --mode display  # Uses mode: display
+```
+
+## Debugging Configuration
+
+Use the `--debug` flag to see configuration loading details:
+
+```bash
+# Debug configuration loading
+ccusage daily --debug
+
+# Debug custom config file
+ccusage daily --debug --config ./my-config.json
+```
+
+Debug output shows:
+- Which config files are checked and found
+- Schema and option details from loaded configs
+- How options are merged from different sources
+- Final values used for each option
+
+Example debug output:
+```
+[ccusage] ℹ Debug mode enabled - showing config loading details
+
+[ccusage] ℹ Searching for config files:
+  • Checking: .ccusage/ccusage.json (found ✓)
+  • Checking: ~/.config/claude/ccusage.json (found ✓)
+  • Checking: ~/.claude/ccusage.json (not found)
+
+[ccusage] ℹ Loaded config from: .ccusage/ccusage.json
+  • Schema: https://ccusage.com/config-schema.json
+  • Has defaults: yes (3 options)
+  • Has command configs: yes (daily)
+
+[ccusage] ℹ Merging options for 'daily' command:
+  • From defaults: mode="auto", offline=false
+  • From command config: instances=true
+  • From CLI args: debug=true
+  • Final merged options: {
+      mode: "auto" (from defaults),
+      offline: false (from defaults),
+      instances: true (from command config),
+      debug: true (from CLI)
+    }
+```
+
+## Best Practices
+
+### Version Control
+
+For project configs, commit `.ccusage/ccusage.json` to version control:
+
+```bash
+# Add to git
+git add .ccusage/ccusage.json
+git commit -m "Add ccusage configuration"
+```
+
+### Document Team Configs
+
+Add comments using a README alongside team configs:
+
+```
+team-configs/
+├── ccusage.json
+└── README.md  # Explain configuration choices
+```
+
+## Troubleshooting
+
+### Config Not Being Applied
+
+1. Check file location is correct
+2. Verify JSON syntax is valid
+3. Use `--debug` to see loading details
+4. Ensure option names match exactly
+
+### Invalid JSON
+
+Use a JSON validator or IDE with JSON support:
+
+```bash
+# Validate JSON syntax
+jq . < ccusage.json
+```
+
+### Schema Validation Errors
+
+Ensure option values match expected types:
+
+```json
+{
+  "defaults": {
+    "tokenLimit": "500000",  // ✅ String or number
+    "active": true,          // ✅ Boolean
+    "refreshInterval": 2     // ✅ Number
+  }
+}
+```
+
+## Related Documentation
+
+- [Command-Line Options](/guide/cli-options) - Available CLI arguments
+- [Environment Variables](/guide/environment-variables) - Environment configuration
+- [Configuration Overview](/guide/configuration) - Complete configuration guide

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,236 +1,57 @@
-# Configuration
+# Configuration Overview
 
-ccusage supports various configuration options to customize its behavior and adapt to different Claude Code installations. You can configure ccusage through configuration files, environment variables, and command-line options.
+ccusage provides multiple ways to configure its behavior, allowing you to customize it for your specific needs. Configuration can be done through command-line options, environment variables, configuration files, or a combination of all three.
 
-## Configuration Files
+## Configuration Methods
 
-ccusage supports JSON configuration files to set default options for all commands or specific commands. This allows you to customize behavior without repeating options every time.
+ccusage supports four configuration methods, each with its own use case:
 
-### Configuration File Locations
+1. **[Command-Line Options](/guide/cli-options)** - Direct control for individual commands
+2. **[Environment Variables](/guide/environment-variables)** - System-wide or session settings
+3. **[Configuration Files](/guide/config-files)** - Persistent, shareable settings
+4. **[Directory Detection](/guide/directory-detection)** - Automatic Claude data discovery
 
-ccusage searches for configuration files in these locations (in priority order):
-
-1. **Local project**: `.ccusage/ccusage.json` (highest priority)
-2. **User config**: `~/.config/claude/ccusage.json`
-3. **Legacy location**: `~/.claude/ccusage.json` (lowest priority)
-
-Configuration files are merged in priority order, with local project settings overriding user settings.
-
-### Basic Configuration
-
-Create a `ccusage.json` file with default options:
-
-```json
-{
-  "$schema": "https://ccusage.com/config-schema.json",
-  "defaults": {
-    "json": false,
-    "mode": "auto",
-    "offline": false,
-    "timezone": "Asia/Tokyo",
-    "locale": "ja-JP",
-    "breakdown": true
-  }
-}
-```
-
-### Command-Specific Configuration
-
-Override defaults for specific commands:
-
-```json
-{
-  "$schema": "https://ccusage.com/config-schema.json",
-  "defaults": {
-    "mode": "auto",
-    "offline": false
-  },
-  "commands": {
-    "daily": {
-      "instances": true,
-      "breakdown": true
-    },
-    "blocks": {
-      "active": true,
-      "tokenLimit": "500000",
-      "live": false
-    },
-    "statusline": {
-      "offline": true,
-      "cache": true,
-      "refreshInterval": 2
-    }
-  }
-}
-```
-
-### Available Configuration Options
-
-#### Global Defaults
-
-Set default values that apply to all commands:
-
-```json
-{
-  "defaults": {
-    "since": "20250101",
-    "until": "20250630",
-    "json": false,
-    "mode": "auto",
-    "debug": false,
-    "debugSamples": 5,
-    "order": "asc",
-    "breakdown": false,
-    "offline": false,
-    "timezone": "UTC",
-    "locale": "en-CA",
-    "jq": ".data[]"
-  }
-}
-```
-
-#### Command-Specific Options
-
-##### Daily Command
-
-```json
-{
-  "commands": {
-    "daily": {
-      "instances": true,
-      "project": "my-project",
-      "breakdown": true
-    }
-  }
-}
-```
-
-##### Weekly Command
-
-```json
-{
-  "commands": {
-    "weekly": {
-      "startOfWeek": "monday",
-      "breakdown": true
-    }
-  }
-}
-```
-
-##### Session Command
-
-```json
-{
-  "commands": {
-    "session": {
-      "id": "abc123-session"
-    }
-  }
-}
-```
-
-##### Blocks Command
-
-```json
-{
-  "commands": {
-    "blocks": {
-      "active": true,
-      "recent": false,
-      "tokenLimit": "max",
-      "sessionLength": 5,
-      "live": false,
-      "refreshInterval": 1
-    }
-  }
-}
-```
-
-##### MCP Server
-
-```json
-{
-  "commands": {
-    "mcp": {
-      "type": "stdio",
-      "port": 8080,
-      "mode": "auto"
-    }
-  }
-}
-```
-
-##### Statusline
-
-```json
-{
-  "commands": {
-    "statusline": {
-      "offline": true,
-      "cache": true,
-      "refreshInterval": 1
-    }
-  }
-}
-```
-
-### Configuration Priority
+## Configuration Priority
 
 Settings are applied in this priority order (highest to lowest):
 
 1. **Command-line arguments** (e.g., `--json`, `--offline`)
-2. **Custom config file** (specified with `--config /path/to/config.json`)
-3. **Local project config** (`.ccusage/ccusage.json`)
-4. **User config** (`~/.config/claude/ccusage.json`)
-5. **Legacy config** (`~/.claude/ccusage.json`)
-6. **Built-in defaults**
+2. **Custom config file** (via `--config` flag)
+3. **Environment variables** (e.g., `CLAUDE_CONFIG_DIR`)
+4. **Local project config** (`.ccusage/ccusage.json`)
+5. **User config** (`~/.config/claude/ccusage.json`)
+6. **Legacy config** (`~/.claude/ccusage.json`)
+7. **Built-in defaults**
 
-### Custom Configuration Files
-
-You can specify a custom configuration file using the `--config` option:
+### Priority Example
 
 ```bash
-# Use a specific configuration file
-ccusage daily --config ./my-config.json
-
-# Works with all commands
-ccusage blocks --config /path/to/team-config.json
-```
-
-This is useful for:
-- **Team configurations** - Share configuration files across team members
-- **Environment-specific settings** - Different configs for development/production
-- **Project-specific overrides** - Use different settings for different projects
-
-### IDE Support
-
-ccusage provides JSON Schema for autocomplete and validation. Add the `$schema` property to get IntelliSense:
-
-```json
+# Configuration file sets mode to "calculate"
+# .ccusage/ccusage.json
 {
-  "$schema": "https://ccusage.com/config-schema.json",
   "defaults": {
-    "mode": "auto"
+    "mode": "calculate"
   }
 }
+
+# Environment variable sets timezone
+export CCUSAGE_TIMEZONE="Asia/Tokyo"
+
+# Command-line argument takes highest priority
+ccusage daily --mode display --timezone UTC
+# Result: mode=display (CLI), timezone=UTC (CLI)
 ```
 
-You can also reference a local schema file (after installing ccusage):
+## Quick Start
 
-```json
-{
-  "$schema": "./node_modules/ccusage/config-schema.json",
-  "defaults": {
-    "mode": "auto"
-  }
-}
+### Basic Setup
+
+1. **Set your Claude directory** (if not using defaults):
+```bash
+export CLAUDE_CONFIG_DIR="$HOME/.config/claude"
 ```
 
-### Configuration Examples
-
-#### Team Development
-
+2. **Create a configuration file** for your preferences:
 ```json
 {
   "$schema": "https://ccusage.com/config-schema.json",
@@ -238,637 +59,263 @@ You can also reference a local schema file (after installing ccusage):
     "timezone": "America/New_York",
     "locale": "en-US",
     "breakdown": true
+  }
+}
+```
+
+3. **Use command-line options** for one-off changes:
+```bash
+ccusage daily --since 20250101 --json
+```
+
+## Common Configuration Scenarios
+
+### Personal Development
+
+For individual developers working on multiple projects:
+
+```json
+// ~/.config/claude/ccusage.json
+{
+  "$schema": "https://ccusage.com/config-schema.json",
+  "defaults": {
+    "breakdown": true,
+    "timezone": "local"
   },
   "commands": {
     "daily": {
       "instances": true
-    },
-    "blocks": {
-      "active": true,
-      "tokenLimit": "500000"
     }
   }
 }
 ```
 
-#### International Team
+### Team Collaboration
+
+For teams sharing configuration:
 
 ```json
+// .ccusage/ccusage.json (committed to repo)
 {
   "$schema": "https://ccusage.com/config-schema.json",
   "defaults": {
     "timezone": "UTC",
     "locale": "en-CA",
-    "json": true
+    "mode": "auto"
+  }
+}
+```
+
+### CI/CD Pipeline
+
+For automated environments:
+
+```bash
+# Environment variables
+export CLAUDE_CONFIG_DIR="/ci/claude-data"
+export LOG_LEVEL=1  # Warnings only
+
+# Run with specific options
+ccusage daily --offline --json > report.json
+```
+
+### Multiple Claude Installations
+
+For users with multiple Claude Code versions:
+
+```bash
+# Aggregate from multiple directories
+export CLAUDE_CONFIG_DIR="$HOME/.claude,$HOME/.config/claude"
+ccusage daily
+```
+
+## Configuration by Feature
+
+### Cost Calculation
+
+Control how costs are calculated:
+
+- **Mode**: `auto` (default), `calculate`, or `display`
+- **Offline**: Use cached pricing data
+- **Breakdown**: Show per-model costs
+
+```bash
+ccusage daily --mode calculate --breakdown --offline
+```
+
+### Date and Time
+
+Customize date/time handling:
+
+- **Timezone**: Any valid timezone (e.g., `UTC`, `America/New_York`)
+- **Locale**: Format preferences (e.g., `en-US`, `ja-JP`)
+- **Date Range**: Filter with `--since` and `--until`
+
+```bash
+ccusage daily --timezone UTC --locale en-CA --since 20250101
+```
+
+### Output Format
+
+Control output presentation:
+
+- **JSON**: Machine-readable output with `--json`
+- **JQ Filtering**: Process JSON with `--jq`
+- **Debug**: Show detailed information with `--debug`
+
+```bash
+ccusage daily --json --jq ".data[] | select(.cost > 10)"
+```
+
+### Project Analysis
+
+Analyze usage by project:
+
+- **Instances**: Group by project with `--instances`
+- **Project Filter**: Focus on specific project with `--project`
+- **Aliases**: Set custom names via `CCUSAGE_PROJECT_ALIASES`
+
+```bash
+export CCUSAGE_PROJECT_ALIASES="uuid-123=My App"
+ccusage daily --instances --project "My App"
+```
+
+## Debugging Configuration
+
+Use debug mode to understand configuration loading:
+
+```bash
+# See which config files are loaded
+ccusage daily --debug
+
+# Check environment variables
+env | grep -E "CLAUDE|CCUSAGE|LOG_LEVEL"
+
+# Verbose logging
+LOG_LEVEL=5 ccusage daily
+```
+
+### Debug Output
+
+Debug mode shows:
+- Config file discovery and loading
+- Option merging from different sources
+- Final configuration values
+- Pricing calculation details
+
+## Best Practices
+
+### 1. Layer Your Configuration
+
+Use different configuration methods for different scopes:
+
+- **Environment variables**: Machine-specific settings (paths)
+- **User config**: Personal preferences (timezone, locale)
+- **Project config**: Team standards (mode, formatting)
+- **CLI arguments**: One-off overrides
+
+### 2. Use Configuration Files for Teams
+
+Share consistent settings across team members:
+
+```bash
+# Commit to version control
+git add .ccusage/ccusage.json
+git commit -m "Add team ccusage configuration"
+```
+
+### 3. Document Your Configuration
+
+Add comments or README files explaining configuration choices:
+
+```markdown
+# ccusage Configuration
+
+Our team uses:
+- UTC timezone for consistency
+- JSON output for automated processing
+- Calculate mode for accurate cost tracking
+```
+
+### 4. Validate Configuration
+
+Use the schema for validation:
+
+```json
+{
+  "$schema": "https://ccusage.com/config-schema.json"
+}
+```
+
+### 5. Keep Secrets Secure
+
+Never put sensitive information in configuration files:
+
+- ❌ API keys or tokens
+- ❌ Personal identifiers
+- ✅ Timezone preferences
+- ✅ Output formats
+
+## Migration Guide
+
+### From v1 to v2
+
+If upgrading from older versions:
+
+1. Update directory paths (now supports `~/.config/claude`)
+2. Migrate environment variables to config files
+3. Update any scripts using old CLI options
+
+### From Manual Commands
+
+Convert repeated commands to configuration:
+
+```bash
+# Before: Repeated commands
+ccusage daily --breakdown --instances --timezone UTC
+
+# After: Configuration file
+{
+  "defaults": {
+    "breakdown": true,
+    "timezone": "UTC"
   },
   "commands": {
     "daily": {
-      "jq": ".data[] | select(.cost > 1.0)"
+      "instances": true
     }
   }
 }
-```
 
-#### High-Performance Setup
-
-```json
-{
-  "$schema": "https://ccusage.com/config-schema.json",
-  "defaults": {
-    "offline": true,
-    "mode": "calculate"
-  },
-  "commands": {
-    "statusline": {
-      "cache": true,
-      "refreshInterval": 5
-    },
-    "blocks": {
-      "live": true,
-      "refreshInterval": 2
-    }
-  }
-}
-```
-
-## Environment Variables
-
-### CLAUDE_CONFIG_DIR
-
-The `CLAUDE_CONFIG_DIR` environment variable specifies where ccusage should look for Claude Code data.
-
-#### Single Directory
-
-```bash
-# Set a single custom Claude data directory
-export CLAUDE_CONFIG_DIR="/path/to/your/claude/data"
+# Simplified command
 ccusage daily
 ```
 
-#### Multiple Directories
-
-```bash
-# Set multiple directories (comma-separated)
-export CLAUDE_CONFIG_DIR="/path/to/claude1,/path/to/claude2"
-ccusage daily
-```
-
-When multiple directories are specified, ccusage automatically aggregates usage data from all valid locations.
-
-### LOG_LEVEL
-
-Control the verbosity of log output using the `LOG_LEVEL` environment variable. ccusage uses [consola](https://github.com/unjs/consola) for logging under the hood:
-
-```bash
-# Set logging level
-export LOG_LEVEL=0  # Silent (errors only)
-export LOG_LEVEL=1  # Warnings
-export LOG_LEVEL=2  # Normal logs
-export LOG_LEVEL=3  # Informational logs (default)
-export LOG_LEVEL=4  # Debug logs
-export LOG_LEVEL=5  # Trace logs (most verbose)
-
-# Examples
-LOG_LEVEL=0 ccusage daily       # Silent output, only show results
-LOG_LEVEL=4 ccusage daily       # Debug output for troubleshooting
-LOG_LEVEL=5 ccusage session     # Trace all operations
-```
-
-#### Use Cases
-
-- **Clean Output**: Use `LOG_LEVEL=0` for scripts or when piping output
-- **Debugging**: Use `LOG_LEVEL=4` or `5` to troubleshoot issues
-- **CI/CD**: Use `LOG_LEVEL=1` to only see warnings and errors
-- **Development**: Use higher levels to understand internal operations
-
-### CCUSAGE_PROJECT_ALIASES
-
-Configure custom display names for project directories using the `CCUSAGE_PROJECT_ALIASES` environment variable:
-
-```bash
-# Set custom project aliases
-export CCUSAGE_PROJECT_ALIASES="long-project-name=Short Name,uuid-project=My Project"
-ccusage daily --instances
-```
-
-#### Format
-
-Use comma-separated `raw-name=alias` pairs:
-
-```bash
-export CCUSAGE_PROJECT_ALIASES="project1=Production API,project2=Dev Environment"
-```
-
-#### Use Cases
-
-- **UUID Projects**: Replace cryptic UUIDs with readable names
-- **Long Paths**: Shorten verbose directory names for better table display
-- **Team Consistency**: Standardize project names across team members
-
-#### Example
-
-```bash
-# Without aliases
-ccusage daily --instances
-# Shows: a2cd99ed-a586-4fe4-8f59-b0026409ec09
-
-# With aliases
-export CCUSAGE_PROJECT_ALIASES="a2cd99ed-a586-4fe4-8f59-b0026409ec09=My Project"
-ccusage daily --instances
-# Shows: My Project
-```
-
-#### Project Name Formatting
-
-ccusage automatically formats complex project directory names into readable display names:
-
-**Automatic Cleanup:**
-- **Path Removal**: Strips common directory prefixes like `/Users/username/Development/`
-- **UUID Shortening**: Reduces long UUIDs to last two segments for brevity
-- **Feature Branch Parsing**: Extracts meaningful names from complex paths
-
-**Examples:**
-
-```bash
-# Complex project paths → Formatted names
--Users-phaedrus-Development-adminifi-edugakko-api--feature-ticket-002-configure-dependabot
-→ configure-dependabot
-
-a2cd99ed-a586-4fe4-8f59-b0026409ec09.jsonl  
-→ 8f59-b0026409ec09.jsonl
-
-/Users/john/Development/my-app
-→ my-app
-```
-
-**Priority Order:**
-1. **Custom aliases** (via `CCUSAGE_PROJECT_ALIASES`) take highest priority
-2. **Automatic formatting** applies intelligent parsing rules
-3. **Original name** used as fallback if parsing fails
-
-## Default Directory Detection
-
-### Automatic Detection
-
-ccusage automatically searches for Claude Code data in these locations:
-
-- **`~/.config/claude/projects/`** - New default location (Claude Code v1.0.30+)
-- **`~/.claude/projects/`** - Legacy location (pre-v1.0.30)
-
-::: info Directory Change
-The directory change from `~/.claude` to `~/.config/claude` in Claude Code v1.0.30 was an undocumented breaking change. ccusage handles both locations automatically for compatibility.
-:::
-
-### Search Priority
-
-When `CLAUDE_CONFIG_DIR` is not set, ccusage searches in this order:
-
-1. `~/.config/claude/projects/` (preferred)
-2. `~/.claude/projects/` (fallback)
-
-Data from all valid directories is automatically combined.
-
-## Command-Line Options
-
-### Global Options
-
-All ccusage commands support these configuration options:
-
-```bash
-# Date filtering
-ccusage daily --since 20250101 --until 20250630
-
-# Output format
-ccusage daily --json                    # JSON output
-ccusage daily --breakdown              # Per-model breakdown
-
-# Cost calculation modes
-ccusage daily --mode auto              # Use costUSD when available (default)
-ccusage daily --mode calculate         # Always calculate from tokens
-ccusage daily --mode display           # Always use pre-calculated costUSD
-
-# Sort order
-ccusage daily --order desc             # Newest first (default)
-ccusage daily --order asc              # Oldest first
-
-# Offline mode
-ccusage daily --offline                # Use cached pricing data
-ccusage daily -O                       # Short alias
-
-# Timezone
-ccusage daily --timezone UTC           # Use UTC timezone
-ccusage daily -z America/New_York      # Use New York timezone
-ccusage daily --timezone Asia/Tokyo    # Use Tokyo timezone
-
-# Locale
-ccusage daily --locale en-US           # US English (12-hour time)
-ccusage daily -l ja-JP                 # Japanese (24-hour time)
-ccusage daily --locale de-DE           # German (24-hour time)
-
-# Project analysis (daily command only)
-ccusage daily --instances              # Group by project
-ccusage daily --project myproject      # Filter to specific project
-ccusage daily --instances --project myproject  # Combined usage
-```
-
-### Timezone Configuration
-
-The `--timezone` option controls how dates are calculated for grouping usage data:
-
-```bash
-# Use UTC timezone for consistent reports
-ccusage daily --timezone UTC
-
-# Use specific timezone
-ccusage daily --timezone America/New_York
-ccusage monthly -z Asia/Tokyo
-
-# Default behavior (no timezone specified)
-ccusage daily  # Uses system's local timezone
-```
-
-#### Timezone Effect
-
-The timezone affects how usage is grouped by date. For example, usage at 11 PM UTC on January 1st would appear on:
-- **January 1st** when `--timezone UTC`
-- **January 1st** when `--timezone America/New_York` (6 PM EST)
-- **January 2nd** when `--timezone Asia/Tokyo` (8 AM JST next day)
-
-#### Use Cases
-
-- **UTC Alignment**: Use `--timezone UTC` for consistent reports across different locations
-- **Remote Teams**: Align reports to team's primary timezone
-- **Cross-Timezone Analysis**: Compare usage patterns across different time zones
-- **CI/CD Environments**: Use UTC for consistent automated reports
-
-### Locale Configuration
-
-The `--locale` option controls date and time formatting:
-
-```bash
-# Use US English locale (12-hour time format)
-ccusage daily --locale en-US
-
-# Use Japanese locale (24-hour time format)
-ccusage blocks --locale ja-JP
-
-# Use German locale (24-hour time format)
-ccusage session -l de-DE
-
-# Default behavior (no locale specified)
-ccusage daily  # Uses en-CA (ISO date format, 24-hour time)
-```
-
-#### Locale Effects
-
-The locale affects how dates and times are displayed:
-
-- **Date Format**:
-  - `en-US`: 08/04/2025
-  - `en-CA`: 2025-08-04 (ISO format)
-  - `ja-JP`: 2025/08/04
-  - `de-DE`: 04.08.2025
-
-- **Time Format**:
-  - `en-US`: 3:30:00 PM (12-hour)
-  - `en-CA`, `ja-JP`, `de-DE`: 15:30:00 (24-hour)
-
-#### Use Cases
-
-- **International Teams**: Display dates/times in familiar formats
-- **12/24 Hour Preference**: Choose between AM/PM or 24-hour time
-- **Regional Standards**: Match local date formatting conventions
-- **ISO Compliance**: Use `en-CA` for ISO 8601 date format
-
-### Debug Options
-
-The `--debug` flag provides detailed information about configuration loading and option merging, in addition to showing pricing mismatches.
-
-```bash
-# Debug pricing mismatches
-ccusage daily --debug
-
-# Show sample discrepancies
-ccusage daily --debug --debug-samples 10
-
-# Debug configuration loading
-ccusage daily --debug --config ./my-config.json
-```
-
-#### Debug Output for Configuration
-
-When `--debug` is enabled, ccusage shows detailed information about:
-
-1. **Config file discovery**: Which files are checked and found
-2. **Config file contents**: Schema, defaults, and command-specific options
-3. **Option merging**: How CLI args, command config, and defaults are combined
-
-**Example debug output:**
-
-```
-[ccusage] ℹ Debug mode enabled - showing config loading details
-
-[ccusage] ℹ Searching for config files:
-  • Checking: .ccusage/ccusage.json (not found)
-  • Checking: ~/.config/claude/ccusage.json (found ✓)
-  • Checking: ~/.claude/ccusage.json (not found)
-
-[ccusage] ℹ Loaded config from: ~/.config/claude/ccusage.json
-  • Schema: https://ccusage.com/config-schema.json
-  • Has defaults: yes (6 options)
-  • Has command configs: yes (daily, blocks)
-
-[ccusage] ℹ Merging options for 'daily' command:
-  • From defaults: mode="auto", offline=false, breakdown=true
-  • From command config: instances=true, project="my-project"
-  • From CLI args: debug=true, since="20250101"
-  • Final merged options: {
-      mode: "auto" (from defaults),
-      offline: false (from defaults),
-      breakdown: true (from defaults),
-      instances: true (from command config),
-      project: "my-project" (from command config),
-      debug: true (from CLI),
-      since: "20250101" (from CLI)
-    }
-```
-
-This debug information helps you:
-
-- **Verify config file locations**: Ensure the right config file is being loaded
-- **Understand option precedence**: See which source provides each option value
-- **Troubleshoot configuration issues**: Identify why certain options aren't being applied
-- **Validate custom config paths**: Confirm `--config` points to the right file
-
-## Cost Calculation Modes
-
-ccusage supports three different cost calculation modes:
-
-### auto (Default)
-
-Uses pre-calculated `costUSD` values when available, falls back to calculating costs from token counts:
-
-```bash
-ccusage daily --mode auto
-```
-
-- ✅ Most accurate when Claude provides cost data
-- ✅ Falls back gracefully for older data
-- ✅ Best for general use
-
-### calculate
-
-Always calculates costs from token counts using model pricing, ignores pre-calculated values:
-
-```bash
-ccusage daily --mode calculate
-```
-
-- ✅ Consistent calculation method
-- ✅ Useful for comparing different time periods
-- ❌ May differ from actual Claude billing
-
-### display
-
-Always uses pre-calculated `costUSD` values only, shows $0.00 for missing costs:
-
-```bash
-ccusage daily --mode display
-```
-
-- ✅ Shows only Claude-provided cost data
-- ✅ Most accurate for recent usage
-- ❌ Shows $0.00 for older entries without cost data
-
-## Offline Mode
-
-ccusage can operate without network connectivity by using pre-cached pricing data:
-
-```bash
-# Use offline mode
-ccusage daily --offline
-ccusage monthly -O
-```
-
-### When to Use Offline Mode
-
-#### ✅ Ideal For
-
-- **Air-gapped systems** - Networks with restricted internet access
-- **Corporate environments** - Behind firewalls or proxies
-- **Consistent pricing** - Using cached model pricing for consistent reports
-- **Fast execution** - Avoiding network delays
-
-#### ❌ Limitations
-
-- **Claude models only** - Only supports Claude models (Opus, Sonnet, etc.)
-- **Pricing updates** - Won't get latest pricing information
-- **New models** - May not support newly released models
-
-### Updating Cached Data
-
-Cached pricing data is updated automatically when running in online mode. To refresh:
-
-```bash
-# Run online to update cache
-ccusage daily
-
-# Then use offline mode
-ccusage daily --offline
-```
-
-## MCP Server Configuration
-
-ccusage includes a built-in MCP (Model Context Protocol) server for integration with other tools.
-
-### Basic Usage
-
-```bash
-# Start MCP server with stdio transport (default)
-ccusage mcp
-
-# Start with HTTP transport
-ccusage mcp --type http --port 8080
-
-# Configure cost calculation mode
-ccusage mcp --mode calculate
-```
-
-### Claude Desktop Integration
-
-Add to your Claude Desktop configuration file:
-
-**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-	"mcpServers": {
-		"ccusage": {
-			"command": "npx",
-			"args": ["ccusage@latest", "mcp"],
-			"env": {
-				"CLAUDE_CONFIG_DIR": "/custom/path/to/claude"
-			}
-		}
-	}
-}
-```
-
-Or with global installation:
-
-```json
-{
-	"mcpServers": {
-		"ccusage": {
-			"command": "ccusage",
-			"args": ["mcp"],
-			"env": {}
-		}
-	}
-}
-```
-
-### Available MCP Tools
-
-- **`daily`** - Daily usage reports
-- **`monthly`** - Monthly usage reports
-- **`session`** - Session-based reports
-- **`blocks`** - 5-hour billing blocks reports
-
-Each tool accepts `since`, `until`, `mode`, `timezone`, and `locale` parameters.
-
-## Terminal Display Configuration
-
-ccusage automatically adapts its display based on terminal width:
-
-### Wide Terminals (≥100 characters)
-
-- Shows all columns with full model names
-- Displays cache metrics and total tokens
-- Uses bulleted model lists for readability
-
-### Narrow Terminals (<100 characters)
-
-- Automatic compact mode with essential columns only
-- Shows Date, Models, Input, Output, Cost (USD)
-- Helpful message about expanding terminal width
-
-### Force Display Mode
-
-Currently, display mode is automatic based on terminal width. Future versions may include manual override options.
-
-## Configuration Examples
-
-### Development Environment
-
-```bash
-# Set environment variables in your shell profile
-export CLAUDE_CONFIG_DIR="$HOME/.config/claude"
-
-# Add aliases for common commands
-alias ccu-daily="ccusage daily --breakdown"
-alias ccu-live="ccusage blocks --live"
-alias ccu-json="ccusage daily --json"
-```
-
-### CI/CD Environment
-
-```bash
-# Use offline mode in CI
-export CCUSAGE_OFFLINE=1
-ccusage daily --offline --json > usage-report.json
-```
-
-### Multiple Team Members
-
-```bash
-# Each team member sets their own Claude directory
-export CLAUDE_CONFIG_DIR="/team-shared/claude-data/$USER"
-ccusage daily --since 20250101
-```
-
-## Troubleshooting Configuration
+## Troubleshooting
 
 ### Common Issues
 
-#### No Data Found
+1. **Configuration not applied**: Check priority order
+2. **Invalid JSON**: Validate syntax with `jq`
+3. **Directory not found**: Verify `CLAUDE_CONFIG_DIR`
+4. **No data**: Check directory permissions
 
-If ccusage reports no data found:
+### Getting Help
 
-```bash
-# Check if Claude directories exist
-ls -la ~/.claude/projects/
-ls -la ~/.config/claude/projects/
+If configuration issues persist:
 
-# Verify environment variable
-echo $CLAUDE_CONFIG_DIR
-
-# Test with explicit environment variable
-export CLAUDE_CONFIG_DIR="/path/to/claude/projects"
-ccusage daily
-```
-
-#### Permission Errors
-
-```bash
-# Check directory permissions
-ls -la ~/.claude/
-ls -la ~/.config/claude/
-
-# Fix permissions if needed
-chmod -R 755 ~/.claude/
-chmod -R 755 ~/.config/claude/
-```
-
-#### Network Issues in Offline Mode
-
-```bash
-# Run online first to cache pricing data
-ccusage daily
-
-# Then use offline mode
-ccusage daily --offline
-```
-
-#### Configuration Not Being Applied
-
-If your configuration options don't seem to be working:
-
-```bash
-# Use debug mode to see which config file is loaded
-ccusage daily --debug
-
-# Check if options are being applied correctly
-ccusage daily --debug --instances
-
-# Verify custom config file path
-ccusage daily --debug --config ./my-config.json
-```
-
-The debug output will show:
-- Which config files are being checked and loaded
-- How options from different sources (CLI, config file, defaults) are merged
-- The final values being used for each option
-
-**Common configuration issues:**
-
-1. **Config file not found**: Debug output shows "not found" for all search paths
-   - Solution: Place config file in `.ccusage/ccusage.json` or use `--config` to specify path
-
-2. **CLI args not overriding config**: Final merged options show config values instead of CLI values
-   - Solution: Ensure you're using the correct flag names and that they're being passed to the command
-
-3. **Command-specific config ignored**: Debug shows only defaults being applied
-   - Solution: Check that your command name in the config file matches exactly (e.g., "daily", not "Daily")
-
-4. **Invalid JSON structure**: Error messages about parsing configuration files
-   - Solution: Validate your JSON syntax and ensure it follows the expected schema
+1. Run with debug mode: `ccusage daily --debug`
+2. Check verbose logs: `LOG_LEVEL=5 ccusage daily`
+3. Validate JSON config: `jq . < ccusage.json`
+4. Report issues on [GitHub](https://github.com/ryoppippi/ccusage/issues)
 
 ## Next Steps
 
-After configuring ccusage:
+Explore specific configuration topics:
 
-- Learn about [Custom Paths](/guide/custom-paths) for advanced directory management
-- Explore [Cost Modes](/guide/cost-modes) for different calculation approaches
-- Try [Live Monitoring](/guide/live-monitoring) for real-time usage tracking
+- [Command-Line Options](/guide/cli-options) - All available CLI arguments
+- [Environment Variables](/guide/environment-variables) - System configuration
+- [Configuration Files](/guide/config-files) - Persistent settings
+- [Directory Detection](/guide/directory-detection) - Claude data discovery
+- [Cost Modes](/guide/cost-modes) - Understanding calculation modes
+- [Custom Paths](/guide/custom-paths) - Advanced path management

--- a/docs/guide/directory-detection.md
+++ b/docs/guide/directory-detection.md
@@ -1,0 +1,114 @@
+# Directory Detection
+
+ccusage automatically detects and manages Claude Code data directories.
+
+## Default Directory Locations
+
+ccusage automatically searches for Claude Code data in these locations:
+
+- **`~/.config/claude/projects/`** - New default location (Claude Code v1.0.30+)
+- **`~/.claude/projects/`** - Legacy location (pre-v1.0.30)
+
+When no custom directory is specified, ccusage searches both locations and aggregates data from all valid directories found.
+
+::: info Breaking Change
+The directory change from `~/.claude` to `~/.config/claude` in Claude Code v1.0.30 was an undocumented breaking change. ccusage handles both locations automatically to ensure backward compatibility.
+:::
+
+## Search Priority
+
+When `CLAUDE_CONFIG_DIR` environment variable is not set, ccusage searches in this order:
+
+1. **Primary**: `~/.config/claude/projects/` (preferred for newer installations)
+2. **Fallback**: `~/.claude/projects/` (for legacy installations)
+
+Data from all valid directories is automatically combined.
+
+## Custom Directory Configuration
+
+### Single Custom Directory
+
+Override the default search with a specific directory:
+
+```bash
+export CLAUDE_CONFIG_DIR="/custom/path/to/claude"
+ccusage daily
+```
+
+### Multiple Directories
+
+Aggregate data from multiple Claude installations:
+
+```bash
+export CLAUDE_CONFIG_DIR="/path/to/claude1,/path/to/claude2"
+ccusage daily
+```
+
+## Directory Structure
+
+Claude Code stores usage data in a specific structure:
+
+```
+~/.config/claude/projects/
+├── project-name-1/
+│   ├── session-id-1.jsonl
+│   ├── session-id-2.jsonl
+│   └── session-id-3.jsonl
+├── project-name-2/
+│   └── session-id-4.jsonl
+└── project-name-3/
+    └── session-id-5.jsonl
+```
+
+Each:
+- **Project directory** represents a different Claude Code project/workspace
+- **JSONL file** contains usage data for a specific session
+- **Session ID** in the filename matches the `sessionId` field within the file
+
+## Troubleshooting
+
+### No Data Found
+
+If ccusage reports no data found:
+
+```bash
+# Check if directories exist
+ls -la ~/.claude/projects/
+ls -la ~/.config/claude/projects/
+
+# Verify environment variable
+echo $CLAUDE_CONFIG_DIR
+
+# Test with explicit directory
+export CLAUDE_CONFIG_DIR="/path/to/claude"
+ccusage daily
+```
+
+### Permission Errors
+
+```bash
+# Check directory permissions
+ls -la ~/.claude/
+ls -la ~/.config/claude/
+
+# Fix permissions if needed
+chmod -R 755 ~/.claude/
+chmod -R 755 ~/.config/claude/
+```
+
+### Wrong Directory Detection
+
+```bash
+# Force specific directory
+export CLAUDE_CONFIG_DIR="/exact/path/to/claude"
+ccusage daily
+
+# Verify which directory is being used
+LOG_LEVEL=4 ccusage daily
+```
+
+## Related Documentation
+
+- [Environment Variables](/guide/environment-variables) - Configure with CLAUDE_CONFIG_DIR
+- [Custom Paths](/guide/custom-paths) - Advanced path management
+- [Configuration Overview](/guide/configuration) - Complete configuration guide

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -1,0 +1,319 @@
+# Environment Variables
+
+ccusage supports several environment variables for configuration and customization. Environment variables provide a way to configure ccusage without modifying command-line arguments or configuration files.
+
+## CLAUDE_CONFIG_DIR
+
+Specifies where ccusage should look for Claude Code data. This is the most important environment variable for ccusage.
+
+### Single Directory
+
+Set a single custom Claude data directory:
+
+```bash
+export CLAUDE_CONFIG_DIR="/path/to/your/claude/data"
+ccusage daily
+```
+
+### Multiple Directories
+
+Set multiple directories (comma-separated) to aggregate data from multiple sources:
+
+```bash
+export CLAUDE_CONFIG_DIR="/path/to/claude1,/path/to/claude2"
+ccusage daily
+```
+
+When multiple directories are specified, ccusage automatically aggregates usage data from all valid locations.
+
+### Default Behavior
+
+When `CLAUDE_CONFIG_DIR` is not set, ccusage automatically searches in:
+1. `~/.config/claude/projects/` (new default, Claude Code v1.0.30+)
+2. `~/.claude/projects/` (legacy location, pre-v1.0.30)
+
+Data from all valid directories is automatically combined.
+
+::: info Directory Change
+The directory change from `~/.claude` to `~/.config/claude` in Claude Code v1.0.30 was an undocumented breaking change. ccusage handles both locations automatically for backward compatibility.
+:::
+
+### Use Cases
+
+#### Development Environment
+
+```bash
+# Set in your shell profile (.bashrc, .zshrc, config.fish)
+export CLAUDE_CONFIG_DIR="$HOME/.config/claude"
+```
+
+#### Multiple Claude Installations
+
+```bash
+# Aggregate data from different Claude installations
+export CLAUDE_CONFIG_DIR="$HOME/.claude,$HOME/.config/claude"
+```
+
+#### Team Shared Directory
+
+```bash
+# Use team-shared data directory
+export CLAUDE_CONFIG_DIR="/team-shared/claude-data/$USER"
+```
+
+#### CI/CD Environment
+
+```bash
+# Use specific directory in CI pipeline
+export CLAUDE_CONFIG_DIR="/ci-data/claude-logs"
+ccusage daily --json > usage-report.json
+```
+
+## LOG_LEVEL
+
+Controls the verbosity of log output. ccusage uses [consola](https://github.com/unjs/consola) for logging under the hood.
+
+### Log Levels
+
+| Level | Value | Description | Use Case |
+|-------|-------|-------------|----------|
+| Silent | `0` | Errors only | Scripts, piping output |
+| Warn | `1` | Warnings and errors | CI/CD environments |
+| Log | `2` | Normal logs | General use |
+| Info | `3` | Informational logs (default) | Standard operation |
+| Debug | `4` | Debug information | Troubleshooting |
+| Trace | `5` | All operations | Deep debugging |
+
+### Usage Examples
+
+```bash
+# Silent mode - only show results
+LOG_LEVEL=0 ccusage daily
+
+# Warning level - for CI/CD
+LOG_LEVEL=1 ccusage monthly
+
+# Debug mode - troubleshooting
+LOG_LEVEL=4 ccusage session
+
+# Trace everything - deep debugging
+LOG_LEVEL=5 ccusage blocks
+```
+
+### Practical Applications
+
+#### Clean Output for Scripts
+
+```bash
+# Get clean JSON output without logs
+LOG_LEVEL=0 ccusage daily --json | jq '.summary.totalCost'
+```
+
+#### CI/CD Pipeline
+
+```bash
+# Show only warnings and errors in CI
+LOG_LEVEL=1 ccusage daily --instances
+```
+
+#### Debugging Issues
+
+```bash
+# Maximum verbosity for troubleshooting
+LOG_LEVEL=5 ccusage daily --debug
+```
+
+#### Piping Output
+
+```bash
+# Silent logs when piping to other commands
+LOG_LEVEL=0 ccusage monthly --json | python analyze.py
+```
+
+## CCUSAGE_PROJECT_ALIASES
+
+Configure custom display names for project directories. This is useful for replacing cryptic directory names with human-readable aliases.
+
+### Format
+
+Use comma-separated `raw-name=alias` pairs:
+
+```bash
+export CCUSAGE_PROJECT_ALIASES="long-project-name=Short Name,uuid-project=My Project"
+```
+
+### Examples
+
+#### UUID Projects
+
+Replace cryptic UUIDs with readable names:
+
+```bash
+# Without aliases
+ccusage daily --instances
+# Shows: a2cd99ed-a586-4fe4-8f59-b0026409ec09
+
+# With aliases
+export CCUSAGE_PROJECT_ALIASES="a2cd99ed-a586-4fe4-8f59-b0026409ec09=Production API"
+ccusage daily --instances
+# Shows: Production API
+```
+
+#### Long Directory Names
+
+Shorten verbose directory names for better display:
+
+```bash
+export CCUSAGE_PROJECT_ALIASES="-Users-john-Development-my-app=My App"
+ccusage daily --instances
+```
+
+#### Multiple Projects
+
+Set aliases for multiple projects:
+
+```bash
+export CCUSAGE_PROJECT_ALIASES="project1=Frontend,project2=Backend,project3=Database"
+ccusage session
+```
+
+### Automatic Formatting
+
+ccusage automatically formats complex project names even without aliases:
+
+**Automatic Cleanup:**
+- Strips common directory prefixes
+- Shortens long UUIDs to last two segments
+- Extracts meaningful names from complex paths
+
+**Examples:**
+```
+# Original → Formatted
+-Users-phaedrus-Development-adminifi-edugakko-api--feature-ticket-002-configure-dependabot
+→ configure-dependabot
+
+a2cd99ed-a586-4fe4-8f59-b0026409ec09
+→ 8f59-b0026409ec09
+
+/Users/john/Development/my-app
+→ my-app
+```
+
+**Priority Order:**
+1. Custom aliases (via `CCUSAGE_PROJECT_ALIASES`)
+2. Automatic formatting
+3. Original name (fallback)
+
+## Additional Environment Variables
+
+### CCUSAGE_OFFLINE
+
+Force offline mode by default:
+
+```bash
+export CCUSAGE_OFFLINE=1
+ccusage daily  # Runs in offline mode
+```
+
+### NO_COLOR
+
+Disable colored output (standard CLI convention):
+
+```bash
+export NO_COLOR=1
+ccusage daily  # No color formatting
+```
+
+### FORCE_COLOR
+
+Force colored output even when piping:
+
+```bash
+export FORCE_COLOR=1
+ccusage daily | less -R  # Preserves colors
+```
+
+## Setting Environment Variables
+
+### Temporary (Current Session)
+
+```bash
+# Set for single command
+LOG_LEVEL=0 ccusage daily
+
+# Set for current shell session
+export CLAUDE_CONFIG_DIR="/custom/path"
+ccusage daily
+```
+
+### Permanent (Shell Profile)
+
+Add to your shell configuration file:
+
+#### Bash (~/.bashrc)
+
+```bash
+export CLAUDE_CONFIG_DIR="$HOME/.config/claude"
+export LOG_LEVEL=3
+export CCUSAGE_PROJECT_ALIASES="project1=MyApp,project2=API"
+```
+
+#### Zsh (~/.zshrc)
+
+```zsh
+export CLAUDE_CONFIG_DIR="$HOME/.config/claude"
+export LOG_LEVEL=3
+export CCUSAGE_PROJECT_ALIASES="project1=MyApp,project2=API"
+```
+
+#### Fish (~/.config/fish/config.fish)
+
+```fish
+set -x CLAUDE_CONFIG_DIR "$HOME/.config/claude"
+set -x LOG_LEVEL 3
+set -x CCUSAGE_PROJECT_ALIASES "project1=MyApp,project2=API"
+```
+
+#### PowerShell (Profile.ps1)
+
+```powershell
+$env:CLAUDE_CONFIG_DIR = "$env:USERPROFILE\.config\claude"
+$env:LOG_LEVEL = "3"
+$env:CCUSAGE_PROJECT_ALIASES = "project1=MyApp,project2=API"
+```
+
+## Precedence
+
+Environment variables have lower precedence than command-line arguments but higher than configuration files:
+
+1. **Command-line arguments** (highest priority)
+2. **Environment variables**
+3. **Configuration files**
+4. **Built-in defaults** (lowest priority)
+
+Example:
+```bash
+# Environment variable sets offline mode
+export CCUSAGE_OFFLINE=1
+
+# But command-line argument overrides it
+ccusage daily --no-offline  # Runs in online mode
+```
+
+## Debugging
+
+To see which environment variables are being used:
+
+```bash
+# Show all environment variables
+env | grep -E "CLAUDE|CCUSAGE|LOG_LEVEL"
+
+# Debug mode shows environment variable usage
+LOG_LEVEL=4 ccusage daily --debug
+```
+
+## Related Documentation
+
+- [Command-Line Options](/guide/cli-options) - CLI arguments and flags
+- [Configuration Files](/guide/config-files) - JSON configuration files
+- [Configuration Overview](/guide/configuration) - Complete configuration guide

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -105,16 +105,14 @@ ccusage blocks --live
 
 ccusage automatically colors the output based on the terminal's capabilities. If you want to disable colors, you can use the `--no-color` flag. Or you can use the `--color` flag to force colors on.
 
-## Compact Mode
+## Automatic Table Adjustment
 
-ccusage automatically adjusts its table layout based on terminal width. For narrow terminals (< 100 characters), it shows a compact view with essential columns. You can also force compact mode for better screenshots:
+ccusage automatically adjusts its table layout based on terminal width:
 
-```bash
-ccusage --compact            # Force compact mode
-ccusage monthly --compact    # Compact monthly report
-```
+- **Wide terminals (≥100 characters)**: Full table with all columns including cache metrics, model names, and detailed breakdowns
+- **Narrow terminals (<100 characters)**: Compact view with essential columns only (Date, Models, Input, Output, Cost)
 
-This is particularly useful when sharing screenshots or working in constrained terminals.
+The layout adjusts automatically based on your terminal width - no configuration needed. If you're in compact mode and want to see the full data, simply expand your terminal window.
 
 ## Troubleshooting
 

--- a/docs/update-api-index.ts
+++ b/docs/update-api-index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S bun -b
+#!/usr/bin/env -S bun
 
 /**
  * Post-processing script to update API index with module descriptions
@@ -74,7 +74,7 @@ ${noteText}`;
 }
 
 async function main() {
-	await $`bun -b typedoc --excludeInternal`
+	await $`bun typedoc --excludeInternal`
 	await updateApiIndex();
 	await updateConstsPage();
 }


### PR DESCRIPTION
## Summary
- Split large configuration.md into focused, manageable pages for better navigation
- Each configuration method now has its own dedicated page
- Main configuration.md serves as an overview/hub page

## Changes
### New Pages Created
- **cli-options.md**: Command-line arguments and flags
- **environment-variables.md**: Environment variable configuration  
- **config-files.md**: JSON configuration files
- **directory-detection.md**: Claude data directory detection

### Improvements
- Added Quick Start section to config-files.md for easier onboarding
- Removed redundant MCP server configuration (already covered in mcp-server.md)
- Fixed incorrect \`--compact\` option reference in getting-started.md
- Simplified examples by linking to ccusage.example.json
- Updated sidebar navigation to reflect new documentation structure
- Removed unnecessary "Best Practices" sections to keep docs concise

## Test Plan
- [ ] Preview documentation site locally with \`bun run docs:dev\`
- [ ] Verify all internal links work correctly
- [ ] Check sidebar navigation reflects new structure
- [ ] Confirm no broken references to old sections