### PR TITLE
fix(internal): fix context size bug by using max_input_tokens instead of max_tokens

### DIFF
--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -202,7 +202,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 				if (pricing == null) {
 					return null;
 				}
-				return pricing.max_input_tokens ?? pricing.max_tokens ?? null;
+				return pricing.max_input_tokens ?? null;
 			}),
 		);
 	}

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -198,12 +198,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 	async getModelContextLimit(modelName: string): Result.ResultAsync<number | null, Error> {
 		return Result.pipe(
 			this.getModelPricing(modelName),
-			Result.map((pricing) => {
-				if (pricing == null) {
-					return null;
-				}
-				return pricing.max_input_tokens ?? null;
-			}),
+			Result.map(pricing => pricing?.max_input_tokens ?? null),
 		);
 	}
 

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -202,7 +202,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 				if (pricing == null) {
 					return null;
 				}
-				return pricing.max_tokens ?? pricing.max_input_tokens ?? null;
+				return pricing.max_input_tokens ?? pricing.max_tokens ?? null;
 			}),
 		);
 	}


### PR DESCRIPTION
## Summary

**Fixes critical bug** in statusline context size calculation where Claude 4 models were displaying incorrect context window limits.

## Bug Description

The statusline was showing dramatically **incorrect** context sizes for Claude 4 models:
- **Claude Sonnet 4**: Displayed 64K tokens instead of actual 200K context window
- **Claude Opus 4**: Displayed 32K tokens instead of actual 200K context window

This bug caused:
- ❌ Incorrect context utilization calculations in statusline
- ❌ Users seeing wrong context usage percentages
- ❌ Misleading information about available context space

## Root Cause

The `getModelContextLimit()` method was **incorrectly** using `max_tokens` (output token limit) instead of `max_input_tokens` (actual context window size) when fetching context limits from LiteLLM pricing data.

**LiteLLM field meanings:**
- **`max_input_tokens`**: The actual context window size (200K for Claude 4 models) ✅
- **`max_tokens`**: The maximum output tokens per response (64K for Sonnet 4, 32K for Opus 4) ❌ **Not needed for context size!**

## Solution

**Before (buggy):**
```typescript
return pricing.max_tokens ?? pricing.max_input_tokens ?? null;
```

**After (fixed):**
```typescript
return pricing.max_input_tokens ?? null;
```

Removed `max_tokens` entirely since it represents output limits, not context window size. Now only uses the semantically correct field that actually represents the context window.

## Impact

- ✅ **Fixed**: Statusline now correctly shows 200K context window for Claude 4 models
- ✅ **Fixed**: Context utilization percentages are now accurate  
- ✅ **Fixed**: Users get correct feedback about their context usage
- ✅ **Improved**: Simplified logic using only the semantically correct field

## Verification

Verified against LiteLLM pricing data:
- `claude-sonnet-4-20250514`: `max_input_tokens: 200000`, `max_tokens: 64000`
- `claude-opus-4-20250514`: `max_input_tokens: 200000`, `max_tokens: 32000`

The fix ensures we use only the correct field (`max_input_tokens`) that represents the true context window size.

## Test Plan

- [x] Run existing tests to ensure no regressions
- [x] Test statusline with Claude 4 models to verify correct context size display
- [x] Verify context utilization calculations are accurate