### PR TITLE
fix(ccusage): handle case-insensitive session ID lookup

### DIFF
--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -1093,7 +1093,7 @@ export async function loadSessionUsageById(
 	// Find the JSONL file for this session ID
 	// On Windows, replace backslashes from path.join with forward slashes for tinyglobby compatibility
 	const patterns = claudePaths.map(p => path.join(p, 'projects', '**', `${sessionId}.jsonl`).replace(/\\/g, '/'));
-	const jsonlFiles = await glob(patterns);
+	const jsonlFiles = await glob(patterns, { caseSensitiveMatch: false });
 
 	if (jsonlFiles.length === 0) {
 		return null;
@@ -1575,6 +1575,99 @@ if (import.meta.vitest != null) {
 			const result = await loadSessionUsageById('non-existent', { mode: 'display' });
 
 			expect(result).toBeNull();
+		});
+
+		it('loads session with uppercase ID when file is lowercase', async () => {
+			await using fixture = await createFixture({
+				'.claude': {
+					projects: {
+						'test-project': {
+							'session-abc.jsonl': JSON.stringify({
+								timestamp: '2024-01-01T00:00:00Z',
+								sessionId: 'session-abc',
+								message: {
+									usage: {
+										input_tokens: 100,
+										output_tokens: 50,
+									},
+									model: 'claude-sonnet-4-20250514',
+								},
+								costUSD: 0.5,
+							}),
+						},
+					},
+				},
+			});
+
+			vi.stubEnv('CLAUDE_CONFIG_DIR', fixture.getPath('.claude'));
+
+			const result = await loadSessionUsageById('SESSION-ABC', { mode: 'display' });
+
+			expect(result).not.toBeNull();
+			expect(result?.totalCost).toBe(0.5);
+			expect(result?.entries).toHaveLength(1);
+		});
+
+		it('loads session with lowercase ID when file is uppercase', async () => {
+			await using fixture = await createFixture({
+				'.claude': {
+					projects: {
+						'test-project': {
+							'SESSION-XYZ.jsonl': JSON.stringify({
+								timestamp: '2024-01-01T00:00:00Z',
+								sessionId: 'SESSION-XYZ',
+								message: {
+									usage: {
+										input_tokens: 200,
+										output_tokens: 100,
+									},
+									model: 'claude-sonnet-4-20250514',
+								},
+								costUSD: 1.0,
+							}),
+						},
+					},
+				},
+			});
+
+			vi.stubEnv('CLAUDE_CONFIG_DIR', fixture.getPath('.claude'));
+
+			const result = await loadSessionUsageById('session-xyz', { mode: 'display' });
+
+			expect(result).not.toBeNull();
+			expect(result?.totalCost).toBe(1.0);
+			expect(result?.entries).toHaveLength(1);
+		});
+
+		it('loads session with mixed-case ID', async () => {
+			await using fixture = await createFixture({
+				'.claude': {
+					projects: {
+						'test-project': {
+							'MixedCase-123.jsonl': JSON.stringify({
+								timestamp: '2024-01-01T00:00:00Z',
+								sessionId: 'MixedCase-123',
+								message: {
+									usage: {
+										input_tokens: 150,
+										output_tokens: 75,
+									},
+									model: 'claude-sonnet-4-20250514',
+								},
+								costUSD: 0.75,
+							}),
+						},
+					},
+				},
+			});
+
+			vi.stubEnv('CLAUDE_CONFIG_DIR', fixture.getPath('.claude'));
+
+			const result = await loadSessionUsageById('mixedcase-123', { mode: 'display' });
+
+			expect(result).not.toBeNull();
+			expect(result?.totalCost).toBe(0.75);
+			expect(result?.entries).toHaveLength(1);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes #675 - Session cost calculation was breaking when users provided uppercase session IDs because the file lookup used case-sensitive glob matching.

## Changes

- Updated `loadSessionUsageById` function to use case-insensitive glob matching by setting `caseSensitiveMatch: false`
- Added three comprehensive test cases:
  - Uppercase session ID with lowercase file
  - Lowercase session ID with uppercase file
  - Mixed-case session ID matching

## Solution Details

The fix leverages tinyglobby's built-in `caseSensitiveMatch` option (available since v0.2.14) to enable case-insensitive file matching. This allows session IDs to be looked up regardless of case, making the tool more user-friendly.

## Testing

All existing tests pass, plus three new test cases specifically for case-insensitive matching:

```bash
✓ loads session with uppercase ID when file is lowercase
✓ loads session with lowercase ID when file is uppercase  
✓ loads session with mixed-case ID
```

Ran full test suite:
- `pnpm run format` ✓
- `pnpm typecheck` ✓
- `pnpm test` ✓ (259 tests in ccusage, all passing)

## Impact

- **No breaking changes** - purely a bug fix
- **No performance impact** - same glob operation with different matching mode
- Affects: `session` command with `--id` flag and `statusline` command cost calculation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session usage loading now works regardless of filename capitalization, addressing issues where sessions couldn't be found if the file name’s case didn’t match the requested ID. This improves cross-platform reliability (e.g., case-sensitive file systems) and reduces user friction when accessing session data. The change is fully backward-compatible and requires no user action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->