### PR TITLE
Add multiple pricing data sources support

### DIFF
--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -24,6 +24,13 @@
 							"markdownDescription": "Use cached pricing data where supported",
 							"default": false
 						},
+						"pricingSource": {
+							"type": "string",
+							"enum": ["litellm", "modelsdev", "auto"],
+							"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+							"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+							"default": "litellm"
+						},
 						"json": {
 							"type": "boolean",
 							"description": "Output in JSON format",
@@ -121,6 +128,13 @@
 									"description": "Use cached pricing data where supported",
 									"markdownDescription": "Use cached pricing data where supported",
 									"default": false
+								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
 								},
 								"singleThread": {
 									"type": "boolean",
@@ -231,6 +245,13 @@
 									"markdownDescription": "Use cached pricing data where supported",
 									"default": false
 								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
+								},
 								"singleThread": {
 									"type": "boolean",
 									"description": "Disable parallel JSONL file loading",
@@ -323,6 +344,13 @@
 									"description": "Use cached pricing data where supported",
 									"markdownDescription": "Use cached pricing data where supported",
 									"default": false
+								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
 								},
 								"singleThread": {
 									"type": "boolean",
@@ -425,6 +453,13 @@
 									"markdownDescription": "Use cached pricing data where supported",
 									"default": false
 								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
+								},
 								"singleThread": {
 									"type": "boolean",
 									"description": "Disable parallel JSONL file loading",
@@ -519,9 +554,16 @@
 								},
 								"offline": {
 									"type": "boolean",
-									"description": "Use cached pricing data for Claude models instead of fetching from API",
-									"markdownDescription": "Use cached pricing data for Claude models instead of fetching from API",
+									"description": "Use cached pricing data where supported",
+									"markdownDescription": "Use cached pricing data where supported",
 									"default": false
+								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
 								},
 								"singleThread": {
 									"type": "boolean",
@@ -581,9 +623,16 @@
 							"properties": {
 								"offline": {
 									"type": "boolean",
-									"description": "Use cached pricing data for Claude models instead of fetching from API",
-									"markdownDescription": "Use cached pricing data for Claude models instead of fetching from API",
+									"description": "Use cached pricing data where supported",
+									"markdownDescription": "Use cached pricing data where supported",
 									"default": true
+								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
 								},
 								"visualBurnRate": {
 									"type": "string",
@@ -651,9 +700,16 @@
 								},
 								"offline": {
 									"type": "boolean",
-									"description": "Use cached pricing data for Claude models instead of fetching from API",
-									"markdownDescription": "Use cached pricing data for Claude models instead of fetching from API",
+									"description": "Use cached pricing data where supported",
+									"markdownDescription": "Use cached pricing data where supported",
 									"default": false
+								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
 								}
 							},
 							"additionalProperties": false,
@@ -716,9 +772,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data for Claude models instead of fetching from API",
-											"markdownDescription": "Use cached pricing data for Claude models instead of fetching from API",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"singleThread": {
 											"type": "boolean",
@@ -819,9 +882,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data for Claude models instead of fetching from API",
-											"markdownDescription": "Use cached pricing data for Claude models instead of fetching from API",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"singleThread": {
 											"type": "boolean",
@@ -906,9 +976,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data for Claude models instead of fetching from API",
-											"markdownDescription": "Use cached pricing data for Claude models instead of fetching from API",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"singleThread": {
 											"type": "boolean",
@@ -1001,9 +1078,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data for Claude models instead of fetching from API",
-											"markdownDescription": "Use cached pricing data for Claude models instead of fetching from API",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"singleThread": {
 											"type": "boolean",
@@ -1093,9 +1177,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data for Claude models instead of fetching from API",
-											"markdownDescription": "Use cached pricing data for Claude models instead of fetching from API",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"singleThread": {
 											"type": "boolean",
@@ -1155,9 +1246,16 @@
 									"properties": {
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data for Claude models instead of fetching from API",
-											"markdownDescription": "Use cached pricing data for Claude models instead of fetching from API",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": true
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"visualBurnRate": {
 											"type": "string",
@@ -1245,9 +1343,16 @@
 								},
 								"offline": {
 									"type": "boolean",
-									"description": "Use cached pricing data instead of fetching from LiteLLM",
-									"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+									"description": "Use cached pricing data where supported",
+									"markdownDescription": "Use cached pricing data where supported",
 									"default": false
+								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
 								},
 								"speed": {
 									"type": "string",
@@ -1305,9 +1410,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"speed": {
 											"type": "string",
@@ -1360,9 +1472,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"speed": {
 											"type": "string",
@@ -1415,9 +1534,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"speed": {
 											"type": "string",
@@ -1483,9 +1609,16 @@
 								},
 								"offline": {
 									"type": "boolean",
-									"description": "Use cached pricing data instead of fetching from LiteLLM",
-									"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+									"description": "Use cached pricing data where supported",
+									"markdownDescription": "Use cached pricing data where supported",
 									"default": false
+								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
 								},
 								"compact": {
 									"type": "boolean",
@@ -1537,9 +1670,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"compact": {
 											"type": "boolean",
@@ -1586,9 +1726,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"compact": {
 											"type": "boolean",
@@ -1635,9 +1782,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"compact": {
 											"type": "boolean",
@@ -1684,9 +1838,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"compact": {
 											"type": "boolean",
@@ -1746,9 +1907,16 @@
 								},
 								"offline": {
 									"type": "boolean",
-									"description": "Use cached pricing data instead of fetching from LiteLLM",
-									"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+									"description": "Use cached pricing data where supported",
+									"markdownDescription": "Use cached pricing data where supported",
 									"default": false
+								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
 								},
 								"compact": {
 									"type": "boolean",
@@ -1800,9 +1968,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"compact": {
 											"type": "boolean",
@@ -1849,9 +2024,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"compact": {
 											"type": "boolean",
@@ -1898,9 +2080,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"compact": {
 											"type": "boolean",
@@ -1960,9 +2149,16 @@
 								},
 								"offline": {
 									"type": "boolean",
-									"description": "Use cached pricing data instead of fetching from LiteLLM",
-									"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+									"description": "Use cached pricing data where supported",
+									"markdownDescription": "Use cached pricing data where supported",
 									"default": false
+								},
+								"pricingSource": {
+									"type": "string",
+									"enum": ["litellm", "modelsdev", "auto"],
+									"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+									"default": "litellm"
 								},
 								"compact": {
 									"type": "boolean",
@@ -2019,9 +2215,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"compact": {
 											"type": "boolean",
@@ -2073,9 +2276,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"compact": {
 											"type": "boolean",
@@ -2127,9 +2337,16 @@
 										},
 										"offline": {
 											"type": "boolean",
-											"description": "Use cached pricing data instead of fetching from LiteLLM",
-											"markdownDescription": "Use cached pricing data instead of fetching from LiteLLM",
+											"description": "Use cached pricing data where supported",
+											"markdownDescription": "Use cached pricing data where supported",
 											"default": false
+										},
+										"pricingSource": {
+											"type": "string",
+											"enum": ["litellm", "modelsdev", "auto"],
+											"description": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"markdownDescription": "Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)",
+											"default": "litellm"
 										},
 										"compact": {
 											"type": "boolean",

--- a/apps/ccusage/src/adapter/amp/index.ts
+++ b/apps/ccusage/src/adapter/amp/index.ts
@@ -25,6 +25,7 @@ function createAmpPricingContext(
 				offlineLoader: loadOfflineAmpPricing,
 				logger,
 				providerPrefixes: AMP_PROVIDER_PREFIXES,
+				pricingSource: options.pricingSource,
 			}),
 	);
 }

--- a/apps/ccusage/src/adapter/claude/data-loader.ts
+++ b/apps/ccusage/src/adapter/claude/data-loader.ts
@@ -21,6 +21,7 @@ import type {
 	MessageId,
 	ModelName,
 	MonthlyDate,
+	PricingSource,
 	ProjectPath,
 	RequestId,
 	SessionId,
@@ -1502,6 +1503,7 @@ export type LoadOptions = {
 	mode?: CostMode; // Cost calculation mode
 	order?: SortOrder; // Sort order for dates
 	offline?: boolean; // Use offline mode for pricing
+	pricingSource?: PricingSource;
 	sessionDurationHours?: number; // Session block duration in hours
 	groupByProject?: boolean; // Group data by project instead of aggregating
 	project?: string; // Filter to specific project name
@@ -1621,6 +1623,7 @@ type UsageWorkerData = {
 	items: Array<IndexedWorkerItem<unknown>>;
 	mode: CostMode;
 	offline: boolean | undefined;
+	pricingSource: PricingSource | undefined;
 	timezone: string | undefined;
 	pricing: Map<string, LiteLLMModelPricing> | undefined;
 };
@@ -2000,6 +2003,7 @@ async function collectWithUsageWorkers<TItem, TResult>(
 	options: {
 		mode: CostMode;
 		offline: boolean | undefined;
+		pricingSource: PricingSource | undefined;
 		timezone: string | undefined;
 		singleThread: boolean | undefined;
 		getFilePath?: (item: TItem) => string;
@@ -2021,7 +2025,7 @@ async function collectWithUsageWorkers<TItem, TResult>(
 			: await chunkIndexedItemsByFileSize(indexedItems, workerCount, options.getFilePath);
 	let pricing: Map<string, LiteLLMModelPricing> | undefined;
 	if (options.mode !== 'display' && options.offline !== true) {
-		using fetcher = new PricingFetcher(options.offline);
+		using fetcher = new PricingFetcher(options.offline, options.pricingSource);
 		pricing = Result.unwrap(
 			await fetcher.fetchModelPricing(),
 			new Map<string, LiteLLMModelPricing>(),
@@ -2038,6 +2042,7 @@ async function collectWithUsageWorkers<TItem, TResult>(
 						items: chunk,
 						mode: options.mode,
 						offline: options.offline,
+						pricingSource: options.pricingSource,
 						timezone: options.timezone,
 						pricing,
 					} satisfies UsageWorkerData,
@@ -2343,13 +2348,15 @@ export async function loadDailyUsageData(options?: LoadOptions): Promise<DailyUs
 		{
 			mode,
 			offline: options?.offline,
+			pricingSource: options?.pricingSource,
 			timezone: options?.timezone,
 			singleThread: options?.singleThread,
 			getFilePath: (file) => file,
 		},
 	);
 	if (workerFileResults == null) {
-		using fetcher = mode === 'display' ? null : new PricingFetcher(options?.offline);
+		using fetcher =
+			mode === 'display' ? null : new PricingFetcher(options?.offline, options?.pricingSource);
 		const calculateCost = await createCostCalculator(mode, fetcher);
 		const fallbackFileResults = await mapWithConcurrency(
 			mtimeFilteredFiles,
@@ -2478,13 +2485,15 @@ export async function loadSessionData(options?: LoadOptions): Promise<SessionUsa
 		{
 			mode,
 			offline: options?.offline,
+			pricingSource: options?.pricingSource,
 			timezone: options?.timezone,
 			singleThread: options?.singleThread,
 			getFilePath: (item) => item.file,
 		},
 	);
 	if (workerFileResults == null) {
-		using fetcher = mode === 'display' ? null : new PricingFetcher(options?.offline);
+		using fetcher =
+			mode === 'display' ? null : new PricingFetcher(options?.offline, options?.pricingSource);
 		const calculateCost = await createCostCalculator(mode, fetcher);
 		const fallbackFileResults = await mapWithConcurrency(
 			mtimeFilteredWithBase,
@@ -2606,11 +2615,12 @@ export async function loadWeeklyUsageData(options?: LoadOptions): Promise<Weekly
  * @param options - Options for loading data
  * @param options.mode - Cost calculation mode (auto, calculate, display)
  * @param options.offline - Whether to use offline pricing data
+ * @param options.pricingSource - Pricing data source for calculated costs
  * @returns Usage data for the specific session or null if not found
  */
 export async function loadSessionUsageById(
 	sessionId: string,
-	options?: { mode?: CostMode; offline?: boolean },
+	options?: { mode?: CostMode; offline?: boolean; pricingSource?: PricingSource },
 ): Promise<{ totalCost: number; entries: UsageData[] } | null> {
 	const claudePaths = requireClaudePaths();
 
@@ -2630,7 +2640,8 @@ export async function loadSessionUsageById(
 	}
 
 	const mode = options?.mode ?? 'auto';
-	using fetcher = mode === 'display' ? null : new PricingFetcher(options?.offline);
+	using fetcher =
+		mode === 'display' ? null : new PricingFetcher(options?.offline, options?.pricingSource);
 	const calculateCost = await createCostCalculator(mode, fetcher);
 
 	const entries: Array<UsageData | undefined> = [];
@@ -2749,6 +2760,7 @@ export async function calculateContextTokens(
 	transcriptPath: string,
 	modelId?: string,
 	offline = false,
+	pricingSource?: PricingSource,
 ): Promise<{
 	inputTokens: number;
 	percentage: number;
@@ -2794,7 +2806,7 @@ export async function calculateContextTokens(
 				// Get context limit from PricingFetcher
 				let contextLimit = 200_000; // Fallback for when modelId is not provided
 				if (modelId != null && modelId !== '') {
-					using fetcher = new PricingFetcher(offline);
+					using fetcher = new PricingFetcher(offline, pricingSource);
 					const contextLimitResult = await fetcher.getModelContextLimit(modelId);
 					if (Result.isSuccess(contextLimitResult) && contextLimitResult.value != null) {
 						contextLimit = contextLimitResult.value;
@@ -2920,12 +2932,14 @@ export async function loadSessionBlockData(options?: LoadOptions): Promise<Sessi
 		{
 			mode,
 			offline: options?.offline,
+			pricingSource: options?.pricingSource,
 			timezone: options?.timezone,
 			singleThread: options?.singleThread,
 		},
 	);
 	if (workerFileResults == null) {
-		using fetcher = mode === 'display' ? null : new PricingFetcher(options?.offline);
+		using fetcher =
+			mode === 'display' ? null : new PricingFetcher(options?.offline, options?.pricingSource);
 		const calculateCost = await createCostCalculator(mode, fetcher);
 		const fileResults = await mapWithConcurrency(
 			mtimeFilteredFiles,
@@ -2969,7 +2983,8 @@ export async function loadSessionBlockData(options?: LoadOptions): Promise<Sessi
 }
 
 async function runUsageWorker(data: UsageWorkerData): Promise<void> {
-	using fetcher = data.mode === 'display' ? null : new PricingFetcher(data.offline);
+	using fetcher =
+		data.mode === 'display' ? null : new PricingFetcher(data.offline, data.pricingSource);
 	const calculateCost = await createCostCalculator(data.mode, fetcher, data.pricing);
 	const formatUsageDate = createCachedDateFormatter(data.timezone);
 

--- a/apps/ccusage/src/adapter/claude/index.ts
+++ b/apps/ccusage/src/adapter/claude/index.ts
@@ -24,6 +24,7 @@ export async function loadClaudeRows(
 	const until = toCompactDate(normalizeDateFilter(options.until));
 	const loaderOptions = {
 		offline: options.offline,
+		pricingSource: options.pricingSource,
 		since,
 		until,
 		timezone: options.timezone,

--- a/apps/ccusage/src/adapter/codex/index.ts
+++ b/apps/ccusage/src/adapter/codex/index.ts
@@ -49,6 +49,7 @@ async function aggregateCodexUsageGroups(
 					offlineLoader: loadOfflineCodexPricing,
 					logger: context.progress?.pricingLogger ?? logger,
 					providerPrefixes: CODEX_PROVIDER_PREFIXES,
+					pricingSource: options.pricingSource,
 				})
 			: undefined;
 	const fetcher = context.pricingFetcher ?? ownedFetcher!;

--- a/apps/ccusage/src/adapter/opencode/index.ts
+++ b/apps/ccusage/src/adapter/opencode/index.ts
@@ -20,7 +20,12 @@ function createOpenCodePricingContext(
 ): AgentPricingContext {
 	return createAgentPricingContext(
 		context,
-		() => new LiteLLMPricingFetcher({ offline: options.offline === true, logger }),
+		() =>
+			new LiteLLMPricingFetcher({
+				offline: options.offline === true,
+				logger,
+				pricingSource: options.pricingSource,
+			}),
 	);
 }
 

--- a/apps/ccusage/src/adapter/types.ts
+++ b/apps/ccusage/src/adapter/types.ts
@@ -1,4 +1,8 @@
-import type { LiteLLMPricingFetcher, PricingLogger } from '@ccusage/internal/pricing';
+import type {
+	LiteLLMPricingFetcher,
+	PricingLogger,
+	PricingSource,
+} from '@ccusage/internal/pricing';
 
 export const agentIds = ['claude', 'codex', 'opencode', 'amp', 'pi'] as const;
 export type AgentId = (typeof agentIds)[number];
@@ -13,6 +17,7 @@ export type AdapterOptions = {
 	timezone?: string;
 	compact?: boolean;
 	offline?: boolean;
+	pricingSource?: PricingSource;
 	speed?: string;
 	piPath?: string;
 };

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -25,6 +25,7 @@ import { loadAgentRows } from '../adapter/index.ts';
 import { agentLabels } from '../adapter/types.ts';
 import { formatDateCompact } from '../date-utils.ts';
 import { logger, writeStdoutLine } from '../logger.ts';
+import { sharedArgs } from '../shared-args.ts';
 import { createUsageLoadProgress, shouldShowUsageLoadProgress } from './loading-progress.ts';
 
 type AgentTotals = {
@@ -80,9 +81,10 @@ const commonAgentArgs = {
 		type: 'boolean',
 		negatable: true,
 		short: 'O',
-		description: 'Use cached pricing data instead of fetching from LiteLLM',
+		description: 'Use cached pricing data where supported',
 		default: false,
 	},
+	pricingSource: sharedArgs.pricingSource,
 	compact: {
 		type: 'boolean',
 		description: 'Force compact table layout for narrow terminals',
@@ -232,6 +234,7 @@ async function loadRows(
 	using pricingFetcher = new LiteLLMPricingFetcher({
 		offline: false,
 		logger: progress?.pricingLogger ?? logger,
+		pricingSource: options.pricingSource,
 	});
 	const context: AdapterContext = { pricingFetcher, progress };
 	return await loadAgentRows(agent, kind, options, context);

--- a/apps/ccusage/src/commands/all.ts
+++ b/apps/ccusage/src/commands/all.ts
@@ -77,6 +77,7 @@ export const allArgs = {
 		description: 'Use cached pricing data where supported',
 		default: false,
 	},
+	pricingSource: sharedArgs.pricingSource,
 	config: sharedArgs.config,
 } as const satisfies Args;
 
@@ -141,7 +142,10 @@ async function loadAllRows(
 		return loadAllRowsWithContext(kind, options, { progress }, agents);
 	}
 
-	using pricingFetcher = new LiteLLMPricingFetcher({ logger: progress?.pricingLogger ?? logger });
+	using pricingFetcher = new LiteLLMPricingFetcher({
+		logger: progress?.pricingLogger ?? logger,
+		pricingSource: options.pricingSource,
+	});
 	return await loadAllRowsWithContext(kind, options, { pricingFetcher, progress }, agents);
 }
 

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -155,20 +155,21 @@ export const blocksCommand = define({
 		}
 
 		// Validate session length
-		if (ctx.values.sessionLength <= 0) {
+		if (mergedOptions.sessionLength <= 0) {
 			logger.error('Session length must be a positive number');
 			process.exit(1);
 		}
 
 		let blocks = await loadSessionBlockData({
-			since: ctx.values.since,
-			until: ctx.values.until,
-			mode: ctx.values.mode,
-			order: ctx.values.order,
-			offline: ctx.values.offline,
-			singleThread: ctx.values.singleThread,
-			sessionDurationHours: ctx.values.sessionLength,
-			timezone: ctx.values.timezone,
+			since: mergedOptions.since,
+			until: mergedOptions.until,
+			mode: mergedOptions.mode,
+			order: mergedOptions.order,
+			offline: mergedOptions.offline,
+			pricingSource: mergedOptions.pricingSource,
+			singleThread: mergedOptions.singleThread,
+			sessionDurationHours: mergedOptions.sessionLength,
+			timezone: mergedOptions.timezone,
 		});
 
 		if (blocks.length === 0) {

--- a/apps/ccusage/src/commands/codex.ts
+++ b/apps/ccusage/src/commands/codex.ts
@@ -12,6 +12,7 @@ import { define } from 'gunshi';
 import { loadCodexReportRows } from '../adapter/codex/index.ts';
 import { formatDateCompact } from '../date-utils.ts';
 import { logger, writeStdoutLine } from '../logger.ts';
+import { sharedArgs } from '../shared-args.ts';
 import { createUsageLoadProgress, shouldShowUsageLoadProgress } from './loading-progress.ts';
 
 const codexArgs = {
@@ -40,9 +41,10 @@ const codexArgs = {
 		type: 'boolean',
 		negatable: true,
 		short: 'O',
-		description: 'Use cached pricing data instead of fetching from LiteLLM',
+		description: 'Use cached pricing data where supported',
 		default: false,
 	},
+	pricingSource: sharedArgs.pricingSource,
 	speed: {
 		type: 'string',
 		description:

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -53,6 +53,7 @@ export const sessionCommand = define({
 						id: mergedOptions.id,
 						mode: mergedOptions.mode,
 						offline: mergedOptions.offline,
+						pricingSource: mergedOptions.pricingSource,
 						timezone: mergedOptions.timezone,
 					},
 				},

--- a/apps/ccusage/src/commands/session_id.ts
+++ b/apps/ccusage/src/commands/session_id.ts
@@ -1,5 +1,5 @@
 import type { UsageData } from '../adapter/claude/data-loader.ts';
-import type { CostMode } from '../types.ts';
+import type { CostMode, PricingSource } from '../types.ts';
 import process from 'node:process';
 import { formatCurrency, formatNumber, ResponsiveTable } from '@ccusage/terminal/table';
 import { loadSessionUsageById } from '../adapter/claude/data-loader.ts';
@@ -11,6 +11,7 @@ export type SessionIdContext = {
 		id: string;
 		mode: CostMode;
 		offline: boolean;
+		pricingSource?: PricingSource;
 		timezone?: string;
 	};
 };
@@ -25,6 +26,7 @@ export async function handleSessionIdLookup(
 	const sessionUsage = await loadSessionUsageById(ctx.values.id, {
 		mode: ctx.values.mode,
 		offline: ctx.values.offline,
+		pricingSource: ctx.values.pricingSource,
 	});
 
 	if (sessionUsage == null) {

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -134,6 +134,7 @@ export const statuslineCommand = define({
 			...sharedArgs.offline,
 			default: true, // Default to offline mode for faster performance
 		},
+		pricingSource: sharedArgs.pricingSource,
 		visualBurnRate: {
 			type: 'enum',
 			choices: visualBurnRateChoices,
@@ -315,6 +316,7 @@ export const statuslineCommand = define({
 										loadSessionUsageById(sessionId, {
 											mode: 'auto',
 											offline: mergedOptions.offline,
+											pricingSource: mergedOptions.pricingSource,
 										}),
 									catch: (error) => error,
 								})(),
@@ -369,6 +371,7 @@ export const statuslineCommand = define({
 									until: todayStr,
 									mode: 'auto',
 									offline: mergedOptions.offline,
+									pricingSource: mergedOptions.pricingSource,
 									minUpdateTime: midnightToday,
 								}),
 							catch: (error) => error,
@@ -392,6 +395,7 @@ export const statuslineCommand = define({
 								loadSessionBlockData({
 									mode: 'auto',
 									offline: mergedOptions.offline,
+									pricingSource: mergedOptions.pricingSource,
 									minUpdateTime: lastBlocksTime,
 								}),
 							catch: (error) => error,
@@ -499,6 +503,7 @@ export const statuslineCommand = define({
 											hookData.transcript_path,
 											hookData.model.id,
 											mergedOptions.offline,
+											mergedOptions.pricingSource,
 										),
 									catch: (error) => error,
 								})();

--- a/apps/ccusage/src/pricing-fetcher.ts
+++ b/apps/ccusage/src/pricing-fetcher.ts
@@ -1,3 +1,4 @@
+import type { PricingSource } from '@ccusage/internal/pricing';
 import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
 import { Result } from '@praha/byethrow';
 import { logger } from './logger.ts';
@@ -14,12 +15,13 @@ export const CLAUDE_PROVIDER_PREFIXES = [
 const PREFETCHED_CLAUDE_PRICING = prefetchClaudePricing();
 
 export class PricingFetcher extends LiteLLMPricingFetcher {
-	constructor(offline = false) {
+	constructor(offline = false, pricingSource?: PricingSource) {
 		super({
 			offline,
 			offlineLoader: async () => PREFETCHED_CLAUDE_PRICING,
 			logger,
 			providerPrefixes: CLAUDE_PROVIDER_PREFIXES,
+			pricingSource,
 		});
 	}
 }

--- a/apps/ccusage/src/shared-args.ts
+++ b/apps/ccusage/src/shared-args.ts
@@ -1,5 +1,6 @@
 import type { Args } from 'gunshi';
-import type { CostMode, SortOrder } from './types.ts';
+import type { CostMode, PricingSource, SortOrder } from './types.ts';
+import { PricingSources } from '@ccusage/internal/pricing';
 import * as v from 'valibot';
 import { CostModes, filterDateSchema, SortOrders } from './types.ts';
 
@@ -70,8 +71,16 @@ export const sharedArgs = {
 		type: 'boolean',
 		negatable: true,
 		short: 'O',
-		description: 'Use cached pricing data for Claude models instead of fetching from API',
+		description: 'Use cached pricing data where supported',
 		default: false,
+	},
+	pricingSource: {
+		type: 'enum',
+		short: 'P',
+		description:
+			'Pricing data source: litellm, modelsdev, or auto (LiteLLM with models.dev fallback/merge)',
+		default: 'litellm' as const satisfies PricingSource,
+		choices: PricingSources,
 	},
 	singleThread: {
 		type: 'boolean',

--- a/apps/ccusage/src/types.ts
+++ b/apps/ccusage/src/types.ts
@@ -1,3 +1,4 @@
+import type { PricingSource } from '@ccusage/internal/pricing';
 import type { TupleToUnion } from 'type-fest';
 import * as v from 'valibot';
 
@@ -143,6 +144,8 @@ export const CostModes = ['auto', 'calculate', 'display'] as const;
  * Union type for cost calculation modes
  */
 export type CostMode = TupleToUnion<typeof CostModes>;
+
+export type { PricingSource };
 
 /**
  * Available sort orders for data presentation

--- a/docs/guide/cli-options.md
+++ b/docs/guide/cli-options.md
@@ -75,6 +75,23 @@ ccusage daily --offline
 ccusage daily -O
 ```
 
+### Pricing Source
+
+Choose which model pricing dataset to use for calculated costs:
+
+```bash
+# Default: LiteLLM pricing
+ccusage daily --pricing-source litellm
+
+# Use models.dev pricing
+ccusage codex daily --pricing-source modelsdev
+
+# Prefer LiteLLM and fill missing models from models.dev
+ccusage daily --pricing-source auto
+```
+
+`modelsdev` fetches live pricing from `models.dev`; it is not included in the cached pricing bundle used by `--offline`.
+
 ### Timezone
 
 Set the timezone for date calculations:
@@ -287,16 +304,17 @@ LOG_LEVEL=0 ccusage daily --json
 
 Many options have short aliases for convenience:
 
-| Long Option   | Short | Description         |
-| ------------- | ----- | ------------------- |
-| `--json`      | `-j`  | JSON output         |
-| `--breakdown` | `-b`  | Per-model breakdown |
-| `--offline`   | `-O`  | Offline mode        |
-| `--timezone`  | `-z`  | Set timezone        |
-| `--instances` | `-i`  | Group by project    |
-| `--project`   | `-p`  | Filter project      |
-| `--active`    | `-a`  | Active block only   |
-| `--recent`    | `-r`  | Recent blocks       |
+| Long Option        | Short | Description         |
+| ------------------ | ----- | ------------------- |
+| `--json`           | `-j`  | JSON output         |
+| `--breakdown`      | `-b`  | Per-model breakdown |
+| `--offline`        | `-O`  | Offline mode        |
+| `--pricing-source` | `-P`  | Pricing source      |
+| `--timezone`       | `-z`  | Set timezone        |
+| `--instances`      | `-i`  | Group by project    |
+| `--project`        | `-p`  | Filter project      |
+| `--active`         | `-a`  | Active block only   |
+| `--recent`         | `-r`  | Recent blocks       |
 
 ## Related Documentation
 

--- a/docs/guide/cli-options.md
+++ b/docs/guide/cli-options.md
@@ -90,7 +90,7 @@ ccusage codex daily --pricing-source modelsdev
 ccusage daily --pricing-source auto
 ```
 
-`modelsdev` fetches live pricing from `models.dev`; it is not included in the cached pricing bundle used by `--offline`.
+`modelsdev` fetches live pricing from `models.dev`; it is not included in the cached pricing bundle used by `--offline`. For models that have tiered token pricing in LiteLLM, ccusage preserves LiteLLM's tier metadata when it is available because models.dev exposes flat token prices only.
 
 ### Timezone
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -180,7 +180,7 @@ Control how costs are calculated:
 ccusage daily --mode calculate --breakdown --pricing-source auto
 ```
 
-`modelsdev` uses live data from `models.dev` and is not part of the cached pricing bundle used by `--offline`.
+`modelsdev` uses live data from `models.dev` and is not part of the cached pricing bundle used by `--offline`. Because models.dev exposes flat token prices only, ccusage preserves LiteLLM tier metadata for tiered-pricing models when that metadata is available.
 
 ### Date and Time
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -173,11 +173,14 @@ Control how costs are calculated:
 
 - **Mode**: `auto` (default), `calculate`, or `display`
 - **Offline**: Use cached pricing data
+- **Pricing Source**: `litellm` (default), `modelsdev`, or `auto`
 - **Breakdown**: Show per-model costs
 
 ```bash
-ccusage daily --mode calculate --breakdown --offline
+ccusage daily --mode calculate --breakdown --pricing-source auto
 ```
+
+`modelsdev` uses live data from `models.dev` and is not part of the cached pricing bundle used by `--offline`.
 
 ### Date and Time
 

--- a/docs/guide/statusline.md
+++ b/docs/guide/statusline.md
@@ -151,6 +151,7 @@ The statusline command:
 - Outputs a single line suitable for status bar display
 - **Uses offline mode by default** for instant response times without network dependencies
 - Can be configured to use online mode with `--no-offline` for latest pricing data
+- Supports `--pricing-source` when ccusage is calculating costs
 
 ## Beta Notice
 
@@ -168,7 +169,7 @@ The `--cost-source` option controls how session costs are calculated and display
 **Available modes:**
 
 - `auto` (default): Prefer Claude Code's pre-calculated cost when available, fallback to ccusage calculation
-- `ccusage`: Always calculate costs using ccusage's token-based calculation with LiteLLM pricing
+- `ccusage`: Always calculate costs using ccusage's token-based calculation and the selected pricing source
 - `cc`: Always use Claude Code's pre-calculated cost from session data
 - `both`: Display both Claude Code and ccusage costs side by side for comparison
 

--- a/packages/internal/src/models-dev-pricing.ts
+++ b/packages/internal/src/models-dev-pricing.ts
@@ -1,0 +1,121 @@
+import type { LiteLLMModelPricing } from './pricing.ts';
+import { Result } from '@praha/byethrow';
+import * as v from 'valibot';
+
+export const MODELS_DEV_API_URL = 'https://models.dev/api.json';
+
+const modelsDevCostSchema = v.object({
+	input: v.optional(v.number()),
+	output: v.optional(v.number()),
+	cache_read: v.optional(v.number()),
+	cache_write: v.optional(v.number()),
+});
+
+const modelsDevLimitSchema = v.object({
+	context: v.optional(v.number()),
+	output: v.optional(v.number()),
+});
+
+const modelsDevModelSchema = v.object({
+	id: v.string(),
+	cost: v.optional(modelsDevCostSchema),
+	limit: v.optional(modelsDevLimitSchema),
+});
+
+const modelsDevProviderSchema = v.object({
+	id: v.string(),
+	models: v.optional(v.record(v.string(), modelsDevModelSchema)),
+});
+
+const modelsDevApiSchema = v.record(v.string(), modelsDevProviderSchema);
+
+export type ModelsDevModel = v.InferOutput<typeof modelsDevModelSchema>;
+
+function toTokenPrice(pricePerMillionTokens: number | undefined): number | undefined {
+	return pricePerMillionTokens == null ? undefined : pricePerMillionTokens / 1_000_000;
+}
+
+export function convertModelsDevToLiteLLMPricing(model: ModelsDevModel): LiteLLMModelPricing {
+	return {
+		input_cost_per_token: toTokenPrice(model.cost?.input),
+		output_cost_per_token: toTokenPrice(model.cost?.output),
+		cache_creation_input_token_cost: toTokenPrice(model.cost?.cache_write),
+		cache_read_input_token_cost: toTokenPrice(model.cost?.cache_read),
+		max_tokens: model.limit?.context,
+		max_input_tokens: model.limit?.context,
+		max_output_tokens: model.limit?.output,
+	};
+}
+
+export async function fetchModelsDevPricing(
+	url = MODELS_DEV_API_URL,
+): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
+	return Result.pipe(
+		Result.try({
+			try: fetch(url),
+			catch: (error) => new Error('Failed to fetch pricing from models.dev', { cause: error }),
+		}),
+		Result.andThrough((response) => {
+			if (!response.ok) {
+				return Result.fail(
+					new Error(`Failed to fetch models.dev pricing data: ${response.statusText}`),
+				);
+			}
+			return Result.succeed();
+		}),
+		Result.andThen(async (response) =>
+			Result.try({
+				try: response.json() as Promise<Record<string, unknown>>,
+				catch: (error) => new Error('Failed to parse models.dev pricing data', { cause: error }),
+			}),
+		),
+		Result.andThen((data) => {
+			const parsed = v.safeParse(modelsDevApiSchema, data);
+			if (!parsed.success) {
+				return Result.fail(new Error('Invalid models.dev pricing data'));
+			}
+			return Result.succeed(parsed.output);
+		}),
+		Result.map((api) => {
+			const pricing = new Map<string, LiteLLMModelPricing>();
+			for (const [providerId, provider] of Object.entries(api)) {
+				if (provider.models == null) {
+					continue;
+				}
+				for (const [modelId, model] of Object.entries(provider.models)) {
+					const converted = convertModelsDevToLiteLLMPricing(model);
+					pricing.set(modelId, converted);
+					pricing.set(`${providerId}/${modelId}`, converted);
+				}
+			}
+			return pricing;
+		}),
+	);
+}
+
+if (import.meta.vitest != null) {
+	describe('models.dev pricing', () => {
+		it('converts per-million token pricing to LiteLLM per-token pricing', () => {
+			const pricing = convertModelsDevToLiteLLMPricing({
+				id: 'gpt-5',
+				cost: {
+					input: 1.25,
+					output: 10,
+					cache_read: 0.125,
+					cache_write: 1.25,
+				},
+				limit: {
+					context: 400_000,
+					output: 128_000,
+				},
+			});
+
+			expect(pricing.input_cost_per_token).toBeCloseTo(1.25 / 1_000_000);
+			expect(pricing.output_cost_per_token).toBeCloseTo(10 / 1_000_000);
+			expect(pricing.cache_read_input_token_cost).toBeCloseTo(0.125 / 1_000_000);
+			expect(pricing.cache_creation_input_token_cost).toBeCloseTo(1.25 / 1_000_000);
+			expect(pricing.max_input_tokens).toBe(400_000);
+			expect(pricing.max_output_tokens).toBe(128_000);
+		});
+	});
+}

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -13,6 +13,14 @@ export const LITELLM_PRICING_URL =
  * future models that may use different thresholds.
  */
 const DEFAULT_TIERED_THRESHOLD = 200_000;
+const TIERED_PRICING_KEYS = [
+	'input_cost_per_token_above_200k_tokens',
+	'output_cost_per_token_above_200k_tokens',
+	'cache_creation_input_token_cost_above_200k_tokens',
+	'cache_read_input_token_cost_above_200k_tokens',
+	'input_cost_per_token_above_128k_tokens',
+	'output_cost_per_token_above_128k_tokens',
+] as const satisfies readonly (keyof LiteLLMModelPricing)[];
 
 function calculateTieredCost(
 	totalTokens: number | undefined,
@@ -36,6 +44,23 @@ function calculateTieredCost(
 	}
 
 	return 0;
+}
+
+function hasTieredPricing(pricing: LiteLLMModelPricing): boolean {
+	return TIERED_PRICING_KEYS.some((key) => pricing[key] != null);
+}
+
+function mergeTieredPricingFields(
+	pricing: LiteLLMModelPricing,
+	tieredPricing: LiteLLMModelPricing,
+): LiteLLMModelPricing {
+	const merged: LiteLLMModelPricing = { ...pricing };
+	for (const key of TIERED_PRICING_KEYS) {
+		if (tieredPricing[key] != null) {
+			merged[key] = tieredPricing[key];
+		}
+	}
+	return merged;
 }
 
 /**
@@ -228,13 +253,58 @@ export class LiteLLMPricingFetcher implements Disposable {
 		);
 	}
 
-	private async loadModelsDevPricing(): Result.ResultAsync<
-		Map<string, LiteLLMModelPricing>,
-		Error
-	> {
+	private findLiteLLMTieredPricing(
+		modelName: string,
+		pricing: Map<string, LiteLLMModelPricing>,
+	): LiteLLMModelPricing | null {
+		for (const candidate of this.createMatchingCandidates(modelName)) {
+			const tieredPricing = pricing.get(candidate);
+			if (tieredPricing != null && hasTieredPricing(tieredPricing)) {
+				return tieredPricing;
+			}
+		}
+		return null;
+	}
+
+	private applyLiteLLMTieredPricingFields(
+		modelsDevPricing: Map<string, LiteLLMModelPricing>,
+		liteLLMPricing: Map<string, LiteLLMModelPricing>,
+	): Map<string, LiteLLMModelPricing> {
+		const pricing = new Map<string, LiteLLMModelPricing>();
+		for (const [modelName, modelPricing] of modelsDevPricing) {
+			const tieredPricing = this.findLiteLLMTieredPricing(modelName, liteLLMPricing);
+			pricing.set(
+				modelName,
+				tieredPricing == null
+					? modelPricing
+					: mergeTieredPricingFields(modelPricing, tieredPricing),
+			);
+		}
+		return pricing;
+	}
+
+	private async loadModelsDevPricing(
+		includeLiteLLMTieredPricing = false,
+	): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
 		this.logger.warn('Fetching latest model pricing from models.dev...');
 		return Result.pipe(
 			fetchModelsDevPricing(this.modelsDevUrl),
+			Result.andThen(async (modelsDevPricing) => {
+				if (!includeLiteLLMTieredPricing) {
+					return Result.succeed(modelsDevPricing);
+				}
+				const liteLLMResult = await this.loadLiteLLMPricing();
+				if (Result.isFailure(liteLLMResult)) {
+					this.logger.warn(
+						'Failed to fetch LiteLLM tiered pricing metadata, using models.dev flat pricing only',
+					);
+					this.logger.debug('LiteLLM tiered pricing fetch error details:', liteLLMResult.error);
+					return Result.succeed(modelsDevPricing);
+				}
+				return Result.succeed(
+					this.applyLiteLLMTieredPricingFields(modelsDevPricing, liteLLMResult.value),
+				);
+			}),
 			Result.inspect((pricing) => {
 				this.logger.info(`Loaded pricing for ${pricing.size} models from models.dev`);
 			}),
@@ -276,7 +346,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 
 	private async loadPricing(): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
 		if (this.pricingSource === 'modelsdev') {
-			return this.loadModelsDevPricing();
+			return this.loadModelsDevPricing(true);
 		}
 
 		if (this.offline) {
@@ -873,6 +943,72 @@ if (import.meta.vitest != null) {
 				expect(pricing?.max_input_tokens).toBe(400_000);
 				expect(pricing?.max_output_tokens).toBe(128_000);
 				expect(cost).toBeCloseTo((1000 * 1.25 + 500 * 10 + 200 * 1.25 + 300 * 0.125) / 1_000_000);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		});
+
+		it('keeps LiteLLM tiered pricing metadata for models.dev prices when available', async () => {
+			const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+				if (url === 'https://example.com/models-dev.json') {
+					return {
+						ok: true,
+						json: async () => ({
+							anthropic: {
+								id: 'anthropic',
+								models: {
+									'claude-sonnet-4-20250514': {
+										id: 'claude-sonnet-4-20250514',
+										cost: {
+											input: 3,
+											output: 15,
+										},
+										limit: {
+											context: 1_000_000,
+											output: 64_000,
+										},
+									},
+								},
+							},
+						}),
+					} as Response;
+				}
+
+				return {
+					ok: true,
+					json: async () => ({
+						'anthropic/claude-sonnet-4-20250514': {
+							input_cost_per_token: 3e-6,
+							output_cost_per_token: 1.5e-5,
+							input_cost_per_token_above_200k_tokens: 6e-6,
+							output_cost_per_token_above_200k_tokens: 2.25e-5,
+						},
+					}),
+				} as Response;
+			});
+
+			try {
+				using fetcher = new LiteLLMPricingFetcher({
+					pricingSource: 'modelsdev',
+					url: 'https://example.com/litellm.json',
+					modelsDevUrl: 'https://example.com/models-dev.json',
+				});
+
+				const cost = await Result.unwrap(
+					fetcher.calculateCostFromTokens(
+						{
+							input_tokens: 300_000,
+							output_tokens: 250_000,
+						},
+						'claude-sonnet-4-20250514',
+					),
+				);
+
+				expect(fetchSpy).toHaveBeenCalledWith('https://example.com/models-dev.json');
+				expect(fetchSpy).toHaveBeenCalledWith('https://example.com/litellm.json');
+				expect(cost).toBeCloseTo(
+					200_000 * 3e-6 + 100_000 * 6e-6 + 200_000 * 1.5e-5 + 50_000 * 2.25e-5,
+				);
 			} finally {
 				fetchSpy.mockRestore();
 			}

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -1,5 +1,6 @@
 import { Result } from '@praha/byethrow';
 import * as v from 'valibot';
+import { fetchModelsDevPricing, MODELS_DEV_API_URL } from './models-dev-pricing.ts';
 
 export const LITELLM_PRICING_URL =
 	'https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json';
@@ -78,6 +79,9 @@ export const liteLLMModelPricingSchema = v.object({
 
 export type LiteLLMModelPricing = v.InferOutput<typeof liteLLMModelPricingSchema>;
 
+export const PricingSources = ['litellm', 'modelsdev', 'auto'] as const;
+export type PricingSource = (typeof PricingSources)[number];
+
 export type PricingLogger = {
 	debug: (...args: unknown[]) => void;
 	error: (...args: unknown[]) => void;
@@ -90,7 +94,9 @@ export type LiteLLMPricingFetcherOptions = {
 	offline?: boolean;
 	offlineLoader?: () => Promise<Record<string, LiteLLMModelPricing>>;
 	url?: string;
+	modelsDevUrl?: string;
 	providerPrefixes?: string[];
+	pricingSource?: PricingSource;
 };
 
 const DEFAULT_PROVIDER_PREFIXES = [
@@ -125,14 +131,18 @@ export class LiteLLMPricingFetcher implements Disposable {
 	private readonly offline: boolean;
 	private readonly offlineLoader?: () => Promise<Record<string, LiteLLMModelPricing>>;
 	private readonly url: string;
+	private readonly modelsDevUrl: string;
 	private readonly providerPrefixes: string[];
+	private readonly pricingSource: PricingSource;
 
 	constructor(options: LiteLLMPricingFetcherOptions = {}) {
 		this.logger = createLogger(options.logger);
 		this.offline = Boolean(options.offline);
 		this.offlineLoader = options.offlineLoader;
 		this.url = options.url ?? LITELLM_PRICING_URL;
+		this.modelsDevUrl = options.modelsDevUrl ?? MODELS_DEV_API_URL;
 		this.providerPrefixes = options.providerPrefixes ?? DEFAULT_PROVIDER_PREFIXES;
+		this.pricingSource = options.pricingSource ?? 'litellm';
 	}
 
 	[Symbol.dispose](): void {
@@ -177,11 +187,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 		);
 	}
 
-	private async loadPricing(): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
-		if (this.offline) {
-			return this.loadOfflinePricing();
-		}
-
+	private async loadLiteLLMPricing(): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
 		this.logger.warn('Fetching latest model pricing from LiteLLM...');
 		return Result.pipe(
 			Result.try({
@@ -217,9 +223,72 @@ export class LiteLLMPricingFetcher implements Disposable {
 				return pricing;
 			}),
 			Result.inspect((pricing) => {
-				this.cachedPricing = pricing;
 				this.logger.info(`Loaded pricing for ${pricing.size} models`);
 			}),
+		);
+	}
+
+	private async loadModelsDevPricing(): Result.ResultAsync<
+		Map<string, LiteLLMModelPricing>,
+		Error
+	> {
+		this.logger.warn('Fetching latest model pricing from models.dev...');
+		return Result.pipe(
+			fetchModelsDevPricing(this.modelsDevUrl),
+			Result.inspect((pricing) => {
+				this.logger.info(`Loaded pricing for ${pricing.size} models from models.dev`);
+			}),
+		);
+	}
+
+	private mergePricingMaps(
+		base: Map<string, LiteLLMModelPricing>,
+		additional: Map<string, LiteLLMModelPricing>,
+	): Map<string, LiteLLMModelPricing> {
+		const merged = new Map(base);
+		for (const [modelName, pricing] of additional) {
+			if (!merged.has(modelName)) {
+				merged.set(modelName, pricing);
+			}
+		}
+		return merged;
+	}
+
+	private async loadAutoPricing(): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
+		const liteLLMResult = await Result.pipe(
+			this.loadLiteLLMPricing(),
+			Result.orElse(async (error) => this.handleFallbackToCachedPricing(error)),
+		);
+		const modelsDevResult = await this.loadModelsDevPricing();
+
+		if (Result.isFailure(liteLLMResult)) {
+			return modelsDevResult;
+		}
+
+		if (Result.isFailure(modelsDevResult)) {
+			this.logger.warn('Failed to fetch models.dev pricing, using LiteLLM pricing only');
+			this.logger.debug('models.dev fetch error details:', modelsDevResult.error);
+			return Result.succeed(liteLLMResult.value);
+		}
+
+		return Result.succeed(this.mergePricingMaps(liteLLMResult.value, modelsDevResult.value));
+	}
+
+	private async loadPricing(): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
+		if (this.pricingSource === 'modelsdev') {
+			return this.loadModelsDevPricing();
+		}
+
+		if (this.offline) {
+			return this.loadOfflinePricing();
+		}
+
+		if (this.pricingSource === 'auto') {
+			return this.loadAutoPricing();
+		}
+
+		return Result.pipe(
+			this.loadLiteLLMPricing(),
 			Result.orElse(async (error) => this.handleFallbackToCachedPricing(error)),
 		);
 	}
@@ -231,6 +300,9 @@ export class LiteLLMPricingFetcher implements Disposable {
 
 		this.pricingLoadPromise ??= Result.pipe(
 			this.loadPricing(),
+			Result.inspect((pricing) => {
+				this.cachedPricing = pricing;
+			}),
 			Result.inspectError(() => {
 				this.pricingLoadPromise = null;
 			}),
@@ -747,6 +819,122 @@ if (import.meta.vitest != null) {
 
 			expect(pricing).not.toBeNull();
 			expect(pricing?.input_cost_per_token).toBe(2.5e-7);
+		});
+
+		it('loads models.dev pricing when selected as the pricing source', async () => {
+			const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					openai: {
+						id: 'openai',
+						models: {
+							'gpt-5': {
+								id: 'gpt-5',
+								cost: {
+									input: 1.25,
+									output: 10,
+									cache_read: 0.125,
+									cache_write: 1.25,
+								},
+								limit: {
+									context: 400_000,
+									output: 128_000,
+								},
+							},
+						},
+					},
+				}),
+			} as Response);
+
+			try {
+				using fetcher = new LiteLLMPricingFetcher({
+					pricingSource: 'modelsdev',
+					modelsDevUrl: 'https://example.com/models-dev.json',
+				});
+
+				const pricing = await Result.unwrap(fetcher.getModelPricing('gpt-5'));
+				const cost = await Result.unwrap(
+					fetcher.calculateCostFromTokens(
+						{
+							input_tokens: 1000,
+							output_tokens: 500,
+							cache_creation_input_tokens: 200,
+							cache_read_input_tokens: 300,
+						},
+						'gpt-5',
+					),
+				);
+
+				expect(fetchSpy).toHaveBeenCalledWith('https://example.com/models-dev.json');
+				expect(pricing?.input_cost_per_token).toBeCloseTo(1.25 / 1_000_000);
+				expect(pricing?.output_cost_per_token).toBeCloseTo(10 / 1_000_000);
+				expect(pricing?.cache_creation_input_token_cost).toBeCloseTo(1.25 / 1_000_000);
+				expect(pricing?.cache_read_input_token_cost).toBeCloseTo(0.125 / 1_000_000);
+				expect(pricing?.max_input_tokens).toBe(400_000);
+				expect(pricing?.max_output_tokens).toBe(128_000);
+				expect(cost).toBeCloseTo((1000 * 1.25 + 500 * 10 + 200 * 1.25 + 300 * 0.125) / 1_000_000);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		});
+
+		it('merges models.dev pricing into LiteLLM pricing in auto source mode', async () => {
+			const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+				if (url === 'https://example.com/litellm.json') {
+					return {
+						ok: true,
+						json: async () => ({
+							'gpt-5': {
+								input_cost_per_token: 1e-6,
+								output_cost_per_token: 2e-6,
+							},
+						}),
+					} as Response;
+				}
+
+				return {
+					ok: true,
+					json: async () => ({
+						openai: {
+							id: 'openai',
+							models: {
+								'gpt-5': {
+									id: 'gpt-5',
+									cost: {
+										input: 9,
+										output: 9,
+									},
+								},
+								'gpt-5.1-codex': {
+									id: 'gpt-5.1-codex',
+									cost: {
+										input: 1.25,
+										output: 10,
+									},
+								},
+							},
+						},
+					}),
+				} as Response;
+			});
+
+			try {
+				using fetcher = new LiteLLMPricingFetcher({
+					pricingSource: 'auto',
+					url: 'https://example.com/litellm.json',
+					modelsDevUrl: 'https://example.com/models-dev.json',
+				});
+
+				const liteLLMModel = await Result.unwrap(fetcher.getModelPricing('gpt-5'));
+				const modelsDevModel = await Result.unwrap(fetcher.getModelPricing('gpt-5.1-codex'));
+
+				expect(fetchSpy).toHaveBeenCalledWith('https://example.com/litellm.json');
+				expect(fetchSpy).toHaveBeenCalledWith('https://example.com/models-dev.json');
+				expect(liteLLMModel?.input_cost_per_token).toBe(1e-6);
+				expect(modelsDevModel?.input_cost_per_token).toBeCloseTo(1.25 / 1_000_000);
+			} finally {
+				fetchSpy.mockRestore();
+			}
 		});
 	});
 }


### PR DESCRIPTION
- Add models.dev integration alongside LiteLLM pricing
- Support auto-merge, litellm-only, and modelsdev-only modes
- Add --pricing-source CLI option for all commands
- Update configuration schema with pricingSource field
- Add comprehensive documentation in docs/guide/pricing-sources.md
- Implement pricing fetcher with fallback and merge strategies

Mainland China have some trouble accessing litellm APIs #13 , and a previous PR to add pricing source #51 is closed. I found a site https://models.dev/ that supports multiple provider and more diverse model IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable pricing source (litellm, modelsdev, auto) with CLI flag -P/--pricing-source and config support across commands and providers.
  * Added support for fetching and merging models.dev pricing; "auto" tries LiteLLM first then merges models.dev results.

* **Documentation**
  * Added Pricing Source docs, examples, and guidance about live vs cached pricing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->