### PR TITLE
fix!: remove session order flag

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -483,16 +483,6 @@
 									"markdownDescription": "Number of sample discrepancies to show in debug output (default: 5)",
 									"default": 5
 								},
-								"order": {
-									"type": "string",
-									"enum": [
-										"desc",
-										"asc"
-									],
-									"description": "Sort order: desc (newest first) or asc (oldest first)",
-									"markdownDescription": "Sort order: desc (newest first) or asc (oldest first)",
-									"default": "asc"
-								},
 								"breakdown": {
 									"type": "boolean",
 									"description": "Show per-model cost breakdown",

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -83,7 +83,7 @@ Now that you have your first report, explore these features:
 ccusage daily --since 20241201 --until 20241231
 ```
 
-### Find Expensive Sessions
+### Analyze Sessions
 
 ```bash
 ccusage session

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -86,7 +86,7 @@ ccusage daily --since 20241201 --until 20241231
 ### Find Expensive Sessions
 
 ```bash
-ccusage session --order desc
+ccusage session
 ```
 
 ### Export for Analysis

--- a/docs/guide/session-reports.md
+++ b/docs/guide/session-reports.md
@@ -216,7 +216,6 @@ ccusage session -O
 Session reports help you understand which conversations are most costly:
 
 ```bash
-# Find your most expensive sessions (default sort)
 ccusage session
 ```
 

--- a/docs/guide/session-reports.md
+++ b/docs/guide/session-reports.md
@@ -125,16 +125,6 @@ ccusage session --since 20250520 --until 20250530
 ccusage session --since $(date -d '7 days ago' +%Y%m%d)
 ```
 
-### Sort Order
-
-```bash
-# Show most expensive sessions first (default)
-ccusage session --order desc
-
-# Show least expensive sessions first
-ccusage session --order asc
-```
-
 ### Cost Calculation Modes
 
 ```bash
@@ -226,8 +216,8 @@ ccusage session -O
 Session reports help you understand which conversations are most costly:
 
 ```bash
-# Find your most expensive sessions
-ccusage session --order desc
+# Find your most expensive sessions (default sort)
+ccusage session
 ```
 
 Look at the top sessions to understand:

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -1,5 +1,4 @@
 import type { UsageReportConfig } from '../_table.ts';
-// Types not needed here after extracting --id logic
 import process from 'node:process';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -19,10 +18,8 @@ import { detectMismatches, printMismatchReport } from '../debug.ts';
 import { log, logger } from '../logger.ts';
 import { handleSessionIdLookup } from './_session_id.ts';
 
-// All --id logic moved to ./_session_id.ts
-
-// All shared args except --order (not supported for session)
-const { order, ...sharedArgs } = sharedCommandConfig.args;
+// eslint-disable-next-line ts/no-unused-vars
+const { order: _, ...sharedArgs } = sharedCommandConfig.args;
 
 export const sessionCommand = define({
 	name: 'session',

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -21,12 +21,15 @@ import { handleSessionIdLookup } from './_session_id.ts';
 
 // All --id logic moved to ./_session_id.ts
 
+// All shared args except --order (not supported for session)
+const { order, ...sharedArgs } = sharedCommandConfig.args;
+
 export const sessionCommand = define({
 	name: 'session',
 	description: 'Show usage report grouped by conversation session',
 	...sharedCommandConfig,
 	args: {
-		...sharedCommandConfig.args,
+		...sharedArgs,
 		id: {
 			type: 'string',
 			short: 'i',
@@ -64,7 +67,6 @@ export const sessionCommand = define({
 			since: ctx.values.since,
 			until: ctx.values.until,
 			mode: ctx.values.mode,
-			order: ctx.values.order,
 			offline: ctx.values.offline,
 			timezone: ctx.values.timezone,
 			locale: ctx.values.locale,


### PR DESCRIPTION
Resolves #350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified the session command by removing the explicit --order flag; sessions now use the default sort automatically.

- Documentation
  - Updated Getting Started: renamed “Find Expensive Sessions” to “Analyze Sessions” and simplified the session command examples.
  - Updated Session Reports: removed the “Sort Order” section and revised examples to reflect default sorting (no --order flag).
  - Ensured examples consistently use ccusage session without explicit ordering flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->