### PR TITLE
fix(statusline)!: use -B as short flag for --visual-burn-rate

### DIFF
--- a/src/commands/statusline.ts
+++ b/src/commands/statusline.ts
@@ -91,7 +91,8 @@ export const statuslineCommand = define({
 			choices: visualBurnRateChoices,
 			description: 'Controls the visualization of the burn rate status',
 			default: 'off',
-			short: 'vb',
+			// Use capital 'B' to avoid conflicts and follow 1-letter short alias rule
+			short: 'B',
 			negatable: false,
 			toKebab: true,
 		},


### PR DESCRIPTION
This PR changes the short flag for the statusline command's --visual-burn-rate option.\n\nWhy:\n- Gunshi short aliases must be a single character.\n- -v commonly collides with --version; -b is already used for --breakdown.\n- We already use uppercase short flags (e.g., -O for --offline), so -B fits the convention.\n\nWhat changed:\n- short: 'vb' -> short: 'B' in statusline command.\n- No docs changes needed: our docs reference the long option only.\n\nBREAKING CHANGE:\n- If you used the old multi-letter alias -vb in scripts or settings, replace it with -B or the long option --visual-burn-rate.\n\nMigration:\n- Replace: bun x ccusage statusline -vb emoji  ->  bun x ccusage statusline -B emoji\n- Long option remains: --visual-burn-rate emoji\n\nNotes:\n- Minimal code change; no behavioral changes beyond the flag alias.\n- Local typecheck/tests were not fully runnable in the sandboxed environment (network/FS constraints), but the change is isolated to CLI arg metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated the CLI short flag for the visual burn rate option to a single-letter alias: use -B instead of -vb to align with one-letter alias conventions.
  - The previous short alias (-vb) is no longer recognized; update any scripts or commands that relied on it.
  - No other behavior or output changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->