### PR TITLE
fix(ccusage): support Opus 4.5 pricing from Bedrock-prefixed models

### DIFF
--- a/apps/ccusage/src/_macro.ts
+++ b/apps/ccusage/src/_macro.ts
@@ -6,35 +6,10 @@ import {
 	filterPricingDataset,
 } from '@ccusage/internal/pricing-fetch-utils';
 
-export function isClaudeModel(modelName: string, _pricing: LiteLLMModelPricing): boolean {
+function isClaudeModel(modelName: string, _pricing: LiteLLMModelPricing): boolean {
 	return modelName.startsWith('claude-')
 		|| modelName.startsWith('anthropic.claude-')
 		|| modelName.startsWith('anthropic/claude-');
-}
-
-if (import.meta.vitest != null) {
-	describe('isClaudeModel', () => {
-		const mockPricing = {} as LiteLLMModelPricing;
-
-		it('matches claude- prefixed models', () => {
-			expect(isClaudeModel('claude-sonnet-4-20250514', mockPricing)).toBe(true);
-			expect(isClaudeModel('claude-opus-4-5-20251101', mockPricing)).toBe(true);
-		});
-
-		it('matches anthropic.claude- prefixed models (Bedrock format)', () => {
-			expect(isClaudeModel('anthropic.claude-opus-4-5-20251101-v1:0', mockPricing)).toBe(true);
-			expect(isClaudeModel('anthropic.claude-sonnet-4-20250514-v1:0', mockPricing)).toBe(true);
-		});
-
-		it('matches anthropic/claude- prefixed models', () => {
-			expect(isClaudeModel('anthropic/claude-sonnet-4-20250514', mockPricing)).toBe(true);
-		});
-
-		it('rejects non-Claude models', () => {
-			expect(isClaudeModel('gpt-4', mockPricing)).toBe(false);
-			expect(isClaudeModel('gemini-pro', mockPricing)).toBe(false);
-		});
-	});
 }
 
 export async function prefetchClaudePricing(): Promise<Record<string, LiteLLMModelPricing>> {


### PR DESCRIPTION
_Disclaimer: made with Claude but human verified._

## Summary

Add support for `anthropic.claude-` and `anthropic/claude-` prefixed models in the `isClaudeModel` filter.

## Problem

LiteLLM lists Opus 4.5 models with `anthropic.claude-` prefix (e.g., `anthropic.claude-opus-4-5-20251101-v1:0`) but the `isClaudeModel` filter only kept models starting with `claude-`, causing pricing lookups to fail for Opus 4.5.