### PR TITLE
feat(codex): add color and noColor CLI options

### DIFF
--- a/apps/codex/src/_shared-args.ts
+++ b/apps/codex/src/_shared-args.ts
@@ -42,4 +42,12 @@ export const sharedArgs = {
 		description: 'Force compact table layout for narrow terminals',
 		default: false,
 	},
+	color: { // --color and FORCE_COLOR=1 is handled by picocolors
+		type: 'boolean',
+		description: 'Enable colored output (default: auto). FORCE_COLOR=1 has the same effect.',
+	},
+	noColor: { // --no-color and NO_COLOR=1 is handled by picocolors
+		type: 'boolean',
+		description: 'Disable colored output (default: auto). NO_COLOR=1 has the same effect.',
+	},
 } as const satisfies Args;


### PR DESCRIPTION
## Summary
- Add `--color` option to enable colored output (default: auto)
- Add `--noColor` option to disable colored output (default: auto)
- Options work with `FORCE_COLOR=1` and `NO_COLOR=1` environment variables
- Consistent with ccusage CLI options for better user experience
- Color handling is managed by picocolors automatically

## Changes
- Updated `apps/codex/src/_shared-args.ts` to include color and noColor options
- No additional code changes needed as picocolors handles environment variables automatically
- Follows the same pattern as the main ccusage app

## Test plan
- [x] Verify `--help` shows the new color options
- [x] Test `--color` option enables colors even when `FORCE_COLOR=0`
- [x] Test `--noColor` option disables colors appropriately
- [x] Confirm lint, typecheck, and tests pass
- [x] Verify consistent behavior with main ccusage app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI flags --color and --no-color to control colored output.
  * Defaults to auto-detection; force colors with FORCE_COLOR=1 or disable with NO_COLOR=1.
  * Improves readability in terminals that support colors while avoiding unwanted styling in plain logs.
  * Works consistently across commands and environments, including CI.
  * No changes to existing command behavior beyond output coloring; safe to adopt without modifying workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->