### PR TITLE
feat(ccusage)!: add deprecation warning to blocks --live monitor

### DIFF
--- a/apps/ccusage/src/_live-rendering.ts
+++ b/apps/ccusage/src/_live-rendering.ts
@@ -190,7 +190,8 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 	// Draw header with deprecation warning
 	terminal.write(`${marginStr}┌${'─'.repeat(boxWidth - 2)}┐\n`);
 	terminal.write(`${marginStr}│${pc.bold(centerText('CLAUDE CODE - LIVE TOKEN USAGE MONITOR', boxWidth - 2))}│\n`);
-	terminal.write(`${marginStr}│${pc.yellow(centerText('⚠️  DEPRECATED - Use https://claude.ai/settings/usage', boxWidth - 2))}│\n`);
+	terminal.write(`${marginStr}│${pc.yellow(centerText('⚠️  DEPRECATED - Will be removed in next major version', boxWidth - 2))}│\n`);
+	terminal.write(`${marginStr}│${pc.gray(centerText('Use https://claude.ai/settings/usage instead', boxWidth - 2))}│\n`);
 	terminal.write(`${marginStr}├${'─'.repeat(boxWidth - 2)}┤\n`);
 	terminal.write(`${marginStr}│${' '.repeat(boxWidth - 2)}│\n`);
 


### PR DESCRIPTION
<img width="1056" height="426" alt="SCR-20250929-thik" src="https://github.com/user-attachments/assets/ac05e448-2fbd-4f45-a310-a526a70c215f" />


## Summary

Adds a deprecation warning to the `blocks --live` monitor UI, directing users to Claude's official usage dashboard at https://claude.ai/settings/usage.

## Related

- Related to #126 - The live monitoring feature contributed by @a-c-m

## Acknowledgments

Thank you to @a-c-m for contributing the live monitoring feature in #126! While Claude now provides an official usage dashboard that supersedes this functionality, we're grateful for your contribution to the project.

## Test Plan

- [x] Run `pnpm run format` - passed
- [x] Run `pnpm typecheck` - passed  
- [x] Run `pnpm run test` - all 256 tests passed
- [x] Verified warning appears in live monitor header
- [x] Confirmed warning is visible on every refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a deprecation warning to the live display header: "DEPRECATED - Will be removed in next major version."
  * Included guidance to use https://claude.ai/settings/usage instead.

* **Style**
  * Introduced color-coded header lines for clarity: yellow warning and gray guidance.
  * Placed the new lines immediately below the title and above the header separator.
  * Visual-only update; no changes to behavior or data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixed: https://github.com/ryoppippi/ccusage/issues/676