### PR TITLE
docs(ccusage): prefer npx usage over global installation

### DIFF
--- a/packages/ccusage/README.md
+++ b/packages/ccusage/README.md
@@ -39,43 +39,35 @@ deno run -E -R=$HOME/.claude/projects/ -S=homedir -N='raw.githubusercontent.com:
 
 > 💡 **Tip**: We recommend using `bunx` instead of `npx` for a massive speed improvement!
 
-### Local Installation (Optional)
-
-Since ccusage has such a small bundle size, installation is entirely optional:
-
-```bash
-npm install -g ccusage
-```
-
 ## Usage
 
 ```bash
 # Basic usage
-ccusage          # Show daily report (default)
-ccusage daily    # Daily token usage and costs
-ccusage monthly  # Monthly aggregated report
-ccusage session  # Usage by conversation session
-ccusage blocks   # 5-hour billing windows
-ccusage statusline  # Compact status line for hooks (Beta)
+npx ccusage          # Show daily report (default)
+npx ccusage daily    # Daily token usage and costs
+npx ccusage monthly  # Monthly aggregated report
+npx ccusage session  # Usage by conversation session
+npx ccusage blocks   # 5-hour billing windows
+npx ccusage statusline  # Compact status line for hooks (Beta)
 
 # Live monitoring
-ccusage blocks --live  # Real-time usage dashboard
+npx ccusage blocks --live  # Real-time usage dashboard
 
 # Filters and options
-ccusage daily --since 20250525 --until 20250530
-ccusage daily --json  # JSON output
-ccusage daily --breakdown  # Per-model cost breakdown
-ccusage daily --timezone UTC  # Use UTC timezone
-ccusage daily --locale ja-JP  # Use Japanese locale for date/time formatting
+npx ccusage daily --since 20250525 --until 20250530
+npx ccusage daily --json  # JSON output
+npx ccusage daily --breakdown  # Per-model cost breakdown
+npx ccusage daily --timezone UTC  # Use UTC timezone
+npx ccusage daily --locale ja-JP  # Use Japanese locale for date/time formatting
 
 # Project analysis
-ccusage daily --instances  # Group by project/instance
-ccusage daily --project myproject  # Filter to specific project
-ccusage daily --instances --project myproject --json  # Combined usage
+npx ccusage daily --instances  # Group by project/instance
+npx ccusage daily --project myproject  # Filter to specific project
+npx ccusage daily --instances --project myproject --json  # Combined usage
 
 # Compact mode for screenshots/sharing
-ccusage --compact  # Force compact table mode
-ccusage monthly --compact  # Compact monthly report
+npx ccusage --compact  # Force compact table mode
+npx ccusage monthly --compact  # Compact monthly report
 
 # MCP Server (Model Context Protocol)
 npx @ccusage/mcp@latest  # Run MCP server for Claude Desktop integration


### PR DESCRIPTION
## Summary

Update README documentation to prefer `npx ccusage` over global installation, following modern CLI tool best practices.

## What Changed

- **Removed**: "Local Installation (Optional)" section that recommended `npm install -g ccusage`
- **Updated**: All usage examples to use `npx ccusage` instead of `ccusage`
- **Maintained**: All existing functionality examples and command options
- **Preserved**: Bunx recommendation for speed improvement

## Why

This change aligns with modern Node.js CLI tool best practices:

1. **No Global Pollution**: Avoids cluttering the global npm namespace
2. **Always Latest**: Users automatically get the latest version without manual updates
3. **Dependency-Free**: No need to manage global package installations
4. **Isolation**: Prevents version conflicts with other globally installed tools
5. **Industry Standard**: Most modern CLI tools recommend npx usage over global installation

## Testing

- Verified all command examples still work with npx prefix
- Confirmed documentation formatting and structure remain intact
- Ensured all links and references are still valid

## Impact

- **Users**: Get better experience with always-current version
- **Maintenance**: Reduced support burden from version mismatch issues
- **Onboarding**: Simpler getting-started experience

This is a documentation-only change that doesn't affect the tool's functionality.