### PR TITLE
fix(terminal): support multi-part model version numbers (4.5, 4.1, etc.)

### DIFF
--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -318,14 +318,15 @@ export function formatCurrency(amount: number): string {
 /**
  * Formats Claude model names into a shorter, more readable format
  * Extracts model type and generation from full model name
- * @param modelName - Full model name (e.g., "claude-sonnet-4-20250514")
- * @returns Shortened model name (e.g., "sonnet-4") or original if pattern doesn't match
+ * @param modelName - Full model name (e.g., "claude-sonnet-4-20250514" or "claude-sonnet-4-5-20250929")
+ * @returns Shortened model name (e.g., "sonnet-4" or "sonnet-4-5") or original if pattern doesn't match
  */
 function formatModelName(modelName: string): string {
 	// Extract model type from full model name
 	// e.g., "claude-sonnet-4-20250514" -> "sonnet-4"
 	// e.g., "claude-opus-4-20250514" -> "opus-4"
-	const match = modelName.match(/claude-(\w+)-(\d+)-\d+/);
+	// e.g., "claude-sonnet-4-5-20250929" -> "sonnet-4-5"
+	const match = modelName.match(/claude-(\w+)-([\d-]+)-(\d{8})/);
 	if (match != null) {
 		return `${match[1]}-${match[2]}`;
 	}
@@ -969,6 +970,15 @@ if (import.meta.vitest != null) {
 		it('handles models that do not match pattern with bullet points', () => {
 			const models = ['custom-model', 'claude-sonnet-4-20250514'];
 			expect(formatModelsDisplayMultiline(models)).toBe('- custom-model\n- sonnet-4');
+		});
+
+		it('formats Claude 4.5 models correctly', () => {
+			expect(formatModelsDisplayMultiline(['claude-sonnet-4-5-20250929'])).toBe('- sonnet-4-5');
+		});
+
+		it('formats mixed model versions', () => {
+			const models = ['claude-sonnet-4-20250514', 'claude-sonnet-4-5-20250929', 'claude-opus-4-1-20250805'];
+			expect(formatModelsDisplayMultiline(models)).toBe('- opus-4-1\n- sonnet-4\n- sonnet-4-5');
 		});
 	});
 }


### PR DESCRIPTION
## Summary
- Fix model name formatting regex to support multi-part version numbers like Claude Sonnet 4.5
- Previously claude-sonnet-4-5-20250929 displayed as "sonnet-4", now shows "sonnet-4-5"

## Changes
- Updated regex from `/claude-(\w+)-(\d+)-\d+/` to `/claude-(\w+)-([\d-]+)-(\d{8})/`
- Added `[\d-]+` pattern to match version numbers with hyphens
- Updated JSDoc with new examples
- Added test cases for Claude 4.5 and mixed version formats

## Test Plan
- [x] All existing tests pass
- [x] New tests added for Claude 4.5 model formatting
- [x] Verified output shows "sonnet-4-5" in daily reports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model names like “claude-sonnet-4-5-20250929” now display as “sonnet-4-5”.
  * Improved list formatting and ordering for mixed Claude model versions (e.g., includes “opus-4-1” and multiple sonnet variants).
* **Bug Fixes**
  * Correct multiline rendering for model variants (e.g., “- sonnet-4-5”).
* **Documentation**
  * Updated notes to reflect expanded model naming inputs and displayed outputs.
* **Tests**
  * Added coverage for 4.5-style names and mixed-version scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->