### PR TITLE
feat(ccusage): add subagent breakdown

### DIFF
--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -104,6 +104,12 @@
 							"description": "Force compact mode for narrow displays (better for screenshots)",
 							"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 							"default": false
+						},
+						"subagents": {
+							"type": "boolean",
+							"description": "Show subagent usage breakdown",
+							"markdownDescription": "Show subagent usage breakdown",
+							"default": false
 						}
 					},
 					"additionalProperties": false,
@@ -207,6 +213,12 @@
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+									"default": false
+								},
+								"subagents": {
+									"type": "boolean",
+									"description": "Show subagent usage breakdown",
+									"markdownDescription": "Show subagent usage breakdown",
 									"default": false
 								},
 								"instances": {
@@ -323,6 +335,12 @@
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
+								},
+								"subagents": {
+									"type": "boolean",
+									"description": "Show subagent usage breakdown",
+									"markdownDescription": "Show subagent usage breakdown",
+									"default": false
 								}
 							},
 							"additionalProperties": false
@@ -421,6 +439,12 @@
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+									"default": false
+								},
+								"subagents": {
+									"type": "boolean",
+									"description": "Show subagent usage breakdown",
+									"markdownDescription": "Show subagent usage breakdown",
 									"default": false
 								},
 								"startOfWeek": {
@@ -527,6 +551,12 @@
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
 								},
+								"subagents": {
+									"type": "boolean",
+									"description": "Show subagent usage breakdown",
+									"markdownDescription": "Show subagent usage breakdown",
+									"default": false
+								},
 								"id": {
 									"type": "string",
 									"description": "Load usage data for a specific session ID",
@@ -629,6 +659,12 @@
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+									"default": false
+								},
+								"subagents": {
+									"type": "boolean",
+									"description": "Show subagent usage breakdown",
+									"markdownDescription": "Show subagent usage breakdown",
 									"default": false
 								},
 								"active": {

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -105,10 +105,10 @@
 							"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 							"default": false
 						},
-						"subagents": {
+						"breakdownSubagents": {
 							"type": "boolean",
-							"description": "Show subagent usage breakdown",
-							"markdownDescription": "Show subagent usage breakdown",
+							"description": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
+							"markdownDescription": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
 							"default": false
 						}
 					},
@@ -215,10 +215,10 @@
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
 								},
-								"subagents": {
+								"breakdownSubagents": {
 									"type": "boolean",
-									"description": "Show subagent usage breakdown",
-									"markdownDescription": "Show subagent usage breakdown",
+									"description": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
+									"markdownDescription": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
 									"default": false
 								},
 								"instances": {
@@ -336,10 +336,10 @@
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
 								},
-								"subagents": {
+								"breakdownSubagents": {
 									"type": "boolean",
-									"description": "Show subagent usage breakdown",
-									"markdownDescription": "Show subagent usage breakdown",
+									"description": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
+									"markdownDescription": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
 									"default": false
 								}
 							},
@@ -441,10 +441,10 @@
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
 								},
-								"subagents": {
+								"breakdownSubagents": {
 									"type": "boolean",
-									"description": "Show subagent usage breakdown",
-									"markdownDescription": "Show subagent usage breakdown",
+									"description": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
+									"markdownDescription": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
 									"default": false
 								},
 								"startOfWeek": {
@@ -551,10 +551,10 @@
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
 								},
-								"subagents": {
+								"breakdownSubagents": {
 									"type": "boolean",
-									"description": "Show subagent usage breakdown",
-									"markdownDescription": "Show subagent usage breakdown",
+									"description": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
+									"markdownDescription": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
 									"default": false
 								},
 								"id": {
@@ -661,10 +661,10 @@
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
 								},
-								"subagents": {
+								"breakdownSubagents": {
 									"type": "boolean",
-									"description": "Show subagent usage breakdown",
-									"markdownDescription": "Show subagent usage breakdown",
+									"description": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
+									"markdownDescription": "Show subagent usage as separate breakdown rows (default: aggregated with main usage)",
 									"default": false
 								},
 								"active": {

--- a/apps/ccusage/src/_daily-grouping.ts
+++ b/apps/ccusage/src/_daily-grouping.ts
@@ -31,6 +31,7 @@ export function groupByProject(dailyData: DailyData): Record<string, DailyProjec
 			totalCost: data.totalCost,
 			modelsUsed: data.modelsUsed,
 			modelBreakdowns: data.modelBreakdowns,
+			...(data.subagentUsage != null && { subagentUsage: data.subagentUsage }),
 		});
 	}
 

--- a/apps/ccusage/src/_json-output-types.ts
+++ b/apps/ccusage/src/_json-output-types.ts
@@ -9,7 +9,7 @@
  */
 
 import type { DailyDate, ModelName } from './_types.ts';
-import type { ModelBreakdown } from './data-loader.ts';
+import type { ModelBreakdown, SubagentUsageSummary } from './data-loader.ts';
 
 /**
  * Interface for daily command JSON output structure (groupByProject)
@@ -25,4 +25,5 @@ export type DailyProjectOutput = {
 	totalCost: number;
 	modelsUsed: ModelName[];
 	modelBreakdowns: ModelBreakdown[];
+	subagentUsage?: SubagentUsageSummary;
 };

--- a/apps/ccusage/src/_live-rendering.ts
+++ b/apps/ccusage/src/_live-rendering.ts
@@ -349,6 +349,30 @@ export function renderLiveDisplay(terminal: TerminalManager, block: SessionBlock
 	}
 
 	terminal.write(`${marginStr}│${' '.repeat(boxWidth - 2)}│\n`);
+
+	// Subagent section (if present)
+	if (block.subagentUsage != null) {
+		terminal.write(`${marginStr}├${'─'.repeat(boxWidth - 2)}┤\n`);
+		terminal.write(`${marginStr}│${' '.repeat(boxWidth - 2)}│\n`);
+
+		const subagentLabel = pc.bold('SUBAGENTS');
+		const subagentInfo = `${block.subagentUsage.taskCount} tasks • ${formatTokensShort(block.subagentUsage.totalTokens)} tokens • ${formatCurrency(block.subagentUsage.totalCost)}`;
+		const subagentLine = `${subagentLabel}  ${pc.cyan(subagentInfo)}`;
+		const subagentLinePadded = subagentLine + ' '.repeat(Math.max(0, boxWidth - 3 - stringWidth(subagentLine)));
+		terminal.write(`${marginStr}│ ${subagentLinePadded}│\n`);
+
+		// Subagent details (indented)
+		const inputStr = `${pc.gray('Input:')} ${formatTokensShort(block.subagentUsage.inputTokens)}`;
+		const outputStr = `${pc.gray('Output:')} ${formatTokensShort(block.subagentUsage.outputTokens)}`;
+		const cacheTotal = block.subagentUsage.cacheCreationTokens + block.subagentUsage.cacheReadTokens;
+		const cacheStr = `${pc.gray('Cache:')} ${formatTokensShort(cacheTotal)}`;
+		const subagentDetails = `${' '.repeat(detailsIndent)}${inputStr}  ${outputStr}  ${cacheStr}`;
+		const subagentDetailsPadded = subagentDetails + ' '.repeat(Math.max(0, boxWidth - 3 - stringWidth(subagentDetails)));
+		terminal.write(`${marginStr}│ ${subagentDetailsPadded}│\n`);
+
+		terminal.write(`${marginStr}│${' '.repeat(boxWidth - 2)}│\n`);
+	}
+
 	terminal.write(`${marginStr}├${'─'.repeat(boxWidth - 2)}┤\n`);
 	terminal.write(`${marginStr}│${' '.repeat(boxWidth - 2)}│\n`);
 
@@ -482,6 +506,11 @@ export function renderCompactLiveDisplay(
 
 	// Cost
 	terminal.write(`Cost: ${formatCurrency(block.costUSD)}\n`);
+
+	// Subagent info (if present)
+	if (block.subagentUsage != null) {
+		terminal.write(pc.cyan(`Subagents: ${block.subagentUsage.taskCount} tasks, ${formatTokensShort(block.subagentUsage.totalTokens)}, ${formatCurrency(block.subagentUsage.totalCost)}\n`));
+	}
 
 	// Burn rate
 	const burnRate = calculateBurnRate(block);

--- a/apps/ccusage/src/_shared-args.ts
+++ b/apps/ccusage/src/_shared-args.ts
@@ -108,6 +108,11 @@ export const sharedArgs = {
 		description: 'Force compact mode for narrow displays (better for screenshots)',
 		default: false,
 	},
+	subagents: {
+		type: 'boolean',
+		description: 'Show subagent usage breakdown',
+		default: false,
+	},
 } as const satisfies Args;
 
 /**

--- a/apps/ccusage/src/_shared-args.ts
+++ b/apps/ccusage/src/_shared-args.ts
@@ -108,9 +108,10 @@ export const sharedArgs = {
 		description: 'Force compact mode for narrow displays (better for screenshots)',
 		default: false,
 	},
-	subagents: {
+	breakdownSubagents: {
 		type: 'boolean',
-		description: 'Show subagent usage breakdown',
+		short: 'a',
+		description: 'Show subagent usage as separate breakdown rows (default: aggregated with main usage)',
 		default: false,
 	},
 } as const satisfies Args;

--- a/apps/ccusage/src/commands/_session_id.ts
+++ b/apps/ccusage/src/commands/_session_id.ts
@@ -3,6 +3,7 @@ import type { UsageData } from '../data-loader.ts';
 import process from 'node:process';
 import { formatCurrency, formatNumber, ResponsiveTable } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
+import pc from 'picocolors';
 import { formatDateCompact } from '../_date-utils.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { loadSessionUsageById } from '../data-loader.ts';
@@ -51,6 +52,7 @@ export async function handleSessionIdLookup(ctx: SessionIdContext, useJson: bool
 				cacheReadTokens: entry.message.usage.cache_read_input_tokens ?? 0,
 				model: entry.message.model ?? 'unknown',
 				costUSD: entry.costUSD ?? 0,
+				...(entry.isSidechain === true && { isSubagent: true }),
 			})),
 		};
 
@@ -71,9 +73,17 @@ export async function handleSessionIdLookup(ctx: SessionIdContext, useJson: bool
 
 		const totalTokens = calculateSessionTotalTokens(sessionUsage.entries);
 
+		// Calculate subagent summary
+		const subagentEntries = sessionUsage.entries.filter(entry => entry.isSidechain === true);
+		const hasSubagents = subagentEntries.length > 0;
+
 		log(`Total Cost: ${formatCurrency(sessionUsage.totalCost)}`);
 		log(`Total Tokens: ${formatNumber(totalTokens)}`);
 		log(`Total Entries: ${sessionUsage.entries.length}`);
+		// Note: session --id is a detail command, so we always show subagent count in header
+		if (hasSubagents) {
+			log(`Subagent Tasks: ${subagentEntries.length}`);
+		}
 		log('');
 
 		if (sessionUsage.entries.length > 0) {
@@ -92,9 +102,13 @@ export async function handleSessionIdLookup(ctx: SessionIdContext, useJson: bool
 			});
 
 			for (const entry of sessionUsage.entries) {
+				const modelName = entry.message.model ?? 'unknown';
+				const isSubagent = entry.isSidechain === true;
+				const displayModel = isSubagent ? `[subagent] ${modelName}` : modelName;
+
 				table.push([
 					formatDateCompact(entry.timestamp, ctx.values.timezone, ctx.values.locale),
-					entry.message.model ?? 'unknown',
+					displayModel,
 					formatNumber(entry.message.usage.input_tokens),
 					formatNumber(entry.message.usage.output_tokens),
 					formatNumber(entry.message.usage.cache_creation_input_tokens ?? 0),
@@ -104,6 +118,18 @@ export async function handleSessionIdLookup(ctx: SessionIdContext, useJson: bool
 			}
 
 			log(table.toString());
+
+			// Show subagent summary if there are subagents (session --id always shows detail)
+			if (hasSubagents) {
+				const subagentStats = calculateSubagentStats(subagentEntries);
+				log('');
+				log(pc.cyan(pc.bold('Subagent Usage Summary:')));
+				log(`  Tasks Executed:   ${subagentStats.count}`);
+				log(`  Input Tokens:     ${formatNumber(subagentStats.inputTokens)}`);
+				log(`  Output Tokens:    ${formatNumber(subagentStats.outputTokens)}`);
+				log(`  Total Tokens:     ${formatNumber(subagentStats.totalTokens)}`);
+				log(`  Total Cost:       ${formatCurrency(subagentStats.totalCost)}`);
+			}
 		}
 	}
 }
@@ -119,4 +145,140 @@ function calculateSessionTotalTokens(entries: UsageData[]): number {
 			+ (usage.cache_read_input_tokens ?? 0)
 		);
 	}, 0);
+}
+
+function calculateSubagentStats(entries: UsageData[]): {
+	count: number;
+	inputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+	totalCost: number;
+} {
+	let inputTokens = 0;
+	let outputTokens = 0;
+	let totalCost = 0;
+
+	for (const entry of entries) {
+		const usage = entry.message.usage;
+		inputTokens += usage.input_tokens;
+		outputTokens += usage.output_tokens;
+		totalCost += entry.costUSD ?? 0;
+	}
+
+	const totalTokens = entries.reduce((sum, entry) => {
+		const usage = entry.message.usage;
+		return (
+			sum
+			+ usage.input_tokens
+			+ usage.output_tokens
+			+ (usage.cache_creation_input_tokens ?? 0)
+			+ (usage.cache_read_input_tokens ?? 0)
+		);
+	}, 0);
+
+	return {
+		count: entries.length,
+		inputTokens,
+		outputTokens,
+		totalTokens,
+		totalCost,
+	};
+}
+
+if (import.meta.vitest != null) {
+	describe('calculateSubagentStats', () => {
+		it('calculates stats correctly for subagent entries', () => {
+			const entries = [
+				{
+					timestamp: '2024-01-01T00:00:00Z',
+					message: {
+						usage: {
+							input_tokens: 100,
+							output_tokens: 50,
+							cache_creation_input_tokens: 10,
+							cache_read_input_tokens: 20,
+						},
+					},
+					costUSD: 0.5,
+					isSidechain: true,
+				},
+				{
+					timestamp: '2024-01-01T00:01:00Z',
+					message: {
+						usage: {
+							input_tokens: 200,
+							output_tokens: 100,
+							cache_creation_input_tokens: 0,
+							cache_read_input_tokens: 50,
+						},
+					},
+					costUSD: 0.3,
+					isSidechain: true,
+				},
+			] as unknown as UsageData[];
+
+			const stats = calculateSubagentStats(entries);
+
+			expect(stats.count).toBe(2);
+			expect(stats.inputTokens).toBe(300);
+			expect(stats.outputTokens).toBe(150);
+			expect(stats.totalTokens).toBe(530); // 300 + 150 + 10 + 20 + 0 + 50
+			expect(stats.totalCost).toBe(0.8);
+		});
+
+		it('handles empty entries array', () => {
+			const stats = calculateSubagentStats([] as unknown as UsageData[]);
+
+			expect(stats.count).toBe(0);
+			expect(stats.inputTokens).toBe(0);
+			expect(stats.outputTokens).toBe(0);
+			expect(stats.totalTokens).toBe(0);
+			expect(stats.totalCost).toBe(0);
+		});
+
+		it('handles entries without cache tokens', () => {
+			const entries = [
+				{
+					timestamp: '2024-01-01T00:00:00Z',
+					message: {
+						usage: {
+							input_tokens: 100,
+							output_tokens: 50,
+						},
+					},
+					costUSD: 0.5,
+					isSidechain: true,
+				},
+			] as unknown as UsageData[];
+
+			const stats = calculateSubagentStats(entries);
+
+			expect(stats.count).toBe(1);
+			expect(stats.inputTokens).toBe(100);
+			expect(stats.outputTokens).toBe(50);
+			expect(stats.totalTokens).toBe(150);
+			expect(stats.totalCost).toBe(0.5);
+		});
+
+		it('handles entries with null costUSD', () => {
+			const entries = [
+				{
+					timestamp: '2024-01-01T00:00:00Z',
+					message: {
+						usage: {
+							input_tokens: 100,
+							output_tokens: 50,
+						},
+					},
+					costUSD: null,
+					isSidechain: true,
+				},
+			] as unknown as UsageData[];
+
+			const stats = calculateSubagentStats(entries);
+
+			expect(stats.count).toBe(1);
+			expect(stats.totalCost).toBe(0);
+		});
+	});
 }

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -356,7 +356,7 @@ export const blocksCommand = define({
 				}
 
 				// Show subagent usage summary if present and flag enabled
-				if (block.subagentUsage != null && ctx.values.subagents) {
+				if (block.subagentUsage != null && ctx.values.breakdownSubagents) {
 					log(pc.bold('Subagent Usage:'));
 					log(`  Tasks Executed:   ${block.subagentUsage.taskCount}`);
 					log(`  Input Tokens:     ${formatNumber(block.subagentUsage.inputTokens)}`);
@@ -458,7 +458,7 @@ export const blocksCommand = define({
 						table.push(row);
 
 						// Add subagent usage row if present and flag enabled (show actual data before predictions)
-						if (block.subagentUsage != null && ctx.values.subagents) {
+						if (block.subagentUsage != null && ctx.values.breakdownSubagents) {
 							const subagentRow = [
 								'',
 								pc.cyan(`  └─ Subagents (${block.subagentUsage.taskCount})`),

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -1,6 +1,6 @@
 import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
-import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUsageDataRow, pushBreakdownRows } from '@ccusage/terminal/table';
+import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUsageDataRow, pushBreakdownRows, pushSubagentSummaryRow } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
@@ -112,6 +112,7 @@ export const dailyCommand = define({
 							modelsUsed: data.modelsUsed,
 							modelBreakdowns: data.modelBreakdowns,
 							...(data.project != null && { project: data.project }),
+							...(data.subagentUsage != null && { subagentUsage: data.subagentUsage }),
 						})),
 						totals: createTotalsObject(totals),
 					};
@@ -180,7 +181,12 @@ export const dailyCommand = define({
 
 						// Add model breakdown rows if flag is set
 						if (mergedOptions.breakdown) {
-							pushBreakdownRows(table, data.modelBreakdowns);
+							pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.subagents);
+						}
+
+						// Add subagent usage summary if present and flag enabled
+						if (data.subagentUsage != null && mergedOptions.subagents) {
+							pushSubagentSummaryRow(table, data.subagentUsage);
 						}
 					}
 
@@ -203,7 +209,12 @@ export const dailyCommand = define({
 
 					// Add model breakdown rows if flag is set
 					if (mergedOptions.breakdown) {
-						pushBreakdownRows(table, data.modelBreakdowns);
+						pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.subagents);
+					}
+
+					// Add subagent usage summary if present and flag enabled
+					if (data.subagentUsage != null && mergedOptions.subagents) {
+						pushSubagentSummaryRow(table, data.subagentUsage);
 					}
 				}
 			}

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -181,11 +181,11 @@ export const dailyCommand = define({
 
 						// Add model breakdown rows if flag is set
 						if (mergedOptions.breakdown) {
-							pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.subagents);
+							pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.breakdownSubagents);
 						}
 
 						// Add subagent usage summary if present and flag enabled
-						if (data.subagentUsage != null && mergedOptions.subagents) {
+						if (data.subagentUsage != null && mergedOptions.breakdownSubagents) {
 							pushSubagentSummaryRow(table, data.subagentUsage);
 						}
 					}
@@ -209,11 +209,11 @@ export const dailyCommand = define({
 
 					// Add model breakdown rows if flag is set
 					if (mergedOptions.breakdown) {
-						pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.subagents);
+						pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.breakdownSubagents);
 					}
 
 					// Add subagent usage summary if present and flag enabled
-					if (data.subagentUsage != null && mergedOptions.subagents) {
+					if (data.subagentUsage != null && mergedOptions.breakdownSubagents) {
 						pushSubagentSummaryRow(table, data.subagentUsage);
 					}
 				}

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -1,6 +1,6 @@
 import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
-import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUsageDataRow, pushBreakdownRows } from '@ccusage/terminal/table';
+import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUsageDataRow, pushBreakdownRows, pushSubagentSummaryRow } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
@@ -77,6 +77,7 @@ export const monthlyCommand = define({
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
+					...(data.subagentUsage != null && { subagentUsage: data.subagentUsage }),
 				})),
 				totals: createTotalsObject(totals),
 			};
@@ -121,7 +122,12 @@ export const monthlyCommand = define({
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.subagents);
+				}
+
+				// Add subagent usage summary if present and flag enabled
+				if (data.subagentUsage != null && mergedOptions.subagents) {
+					pushSubagentSummaryRow(table, data.subagentUsage);
 				}
 			}
 

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -122,11 +122,11 @@ export const monthlyCommand = define({
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.subagents);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.breakdownSubagents);
 				}
 
 				// Add subagent usage summary if present and flag enabled
-				if (data.subagentUsage != null && mergedOptions.subagents) {
+				if (data.subagentUsage != null && mergedOptions.breakdownSubagents) {
 					pushSubagentSummaryRow(table, data.subagentUsage);
 				}
 			}

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -1,6 +1,6 @@
 import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
-import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUsageDataRow, pushBreakdownRows } from '@ccusage/terminal/table';
+import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUsageDataRow, pushBreakdownRows, pushSubagentSummaryRow } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
@@ -103,6 +103,7 @@ export const sessionCommand = define({
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
 					projectPath: data.projectPath,
+					...(data.subagentUsage != null && { subagentUsage: data.subagentUsage }),
 				})),
 				totals: createTotalsObject(totals),
 			};
@@ -154,7 +155,13 @@ export const sessionCommand = define({
 				// Add model breakdown rows if flag is set
 				if (ctx.values.breakdown) {
 					// Session has 1 extra column before data and 1 trailing column
-					pushBreakdownRows(table, data.modelBreakdowns, 1, 1);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 1, ctx.values.subagents);
+				}
+
+				// Add subagent usage summary if present and flag enabled
+				if (data.subagentUsage != null && ctx.values.subagents) {
+					// Session has 1 extra column before data and 1 trailing column
+					pushSubagentSummaryRow(table, data.subagentUsage, 1, 1);
 				}
 			}
 

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -155,11 +155,11 @@ export const sessionCommand = define({
 				// Add model breakdown rows if flag is set
 				if (ctx.values.breakdown) {
 					// Session has 1 extra column before data and 1 trailing column
-					pushBreakdownRows(table, data.modelBreakdowns, 1, 1, ctx.values.subagents);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 1, ctx.values.breakdownSubagents);
 				}
 
 				// Add subagent usage summary if present and flag enabled
-				if (data.subagentUsage != null && ctx.values.subagents) {
+				if (data.subagentUsage != null && ctx.values.breakdownSubagents) {
 					// Session has 1 extra column before data and 1 trailing column
 					pushSubagentSummaryRow(table, data.subagentUsage, 1, 1);
 				}

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -347,7 +347,7 @@ export const statuslineCommand = define({
 					);
 
 					// Load session block data to find active block
-					const { blockInfo, burnRateInfo } = await Result.pipe(
+					const { blockInfo, burnRateInfo, subagentInfo } = await Result.pipe(
 						Result.try({
 							try: async () => loadSessionBlockData({
 								mode: 'auto',
@@ -421,13 +421,18 @@ export const statuslineCommand = define({
 										})()
 									: '';
 
-								return { blockInfo, burnRateInfo };
+								// Get subagent info from active block (only if tasks > 0)
+								const subagentInfo = activeBlock.subagentUsage != null && activeBlock.subagentUsage.taskCount > 0
+									? ` (+${activeBlock.subagentUsage.taskCount} subagents)`
+									: '';
+
+								return { blockInfo, burnRateInfo, subagentInfo };
 							}
 
-							return { blockInfo: 'No active block', burnRateInfo: '' };
+							return { blockInfo: 'No active block', burnRateInfo: '', subagentInfo: '' };
 						}),
 						Result.inspectError(error => logger.error('Failed to load block data:', error)),
-						Result.unwrap({ blockInfo: 'No active block', burnRateInfo: '' }),
+						Result.unwrap({ blockInfo: 'No active block', burnRateInfo: '', subagentInfo: '' }),
 					);
 
 					// Calculate context tokens from transcript with model-specific limits
@@ -471,7 +476,7 @@ export const statuslineCommand = define({
 						// Single cost display
 						return sessionCost != null ? formatCurrency(sessionCost) : 'N/A';
 					})();
-					const statusLine = `🤖 ${modelName} | 💰 ${sessionDisplay} session / ${formatCurrency(todayCost)} today / ${blockInfo}${burnRateInfo} | 🧠 ${contextInfo ?? 'N/A'}`;
+					const statusLine = `🤖 ${modelName}${subagentInfo} | 💰 ${sessionDisplay} session / ${formatCurrency(todayCost)} today / ${blockInfo}${burnRateInfo} | 🧠 ${contextInfo ?? 'N/A'}`;
 					return statusLine;
 				},
 				catch: error => error,

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -132,11 +132,11 @@ export const weeklyCommand = define({
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.subagents);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.breakdownSubagents);
 				}
 
 				// Add subagent usage summary if present and flag enabled
-				if (data.subagentUsage != null && mergedOptions.subagents) {
+				if (data.subagentUsage != null && mergedOptions.breakdownSubagents) {
 					pushSubagentSummaryRow(table, data.subagentUsage);
 				}
 			}

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -1,6 +1,6 @@
 import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
-import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUsageDataRow, pushBreakdownRows } from '@ccusage/terminal/table';
+import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUsageDataRow, pushBreakdownRows, pushSubagentSummaryRow } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
@@ -87,6 +87,7 @@ export const weeklyCommand = define({
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
+					...(data.subagentUsage != null && { subagentUsage: data.subagentUsage }),
 				})),
 				totals: createTotalsObject(totals),
 			};
@@ -131,7 +132,12 @@ export const weeklyCommand = define({
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, mergedOptions.subagents);
+				}
+
+				// Add subagent usage summary if present and flag enabled
+				if (data.subagentUsage != null && mergedOptions.subagents) {
+					pushSubagentSummaryRow(table, data.subagentUsage);
 				}
 			}
 


### PR DESCRIPTION
  Add --breakdown-subagents flag to show detailed subagent usage breakdown

  Implements comprehensive tracking and optional detailed display of subagent/Task tool usage through the isSidechain
  flag in Claude's usage data.

  Key changes:

  - Add --breakdown-subagents / -a flag to all report commands (daily, weekly, monthly, session, blocks)
  - Default behavior: Subagent usage is included in totals and aggregated with main agent usage for simplified display
  - With flag: Show detailed breakdown with [subagent] indicators and separate summary row displaying task count,
  tokens, and costs
  - Track subagent data through SubagentUsageSummary type (task count, token breakdown, models used, total cost)
  - Separate model breakdowns by isSubagent flag in JSON output for granular analysis
  - Display subagent info in statusline and live monitoring modes
  - Add pushSubagentSummaryRow utility for consistent table formatting across commands
  - Update config schema with new breakdownSubagents boolean option
  - Comprehensive test coverage for subagent tracking and aggregation (all 274 tests passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New option to show subagent usage as separate breakdown rows across reports.
  * Subagent summaries added to daily, weekly, monthly, session, blocks, compact and live displays (tasks, tokens, cost).
  * JSON exports and status line now include subagent usage info when present.

* **Tests**
  * Added tests covering subagent parsing, aggregation, and summary outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->