### PR TITLE
docs: Include information about the default value for the log retention period in a NOTICE block

### DIFF
--- a/docs/guide/monthly-reports.md
+++ b/docs/guide/monthly-reports.md
@@ -2,6 +2,12 @@
 
 Monthly reports aggregate your Claude Code usage by calendar month, providing a high-level view of your usage patterns and costs over longer time periods.
 
+:::warning NOTICE
+Claude Code can only retain logs for 30 days by default. To be able to check logs for more than a month, you need to change the value of `cleanupPeriodDays` in the settings file.
+
+[Claude Code settings - Claude Docs](https://docs.claude.com/en/docs/claude-code/settings#settings-files)
+:::
+
 ## Basic Usage
 
 ```bash


### PR DESCRIPTION
<img width="1431" height="592" alt="Add a note about log retention period to the Monthly Reports page. It states, Claude Code can only retain logs for 30 days by default. To be able to check logs for more than a month, you need to change the value of `cleanupPeriodDays` in the settings file. There is also a link guiding to the official documentation." src="https://github.com/user-attachments/assets/1d3d16e1-a8de-46ca-8e51-6b9a2f8ffc8a" />

ref: https://github.com/ryoppippi/ccusage/discussions/426
ref: https://x.com/ryoppippi/status/1977668665286721604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prominent notice in the Monthly Reports guide stating Claude Code logs are retained for 30 days by default and explaining how to change the retention period in settings, with a link to the settings documentation.
  * Improves clarity around log retention and configuration options; helps users plan report availability accordingly. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->