### PR TITLE
fix: handle binary name argument when invoked via npx/bunx

### DIFF
--- a/apps/ccusage/src/commands/index.ts
+++ b/apps/ccusage/src/commands/index.ts
@@ -42,7 +42,14 @@ for (const [name, command] of subCommandUnion) {
 const mainCommand = dailyCommand;
 
 export async function run(): Promise<void> {
-	await cli(process.argv.slice(2), mainCommand, {
+	// When invoked through npx, the binary name might be passed as the first argument
+	// Filter it out if it matches the expected binary name
+	let args = process.argv.slice(2);
+	if (args[0] === 'ccusage') {
+		args = args.slice(1);
+	}
+
+	await cli(args, mainCommand, {
 		name,
 		version,
 		description,

--- a/apps/codex/src/run.ts
+++ b/apps/codex/src/run.ts
@@ -14,7 +14,14 @@ const subCommands = new Map([
 const mainCommand = dailyCommand;
 
 export async function run(): Promise<void> {
-	await cli(process.argv.slice(2), mainCommand, {
+	// When invoked through npx, the binary name might be passed as the first argument
+	// Filter it out if it matches the expected binary name
+	let args = process.argv.slice(2);
+	if (args[0] === 'ccusage-codex') {
+		args = args.slice(1);
+	}
+
+	await cli(args, mainCommand, {
 		name,
 		version,
 		description,

--- a/apps/mcp/src/command.ts
+++ b/apps/mcp/src/command.ts
@@ -86,7 +86,14 @@ export const mcpCommand = define({
 });
 
 export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
-	await cli(argv, mcpCommand, {
+	// When invoked through npx/bunx, the binary name might be passed as the first argument
+	// Filter it out if it matches the expected binary name
+	let args = argv;
+	if (args[0] === 'ccusage-mcp') {
+		args = args.slice(1);
+	}
+
+	await cli(args, mcpCommand, {
 		name,
 		version,
 		description,


### PR DESCRIPTION
## Summary

Fix CLI invocation error when using `npx` or `bunx` to run ccusage, codex, and mcp packages.

## Problem

When executing packages via `npx @ccusage/codex` or `bunx ccusage`, the package managers pass the binary name as the first argument to the CLI. This causes gunshi (our CLI framework) to interpret it as an unknown command, resulting in errors like:
```
Error: Command not found: ccusage-codex
```

## Solution

Filter out the binary name from argv when it matches the expected binary name:
- `ccusage` for the main ccusage package
- `ccusage-codex` for the codex package  
- `ccusage-mcp` for the MCP server package

## Changes

- **apps/ccusage**: Filter 'ccusage' from argv when present as first argument
- **apps/codex**: Filter 'ccusage-codex' from argv when present as first argument
- **apps/mcp**: Filter 'ccusage-mcp' from argv when present as first argument

## Test Plan

✅ Direct execution works:
```bash
node dist/index.js daily
```

✅ npx invocation works:
```bash
npx @ccusage/codex daily
npx ccusage daily
npx @ccusage/mcp --help
```

✅ bunx invocation works:
```bash
bunx @ccusage/codex daily
bunx ccusage daily
bunx @ccusage/mcp --help
```

✅ All tests pass
✅ Type checking passes
✅ Linting passes