### PR TITLE
fix(codex): correct date display for timezone-derived date keys

### DIFF
--- a/apps/codex/src/date-utils.ts
+++ b/apps/codex/src/date-utils.ts
@@ -54,8 +54,9 @@ export function isWithinRange(dateKey: string, since?: string, until?: string): 
 	return true;
 }
 
-export function formatDisplayDate(dateKey: string, locale?: string, timezone?: string): string {
-	const tz = safeTimeZone(timezone);
+export function formatDisplayDate(dateKey: string, locale?: string, _timezone?: string): string {
+	// dateKey is already computed for the target timezone via toDateKey().
+	// Treat it as a plain calendar date and avoid shifting it by applying a timezone.
 	const [yearStr = '0', monthStr = '1', dayStr = '1'] = dateKey.split('-');
 	const year = Number.parseInt(yearStr, 10);
 	const month = Number.parseInt(monthStr, 10);
@@ -65,7 +66,7 @@ export function formatDisplayDate(dateKey: string, locale?: string, timezone?: s
 		year: 'numeric',
 		month: 'short',
 		day: '2-digit',
-		timeZone: tz,
+		timeZone: 'UTC',
 	});
 	return formatter.format(date);
 }
@@ -82,8 +83,9 @@ export function toMonthKey(timestamp: string, timezone?: string): string {
 	return `${year}-${month}`;
 }
 
-export function formatDisplayMonth(monthKey: string, locale?: string, timezone?: string): string {
-	const tz = safeTimeZone(timezone);
+export function formatDisplayMonth(monthKey: string, locale?: string, _timezone?: string): string {
+	// monthKey is already derived in the target timezone via toMonthKey().
+	// Render it as a calendar month without shifting by timezone.
 	const [yearStr = '0', monthStr = '1'] = monthKey.split('-');
 	const year = Number.parseInt(yearStr, 10);
 	const month = Number.parseInt(monthStr, 10);
@@ -91,7 +93,7 @@ export function formatDisplayMonth(monthKey: string, locale?: string, timezone?:
 	const formatter = new Intl.DateTimeFormat(locale ?? 'en-US', {
 		year: 'numeric',
 		month: 'short',
-		timeZone: tz,
+		timeZone: 'UTC',
 	});
 	return formatter.format(date);
 }


### PR DESCRIPTION
Fix daily/session table Date values showing a day earlier in western timezones. Root cause was re-applying timezone formatting to already timezone-derived date/month keys.

Changes
- apps/codex/src/date-utils.ts: render date/month keys with timeZone: 'UTC' to avoid shifting calendar keys by timezone.

Validation
- Built @ccusage/codex and ran daily and session reports against ~/.codex with --timezone America/Denver; dates now match Last Activity/filters.
- All @ccusage/codex tests pass.

- No package.json or unrelated changes included.

**Without fix (no Oct-3 use showing for today):**
<img width="2004" height="2314" alt="CleanShot 2025-10-03 at 11 26 36@2x" src="https://github.com/user-attachments/assets/828a63eb-0aae-437a-ae21-96d010f54f56" />

**With fix (Oct-3 morning use correctly attributed):**
<img width="2002" height="2314" alt="CleanShot 2025-10-03 at 11 27 34@2x" src="https://github.com/user-attachments/assets/8003b60d-ceb7-4651-bd4b-e519e2fac436" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Standardized all date and month displays to UTC, preventing unintended timezone shifts.
  - Ensures displayed values are derived directly from provided date/month keys without additional adjustments.
  - Users in non-UTC regions may notice slight changes in displayed dates/months; outputs are now consistent across locales and time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->