### PR TITLE
docs(codex): add critical bunx warning and shell alias recommendation

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -20,6 +20,20 @@
 
 > Analyze your Claude Code token usage and costs from local JSONL files — incredibly fast and informative!
 
+## ccusage Family
+
+### 📊 [ccusage](https://www.npmjs.com/package/ccusage) - Claude Code Usage Analyzer
+
+The main CLI tool for analyzing Claude Code usage from local JSONL files. Track daily, monthly, and session-based usage with beautiful tables and live monitoring.
+
+### 🤖 [@ccusage/codex](https://www.npmjs.com/package/@ccusage/codex) - OpenAI Codex Usage Analyzer
+
+Companion tool for analyzing OpenAI Codex usage. Same powerful features as ccusage but tailored for Codex users, including GPT-5 support and 1M token context windows.
+
+### 🔌 [@ccusage/mcp](https://www.npmjs.com/package/@ccusage/mcp) - MCP Server Integration
+
+Model Context Protocol server that exposes ccusage data to Claude Desktop and other MCP-compatible tools. Enable real-time usage tracking directly in your AI workflows.
+
 ## Installation
 
 ### Quick Start (Recommended)
@@ -27,17 +41,51 @@
 Thanks to ccusage's incredibly small bundle size ([![install size](https://packagephobia.com/badge?p=ccusage)](https://packagephobia.com/result?p=ccusage)), you can run it directly without installation:
 
 ```bash
-# Using bunx (recommended for speed)
+# Recommended - always include @latest to ensure you get the newest version
+npx ccusage@latest
 bunx ccusage
 
-# Using npx
-npx ccusage@latest
+# Alternative package runners
+pnpm dlx ccusage
+pnpx ccusage
 
 # Using deno (with security flags)
 deno run -E -R=$HOME/.claude/projects/ -S=homedir -N='raw.githubusercontent.com:443' npm:ccusage@latest
 ```
 
-> 💡 **Tip**: We recommend using `bunx` instead of `npx` for a massive speed improvement!
+> 💡 **Important**: We strongly recommend using `@latest` suffix with npx (e.g., `npx ccusage@latest`) to ensure you're running the most recent version with the latest features and bug fixes.
+
+### Related Tools
+
+#### Codex CLI
+
+Analyze OpenAI Codex usage with our companion tool [@ccusage/codex](https://www.npmjs.com/package/@ccusage/codex):
+
+```bash
+# Recommended - always include @latest
+npx @ccusage/codex@latest
+bunx @ccusage/codex@latest  # ⚠️ MUST include @latest with bunx
+
+# Alternative package runners
+pnpm dlx @ccusage/codex
+pnpx @ccusage/codex
+
+# Using deno (with security flags)
+deno run -E -R=$HOME/.codex/ -S=homedir -N='raw.githubusercontent.com:443' npm:@ccusage/codex@latest
+```
+
+> ⚠️ **Critical for bunx users**: Bun 1.2.x's bunx prioritizes binaries matching the package name suffix when given a scoped package. For `@ccusage/codex`, it looks for a `codex` binary in PATH first. If you have an existing `codex` command installed (e.g., GitHub Copilot's codex), that will be executed instead. **Always use `bunx @ccusage/codex@latest` with the version tag** to force bunx to fetch and run the correct package.
+
+#### MCP Server
+
+Integrate ccusage with Claude Desktop using [@ccusage/mcp](https://www.npmjs.com/package/@ccusage/mcp):
+
+```bash
+# Start MCP server for Claude Desktop integration
+npx @ccusage/mcp@latest --type http --port 8080
+```
+
+This enables real-time usage tracking and analysis directly within Claude Desktop conversations.
 
 ## Usage
 
@@ -68,9 +116,6 @@ npx ccusage daily --instances --project myproject --json  # Combined usage
 # Compact mode for screenshots/sharing
 npx ccusage --compact  # Force compact table mode
 npx ccusage monthly --compact  # Compact monthly report
-
-# MCP Server (Model Context Protocol)
-npx @ccusage/mcp@latest  # Run MCP server for Claude Desktop integration
 ```
 
 ## Features

--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -36,6 +36,19 @@ deno run -E -R=$HOME/.codex/ -S=homedir -N='raw.githubusercontent.com:443' npm:@
 
 > ⚠️ **Critical for bunx users**: Bun 1.2.x's bunx prioritizes binaries matching the package name suffix when given a scoped package. For `@ccusage/codex`, it looks for a `codex` binary in PATH first. If you have an existing `codex` command installed (e.g., GitHub Copilot's codex), that will be executed instead. **Always use `bunx @ccusage/codex@latest` with the version tag** to force bunx to fetch and run the correct package.
 
+### Recommended: Shell Alias
+
+Since `npx @ccusage/codex@latest` is quite long to type repeatedly, we strongly recommend setting up a shell alias:
+
+```bash
+# bash/zsh: alias codex-usage='bunx @ccusage/codex@latest'
+# fish:     alias codex-usage 'bunx @ccusage/codex@latest'
+
+# Then simply run:
+codex-usage daily
+codex-usage monthly --json
+```
+
 > 💡 The CLI looks for Codex session JSONL files under `CODEX_HOME` (defaults to `~/.codex`).
 
 ## Common Commands

--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -22,12 +22,19 @@
 ## Quick Start
 
 ```bash
-# Recommended (fastest)
-bunx @ccusage/codex --help
-
-# Using npx
+# Recommended - always include @latest
 npx @ccusage/codex@latest --help
+bunx @ccusage/codex@latest --help  # ⚠️ MUST include @latest with bunx
+
+# Alternative package runners
+pnpm dlx @ccusage/codex
+pnpx @ccusage/codex
+
+# Using deno (with security flags)
+deno run -E -R=$HOME/.codex/ -S=homedir -N='raw.githubusercontent.com:443' npm:@ccusage/codex@latest --help
 ```
+
+> ⚠️ **Critical for bunx users**: Bun 1.2.x's bunx prioritizes binaries matching the package name suffix when given a scoped package. For `@ccusage/codex`, it looks for a `codex` binary in PATH first. If you have an existing `codex` command installed (e.g., GitHub Copilot's codex), that will be executed instead. **Always use `bunx @ccusage/codex@latest` with the version tag** to force bunx to fetch and run the correct package.
 
 > 💡 The CLI looks for Codex session JSONL files under `CODEX_HOME` (defaults to `~/.codex`).
 
@@ -35,19 +42,19 @@ npx @ccusage/codex@latest --help
 
 ```bash
 # Daily usage grouped by date (default command)
-bunx @ccusage/codex daily
+npx @ccusage/codex@latest daily
 
 # Date range filtering
-bunx @ccusage/codex daily --since 20250911 --until 20250917
+npx @ccusage/codex@latest daily --since 20250911 --until 20250917
 
 # JSON output for scripting
-bunx @ccusage/codex daily --json
+npx @ccusage/codex@latest daily --json
 
 # Monthly usage grouped by month
-bunx @ccusage/codex monthly
+npx @ccusage/codex@latest monthly
 
 # Monthly JSON report for integrations
-bunx @ccusage/codex monthly --json
+npx @ccusage/codex@latest monthly --json
 ```
 
 Useful environment variables:

--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -41,12 +41,12 @@ deno run -E -R=$HOME/.codex/ -S=homedir -N='raw.githubusercontent.com:443' npm:@
 Since `npx @ccusage/codex@latest` is quite long to type repeatedly, we strongly recommend setting up a shell alias:
 
 ```bash
-# bash/zsh: alias codex-usage='bunx @ccusage/codex@latest'
-# fish:     alias codex-usage 'bunx @ccusage/codex@latest'
+# bash/zsh: alias ccusage-codex='bunx @ccusage/codex@latest'
+# fish:     alias ccusage-codex 'bunx @ccusage/codex@latest'
 
 # Then simply run:
-codex-usage daily
-codex-usage monthly --json
+ccusage-codex daily
+ccusage-codex monthly --json
 ```
 
 > 💡 The CLI looks for Codex session JSONL files under `CODEX_HOME` (defaults to `~/.codex`).

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -25,6 +25,23 @@ deno run -E -R=$HOME/.codex/ -S=homedir -N='raw.githubusercontent.com:443' npm:@
 Bun 1.2.x's bunx prioritizes binaries matching the package name suffix when given a scoped package. For `@ccusage/codex`, it looks for a `codex` binary in PATH first. If you have an existing `codex` command installed (e.g., GitHub Copilot's codex), that will be executed instead. **Always use `bunx @ccusage/codex@latest` with the version tag** to force bunx to fetch and run the correct package.
 :::
 
+### Recommended: Shell Alias
+
+Since `npx @ccusage/codex@latest` is quite long to type repeatedly, we strongly recommend setting up a shell alias for convenience:
+
+```bash
+# bash/zsh: alias codex-usage='bunx @ccusage/codex@latest'
+# fish:     alias codex-usage 'bunx @ccusage/codex@latest'
+
+# Then simply run:
+codex-usage daily
+codex-usage monthly --json
+```
+
+::: tip
+After adding the alias to your shell config file (`.bashrc`, `.zshrc`, or `config.fish`), restart your shell or run `source` on the config file to apply the changes.
+:::
+
 ## Data Source
 
 The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to `~/.codex`). Each file represents a single Codex CLI session and contains running token totals that the tool converts into per-day or per-month deltas.

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -9,12 +9,21 @@ The `@ccusage/codex` package reuses ccusage's responsive tables, pricing cache, 
 ## Installation & Launch
 
 ```bash
-# Recommended (fastest)
-bunx @ccusage/codex --help
-
-# Using npx
+# Recommended - always include @latest
 npx @ccusage/codex@latest --help
+bunx @ccusage/codex@latest --help  # ⚠️ MUST include @latest with bunx
+
+# Alternative package runners
+pnpm dlx @ccusage/codex --help
+pnpx @ccusage/codex --help
+
+# Using deno (with security flags)
+deno run -E -R=$HOME/.codex/ -S=homedir -N='raw.githubusercontent.com:443' npm:@ccusage/codex@latest --help
 ```
+
+::: warning ⚠️ Critical for bunx users
+Bun 1.2.x's bunx prioritizes binaries matching the package name suffix when given a scoped package. For `@ccusage/codex`, it looks for a `codex` binary in PATH first. If you have an existing `codex` command installed (e.g., GitHub Copilot's codex), that will be executed instead. **Always use `bunx @ccusage/codex@latest` with the version tag** to force bunx to fetch and run the correct package.
+:::
 
 ## Data Source
 

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -30,12 +30,12 @@ Bun 1.2.x's bunx prioritizes binaries matching the package name suffix when give
 Since `npx @ccusage/codex@latest` is quite long to type repeatedly, we strongly recommend setting up a shell alias for convenience:
 
 ```bash
-# bash/zsh: alias codex-usage='bunx @ccusage/codex@latest'
-# fish:     alias codex-usage 'bunx @ccusage/codex@latest'
+# bash/zsh: alias ccusage-codex='bunx @ccusage/codex@latest'
+# fish:     alias ccusage-codex 'bunx @ccusage/codex@latest'
 
 # Then simply run:
-codex-usage daily
-codex-usage monthly --json
+ccusage-codex daily
+ccusage-codex monthly --json
 ```
 
 ::: tip


### PR DESCRIPTION
## Summary
- Add critical warning about bunx behavior with @ccusage/codex
- Recommend shell alias `ccusage-codex` for convenience
- Document ccusage family of tools in main README

## Problem
Users were experiencing issues where `bunx @ccusage/codex` would execute an existing 'codex' binary from their PATH instead of the intended npm package. This was due to Bun 1.2.x's bunx behavior with scoped packages.

## Solution
### 🚨 Critical bunx warning
- Added prominent warning that `bunx @ccusage/codex@latest` **requires** the `@latest` suffix
- Documented the root cause: Bun 1.2.x prioritizes PATH binaries matching the package suffix when given scoped packages
- For `@ccusage/codex`, bunx looks for existing `codex` binaries first (e.g., GitHub Copilot's codex)

### 💡 Shell alias recommendation
- Recommend `ccusage-codex` alias since the full command is long to type
- Provides consistency with ccusage naming convention
- Improves shell tab completion experience

## Changes
- ✅ Updated codex README with bunx warning and shell alias
- ✅ Updated documentation site (guide/codex/index.md) 
- ✅ Added ccusage family section to main README
- ✅ Clarified that ccusage (non-scoped) works fine with bunx without @latest

## Related
- Addresses user confusion reported in v17.0.0 release
- Part of improving developer experience for the ccusage ecosystem