### PR TITLE
feat(statusline): add costSource option to use Claude Code session cost

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -721,6 +721,17 @@
 									"markdownDescription": "Controls the visualization of the burn rate status",
 									"default": "off"
 								},
+								"costSource": {
+									"type": "string",
+									"enum": [
+										"auto",
+										"ccusage",
+										"cc"
+									],
+									"description": "Session cost source: auto (prefer CC then ccusage), ccusage (always calculate), cc (always use Claude Code cost)",
+									"markdownDescription": "Session cost source: auto (prefer CC then ccusage), ccusage (always calculate), cc (always use Claude Code cost)",
+									"default": "auto"
+								},
 								"cache": {
 									"type": "boolean",
 									"description": "Enable cache for status line output (default: true)",

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -187,7 +187,6 @@ export type TranscriptMessage = {
 		usage?: TranscriptUsage;
 	};
 };
-
 if (import.meta.vitest != null) {
 	describe('statuslineHookJsonSchema', () => {
 		it('should parse valid statusline hook data without cost field', () => {

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -156,6 +156,13 @@ export const statuslineHookJsonSchema = z.object({
 		project_dir: z.string(),
 	}),
 	version: z.string().optional(),
+	cost: z.object({
+		total_cost_usd: z.number(),
+		total_duration_ms: z.number().optional(),
+		total_api_duration_ms: z.number().optional(),
+		total_lines_added: z.number().optional(),
+		total_lines_removed: z.number().optional(),
+	}).optional(),
 });
 
 /**
@@ -180,3 +187,134 @@ export type TranscriptMessage = {
 		usage?: TranscriptUsage;
 	};
 };
+
+if (import.meta.vitest != null) {
+	describe('statuslineHookJsonSchema', () => {
+		it('should parse valid statusline hook data without cost field', () => {
+			const validData = {
+				session_id: '73cc9f9a-2775-4418-beec-bc36b62a1c6f',
+				transcript_path: '/path/to/transcript.jsonl',
+				cwd: '/path/to/project',
+				model: {
+					id: 'claude-sonnet-4-20250514',
+					display_name: 'Sonnet 4',
+				},
+				workspace: {
+					current_dir: '/path/to/project',
+					project_dir: '/path/to/project',
+				},
+				version: '1.0.88',
+			};
+
+			const result = statuslineHookJsonSchema.safeParse(validData);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.session_id).toBe('73cc9f9a-2775-4418-beec-bc36b62a1c6f');
+				expect(result.data.cost).toBeUndefined();
+			}
+		});
+
+		it('should parse valid statusline hook data with cost field', () => {
+			const validDataWithCost = {
+				session_id: '73cc9f9a-2775-4418-beec-bc36b62a1c6f',
+				transcript_path: '/path/to/transcript.jsonl',
+				cwd: '/path/to/project',
+				model: {
+					id: 'claude-sonnet-4-20250514',
+					display_name: 'Sonnet 4',
+				},
+				workspace: {
+					current_dir: '/path/to/project',
+					project_dir: '/path/to/project',
+				},
+				version: '1.0.88',
+				cost: {
+					total_cost_usd: 0.056266149999999994,
+					total_duration_ms: 164055,
+					total_api_duration_ms: 13577,
+					total_lines_added: 0,
+					total_lines_removed: 0,
+				},
+			};
+
+			const result = statuslineHookJsonSchema.safeParse(validDataWithCost);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.session_id).toBe('73cc9f9a-2775-4418-beec-bc36b62a1c6f');
+				expect(result.data.cost?.total_cost_usd).toBe(0.056266149999999994);
+				expect(result.data.cost?.total_duration_ms).toBe(164055);
+			}
+		});
+
+		it('should parse valid statusline hook data with minimal cost field', () => {
+			const validDataWithMinimalCost = {
+				session_id: '73cc9f9a-2775-4418-beec-bc36b62a1c6f',
+				transcript_path: '/path/to/transcript.jsonl',
+				cwd: '/path/to/project',
+				model: {
+					id: 'claude-sonnet-4-20250514',
+					display_name: 'Sonnet 4',
+				},
+				workspace: {
+					current_dir: '/path/to/project',
+					project_dir: '/path/to/project',
+				},
+				cost: {
+					total_cost_usd: 0.05,
+				},
+			};
+
+			const result = statuslineHookJsonSchema.safeParse(validDataWithMinimalCost);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.cost?.total_cost_usd).toBe(0.05);
+				expect(result.data.cost?.total_duration_ms).toBeUndefined();
+			}
+		});
+
+		it('should reject data with invalid cost field', () => {
+			const invalidData = {
+				session_id: '73cc9f9a-2775-4418-beec-bc36b62a1c6f',
+				transcript_path: '/path/to/transcript.jsonl',
+				cwd: '/path/to/project',
+				model: {
+					id: 'claude-sonnet-4-20250514',
+					display_name: 'Sonnet 4',
+				},
+				workspace: {
+					current_dir: '/path/to/project',
+					project_dir: '/path/to/project',
+				},
+				cost: {
+					total_cost_usd: 'invalid_string', // Should be number
+				},
+			};
+
+			const result = statuslineHookJsonSchema.safeParse(invalidData);
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject data missing required cost.total_cost_usd field', () => {
+			const invalidData = {
+				session_id: '73cc9f9a-2775-4418-beec-bc36b62a1c6f',
+				transcript_path: '/path/to/transcript.jsonl',
+				cwd: '/path/to/project',
+				model: {
+					id: 'claude-sonnet-4-20250514',
+					display_name: 'Sonnet 4',
+				},
+				workspace: {
+					current_dir: '/path/to/project',
+					project_dir: '/path/to/project',
+				},
+				cost: {
+					// Missing total_cost_usd
+					total_duration_ms: 164055,
+				},
+			};
+
+			const result = statuslineHookJsonSchema.safeParse(invalidData);
+			expect(result.success).toBe(false);
+		});
+	});
+}

--- a/src/commands/statusline.ts
+++ b/src/commands/statusline.ts
@@ -70,6 +70,7 @@ type SemaphoreType = {
 };
 
 const visualBurnRateChoices = ['off', 'emoji', 'text', 'emoji-text'] as const;
+const costSourceChoices = ['auto', 'ccusage', 'cc'] as const;
 
 export const statuslineCommand = define({
 	name: 'statusline',
@@ -86,6 +87,15 @@ export const statuslineCommand = define({
 			description: 'Controls the visualization of the burn rate status',
 			default: 'off',
 			short: 'vb',
+			negatable: false,
+			toKebab: true,
+		},
+		costSource: {
+			type: 'enum',
+			choices: costSourceChoices,
+			description: 'Session cost source: auto (prefer CC then ccusage), ccusage (always calculate), cc (always use Claude Code cost)',
+			default: 'auto',
+			short: 'cs',
 			negatable: false,
 			toKebab: true,
 		},
@@ -216,18 +226,54 @@ export const statuslineCommand = define({
 		const mainProcessingResult = Result.pipe(
 			await Result.try({
 				try: async () => {
-					const sessionCost = await Result.pipe(
-						Result.try({
-							try: async () => loadSessionUsageById(sessionId, {
-								mode: 'auto',
-								offline: mergedOptions.offline,
-							}),
-							catch: error => error,
-						})(),
-						Result.map(sessionCost => sessionCost?.totalCost),
-						Result.inspectError(error => logger.error('Failed to load session data:', error)),
-						Result.unwrap(undefined),
-					);
+					// Determine session cost based on cost source
+					const sessionCost = await (async (): Promise<number | undefined> => {
+						const costSource = ctx.values.costSource;
+
+						// If 'cc' mode and cost is available from Claude Code, use it
+						if (costSource === 'cc' && hookData.cost?.total_cost_usd != null) {
+							return hookData.cost.total_cost_usd;
+						}
+
+						// If 'ccusage' mode, always calculate using ccusage
+						if (costSource === 'ccusage') {
+							return Result.pipe(
+								Result.try({
+									try: async () => loadSessionUsageById(sessionId, {
+										mode: 'auto',
+										offline: mergedOptions.offline,
+									}),
+									catch: error => error,
+								})(),
+								Result.map(sessionCost => sessionCost?.totalCost),
+								Result.inspectError(error => logger.error('Failed to load session data:', error)),
+								Result.unwrap(undefined),
+							);
+						}
+
+						// If 'auto' mode (default), prefer Claude Code cost, fallback to ccusage
+						if (costSource === 'auto') {
+							if (hookData.cost?.total_cost_usd != null) {
+								return hookData.cost.total_cost_usd;
+							}
+							// Fallback to ccusage calculation
+							return Result.pipe(
+								Result.try({
+									try: async () => loadSessionUsageById(sessionId, {
+										mode: 'auto',
+										offline: mergedOptions.offline,
+									}),
+									catch: error => error,
+								})(),
+								Result.map(sessionCost => sessionCost?.totalCost),
+								Result.inspectError(error => logger.error('Failed to load session data:', error)),
+								Result.unwrap(undefined),
+							);
+						}
+
+						// If 'cc' mode but no cost available, return undefined (will show N/A)
+						return undefined;
+					})();
 
 					// Load today's usage data
 					const today = new Date();

--- a/src/commands/statusline.ts
+++ b/src/commands/statusline.ts
@@ -231,8 +231,8 @@ export const statuslineCommand = define({
 						const costSource = ctx.values.costSource;
 
 						// If 'cc' mode and cost is available from Claude Code, use it
-						if (costSource === 'cc' && hookData.cost?.total_cost_usd != null) {
-							return hookData.cost.total_cost_usd;
+						if (costSource === 'cc') {
+							return hookData.cost?.total_cost_usd;
 						}
 
 						// If 'ccusage' mode, always calculate using ccusage
@@ -270,9 +270,7 @@ export const statuslineCommand = define({
 								Result.unwrap(undefined),
 							);
 						}
-
-						// If 'cc' mode but no cost available, return undefined (will show N/A)
-						return undefined;
+						costSource satisfies never; // Exhaustiveness check
 					})();
 
 					// Load today's usage data


### PR DESCRIPTION
## Summary

- Add support for using session cost data directly from Claude Code's statusline hook input
- Add `costSource` CLI option with three modes: `auto` (default), `ccusage`, and `cc`
- Update statusline hook JSON schema to support optional `cost` field from Claude Code

## Changes

### Schema Updates
- Extended `statuslineHookJsonSchema` to include optional `cost` field with `total_cost_usd` and metadata
- Maintains backward compatibility with existing statusline input format

### Cost Source Options
- `auto` (default): Prefer Claude Code cost if available, fallback to ccusage calculation
- `ccusage`: Always calculate using ccusage's token-based calculation
- `cc`: Always use Claude Code's provided cost (show N/A if unavailable)

### Implementation
- Refactored session cost calculation logic to support multiple cost sources
- Added comprehensive tests for new cost field schema validation
- All existing functionality preserved

## Test Plan

- [x] Schema validation tests for cost field
- [x] Backward compatibility with existing input format  
- [x] All existing tests pass
- [x] Code formatting and type checking passes

## Example Usage

```bash
# Use auto mode (default - prefer CC cost, fallback to ccusage)
bun run start statusline --cost-source auto

# Always use ccusage calculation
bun run start statusline --cost-source ccusage

# Always use Claude Code cost
bun run start statusline --cost-source cc
```