### PR TITLE
docs: add README documentation for MCP package

### DIFF
--- a/packages/ccusage/README.md
+++ b/packages/ccusage/README.md
@@ -76,6 +76,9 @@ ccusage daily --instances --project myproject --json  # Combined usage
 # Compact mode for screenshots/sharing
 ccusage --compact  # Force compact table mode
 ccusage monthly --compact  # Compact monthly report
+
+# MCP Server (Model Context Protocol)
+npx @ccusage/mcp@latest  # Run MCP server for Claude Desktop integration
 ```
 
 ## Features

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,48 @@
+# @ccusage/mcp
+
+MCP (Model Context Protocol) server implementation for ccusage - provides Claude Code usage data through the MCP protocol.
+
+## Quick Start
+
+```bash
+# Using bunx (recommended for speed)
+bunx @ccusage/mcp@latest
+
+# Using npx
+npx @ccusage/mcp@latest
+
+# Start with HTTP transport
+bunx @ccusage/mcp@latest -- --type http --port 8080
+```
+
+## Integrations
+
+### Claude Desktop Integration
+
+Add to your Claude Desktop MCP configuration:
+
+```json
+{
+	"mcpServers": {
+		"ccusage": {
+			"command": "npx",
+			"args": ["@ccusage/mcp@latest"],
+			"type": "stdio"
+		}
+	}
+}
+```
+
+### Claude Code
+
+```sh
+claude mcp add ccusage npx -- @ccusage/mcp@latest
+```
+
+## Documentation
+
+For full documentation, visit **[ccusage.com/guide/mcp-server](https://ccusage.com/guide/mcp-server)**
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Add comprehensive README documentation for the `@ccusage/mcp` package to improve discoverability and usability of the MCP server functionality.

## What Changed

- **Added `packages/mcp/README.md`**: Complete documentation for the MCP package including:
  - Quick start instructions with bunx/npx examples
  - Claude Desktop integration configuration
  - Claude Code MCP setup command
  - Reference link to full documentation
- **Updated `packages/ccusage/README.md`**: Added MCP server usage example to the CLI examples section

## Why

The MCP package was previously missing user-facing documentation, making it difficult for users to discover and integrate the MCP server with Claude Desktop. This documentation provides essential setup instructions and integration examples.

## Testing

- Verified README formatting and links
- Confirmed integration examples match current MCP server capabilities
- Pre-commit hooks automatically formatted the documentation

The documentation follows the established patterns from the main ccusage package and provides clear, actionable guidance for users.