### PR TITLE
fix: correct Result.try usage patterns in statusline command

### DIFF
--- a/src/commands/statusline.ts
+++ b/src/commands/statusline.ts
@@ -218,12 +218,12 @@ export const statuslineCommand = define({
 				try: async () => {
 					const sessionCost = await Result.pipe(
 						Result.try({
-							try: loadSessionUsageById(sessionId, {
+							try: async () => loadSessionUsageById(sessionId, {
 								mode: 'auto',
 								offline: mergedOptions.offline,
 							}),
 							catch: error => error,
-						}),
+						})(),
 						Result.map(sessionCost => sessionCost?.totalCost),
 						Result.inspectError(error => logger.error('Failed to load session data:', error)),
 						Result.unwrap(undefined),
@@ -235,14 +235,14 @@ export const statuslineCommand = define({
 
 					const todayCost = await Result.pipe(
 						Result.try({
-							try: loadDailyUsageData({
+							try: async () => loadDailyUsageData({
 								since: todayStr,
 								until: todayStr,
 								mode: 'auto',
 								offline: mergedOptions.offline,
 							}),
 							catch: error => error,
-						}),
+						})(),
 						Result.map((dailyData) => {
 							if (dailyData.length > 0) {
 								const totals = calculateTotals(dailyData);
@@ -257,12 +257,12 @@ export const statuslineCommand = define({
 					// Load session block data to find active block
 					const { blockInfo, burnRateInfo } = await Result.pipe(
 						Result.try({
-							try: loadSessionBlockData({
+							try: async () => loadSessionBlockData({
 								mode: 'auto',
 								offline: mergedOptions.offline,
 							}),
 							catch: error => error,
-						}),
+						})(),
 						Result.map((blocks) => {
 						// Only identify blocks if we have data
 							if (blocks.length === 0) {


### PR DESCRIPTION
## Summary
- Fixed three instances of incorrect `Result.try` usage in `src/commands/statusline.ts`
- The `try` property was receiving function call results instead of functions
- All instances now use the correct pattern: `Result.try({ try: () => func(), catch: error => error })()`

## Changes Made
- `loadSessionUsageById` call at line 221
- `loadDailyUsageData` call at line 238  
- `loadSessionBlockData` call at line 260

## Test Plan
- [x] All existing tests pass
- [x] TypeScript type checking passes
- [x] ESLint formatting applied
- [x] Manual verification of Result.try pattern correctness