### PR TITLE
feat(codex): add blocks reporting and live monitor (needs refactor discussion)

### DIFF
--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -45,6 +45,7 @@
 		"fast-sort": "catalog:runtime",
 		"fs-fixture": "catalog:testing",
 		"gunshi": "catalog:runtime",
+		"nano-spawn": "catalog:runtime",
 		"picocolors": "catalog:runtime",
 		"sort-package-json": "catalog:release",
 		"tinyglobby": "catalog:runtime",

--- a/apps/codex/src/_block-entry.ts
+++ b/apps/codex/src/_block-entry.ts
@@ -1,0 +1,90 @@
+import type { TokenUsageEvent } from './_types.ts';
+
+export type CodexLoadedUsageEntry = {
+	timestamp: Date;
+	sessionId: string;
+	model: string;
+	usage: {
+		inputTokens: number;
+		outputTokens: number;
+		cachedInputTokens: number;
+		reasoningOutputTokens: number;
+		totalTokens: number;
+	};
+	costUSD: number;
+	isFallbackModel?: boolean;
+};
+
+export function convertEventsToBlockEntries(events: TokenUsageEvent[]): CodexLoadedUsageEntry[] {
+	return events
+		.flatMap((event) => {
+			const model = event.model?.trim();
+			if (model == null || model === '') {
+				return [];
+			}
+
+			const inputTokens = Math.max(event.inputTokens, 0);
+			const cachedInputTokens = Math.max(Math.min(event.cachedInputTokens, inputTokens), 0);
+			const outputTokens = Math.max(event.outputTokens, 0);
+			const reasoningOutputTokens = Math.max(event.reasoningOutputTokens, 0);
+			const totalTokens = Math.max(event.totalTokens, 0);
+
+			return [{
+				timestamp: new Date(event.timestamp),
+				sessionId: event.sessionId,
+				model,
+				usage: {
+					inputTokens,
+					outputTokens,
+					cachedInputTokens,
+					reasoningOutputTokens,
+					totalTokens,
+				},
+				costUSD: 0,
+				isFallbackModel: event.isFallbackModel,
+			} satisfies CodexLoadedUsageEntry];
+		})
+		.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+}
+
+if (import.meta.vitest != null) {
+	describe('convertEventsToBlockEntries', () => {
+		const baseEvent: TokenUsageEvent = {
+			sessionId: 'session-1',
+			timestamp: '2025-10-05T00:00:00.000Z',
+			model: 'gpt-5',
+			inputTokens: 100,
+			cachedInputTokens: 50,
+			outputTokens: 30,
+			reasoningOutputTokens: 5,
+			totalTokens: 130,
+		};
+
+		it('converts timestamps to Date objects and sorts ascending', () => {
+			const events: TokenUsageEvent[] = [
+				{ ...baseEvent, timestamp: '2025-10-05T02:00:00.000Z', inputTokens: -10 },
+				{ ...baseEvent, timestamp: '2025-10-05T01:00:00.000Z', cachedInputTokens: 120 },
+			];
+
+			const entries = convertEventsToBlockEntries(events);
+			expect(entries).toHaveLength(2);
+			expect(entries[0]?.timestamp.toISOString()).toBe('2025-10-05T01:00:00.000Z');
+			expect(entries[0]?.usage.inputTokens).toBe(100);
+			expect(entries[0]?.usage.cachedInputTokens).toBe(100);
+			expect(entries[1]?.usage.inputTokens).toBe(0);
+			expect(entries[1]?.usage.cachedInputTokens).toBe(0);
+		});
+
+		it('filters out events without model names', () => {
+			const events: TokenUsageEvent[] = [
+				baseEvent,
+				{ ...baseEvent, timestamp: '2025-10-05T01:00:00.000Z', model: undefined },
+				{ ...baseEvent, timestamp: '2025-10-05T01:30:00.000Z', model: '' },
+			];
+
+			const entries = convertEventsToBlockEntries(events);
+			expect(entries).toHaveLength(1);
+			expect(entries[0]?.model).toBe('gpt-5');
+		});
+	});
+}

--- a/apps/codex/src/_jq-processor.ts
+++ b/apps/codex/src/_jq-processor.ts
@@ -1,0 +1,76 @@
+import { Result } from '@praha/byethrow';
+import spawn from 'nano-spawn';
+
+export async function processWithJq(jsonData: unknown, jqCommand: string): Result.ResultAsync<string, Error> {
+	const jsonString = JSON.stringify(jsonData);
+
+	const result = Result.try({
+		try: async () => {
+			const spawnResult = await spawn('jq', [jqCommand], {
+				stdin: { string: jsonString },
+			});
+			return spawnResult.output.trim();
+		},
+		catch: (error: unknown) => {
+			if (error instanceof Error) {
+				if (error.message.includes('ENOENT') || error.message.includes('not found')) {
+					return new Error('jq command not found. Please install jq to use the --jq option.');
+				}
+				return new Error(`jq processing failed: ${error.message}`);
+			}
+			return new Error('Unknown error during jq processing');
+		},
+	});
+
+	return result();
+}
+
+if (import.meta.vitest != null) {
+	const ensureJqAvailable = async (result: Awaited<ReturnType<typeof processWithJq>>): Promise<string | null> => {
+		if (Result.isFailure(result)) {
+			if (result.error.message.includes('jq command not found')) {
+				return null;
+			}
+			throw result.error;
+		}
+		return result.value;
+	};
+
+	describe('processWithJq', () => {
+		it('returns jq output when command succeeds', async () => {
+			const data = { name: 'codex', value: 7 };
+			const result = await processWithJq(data, '.name');
+			const output = await ensureJqAvailable(result);
+			if (output == null) {
+				expect(true).toBe(true);
+				return;
+			}
+			expect(output).toBe('"codex"');
+		});
+
+		it('wraps jq errors when the filter is invalid', async () => {
+			const data = { message: 'hello' };
+			const result = await processWithJq(data, 'invalid {');
+			if (Result.isFailure(result)) {
+				if (result.error.message.includes('jq command not found')) {
+					expect(result.error.message).toContain('jq');
+					return;
+				}
+				expect(result.error.message).toContain('jq processing failed');
+			}
+			else {
+				expect.fail('Expected jq to report an error for invalid syntax');
+			}
+		});
+
+		it('provides a helpful error when jq is missing', async () => {
+			const result = await processWithJq({ value: 1 }, '.');
+			if (Result.isFailure(result)) {
+				expect(result.error.message).toContain('jq command not found');
+			}
+			else {
+				expect(result.value.length).toBeGreaterThan(0);
+			}
+		});
+	});
+}

--- a/apps/codex/src/_session-blocks.ts
+++ b/apps/codex/src/_session-blocks.ts
@@ -1,0 +1,378 @@
+import type { CodexLoadedUsageEntry } from './_block-entry.ts';
+
+export const DEFAULT_SESSION_DURATION_HOURS = 5;
+export const DEFAULT_RECENT_DAYS = 3;
+
+export type CodexSessionBlock = {
+	id: string;
+	startTime: Date;
+	endTime: Date;
+	actualEndTime?: Date;
+	isActive: boolean;
+	isGap?: boolean;
+	entries: CodexLoadedUsageEntry[];
+	tokenCounts: {
+		inputTokens: number;
+		outputTokens: number;
+		cachedInputTokens: number;
+		reasoningOutputTokens: number;
+		totalTokens: number;
+	};
+	costUSD: number;
+	models: string[];
+};
+
+export function identifyCodexSessionBlocks(
+	entries: CodexLoadedUsageEntry[],
+	sessionDurationHours: number = DEFAULT_SESSION_DURATION_HOURS,
+): CodexSessionBlock[] {
+	if (entries.length === 0) {
+		return [];
+	}
+
+	const sortedEntries = [...entries].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+	const sessionDurationMs = sessionDurationHours * 60 * 60 * 1000;
+	const now = new Date();
+	const blocks: CodexSessionBlock[] = [];
+
+	let currentBlockStart: Date | null = null;
+	let currentBlockEntries: CodexLoadedUsageEntry[] = [];
+
+	for (const entry of sortedEntries) {
+		if (currentBlockStart == null) {
+			currentBlockStart = floorToHour(entry.timestamp);
+			currentBlockEntries = [entry];
+			continue;
+		}
+
+		const timeSinceBlockStart = entry.timestamp.getTime() - currentBlockStart.getTime();
+		const previousEntry = currentBlockEntries.at(-1);
+		const timeSincePrevious = previousEntry == null ? 0 : entry.timestamp.getTime() - previousEntry.timestamp.getTime();
+
+		if (timeSinceBlockStart > sessionDurationMs || timeSincePrevious > sessionDurationMs) {
+			blocks.push(createBlock(currentBlockStart, currentBlockEntries, sessionDurationMs, now));
+
+			if (previousEntry != null && timeSincePrevious > sessionDurationMs) {
+				const gap = createGapBlock(previousEntry.timestamp, entry.timestamp, sessionDurationMs);
+				if (gap != null) {
+					blocks.push(gap);
+				}
+			}
+
+			currentBlockStart = floorToHour(entry.timestamp);
+			currentBlockEntries = [entry];
+		}
+		else {
+			currentBlockEntries.push(entry);
+		}
+	}
+
+	if (currentBlockStart != null && currentBlockEntries.length > 0) {
+		blocks.push(createBlock(currentBlockStart, currentBlockEntries, sessionDurationMs, now));
+	}
+
+	return blocks;
+}
+
+function floorToHour(timestamp: Date): Date {
+	const floored = new Date(timestamp);
+	floored.setUTCMinutes(0, 0, 0);
+	return floored;
+}
+
+function createBlock(
+	startTime: Date,
+	entries: CodexLoadedUsageEntry[],
+	sessionDurationMs: number,
+	now: Date,
+): CodexSessionBlock {
+	const endTime = new Date(startTime.getTime() + sessionDurationMs);
+	const actualEndTime = entries.at(-1)?.timestamp ?? startTime;
+	const isActive = now.getTime() - actualEndTime.getTime() < sessionDurationMs && now < endTime;
+
+	let inputTokens = 0;
+	let outputTokens = 0;
+	let cachedInputTokens = 0;
+	let reasoningOutputTokens = 0;
+	let totalTokens = 0;
+	let costUSD = 0;
+	const models: string[] = [];
+
+	for (const entry of entries) {
+		inputTokens += entry.usage.inputTokens;
+		outputTokens += entry.usage.outputTokens;
+		cachedInputTokens += entry.usage.cachedInputTokens;
+		reasoningOutputTokens += entry.usage.reasoningOutputTokens;
+		totalTokens += entry.usage.totalTokens;
+		costUSD += entry.costUSD;
+		models.push(entry.model);
+	}
+
+	return {
+		id: startTime.toISOString(),
+		startTime,
+		endTime,
+		actualEndTime,
+		isActive,
+		entries,
+		tokenCounts: {
+			inputTokens,
+			outputTokens,
+			cachedInputTokens,
+			reasoningOutputTokens,
+			totalTokens,
+		},
+		costUSD,
+		models: Array.from(new Set(models)),
+	};
+}
+
+function createGapBlock(
+	lastActivityTime: Date,
+	nextActivityTime: Date,
+	sessionDurationMs: number,
+): CodexSessionBlock | null {
+	const gapDuration = nextActivityTime.getTime() - lastActivityTime.getTime();
+	if (gapDuration <= sessionDurationMs) {
+		return null;
+	}
+
+	const startTime = new Date(lastActivityTime.getTime() + sessionDurationMs);
+	return {
+		id: `gap-${startTime.toISOString()}`,
+		startTime,
+		endTime: nextActivityTime,
+		isActive: false,
+		isGap: true,
+		entries: [],
+		tokenCounts: {
+			inputTokens: 0,
+			outputTokens: 0,
+			cachedInputTokens: 0,
+			reasoningOutputTokens: 0,
+			totalTokens: 0,
+		},
+		costUSD: 0,
+		models: [],
+	};
+}
+
+export type CodexBlockBurnRate = {
+	tokensPerMinute: number;
+	tokensPerMinuteForIndicator: number;
+	costPerHour: number;
+};
+
+export type CodexBlockProjection = {
+	totalTokens: number;
+	totalCost: number;
+	remainingMinutes: number;
+};
+
+export function calculateBurnRate(block: CodexSessionBlock): CodexBlockBurnRate | null {
+	if (block.entries.length === 0 || block.isGap === true) {
+		return null;
+	}
+
+	const first = block.entries[0];
+	const last = block.entries[block.entries.length - 1];
+	if (first == null || last == null) {
+		return null;
+	}
+
+	const durationMinutes = (last.timestamp.getTime() - first.timestamp.getTime()) / (1000 * 60);
+	if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) {
+		return null;
+	}
+
+	const totalTokens = block.tokenCounts.totalTokens;
+	const tokensPerMinute = totalTokens / durationMinutes;
+	const tokensPerMinuteForIndicator = (block.tokenCounts.inputTokens + block.tokenCounts.outputTokens) / durationMinutes;
+	const costPerHour = (block.costUSD / durationMinutes) * 60;
+
+	return {
+		tokensPerMinute,
+		tokensPerMinuteForIndicator,
+		costPerHour,
+	};
+}
+
+export function projectBlockUsage(block: CodexSessionBlock): CodexBlockProjection | null {
+	if (!block.isActive || block.isGap === true) {
+		return null;
+	}
+
+	const burnRate = calculateBurnRate(block);
+	if (burnRate == null) {
+		return null;
+	}
+
+	const now = new Date();
+	const remainingMinutes = Math.max(0, (block.endTime.getTime() - now.getTime()) / (1000 * 60));
+	if (remainingMinutes <= 0) {
+		return null;
+	}
+
+	const projectedTokens = block.tokenCounts.totalTokens + burnRate.tokensPerMinute * remainingMinutes;
+	const projectedCost = block.costUSD + (burnRate.costPerHour / 60) * remainingMinutes;
+
+	return {
+		totalTokens: Math.round(projectedTokens),
+		totalCost: Math.round(projectedCost * 100) / 100,
+		remainingMinutes: Math.round(remainingMinutes),
+	};
+}
+
+export function filterRecentBlocks(blocks: CodexSessionBlock[], days = DEFAULT_RECENT_DAYS): CodexSessionBlock[] {
+	const now = new Date();
+	const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+	return blocks.filter(block => block.isActive || block.startTime >= cutoff);
+}
+
+if (import.meta.vitest != null) {
+	function createEntry(timestamp: string, overrides: Partial<CodexLoadedUsageEntry> = {}): CodexLoadedUsageEntry {
+		return {
+			timestamp: new Date(timestamp),
+			sessionId: 'session-1',
+			model: 'gpt-5',
+			usage: {
+				inputTokens: 100,
+				outputTokens: 50,
+				cachedInputTokens: 10,
+				reasoningOutputTokens: 5,
+				totalTokens: 150,
+			},
+			costUSD: 0.1,
+			...overrides,
+		};
+	}
+
+	describe('identifyCodexSessionBlocks', () => {
+		it('returns an empty array when no entries are provided', () => {
+			const blocks = identifyCodexSessionBlocks([]);
+			expect(blocks).toEqual([]);
+		});
+
+		it('groups entries that fall within the session duration into one block', () => {
+			const entries = [
+				createEntry('2025-10-05T00:00:00.000Z'),
+				createEntry('2025-10-05T02:00:00.000Z'),
+			];
+			const blocks = identifyCodexSessionBlocks(entries);
+			expect(blocks).toHaveLength(1);
+			expect(blocks[0]?.entries).toHaveLength(2);
+			expect(blocks[0]?.tokenCounts.inputTokens).toBe(200);
+			expect(blocks[0]?.costUSD).toBeCloseTo(0.2);
+		});
+
+		it('creates a new block and a gap block when entries exceed the session duration', () => {
+			const entries = [
+				createEntry('2025-10-05T00:00:00.000Z'),
+				createEntry('2025-10-05T06:30:00.000Z'),
+			];
+			const blocks = identifyCodexSessionBlocks(entries);
+			expect(blocks).toHaveLength(3);
+			expect(blocks[1]?.isGap).toBe(true);
+		});
+
+		it('deduplicates the model list for each block', () => {
+			const entries = [
+				createEntry('2025-10-05T00:00:00.000Z', { model: 'gpt-5' }),
+				createEntry('2025-10-05T01:00:00.000Z', { model: 'gpt-5-mini' }),
+				createEntry('2025-10-05T01:30:00.000Z', { model: 'gpt-5' }),
+			];
+			const blocks = identifyCodexSessionBlocks(entries);
+			expect(blocks[0]?.models).toEqual(['gpt-5', 'gpt-5-mini']);
+		});
+	});
+
+	describe('calculateBurnRate', () => {
+		it('returns null for empty blocks or gap blocks', () => {
+			const emptyBlock: CodexSessionBlock = {
+				id: 'block-empty',
+				startTime: new Date('2025-10-05T00:00:00.000Z'),
+				endTime: new Date('2025-10-05T05:00:00.000Z'),
+				isActive: false,
+				entries: [],
+				tokenCounts: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
+				costUSD: 0,
+				models: [],
+			};
+			expect(calculateBurnRate(emptyBlock)).toBeNull();
+
+			const gapBlock: CodexSessionBlock = { ...emptyBlock, id: 'gap', isGap: true };
+			expect(calculateBurnRate(gapBlock)).toBeNull();
+		});
+
+		it('calculates burn rate metrics from token usage and cost', () => {
+			const start = new Date('2025-10-05T00:00:00.000Z');
+			const later = new Date('2025-10-05T01:00:00.000Z');
+			const block = identifyCodexSessionBlocks([
+				createEntry(start.toISOString()),
+				createEntry(later.toISOString()),
+			])[0]!;
+			const burnRate = calculateBurnRate(block);
+			expect(burnRate).not.toBeNull();
+			expect(burnRate?.tokensPerMinute).toBeGreaterThan(0);
+			expect(burnRate?.costPerHour).toBeGreaterThan(0);
+		});
+	});
+
+	describe('projectBlockUsage', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2025-10-05T02:30:00.000Z'));
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('returns null for inactive blocks or gap blocks', () => {
+			const block = identifyCodexSessionBlocks([
+				createEntry('2025-10-05T00:00:00.000Z'),
+			])[0]!;
+			block.isActive = false;
+			expect(projectBlockUsage(block)).toBeNull();
+
+			const gapBlock: CodexSessionBlock = { ...block, isActive: true, isGap: true };
+			expect(projectBlockUsage(gapBlock)).toBeNull();
+		});
+
+		it('projects remaining usage for active blocks', () => {
+			const start = new Date('2025-10-05T00:00:00.000Z');
+			const later = new Date('2025-10-05T01:00:00.000Z');
+			const block = identifyCodexSessionBlocks([
+				createEntry(start.toISOString()),
+				createEntry(later.toISOString()),
+			])[0]!;
+			block.isActive = true;
+			const projection = projectBlockUsage(block);
+			expect(projection).not.toBeNull();
+			expect(projection?.totalTokens).toBeGreaterThan(block.tokenCounts.totalTokens);
+		});
+	});
+
+	describe('filterRecentBlocks', () => {
+		it('keeps only recent blocks or those still active', () => {
+			const now = new Date();
+			const mk = (id: string, offsetDays: number, isActive = false): CodexSessionBlock => ({
+				id,
+				startTime: new Date(now.getTime() - offsetDays * 24 * 60 * 60 * 1000),
+				endTime: new Date(now.getTime() - (offsetDays - 0.5) * 24 * 60 * 60 * 1000),
+				isActive,
+				entries: [],
+				tokenCounts: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
+				costUSD: 0,
+				models: [],
+			});
+
+			const recent = mk('recent', 1);
+			const old = mk('old', 10);
+			const active = mk('active', 8, true);
+
+			const filtered = filterRecentBlocks([recent, old, active], 3);
+			expect(filtered).toEqual([recent, active]);
+		});
+	});
+}

--- a/apps/codex/src/block-calculator.ts
+++ b/apps/codex/src/block-calculator.ts
@@ -1,0 +1,246 @@
+import type { CodexBlockBurnRate, CodexBlockProjection, CodexSessionBlock } from './_session-blocks.ts';
+import type { ModelPricing, PricingSource, TokenUsageEvent } from './_types.ts';
+import { convertEventsToBlockEntries } from './_block-entry.ts';
+import { calculateBurnRate, identifyCodexSessionBlocks, projectBlockUsage } from './_session-blocks.ts';
+import { calculateCostUSD } from './token-utils.ts';
+
+export type TokenLimitStatus = 'ok' | 'warning' | 'exceeds';
+
+export type ModelUsageSummary = {
+	inputTokens: number;
+	cachedInputTokens: number;
+	outputTokens: number;
+	reasoningOutputTokens: number;
+	totalTokens: number;
+	costUSD: number;
+	isFallback?: boolean;
+};
+
+export type CodexBlockSummary = {
+	block: CodexSessionBlock;
+	burnRate: CodexBlockBurnRate | null;
+	projection: CodexBlockProjection | null;
+	models: Record<string, ModelUsageSummary>;
+	tokenLimitStatus: TokenLimitStatus | null;
+	usagePercent: number | null;
+};
+
+export type CodexBlocksReport = {
+	blocks: CodexBlockSummary[];
+	totals: {
+		tokenCounts: CodexSessionBlock['tokenCounts'];
+		costUSD: number;
+	};
+};
+
+export type BuildReportOptions = {
+	blocks: CodexSessionBlock[];
+	pricingSource: PricingSource;
+	tokenLimit?: number;
+};
+
+export async function buildCodexBlocksReport(options: BuildReportOptions): Promise<CodexBlocksReport> {
+	const { blocks, pricingSource, tokenLimit } = options;
+	const uniqueModels = new Set<string>();
+	for (const block of blocks) {
+		for (const entry of block.entries) {
+			uniqueModels.add(entry.model);
+		}
+	}
+
+	const pricingCache = new Map<string, ModelPricing>();
+	for (const model of uniqueModels) {
+		pricingCache.set(model, await pricingSource.getPricing(model));
+	}
+
+	const summaries: CodexBlockSummary[] = [];
+	const totals = {
+		tokenCounts: {
+			inputTokens: 0,
+			outputTokens: 0,
+			cachedInputTokens: 0,
+			reasoningOutputTokens: 0,
+			totalTokens: 0,
+		},
+		costUSD: 0,
+	};
+
+	for (const block of blocks) {
+		const modelUsageMap = new Map<string, ModelUsageSummary>();
+		for (const entry of block.entries) {
+			const summary = modelUsageMap.get(entry.model) ?? {
+				inputTokens: 0,
+				cachedInputTokens: 0,
+				outputTokens: 0,
+				reasoningOutputTokens: 0,
+				totalTokens: 0,
+				costUSD: 0,
+				isFallback: false,
+			};
+			summary.inputTokens += entry.usage.inputTokens;
+			summary.cachedInputTokens += entry.usage.cachedInputTokens;
+			summary.outputTokens += entry.usage.outputTokens;
+			summary.reasoningOutputTokens += entry.usage.reasoningOutputTokens;
+			summary.totalTokens += entry.usage.totalTokens;
+			if (entry.isFallbackModel === true) {
+				summary.isFallback = true;
+			}
+			modelUsageMap.set(entry.model, summary);
+		}
+
+		let blockCost = 0;
+		const models: Record<string, ModelUsageSummary> = {};
+		for (const [model, usage] of modelUsageMap) {
+			const pricing = pricingCache.get(model);
+			if (pricing == null) {
+				continue;
+			}
+			const cost = calculateCostUSD(usage, pricing);
+			usage.costUSD = cost;
+			blockCost += cost;
+			models[model] = { ...usage };
+		}
+
+		block.costUSD = blockCost;
+		totals.tokenCounts.inputTokens += block.tokenCounts.inputTokens;
+		totals.tokenCounts.outputTokens += block.tokenCounts.outputTokens;
+		totals.tokenCounts.cachedInputTokens += block.tokenCounts.cachedInputTokens;
+		totals.tokenCounts.reasoningOutputTokens += block.tokenCounts.reasoningOutputTokens;
+		totals.tokenCounts.totalTokens += block.tokenCounts.totalTokens;
+		totals.costUSD += blockCost;
+
+		const burnRate = calculateBurnRate(block);
+		const projection = projectBlockUsage(block);
+		const usagePercent = tokenLimit != null && tokenLimit > 0
+			? block.tokenCounts.totalTokens / tokenLimit
+			: null;
+
+		let tokenLimitStatus: TokenLimitStatus | null = null;
+		if (tokenLimit != null && tokenLimit > 0) {
+			const projectedTokens = projection?.totalTokens ?? block.tokenCounts.totalTokens;
+			if (projectedTokens >= tokenLimit) {
+				tokenLimitStatus = 'exceeds';
+			}
+			else if (projectedTokens >= tokenLimit * 0.8) {
+				tokenLimitStatus = 'warning';
+			}
+			else {
+				tokenLimitStatus = 'ok';
+			}
+		}
+
+		summaries.push({
+			block,
+			burnRate,
+			projection,
+			models,
+			tokenLimitStatus,
+			usagePercent,
+		});
+	}
+
+	return {
+		blocks: summaries,
+		totals,
+	};
+}
+
+if (import.meta.vitest != null) {
+	describe('buildCodexBlocksReport', () => {
+		it('calculates costs via LiteLLM pricing and assigns token limit status', async () => {
+			const events: TokenUsageEvent[] = [
+				{
+					sessionId: 'session-1',
+					timestamp: '2025-10-05T00:00:00.000Z',
+					model: 'gpt-5',
+					inputTokens: 400,
+					cachedInputTokens: 100,
+					outputTokens: 200,
+					reasoningOutputTokens: 50,
+					totalTokens: 600,
+				},
+				{
+					sessionId: 'session-1',
+					timestamp: '2025-10-05T01:00:00.000Z',
+					model: 'gpt-5-mini',
+					inputTokens: 300,
+					cachedInputTokens: 0,
+					outputTokens: 150,
+					reasoningOutputTokens: 0,
+					totalTokens: 450,
+				},
+			];
+
+			const entries = convertEventsToBlockEntries(events);
+			const blocks = identifyCodexSessionBlocks(entries);
+
+			const pricing = new Map([
+				['gpt-5', { inputCostPerMToken: 1.25, cachedInputCostPerMToken: 0.125, outputCostPerMToken: 10 }],
+				['gpt-5-mini', { inputCostPerMToken: 0.6, cachedInputCostPerMToken: 0.06, outputCostPerMToken: 2 }],
+			]);
+
+			const stubPricingSource: PricingSource = {
+				async getPricing(model: string) {
+					const value = pricing.get(model);
+					if (value == null) {
+						throw new Error(`missing pricing for ${model}`);
+					}
+					return value;
+				},
+			};
+
+			blocks[0]!.isActive = false;
+			const report = await buildCodexBlocksReport({
+				blocks,
+				pricingSource: stubPricingSource,
+				tokenLimit: 1_200,
+			});
+
+			expect(report.blocks).toHaveLength(1);
+			const summary = report.blocks[0]!;
+			expect(summary.block.costUSD).toBeGreaterThan(0);
+			expect(summary.models['gpt-5']?.costUSD).toBeGreaterThan(0);
+			expect(summary.tokenLimitStatus).toBe('warning');
+			expect(summary.usagePercent).toBeGreaterThan(0);
+			const expectedGpt5Cost = calculateCostUSD(
+				{
+					inputTokens: 400,
+					cachedInputTokens: 100,
+					outputTokens: 200,
+					reasoningOutputTokens: 50,
+					totalTokens: 600,
+				},
+				pricing.get('gpt-5')!,
+			);
+			expect(summary.models['gpt-5']?.costUSD).toBeCloseTo(expectedGpt5Cost, 10);
+		});
+
+		it('marks token limit status as exceeds when projected usage is over the limit', async () => {
+			const events: TokenUsageEvent[] = [
+				{
+					sessionId: 'session-1',
+					timestamp: '2025-10-05T00:00:00.000Z',
+					model: 'gpt-5',
+					inputTokens: 2_000,
+					cachedInputTokens: 0,
+					outputTokens: 1_000,
+					reasoningOutputTokens: 0,
+					totalTokens: 3_000,
+				},
+			];
+			const entries = convertEventsToBlockEntries(events);
+			const blocks = identifyCodexSessionBlocks(entries);
+			const stubPricingSource: PricingSource = {
+				async getPricing() {
+					return { inputCostPerMToken: 1, cachedInputCostPerMToken: 0.1, outputCostPerMToken: 1 };
+				},
+			};
+			const report = await buildCodexBlocksReport({
+				blocks,
+				pricingSource: stubPricingSource,
+				tokenLimit: 1_000,
+			});
+			expect(report.blocks[0]?.tokenLimitStatus).toBe('exceeds');
+		});
+	});
+}

--- a/apps/codex/src/commands/blocks.ts
+++ b/apps/codex/src/commands/blocks.ts
@@ -1,0 +1,472 @@
+import type { CodexSessionBlock } from '../_session-blocks.ts';
+import process from 'node:process';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { convertEventsToBlockEntries } from '../_block-entry.ts';
+import { processWithJq } from '../_jq-processor.ts';
+import { DEFAULT_SESSION_DURATION_HOURS, filterRecentBlocks, identifyCodexSessionBlocks } from '../_session-blocks.ts';
+import { sharedArgs } from '../_shared-args.ts';
+import { buildCodexBlocksReport } from '../block-calculator.ts';
+import { formatModelsList, splitUsageTokens } from '../command-utils.ts';
+import { loadTokenUsageEvents } from '../data-loader.ts';
+import { isWithinRange, normalizeFilterDate } from '../date-utils.ts';
+import { startCodexLiveMonitor } from '../live-monitor.ts';
+import { log, logger } from '../logger.ts';
+
+import { CodexPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 8;
+
+export const blocksCommand = define({
+	name: 'blocks',
+	description: 'Show Codex usage grouped by billing blocks',
+	args: {
+		...sharedArgs,
+		jq: {
+			type: 'string',
+			description: 'Process JSON output with jq',
+		},
+		active: {
+			type: 'boolean',
+			description: 'Show only active block',
+			default: false,
+		},
+		recent: {
+			type: 'boolean',
+			description: 'Show blocks from the last 3 days (including active)',
+			default: false,
+		},
+		tokenLimit: {
+			type: 'string',
+			description: 'Token limit for usage warnings (number or "max")',
+		},
+		sessionLength: {
+			type: 'number',
+			description: 'Session block duration in hours',
+			default: DEFAULT_SESSION_DURATION_HOURS,
+		},
+		order: {
+			type: 'string',
+			description: 'Sort order for blocks (asc or desc)',
+			default: 'asc',
+		},
+		live: {
+			type: 'boolean',
+			description: 'Live monitoring mode',
+			default: false,
+		},
+		refreshInterval: {
+			type: 'number',
+			description: 'Refresh interval for live mode in seconds',
+			default: 5,
+		},
+	},
+	toKebab: true,
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json || ctx.values.jq);
+		if (jsonOutput) {
+			logger.level = 0;
+		}
+
+		if (ctx.values.sessionLength <= 0) {
+			logger.error('Session length must be a positive number');
+			process.exit(1);
+		}
+
+		const order = ctx.values.order === 'desc' ? 'desc' : 'asc';
+
+		if (ctx.values.live) {
+			const refreshSeconds = Number.isFinite(ctx.values.refreshInterval)
+				? Math.min(Math.max(ctx.values.refreshInterval, 1), 60)
+				: 5;
+			const controller = new AbortController();
+			const handleAbort = () => controller.abort();
+			process.once('SIGINT', handleAbort);
+			try {
+				await startCodexLiveMonitor({
+					codexPaths: [],
+					sessionDurationHours: ctx.values.sessionLength,
+					refreshIntervalMs: refreshSeconds * 1_000,
+					tokenLimit: parseTokenLimit(ctx.values.tokenLimit, 0),
+					offline: ctx.values.offline,
+				}, controller.signal);
+			}
+			finally {
+				process.removeListener('SIGINT', handleAbort);
+			}
+			return;
+		}
+
+		let since: string | undefined;
+		let until: string | undefined;
+		try {
+			if (ctx.values.since != null) {
+				since = normalizeFilterDate(ctx.values.since);
+			}
+			if (ctx.values.until != null) {
+				until = normalizeFilterDate(ctx.values.until);
+			}
+		}
+		catch (error) {
+			logger.error(String(error));
+			process.exit(1);
+		}
+
+		const sessionDurationHours = ctx.values.sessionLength ?? DEFAULT_SESSION_DURATION_HOURS;
+		const { events, missingDirectories } = await loadTokenUsageEvents();
+
+		for (const missing of missingDirectories) {
+			logger.warn(`Codex session directory not found: ${missing}`);
+		}
+
+		if (events.length === 0) {
+			const emptyJson = { blocks: [], totals: null, metadata: { missingDirectories } };
+			if (ctx.values.jq != null) {
+				const jqResult = await processWithJq(emptyJson, ctx.values.jq);
+				if (Result.isFailure(jqResult)) {
+					logger.error(jqResult.error.message);
+					process.exit(1);
+				}
+				log(jqResult.value);
+				return;
+			}
+			if (jsonOutput) {
+				log(JSON.stringify(emptyJson, null, 2));
+			}
+			else {
+				logger.warn('No Codex usage data found.');
+			}
+			return;
+		}
+
+		const entries = convertEventsToBlockEntries(events);
+		let blocks = identifyCodexSessionBlocks(entries, sessionDurationHours);
+
+		blocks = blocks.filter((block) => {
+			const dateKey = block.startTime.toISOString().slice(0, 10);
+			return isWithinRange(dateKey, since, until);
+		});
+
+		let maxTokensFromAll = 0;
+		for (const block of blocks) {
+			if (block.isGap === true || block.isActive) {
+				continue;
+			}
+			if (block.tokenCounts.totalTokens > maxTokensFromAll) {
+				maxTokensFromAll = block.tokenCounts.totalTokens;
+			}
+		}
+
+		if (ctx.values.recent) {
+			blocks = filterRecentBlocks(blocks);
+		}
+
+		if (ctx.values.active) {
+			blocks = blocks.filter(block => block.isActive);
+		}
+
+		blocks.sort((a, b) => {
+			const diff = a.startTime.getTime() - b.startTime.getTime();
+			return order === 'asc' ? diff : -diff;
+		});
+
+		if (blocks.length === 0) {
+			const emptyJson = { blocks: [], totals: null, metadata: { missingDirectories } };
+			if (ctx.values.jq != null) {
+				const jqResult = await processWithJq(emptyJson, ctx.values.jq);
+				if (Result.isFailure(jqResult)) {
+					logger.error(jqResult.error.message);
+					process.exit(1);
+				}
+				log(jqResult.value);
+				return;
+			}
+			if (jsonOutput) {
+				log(JSON.stringify(emptyJson, null, 2));
+			}
+			else {
+				logger.warn('No Codex usage data found for provided filters.');
+			}
+			return;
+		}
+
+		const tokenLimit = parseTokenLimit(ctx.values.tokenLimit, maxTokensFromAll);
+
+		using pricingSource = new CodexPricingSource({ offline: ctx.values.offline });
+		const report = await buildCodexBlocksReport({
+			blocks,
+			pricingSource,
+			tokenLimit,
+		});
+
+		const jsonPayload = {
+			blocks: report.blocks.map(summary => ({
+				id: summary.block.id,
+				startTime: summary.block.startTime.toISOString(),
+				endTime: summary.block.endTime.toISOString(),
+				actualEndTime: summary.block.actualEndTime?.toISOString() ?? null,
+				isActive: summary.block.isActive,
+				isGap: summary.block.isGap ?? false,
+				tokenCounts: summary.block.tokenCounts,
+				costUSD: summary.block.costUSD,
+				models: summary.models,
+				burnRate: summary.burnRate,
+				projection: summary.projection,
+				tokenLimitStatus: summary.tokenLimitStatus,
+				usagePercent: summary.usagePercent,
+			})),
+			totals: {
+				tokenCounts: report.totals.tokenCounts,
+				costUSD: report.totals.costUSD,
+			},
+			metadata: {
+				timezone: ctx.values.timezone,
+				locale: ctx.values.locale,
+				order,
+				generatedAt: new Date().toISOString(),
+				missingDirectories,
+			},
+		};
+
+		if (ctx.values.jq != null) {
+			const jqResult = await processWithJq(jsonPayload, ctx.values.jq);
+			if (Result.isFailure(jqResult)) {
+				logger.error(jqResult.error.message);
+				process.exit(1);
+			}
+			log(jqResult.value);
+			return;
+		}
+
+		if (jsonOutput) {
+			log(JSON.stringify(jsonPayload, null, 2));
+			return;
+		}
+
+		logger.box(`Codex Blocks Report (Timezone: ${ctx.values.timezone})`);
+
+		const table = new ResponsiveTable({
+			head: ['Window', 'Models', 'Input', 'Output', 'Cache', 'Total Tokens', 'Cost (USD)', 'Status'],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'left'],
+			compactHead: ['Window', 'Models', 'Tokens', 'Cost', 'Status'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'left'],
+			compactThreshold: 100,
+			forceCompact: ctx.values.compact,
+			style: { head: ['cyan'] },
+		});
+
+		const totalsForDisplay = {
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheReadTokens: 0,
+			reasoningTokens: 0,
+			totalTokens: 0,
+			costUSD: 0,
+		};
+
+		for (const summary of report.blocks) {
+			const split = splitUsageTokens(summary.block.tokenCounts);
+			totalsForDisplay.inputTokens += split.inputTokens;
+			totalsForDisplay.outputTokens += split.outputTokens;
+			totalsForDisplay.cacheReadTokens += split.cacheReadTokens;
+			totalsForDisplay.reasoningTokens += split.reasoningTokens;
+			totalsForDisplay.totalTokens += summary.block.tokenCounts.totalTokens;
+			totalsForDisplay.costUSD += summary.block.costUSD;
+
+			if (summary.block.isGap === true) {
+				table.push([
+					pc.gray(formatBlockTime(summary.block, table.isCompactMode(), ctx.values.locale)),
+					pc.gray('-'),
+					pc.gray('-'),
+					pc.gray('-'),
+					pc.gray('-'),
+					pc.gray('-'),
+					pc.gray('-'),
+					pc.gray('GAP'),
+				]);
+				continue;
+			}
+
+			const modelMap = Object.fromEntries(Object.entries(summary.models).map(([model, usage]) => [
+				model,
+				{ totalTokens: usage.totalTokens, isFallback: usage.isFallback },
+			]));
+
+			const statusParts: string[] = [];
+			if (summary.block.isActive) {
+				statusParts.push(pc.cyan('ACTIVE'));
+			}
+			if (summary.tokenLimitStatus === 'warning') {
+				const percent = summary.usagePercent != null ? Math.round(summary.usagePercent * 100) : undefined;
+				statusParts.push(pc.yellow(percent != null ? `⚠️ ${percent}%` : '⚠️ WARNING'));
+			}
+			if (summary.tokenLimitStatus === 'exceeds') {
+				const percent = summary.usagePercent != null ? Math.round(summary.usagePercent * 100) : undefined;
+				statusParts.push(pc.red(percent != null ? `🔥 ${percent}%` : '🔥 EXCEEDS'));
+			}
+
+			table.push([
+				formatBlockTime(summary.block, table.isCompactMode(), ctx.values.locale),
+				formatModelsDisplayMultiline(formatModelsList(modelMap)),
+				formatNumber(split.inputTokens),
+				formatNumber(split.outputTokens),
+				formatNumber(split.cacheReadTokens),
+				formatNumber(summary.block.tokenCounts.totalTokens),
+				formatCurrency(summary.block.costUSD),
+				statusParts.join(' '),
+			]);
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totalsForDisplay.inputTokens)),
+			pc.yellow(formatNumber(totalsForDisplay.outputTokens)),
+			pc.yellow(formatNumber(totalsForDisplay.cacheReadTokens)),
+			pc.yellow(formatNumber(totalsForDisplay.totalTokens)),
+			pc.yellow(formatCurrency(totalsForDisplay.costUSD)),
+			'',
+		]);
+
+		log(table.toString());
+
+		if (table.isCompactMode()) {
+			logger.info('\nRunning in Compact Mode');
+			logger.info('Expand terminal width to see cache metrics and totals');
+		}
+	},
+});
+
+export function formatBlockTime(block: CodexSessionBlock, compact = false, locale?: string): string {
+	const formatterOptions: Intl.DateTimeFormatOptions = compact
+		? { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' }
+		: { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' };
+
+	const formatDate = (date: Date): string => date.toLocaleString(locale, formatterOptions);
+
+	if (block.isGap === true) {
+		const start = formatDate(block.startTime);
+		const end = formatDate(block.endTime);
+		const durationHours = Math.round((block.endTime.getTime() - block.startTime.getTime()) / (1000 * 60 * 60));
+		return compact
+			? `${start}\n${end}\n(${durationHours}h gap)`
+			: `${start} - ${end} (${durationHours}h gap)`;
+	}
+
+	const start = formatDate(block.startTime);
+
+	if (block.isActive) {
+		const now = new Date();
+		const elapsedMinutes = Math.max(0, Math.floor((now.getTime() - block.startTime.getTime()) / (1000 * 60)));
+		const remainingMinutes = Math.max(0, Math.floor((block.endTime.getTime() - now.getTime()) / (1000 * 60)));
+		const elapsedHours = Math.floor(elapsedMinutes / 60);
+		const elapsedMins = elapsedMinutes % 60;
+		const remainingHours = Math.floor(remainingMinutes / 60);
+		const remainingMins = remainingMinutes % 60;
+		if (compact) {
+			return `${start}\n(${elapsedHours}h${elapsedMins}m/${remainingHours}h${remainingMins}m)`;
+		}
+		return `${start} (${elapsedHours}h ${elapsedMins}m elapsed, ${remainingHours}h ${remainingMins}m remaining)`;
+	}
+
+	const actualEnd = block.actualEndTime ?? block.endTime;
+	const durationMinutes = Math.max(0, Math.floor((actualEnd.getTime() - block.startTime.getTime()) / (1000 * 60)));
+	const durationHours = Math.floor(durationMinutes / 60);
+	const remainingMins = durationMinutes % 60;
+	if (compact) {
+		return `${start}\n(${durationHours}h${remainingMins}m)`;
+	}
+	if (durationHours > 0) {
+		return `${start} (${durationHours}h ${remainingMins}m)`;
+	}
+	return `${start} (${remainingMins}m)`;
+}
+
+export function parseTokenLimit(value: string | undefined, maxFromAll: number): number | undefined {
+	if (value == null || value.trim() === '') {
+		return undefined;
+	}
+
+	const trimmed = value.trim().toLowerCase();
+	if (trimmed === 'max') {
+		return maxFromAll > 0 ? maxFromAll : undefined;
+	}
+
+	const limit = Number.parseInt(trimmed, 10);
+	return Number.isNaN(limit) ? undefined : limit;
+}
+
+if (import.meta.vitest != null) {
+	function createBlock(overrides: Partial<CodexSessionBlock> = {}): CodexSessionBlock {
+		const startTime = overrides.startTime ?? new Date('2025-10-05T00:00:00.000Z');
+		return {
+			id: startTime.toISOString(),
+			startTime,
+			endTime: overrides.endTime ?? new Date(startTime.getTime() + DEFAULT_SESSION_DURATION_HOURS * 60 * 60 * 1000),
+			actualEndTime: overrides.actualEndTime,
+			isActive: overrides.isActive ?? false,
+			isGap: overrides.isGap,
+			entries: overrides.entries ?? [],
+			tokenCounts: overrides.tokenCounts ?? {
+				inputTokens: 0,
+				outputTokens: 0,
+				cachedInputTokens: 0,
+				reasoningOutputTokens: 0,
+				totalTokens: 0,
+			},
+			costUSD: overrides.costUSD ?? 0,
+			models: overrides.models ?? [],
+		};
+	}
+
+	describe('formatBlockTime', () => {
+		it('renders elapsed and remaining time for active blocks', () => {
+			const now = new Date();
+			const start = new Date(now.getTime() - 60 * 60 * 1000);
+			const block = createBlock({
+				startTime: start,
+				endTime: new Date(start.getTime() + DEFAULT_SESSION_DURATION_HOURS * 60 * 60 * 1000),
+				actualEndTime: new Date(now.getTime() - 5 * 60 * 1000),
+				isActive: true,
+			});
+			const formatted = formatBlockTime(block, true, 'en-US');
+			expect(formatted).toContain('h');
+			expect(formatted).toContain('m');
+		});
+
+		it('renders gap block start and end as a range', () => {
+			const block = createBlock({
+				isGap: true,
+				startTime: new Date('2025-10-05T05:00:00.000Z'),
+				endTime: new Date('2025-10-05T07:30:00.000Z'),
+			});
+			const formatted = formatBlockTime(block, false, 'en-US');
+			expect(formatted).toContain('2025');
+			expect(formatted).toContain('gap');
+		});
+	});
+
+	describe('parseTokenLimit', () => {
+		it('parses numeric string token limits', () => {
+			expect(parseTokenLimit('5000', 0)).toBe(5000);
+		});
+
+		it('returns the maximum token count when value is max', () => {
+			expect(parseTokenLimit('max', 1200)).toBe(1200);
+		});
+
+		it('returns undefined for invalid input', () => {
+			expect(parseTokenLimit('invalid', 100)).toBeUndefined();
+			expect(parseTokenLimit(undefined, 100)).toBeUndefined();
+		});
+	});
+}

--- a/apps/codex/src/live-monitor.ts
+++ b/apps/codex/src/live-monitor.ts
@@ -1,0 +1,213 @@
+import type { PricingSource, TokenUsageEvent } from './_types.ts';
+import type { CodexBlockSummary } from './block-calculator.ts';
+import process from 'node:process';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import pc from 'picocolors';
+import { convertEventsToBlockEntries } from './_block-entry.ts';
+import { DEFAULT_SESSION_DURATION_HOURS, identifyCodexSessionBlocks } from './_session-blocks.ts';
+import { buildCodexBlocksReport } from './block-calculator.ts';
+import { formatModelsList } from './command-utils.ts';
+import { formatBlockTime } from './commands/blocks.ts';
+import { loadTokenUsageEvents } from './data-loader.ts';
+import { log, logger } from './logger.ts';
+import { CodexPricingSource } from './pricing.ts';
+
+export type CodexLiveMonitorConfig = {
+	codexPaths: string[];
+	sessionDurationHours: number;
+	tokenLimit?: number;
+	refreshIntervalMs: number;
+	offline?: boolean;
+	pricingSource?: PricingSource;
+};
+
+export type LiveSnapshot = {
+	blocks: CodexBlockSummary[];
+};
+
+export async function generateLiveSnapshot(
+	events: TokenUsageEvent[],
+	config: CodexLiveMonitorConfig,
+): Promise<LiveSnapshot> {
+	if (events.length === 0) {
+		return { blocks: [] };
+	}
+
+	const entries = convertEventsToBlockEntries(events);
+	const blocks = identifyCodexSessionBlocks(entries, config.sessionDurationHours);
+
+	let targets = blocks.filter(block => block.isActive);
+	if (targets.length === 0 && blocks.length > 0) {
+		targets = [blocks.at(-1)!];
+	}
+
+	if (targets.length === 0) {
+		return { blocks: [] };
+	}
+
+	if (config.pricingSource != null) {
+		const report = await buildCodexBlocksReport({
+			blocks: targets,
+			pricingSource: config.pricingSource,
+			tokenLimit: config.tokenLimit,
+		});
+		return { blocks: report.blocks };
+	}
+
+	using pricingSource = new CodexPricingSource({ offline: config.offline });
+	const report = await buildCodexBlocksReport({
+		blocks: targets,
+		pricingSource,
+		tokenLimit: config.tokenLimit,
+	});
+	return { blocks: report.blocks };
+}
+
+export async function startCodexLiveMonitor(
+	config: CodexLiveMonitorConfig,
+	abortSignal: AbortSignal,
+): Promise<void> {
+	const refreshInterval = Math.min(Math.max(config.refreshIntervalMs, 1_000), 60_000);
+	const pricingSource = config.pricingSource ?? new CodexPricingSource({ offline: config.offline });
+	const disposePricing = config.pricingSource == null;
+
+	const cleanup = () => {
+		if (disposePricing) {
+			(pricingSource as CodexPricingSource)[Symbol.dispose]();
+		}
+	};
+
+	try {
+		while (!abortSignal.aborted) {
+			const loadOptions = config.codexPaths.length > 0 ? { sessionDirs: config.codexPaths } : undefined;
+			const { events, missingDirectories } = await loadTokenUsageEvents(loadOptions);
+
+			process.stdout.write('\u001Bc');
+			logger.box('Codex Blocks Live Monitor');
+			if (missingDirectories.length > 0) {
+				for (const missing of missingDirectories) {
+					logger.warn(`Codex session directory not found: ${missing}`);
+				}
+			}
+
+			const snapshot = await generateLiveSnapshot(events, {
+				...config,
+				pricingSource,
+			});
+
+			if (snapshot.blocks.length === 0) {
+				log('No active blocks detected. Waiting for new activity...');
+			}
+			else {
+				displayLiveTable(snapshot.blocks, config.tokenLimit);
+			}
+
+			if (abortSignal.aborted) {
+				break;
+			}
+
+			await new Promise(resolve => setTimeout(resolve, refreshInterval));
+		}
+	}
+	finally {
+		cleanup();
+	}
+}
+
+const LIVE_TABLE_COLUMNS = 6;
+
+function displayLiveTable(blocks: CodexBlockSummary[], tokenLimit?: number): void {
+	const table = new ResponsiveTable({
+		head: ['Window', 'Models', 'Tokens', 'Cost (USD)', 'Burn Rate (tokens/min)', 'Status'],
+		colAligns: ['left', 'left', 'right', 'right', 'right', 'left'],
+		compactHead: ['Window', 'Tokens', 'Cost', 'Status'],
+		compactColAligns: ['left', 'right', 'right', 'left'],
+		compactThreshold: 80,
+		forceCompact: false,
+		style: { head: ['magenta'] },
+	});
+
+	for (const summary of blocks) {
+		const models = formatModelsList(Object.fromEntries(Object.entries(summary.models).map(([model, usage]) => [
+			model,
+			{ totalTokens: usage.totalTokens, isFallback: usage.isFallback },
+		])));
+
+		const burnRate = summary.burnRate != null
+			? `${formatNumber(Math.round(summary.burnRate.tokensPerMinute))}`
+			: '-';
+
+		const statusParts: string[] = [];
+		if (summary.block.isActive === true) {
+			statusParts.push(pc.cyan('ACTIVE'));
+		}
+		if (summary.block.isGap === true) {
+			statusParts.push(pc.gray('GAP'));
+		}
+		if (summary.tokenLimitStatus === 'warning') {
+			statusParts.push(pc.yellow('⚠️ nearing limit'));
+		}
+		if (summary.tokenLimitStatus === 'exceeds') {
+			statusParts.push(pc.red('🔥 limit exceeded'));
+		}
+		if (summary.projection != null && tokenLimit != null && summary.projection.totalTokens >= tokenLimit) {
+			statusParts.push(pc.red('projection over limit'));
+		}
+
+		table.push([
+			formatBlockTime(summary.block, table.isCompactMode()),
+			table.isCompactMode() ? '' : models.join('\n'),
+			formatNumber(summary.block.tokenCounts.totalTokens),
+			formatCurrency(summary.block.costUSD),
+			burnRate,
+			statusParts.join(' '),
+		]);
+	}
+
+	addEmptySeparatorRow(table, LIVE_TABLE_COLUMNS);
+	log(table.toString());
+}
+
+if (import.meta.vitest != null) {
+	describe('generateLiveSnapshot', () => {
+		it('builds a summary for active blocks', async () => {
+			const now = new Date();
+			const events: TokenUsageEvent[] = [
+				{
+					sessionId: 'session-1',
+					timestamp: new Date(now.getTime() - 2 * 60 * 1000).toISOString(),
+					model: 'gpt-5',
+					inputTokens: 200,
+					cachedInputTokens: 50,
+					outputTokens: 100,
+					reasoningOutputTokens: 0,
+					totalTokens: 300,
+				},
+			];
+
+			const pricingSource: PricingSource = {
+				async getPricing() {
+					return { inputCostPerMToken: 1, cachedInputCostPerMToken: 0.5, outputCostPerMToken: 2 };
+				},
+			};
+
+			const snapshot = await generateLiveSnapshot(events, {
+				codexPaths: [],
+				sessionDurationHours: DEFAULT_SESSION_DURATION_HOURS,
+				refreshIntervalMs: 1_000,
+				tokenLimit: 1_000,
+				pricingSource,
+			});
+
+			expect(snapshot.blocks).toHaveLength(1);
+			const summary = snapshot.blocks[0]!;
+			expect(summary.block.isActive || summary.block.isGap).toBe(true);
+			expect(summary.tokenLimitStatus).toBeDefined();
+		});
+	});
+}

--- a/apps/codex/src/run.ts
+++ b/apps/codex/src/run.ts
@@ -1,11 +1,13 @@
 import process from 'node:process';
 import { cli } from 'gunshi';
 import { description, name, version } from '../package.json';
+import { blocksCommand } from './commands/blocks.ts';
 import { dailyCommand } from './commands/daily.ts';
 import { monthlyCommand } from './commands/monthly.ts';
 import { sessionCommand } from './commands/session.ts';
 
 const subCommands = new Map([
+	['blocks', blocksCommand],
 	['daily', dailyCommand],
 	['monthly', monthlyCommand],
 	['session', sessionCommand],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       gunshi:
         specifier: catalog:runtime
         version: 0.26.3
+      nano-spawn:
+        specifier: catalog:runtime
+        version: 1.0.3
       node:
         specifier: runtime:^24.4.0
         version: runtime:24.9.0
@@ -1579,8 +1582,8 @@ packages:
     resolution: {integrity: sha512-LNh5GlJvYHAnMurO+EyA8jJwN1rki7l3PSHuosDh2I7h00T6/u9rCkUjg/SvPmT1CZzvhuW0y+gf7jcqUy/Usg==}
     engines: {node: '>=6.9.0'}
 
-  '@oxc-project/types@0.92.0':
-    resolution: {integrity: sha512-PDLfCbwgXjGdTBxzcuDOUxJYNBl6P8dOp3eDKWw54dYvqONan9rwGDRQU0zrkdEMiItfXQQUOI17uOcMX5Zm7A==}
+  '@oxc-project/types@0.93.0':
+    resolution: {integrity: sha512-yNtwmWZIBtJsMr5TEfoZFDxIWV6OdScOpza/f5YxbqUMJk+j6QX3Cf3jgZShGEFYWQJ5j9mJ6jM0tZHu2J9Yrg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1617,95 +1620,95 @@ packages:
   '@quansync/fs@0.1.5':
     resolution: {integrity: sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==}
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.40':
-    resolution: {integrity: sha512-9Ii9phC7QU6Lb+ncMfG1Xlosq0NBB1N/4sw+EGZ3y0BBWGy02TOb5ghWZalphAKv9rn1goqo5WkBjyd2YvsLmA==}
+  '@rolldown/binding-android-arm64@1.0.0-beta.41':
+    resolution: {integrity: sha512-Edflndd9lU7JVhVIvJlZhdCj5DkhYDJPIRn4Dx0RUdfc8asP9xHOI5gMd8MesDDx+BJpdIT/uAmVTearteU/mQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.40':
-    resolution: {integrity: sha512-5O6d0y2tBQTL+ecQY3qXIwSnF1/Zik8q7LZMKeyF+VJ9l194d0IdMhl2zUF0cqWbYHuF4Pnxplk4OhurPQ/Z9Q==}
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.41':
+    resolution: {integrity: sha512-XGCzqfjdk7550PlyZRTBKbypXrB7ATtXhw/+bjtxnklLQs0mKP/XkQVOKyn9qGKSlvH8I56JLYryVxl0PCvSNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.40':
-    resolution: {integrity: sha512-izB9jygt3miPQbOTZfSu5K51isUplqa8ysByOKQqcJHgrBWmbTU8TM9eouv6tRmBR0kjcEcID9xhmA1CeZ1VIg==}
+  '@rolldown/binding-darwin-x64@1.0.0-beta.41':
+    resolution: {integrity: sha512-Ho6lIwGJed98zub7n0xcRKuEtnZgbxevAmO4x3zn3C3N4GVXZD5xvCvTVxSMoeBJwTcIYzkVDRTIhylQNsTgLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.40':
-    resolution: {integrity: sha512-2fdpEpKT+wwP0vig9dqxu+toTeWmVSjo3psJQVDeLJ51rO+GXcCJ1IkCXjhMKVEevNtZS7B8T8Z2vvmRV9MAdA==}
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.41':
+    resolution: {integrity: sha512-ijAZETywvL+gACjbT4zBnCp5ez1JhTRs6OxRN4J+D6AzDRbU2zb01Esl51RP5/8ZOlvB37xxsRQ3X4YRVyYb3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.40':
-    resolution: {integrity: sha512-HP2lo78OWULN+8TewpLbS9PS00jh0CaF04tA2u8z2I+6QgVgrYOYKvX+T0hlO5smgso4+qb3YchzumWJl3yCPQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.41':
+    resolution: {integrity: sha512-EgIOZt7UildXKFEFvaiLNBXm+4ggQyGe3E5Z1QP9uRcJJs9omihOnm897FwOBQdCuMvI49iBgjFrkhH+wMJ2MA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.40':
-    resolution: {integrity: sha512-ng00gfr9BhA2NPAOU5RWAlTiL+JcwAD+L+4yUD1sbBy6tgHdLiNBOvKtHISIF9RM9/eQeS0tAiWOYZGIH9JMew==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.41':
+    resolution: {integrity: sha512-F8bUwJq8v/JAU8HSwgF4dztoqJ+FjdyjuvX4//3+Fbe2we9UktFeZ27U4lRMXF1vxWtdV4ey6oCSqI7yUrSEeg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.40':
-    resolution: {integrity: sha512-mF0R1l9kLcaag/9cLEiYYdNZ4v1uuX4jklSDZ1s6vJE4RB3LirUney0FavdVRwCJ5sDvfvsPgXgtBXWYr2M2tQ==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
+    resolution: {integrity: sha512-MioXcCIX/wB1pBnBoJx8q4OGucUAfC1+/X1ilKFsjDK05VwbLZGRgOVD5OJJpUQPK86DhQciNBrfOKDiatxNmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.40':
-    resolution: {integrity: sha512-+wi08S7wT5iLPHRZb0USrS6n+T6m+yY++dePYedE5uvKIpWCJJioFTaRtWjpm0V6dVNLcq2OukrvfdlGtH9Wgg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
+    resolution: {integrity: sha512-m66M61fizvRCwt5pOEiZQMiwBL9/y0bwU/+Kc4Ce/Pef6YfoEkR28y+DzN9rMdjo8Z28NXjsDPq9nH4mXnAP0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.40':
-    resolution: {integrity: sha512-W5qBGAemUocIBKCcOsDjlV9GUt28qhl/+M6etWBeLS5gQK0J6XDg0YVzfOQdvq57ZGjYNP0NvhYzqhOOnEx+4g==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
+    resolution: {integrity: sha512-yRxlSfBvWnnfrdtJfvi9lg8xfG5mPuyoSHm0X01oiE8ArmLRvoJGHUTJydCYz+wbK2esbq5J4B4Tq9WAsOlP1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-beta.40':
-    resolution: {integrity: sha512-vJwoDehtt+yqj2zacq1AqNc2uE/oh7mnRGqAUbuldV6pgvU01OSQUJ7Zu+35hTopnjFoDNN6mIezkYlGAv5RFA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
+    resolution: {integrity: sha512-PHVxYhBpi8UViS3/hcvQQb9RFqCtvFmFU1PvUoTRiUdBtgHA6fONNHU4x796lgzNlVSD3DO/MZNk1s5/ozSMQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.40':
-    resolution: {integrity: sha512-Oj3YyqVUPurr1FlMpEE/bJmMC+VWAWPM/SGUfklO5KUX97bk5Q/733nPg4RykK8q8/TluJoQYvRc05vL/B74dw==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.41':
+    resolution: {integrity: sha512-OAfcO37ME6GGWmj9qTaDT7jY4rM0T2z0/8ujdQIJQ2x2nl+ztO32EIwURfmXOK0U1tzkyuaKYvE34Pug/ucXlQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.40':
-    resolution: {integrity: sha512-0ZtO6yN8XjVoFfN4HDWQj4nDu3ndMybr7jIM00DJqOmc+yFhly7rdOy7fNR9Sky3leCpBtsXfepVqRmVpYKPVA==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.41':
+    resolution: {integrity: sha512-NIYGuCcuXaq5BC4Q3upbiMBvmZsTsEPG9k/8QKQdmrch+ocSy5Jv9tdpdmXJyighKqm182nh/zBt+tSJkYoNlg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.40':
-    resolution: {integrity: sha512-BPl1inoJXPpIe38Ja46E4y11vXlJyuleo+9Rmu//pYL5fIDYJkXUj/oAXqjSuwLcssrcwnuPgzvzvlz9++cr3w==}
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.41':
+    resolution: {integrity: sha512-kANdsDbE5FkEOb5NrCGBJBCaZ2Sabp3D7d4PRqMYJqyLljwh9mDyYyYSv5+QNvdAmifj+f3lviNEUUuUZPEFPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.40':
-    resolution: {integrity: sha512-UguA4ltbAk+nbwHRxqaUP/etpTbR0HjyNlsu4Zjbh/ytNbFsbw8CA4tEBkwDyjgI5NIPea6xY11zpl7R2/ddVA==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.41':
+    resolution: {integrity: sha512-UlpxKmFdik0Y2VjZrgUCgoYArZJiZllXgIipdBRV1hw6uK45UbQabSTW6Kp6enuOu7vouYWftwhuxfpE8J2JAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.40':
-    resolution: {integrity: sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w==}
+  '@rolldown/pluginutils@1.0.0-beta.41':
+    resolution: {integrity: sha512-ycMEPrS3StOIeb87BT3/+bu+blEtyvwQ4zmo2IcJQy0Rd1DAAhKksA0iUZ3MYSpJtjlPhg0Eo6mvVS6ggPhRbw==}
 
   '@rollup/rollup-android-arm-eabi@4.50.2':
     resolution: {integrity: sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==}
@@ -2238,6 +2241,10 @@ packages:
 
   ansis@4.1.0:
     resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
+    engines: {node: '>=14'}
+
+  ansis@4.2.0:
+    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
   are-docs-informative@0.0.2:
@@ -4102,8 +4109,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-beta.40:
-    resolution: {integrity: sha512-VqEHbKpOgTPmQrZ4fVn4eshDQS/6g/fRpNE7cFSJY+eQLDZn4B9X61J6L+hnlt1u2uRI+pF7r1USs6S5fuWCvw==}
+  rolldown@1.0.0-beta.41:
+    resolution: {integrity: sha512-U+NPR0Bkg3wm61dteD2L4nAM1U9dtaqVrpDXwC36IKRHpEO/Ubpid4Nijpa2imPchcVNHfxVFwSSMJdwdGFUbg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5639,7 +5646,7 @@ snapshots:
 
   '@oxc-project/runtime@0.82.3': {}
 
-  '@oxc-project/types@0.92.0': {}
+  '@oxc-project/types@0.93.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -5679,51 +5686,51 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.40':
+  '@rolldown/binding-android-arm64@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.40':
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.40':
+  '@rolldown/binding-darwin-x64@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.40':
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.40':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.40':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.40':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.40':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.40':
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-beta.40':
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.40':
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.41':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.5
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.40':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.40':
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.40':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.41':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.40': {}
+  '@rolldown/pluginutils@1.0.0-beta.41': {}
 
   '@rollup/rollup-android-arm-eabi@4.50.2':
     optional: true
@@ -6290,6 +6297,8 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   ansis@4.1.0: {}
+
+  ansis@4.2.0: {}
 
   are-docs-informative@0.0.2: {}
 
@@ -8263,7 +8272,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.15.10(@typescript/native-preview@7.0.0-dev.20250916.1)(rolldown@1.0.0-beta.40)(typescript@5.9.2):
+  rolldown-plugin-dts@0.15.10(@typescript/native-preview@7.0.0-dev.20250916.1)(rolldown@1.0.0-beta.41)(typescript@5.9.2):
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/parser': 7.28.4
@@ -8273,7 +8282,7 @@ snapshots:
       debug: 4.4.3
       dts-resolver: 2.1.2
       get-tsconfig: 4.10.1
-      rolldown: 1.0.0-beta.40
+      rolldown: 1.0.0-beta.41
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20250916.1
       typescript: 5.9.2
@@ -8281,26 +8290,26 @@ snapshots:
       - oxc-resolver
       - supports-color
 
-  rolldown@1.0.0-beta.40:
+  rolldown@1.0.0-beta.41:
     dependencies:
-      '@oxc-project/types': 0.92.0
-      '@rolldown/pluginutils': 1.0.0-beta.40
-      ansis: 4.1.0
+      '@oxc-project/types': 0.93.0
+      '@rolldown/pluginutils': 1.0.0-beta.41
+      ansis: 4.2.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-beta.40
-      '@rolldown/binding-darwin-arm64': 1.0.0-beta.40
-      '@rolldown/binding-darwin-x64': 1.0.0-beta.40
-      '@rolldown/binding-freebsd-x64': 1.0.0-beta.40
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.40
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.40
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.40
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.40
-      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.40
-      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.40
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.40
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.40
-      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.40
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.40
+      '@rolldown/binding-android-arm64': 1.0.0-beta.41
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.41
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.41
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.41
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.41
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.41
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.41
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.41
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.41
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.41
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.41
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.41
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.41
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.41
 
   rollup@4.50.2:
     dependencies:
@@ -8655,8 +8664,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.0.0-beta.40
-      rolldown-plugin-dts: 0.15.10(@typescript/native-preview@7.0.0-dev.20250916.1)(rolldown@1.0.0-beta.40)(typescript@5.9.2)
+      rolldown: 1.0.0-beta.41
+      rolldown-plugin-dts: 0.15.10(@typescript/native-preview@7.0.0-dev.20250916.1)(rolldown@1.0.0-beta.41)(typescript@5.9.2)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15


### PR DESCRIPTION
## Summary

- add Codex-specific session block detection, cost aggregation, and CLI output
- wire the new blocks subcommand with live monitor mode and jq support
- keep the existing Claude implementation unchanged for now
- I'd like to discuss how much code refactoring and standardization we should implement.

## Notes

- currently duplicates a large portion of the Claude blocks pipeline (about 1.6k LoC)

<img width="1290" height="947" alt="CleanShot 2025-10-11 at 20 53 59" src="https://github.com/user-attachments/assets/5cd32b84-cb47-417f-8cb6-d4b1c9ade746" />
<img width="1130" height="197" alt="CleanShot 2025-10-11 at 20 54 11" src="https://github.com/user-attachments/assets/e1be1979-01ad-4921-a6a7-bbd6259ddc3b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a blocks command for usage reporting with per-block tokens/cost, projections, token-limit status, sorting, date-range, and active/recent filters. Supports JSON output and optional JQ filtering.
  - Introduced live monitoring with periodic refresh, active block highlighting, burn-rate/status indicators, and a summarized table view.
- Improvements
  - JQ processing now returns clear, user-friendly errors (including guidance when JQ is not installed).
- Chores
  - Updated development tooling to support new command execution and processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->