### PR TITLE
feat(blocks): add --prompts flag to show prompt count per block

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -101,6 +101,9 @@ npx ccusage statusline  # Compact status line for hooks (Beta)
 # Live monitoring
 npx ccusage blocks --live  # Real-time usage dashboard
 
+# Prompt counting (useful for GLM and other models without token limits)
+npx ccusage blocks --prompts  # Show number of prompts per 5-hour block
+
 # Filters and options
 npx ccusage daily --since 20250525 --until 20250530
 npx ccusage daily --json  # JSON output
@@ -118,12 +121,53 @@ npx ccusage --compact  # Force compact table mode
 npx ccusage monthly --compact  # Compact monthly report
 ```
 
+## Prompt Counting for GLM and Other Models
+
+The `--prompts` flag in the `blocks` command is particularly useful for users of GLM (General Language Model) and other AI models that don't have strict token limits or when you want to track usage patterns rather than costs.
+
+### Why Use Prompt Counting?
+
+- **GLM Users**: GLM models often have different pricing models or usage limits based on the number of prompts rather than tokens
+- **Usage Pattern Analysis**: Understand your interaction frequency with AI models
+- **Productivity Tracking**: Monitor how many prompts you send during different time periods
+- **Budget Planning**: Some services charge per prompt rather than per token
+
+### How It Works
+
+```bash
+# Show prompts per 5-hour block
+npx ccusage blocks --prompts
+
+# Combined with other flags
+npx ccusage blocks --prompts --recent  # Last 3 days
+npx ccusage blocks --prompts --json    # JSON output
+```
+
+### Example Output
+
+```
+Block Start                     Duration/Status  Models             Tokens   Prompts     %     Cost
+2025-09-05, 2:00:00 PM (13m)                     - sonnet-4         92,531        6   0.1%    $0.07
+2025-09-10, 7:00:00 PM (3h 10m)                 - <synthetic>      22,299,…      249  13.2%    $9.57
+2025-09-11, 8:00:00 AM (1h 13m)                 - sonnet-4         2,567,4…      36   1.5%    $1.35
+```
+
+### GLM-Specific Use Cases
+
+- **Prompt Rate Tracking**: Monitor how many prompts you send per 5-hour window
+- **Usage Patterns**: Identify your most productive hours
+- **Service Limit Monitoring**: Track usage against prompt-based service limits
+- **Cost Analysis**: For services that charge per prompt, calculate costs per 5-hour block
+
+The prompt count works by counting individual JSONL entries in each session block, where each entry represents one complete prompt/response interaction with the AI model.
+
 ## Features
 
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
 - ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
+- 🔢 **Prompt Counting**: Show the number of prompts sent in each 5-hour block with `blocks --prompts` - perfect for GLM and other models without strict token limits
 - 📈 **Live Monitoring**: Real-time dashboard showing active session progress, token burn rate, and cost projections with `blocks --live`
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which Claude models you're using (Opus, Sonnet, etc.)

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -653,6 +653,12 @@
 									"description": "Session block duration in hours (default: 5)",
 									"markdownDescription": "Session block duration in hours (default: 5)",
 									"default": 5
+								},
+								"prompts": {
+									"type": "boolean",
+									"description": "Show number of prompts in each block",
+									"markdownDescription": "Show number of prompts in each block",
+									"default": false
 								}
 							},
 							"additionalProperties": false

--- a/apps/ccusage/src/_live-monitor.ts
+++ b/apps/ccusage/src/_live-monitor.ts
@@ -250,6 +250,7 @@ export async function getActiveBlock(
 	// Generate blocks and find active one
 	const blocks = identifySessionBlocks(
 		state.allEntries,
+		[], // No user messages in live monitoring (yet)
 		config.sessionDurationHours,
 	);
 

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -452,7 +452,7 @@ export const blocksCommand = define({
 
 						// Add prompts count if requested
 						if (ctx.values.prompts) {
-							row.push(formatNumber(block.entries.length));
+							row.push(formatNumber(block.userPromptCount));
 						}
 
 						// Add percentage if token limit is set

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -144,6 +144,12 @@ export const blocksCommand = define({
 			description: `Refresh interval in seconds for live mode (default: ${DEFAULT_REFRESH_INTERVAL_SECONDS})`,
 			default: DEFAULT_REFRESH_INTERVAL_SECONDS,
 		},
+		prompts: {
+			type: 'boolean',
+			short: 'p',
+			description: 'Show number of prompts in each block',
+			default: false,
+		},
 	},
 	toKebab: true,
 	async run(ctx) {
@@ -385,6 +391,12 @@ export const blocksCommand = define({
 				const tableHeaders = ['Block Start', 'Duration/Status', 'Models', 'Tokens'];
 				const tableAligns: ('left' | 'right' | 'center')[] = ['left', 'left', 'left', 'right'];
 
+				// Add prompts column if requested
+				if (ctx.values.prompts) {
+					tableHeaders.push('Prompts');
+					tableAligns.push('right');
+				}
+
 				// Add % column if token limit is set
 				if (actualTokenLimit != null && actualTokenLimit > 0) {
 					tableHeaders.push('%');
@@ -417,6 +429,9 @@ export const blocksCommand = define({
 							pc.gray('-'),
 							pc.gray('-'),
 						];
+						if (ctx.values.prompts) {
+							gapRow.push(pc.gray('-'));
+						}
 						if (actualTokenLimit != null && actualTokenLimit > 0) {
 							gapRow.push(pc.gray('-'));
 						}
@@ -434,6 +449,11 @@ export const blocksCommand = define({
 							formatModels(block.models),
 							formatNumber(totalTokens),
 						];
+
+						// Add prompts count if requested
+						if (ctx.values.prompts) {
+							row.push(formatNumber(block.entries.length));
+						}
 
 						// Add percentage if token limit is set
 						if (actualTokenLimit != null && actualTokenLimit > 0) {
@@ -466,9 +486,15 @@ export const blocksCommand = define({
 									pc.blue('REMAINING'),
 									'',
 									remainingText,
-									remainingPercentText,
-									'', // No cost for remaining - it's about token limit, not cost
 								];
+
+								// Add prompts column if requested
+								if (ctx.values.prompts) {
+									remainingRow.push('');
+								}
+
+								remainingRow.push(remainingPercentText);
+								remainingRow.push(''); // No cost for remaining - it's about token limit, not cost
 								table.push(remainingRow);
 							}
 
@@ -486,6 +512,11 @@ export const blocksCommand = define({
 									'',
 									projectedText,
 								];
+
+								// Add prompts column if requested
+								if (ctx.values.prompts) {
+									projectedRow.push('');
+								}
 
 								// Add percentage if token limit is set
 								if (actualTokenLimit != null && actualTokenLimit > 0) {


### PR DESCRIPTION
Add a new --prompts/-p flag to the blocks command that displays the number of prompts sent in each 5-hour billing block. This is particularly useful for GLM users and other models where prompt-based tracking is more relevant than token-based billing.

Changes:
- Add prompts flag to CLI arguments with short option -p
- Add "Prompts" column to table output when flag is enabled
- Show prompt count using block.entries.length
- Update gap rows, REMAINING rows, and PROJECTED rows for column alignment
- Update README with comprehensive documentation for GLM users
- Regenerate config schema to include new flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add --prompts (-p) flag to the blocks command to show a Prompts column with per-block prompt counts across all sections.
  * Add sessionLength and prompts options to the ccusage config to control per-session duration and enable prompt counting.
* **Documentation**
  * Update README with usage examples, rationale, GLM-specific notes, and sample outputs showing prompt counts and related metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1028" height="706" alt="image" src="https://github.com/user-attachments/assets/fca90bfc-185f-4a45-8864-1507a2360f25" />
