### PR TITLE
feat: exclude live and refreshInterval from blocks command JSON schema

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -663,18 +663,6 @@
 									"description": "Session block duration in hours (default: 5)",
 									"markdownDescription": "Session block duration in hours (default: 5)",
 									"default": 5
-								},
-								"live": {
-									"type": "boolean",
-									"description": "Live monitoring mode with real-time updates",
-									"markdownDescription": "Live monitoring mode with real-time updates",
-									"default": false
-								},
-								"refreshInterval": {
-									"type": "number",
-									"description": "Refresh interval in seconds for live mode (default: 1)",
-									"markdownDescription": "Refresh interval in seconds for live mode (default: 1)",
-									"default": 1
 								}
 							},
 							"additionalProperties": false

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -32,6 +32,14 @@ const SCHEMA_FILENAME = 'config-schema.json';
 const EXCLUDE_KEYS = ['config'];
 
 /**
+ * Command-specific keys to exclude from the generated JSON Schema.
+ * These are CLI-only options that shouldn't appear in configuration files.
+ */
+const COMMAND_EXCLUDE_KEYS: Record<string, string[]> = {
+	blocks: ['live', 'refreshInterval'],
+};
+
+/**
  * Convert args-tokens schema to JSON Schema format
  */
 function tokensSchemaToJsonSchema(schema: Record<string, any>): Record<string, any> {
@@ -105,8 +113,11 @@ function createConfigSchemaJson() {
 	// Create schemas for each command's specific arguments (excluding CLI-only options)
 	const commandSchemas: Record<string, any> = {};
 	for (const [commandName, command] of subCommandUnion) {
+		const commandExcludes = COMMAND_EXCLUDE_KEYS[commandName] ?? [];
 		commandSchemas[commandName] = Object.fromEntries(
-			Object.entries(command.args as Record<string, any>).filter(([key]) => !EXCLUDE_KEYS.includes(key)),
+			Object.entries(command.args as Record<string, any>).filter(([key]) =>
+				!EXCLUDE_KEYS.includes(key) && !commandExcludes.includes(key),
+			),
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Excluded CLI-only options  and  from the blocks command JSON schema
- These options should not appear in configuration files as they are only meant for interactive CLI usage

## Changes
- Added  mapping to selectively exclude command-specific keys from JSON schema generation
- Updated schema generation logic to filter out  and  for the blocks command
- Regenerated  without these CLI-only options

## Why
The  and  options are interactive CLI features that do not make sense in configuration files. Excluding them from the schema prevents confusion and ensures the config files only contain persistent settings.