### PR TITLE
fix(ccusage): resolve ESLint violations in data-loader.ts

### DIFF
--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -18,6 +18,7 @@ import type {
 	SortOrder,
 	Version,
 } from './_types.ts';
+import { Buffer } from 'node:buffer';
 import { createReadStream, createWriteStream } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -4166,7 +4167,7 @@ invalid json line
 
 			it('should process large files (600MB+) without RangeError', async () => {
 				// Create a realistic JSONL entry similar to actual Claude data (~283 bytes per line)
-				const sampleEntry = JSON.stringify({
+				const sampleEntry = `${JSON.stringify({
 					timestamp: '2025-01-10T10:00:00Z',
 					message: {
 						id: 'msg_01234567890123456789',
@@ -4175,7 +4176,7 @@ invalid json line
 					},
 					requestId: 'req_01234567890123456789',
 					costUSD: 0.01,
-				}) + '\n';
+				})}\n`;
 
 				// Target 600MB file (this would cause RangeError with readFile in Node.js)
 				const targetMB = 600;
@@ -4201,7 +4202,7 @@ invalid json line
 
 				// Ensure all data is flushed
 				await new Promise<void>((resolve, reject) => {
-					writeStream.end((err?: Error | null) => err ? reject(err) : resolve());
+					writeStream.end((err?: Error | null) => (err != null) ? reject(err) : resolve());
 				});
 
 				// Test streaming processing


### PR DESCRIPTION
## Summary

Fixed three ESLint errors in `apps/ccusage/src/data-loader.ts` that were causing lint failures:

- **prefer-template**: Changed string concatenation to template literal for better readability
- **node/prefer-global/buffer**: Added explicit `Buffer` import from `node:buffer` instead of using global
- **ts/strict-boolean-expressions**: Made null check explicit in error callback using `(err != null)`

## Changes

1. Added `import { Buffer } from 'node:buffer'` to imports
2. Converted `JSON.stringify(...) + '\n'` to template literal `\`${JSON.stringify(...)}\n\``
3. Changed error callback from `err ? reject(err)` to `(err != null) ? reject(err)`

## Test Plan

- [x] `pnpm run lint` - All lint errors resolved
- [x] `pnpm run format` - Code formatted successfully
- [x] `pnpm typecheck` - Type checking passed
- [x] `pnpm run test` - All tests passed (263 tests in ccusage package)

No functional changes, only code style improvements to comply with ESLint rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor code style improvements and refactoring with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->