### PR TITLE
fix: simplify bin configuration and remove npx/bunx workarounds

### DIFF
--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -25,9 +25,7 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
-	"bin": {
-		"ccusage": "./src/index.ts"
-	},
+	"bin": "./src/index.ts",
 	"files": [
 		"config-schema.json",
 		"dist"
@@ -91,9 +89,7 @@
 		"xdg-basedir": "catalog:runtime"
 	},
 	"publishConfig": {
-		"bin": {
-			"ccusage": "./dist/index.js"
-		},
+		"bin": "./dist/index.js",
 		"exports": {
 			".": "./dist/index.js",
 			"./calculate-cost": "./dist/calculate-cost.js",

--- a/apps/ccusage/src/commands/index.ts
+++ b/apps/ccusage/src/commands/index.ts
@@ -42,14 +42,7 @@ for (const [name, command] of subCommandUnion) {
 const mainCommand = dailyCommand;
 
 export async function run(): Promise<void> {
-	// When invoked through npx, the binary name might be passed as the first argument
-	// Filter it out if it matches the expected binary name
-	let args = process.argv.slice(2);
-	if (args[0] === 'ccusage') {
-		args = args.slice(1);
-	}
-
-	await cli(args, mainCommand, {
+	await cli(process.argv.slice(2), mainCommand, {
 		name,
 		version,
 		description,

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -15,9 +15,7 @@
 		"url": "https://github.com/ryoppippi/ccusage/issues"
 	},
 	"main": "./dist/index.js",
-	"bin": {
-		"ccusage-codex": "./src/index.ts"
-	},
+	"bin": "./src/index.ts",
 	"files": [
 		"dist"
 	],
@@ -55,9 +53,7 @@
 		"vitest": "catalog:testing"
 	},
 	"publishConfig": {
-		"bin": {
-			"ccusage-codex": "./dist/index.js"
-		}
+		"bin": "./dist/index.js"
 	},
 	"devEngines": {
 		"runtime": [

--- a/apps/codex/src/run.ts
+++ b/apps/codex/src/run.ts
@@ -14,14 +14,7 @@ const subCommands = new Map([
 const mainCommand = dailyCommand;
 
 export async function run(): Promise<void> {
-	// When invoked through npx, the binary name might be passed as the first argument
-	// Filter it out if it matches the expected binary name
-	let args = process.argv.slice(2);
-	if (args[0] === 'ccusage-codex') {
-		args = args.slice(1);
-	}
-
-	await cli(args, mainCommand, {
+	await cli(process.argv.slice(2), mainCommand, {
 		name,
 		version,
 		description,

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -21,9 +21,7 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
-	"bin": {
-		"ccusage-mcp": "./src/index.ts"
-	},
+	"bin": "./src/index.ts",
 	"files": [
 		"dist"
 	],
@@ -64,9 +62,7 @@
 		"vitest": "catalog:testing"
 	},
 	"publishConfig": {
-		"bin": {
-			"ccusage-mcp": "./dist/index.js"
-		},
+		"bin": "./dist/index.js",
 		"exports": {
 			".": "./dist/index.js",
 			"./package.json": "./package.json"

--- a/apps/mcp/src/ccusage.ts
+++ b/apps/mcp/src/ccusage.ts
@@ -23,7 +23,7 @@ function getCcusageInvocation(): CliInvocation {
 		return cachedCcusageInvocation;
 	}
 
-	const entryPath = resolveBinaryPath('ccusage', 'ccusage');
+	const entryPath = resolveBinaryPath('ccusage');
 	cachedCcusageInvocation = createCliInvocation(entryPath);
 	return cachedCcusageInvocation;
 }

--- a/apps/mcp/src/codex.ts
+++ b/apps/mcp/src/codex.ts
@@ -70,7 +70,7 @@ function getCodexInvocation(): CliInvocation {
 		return cachedCodexInvocation;
 	}
 
-	const entryPath = resolveBinaryPath('@ccusage/codex', 'ccusage-codex');
+	const entryPath = resolveBinaryPath('@ccusage/codex');
 	cachedCodexInvocation = createCliInvocation(entryPath);
 	return cachedCodexInvocation;
 }

--- a/apps/mcp/src/command.ts
+++ b/apps/mcp/src/command.ts
@@ -86,14 +86,7 @@ export const mcpCommand = define({
 });
 
 export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
-	// When invoked through npx/bunx, the binary name might be passed as the first argument
-	// Filter it out if it matches the expected binary name
-	let args = argv;
-	if (args[0] === 'ccusage-mcp') {
-		args = args.slice(1);
-	}
-
-	await cli(args, mcpCommand, {
+	await cli(argv, mcpCommand, {
 		name,
 		version,
 		description,


### PR DESCRIPTION
## Summary

This PR simplifies the binary configuration across all packages and removes the workarounds that were needed for npx/bunx invocation.

## What Changed

- **Package.json bin configuration**: Changed from object format to simple string format for all packages
  - `apps/ccusage/package.json`: `{"ccusage": "./src/index.ts"}` → `"./src/index.ts"`
  - `apps/codex/package.json`: `{"ccusage-codex": "./src/index.ts"}` → `"./src/index.ts"`
  - `apps/mcp/package.json`: `{"ccusage-mcp": "./src/index.ts"}` → `"./src/index.ts"`

- **Removed argv filtering workarounds**: Eliminated special handling for binary names in CLI entry points
  - `apps/ccusage/src/commands/index.ts`: No longer filters 'ccusage' from process.argv
  - `apps/codex/src/run.ts`: No longer filters 'ccusage-codex' from process.argv
  - `apps/mcp/src/command.ts`: No longer filters 'ccusage-mcp' from process.argv

- **Simplified MCP binary resolution**: Updated resolveBinaryPath function to only handle string bin fields
  - `apps/mcp/src/cli-utils.ts`: Simplified resolveBinaryPath to work with string bin fields only
  - `apps/mcp/src/ccusage.ts`: Removed second argument from resolveBinaryPath call
  - `apps/mcp/src/codex.ts`: Removed second argument from resolveBinaryPath call

## Why

When packages use an object for the bin field (e.g., `{"ccusage-codex": "./dist/index.js"}`), npx/bunx pass the binary name as the first argument, causing CLI parsing issues. This required special workarounds to filter out the binary name from argv.

By using simple string values for the bin field, npm/npx/bunx handle the binary invocation cleanly without passing extra arguments.

## Testing

All packages work correctly with:
- Direct execution: `node dist/index.js`
- npx: `npx ccusage`, `npx @ccusage/codex`, `npx @ccusage/mcp`
- bunx: `bunx ccusage`, `bunx @ccusage/codex`, `bunx @ccusage/mcp`

## Benefits

- **Cleaner configuration**: Simpler package.json bin field configuration
- **No special handling**: No need for argv filtering workarounds
- **Reduced complexity**: Simplified CLI argument parsing
- **Better consistency**: More aligned with npm ecosystem conventions
- **Improved maintainability**: Less code to maintain and fewer edge cases

This change makes the codebase more standard and eliminates the need for platform-specific workarounds.