### PR TITLE
feat: add intelligent file caching and time-based filtering for statu…

### DIFF
--- a/src/commands/statusline.ts
+++ b/src/commands/statusline.ts
@@ -331,16 +331,16 @@ export const statuslineCommand = define({
 					);
 
 					// Load session block data to find active block
-					// Only process files modified in the last 6 hours for block data
+					// Only process files modified in the last 24 hours for block data
 					// This ensures we capture the current blocks without processing all historical data
-					const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
+					const lastBlocksTime = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
 					const { blockInfo, burnRateInfo } = await Result.pipe(
 						Result.try({
 							try: async () => loadSessionBlockData({
 								mode: 'auto',
 								offline: mergedOptions.offline,
-								minUpdateTime: sixHoursAgo,
+								minUpdateTime: lastBlocksTime,
 							}),
 							catch: error => error,
 						})(),


### PR DESCRIPTION
…sline performance

Combination of caching pre-computed json files and loading only time relevant data and other performance optimizations In my case where `.claude/projects` weights 216MB this reduced statusline rendering from 18s to 0.6s

Because there are large code blocks with changed indentation, best way to view this PR is with "ignore whitespace" diff option: https://github.com/ryoppippi/ccusage/pull/623/files?diff=unified&w=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time-bounded data loading: daily usage limited to today; session/block data limited to a recent 6-hour window.
  * Option to exclude file content from usage results to reduce output size.

* **Performance**
  * Per-file caching for faster repeated loads.
  * Fewer files scanned via modification-time filtering.

* **Reliability**
  * Consistent, deduplicated, sorted results with preserved formatting and cache-backed incremental processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->