### PR TITLE
chore: remove duplicate consola from catalog section

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,9 +3,6 @@ packages:
   - docs
   - packages/*
 
-catalog:
-  consola: 3.4.2
-
 catalogMode: strict
 
 catalogs:


### PR DESCRIPTION
## Summary

- Remove duplicate consola entry from the top-level `catalog` section in pnpm-workspace.yaml
- Preserve the correct `catalogs.runtime` definition that is used throughout the project

## Details

The consola dependency was defined twice:
1. ❌ In `catalog:` section as `consola: 3.4.2` (removed)
2. ✅ In `catalogs.runtime:` section as `consola: ^3.4.2` (preserved)

All packages in the project use `catalog:runtime` references, so the top-level catalog entry was redundant and potentially confusing.

## Test plan

- [x] Verify no packages reference the removed catalog entry
- [x] Confirm all consola usage goes through `catalog:runtime`
- [x] Check that lint-staged and formatting still work correctly