### PR TITLE
feat(ccusage): add --no-cost flag to hide cost column

### DIFF
--- a/apps/ccusage/src/_shared-args.ts
+++ b/apps/ccusage/src/_shared-args.ts
@@ -108,6 +108,11 @@ export const sharedArgs = {
 		description: 'Force compact mode for narrow displays (better for screenshots)',
 		default: false,
 	},
+	noCost: {
+		type: 'boolean',
+		description: 'Hide cost column from output (useful for Pro subscribers)',
+		default: false,
+	},
 } as const satisfies Args;
 
 /**

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -323,6 +323,7 @@ export const blocksCommand = define({
 				}
 				const burnRate = calculateBurnRate(block);
 				const projection = projectBlockUsage(block);
+				const hideCost = Boolean(ctx.values.noCost);
 
 				logger.box('Current Session Block Status');
 
@@ -340,18 +341,33 @@ export const blocksCommand = define({
 				log(pc.bold('Current Usage:'));
 				log(`  Input Tokens:     ${formatNumber(block.tokenCounts.inputTokens)}`);
 				log(`  Output Tokens:    ${formatNumber(block.tokenCounts.outputTokens)}`);
-				log(`  Total Cost:       ${formatCurrency(block.costUSD)}\n`);
+				if (!hideCost) {
+					log(`  Total Cost:       ${formatCurrency(block.costUSD)}\n`);
+				}
+				else {
+					log('');
+				}
 
 				if (burnRate != null) {
 					log(pc.bold('Burn Rate:'));
 					log(`  Tokens/minute:    ${formatNumber(burnRate.tokensPerMinute)}`);
-					log(`  Cost/hour:        ${formatCurrency(burnRate.costPerHour)}\n`);
+					if (!hideCost) {
+						log(`  Cost/hour:        ${formatCurrency(burnRate.costPerHour)}\n`);
+					}
+					else {
+						log('');
+					}
 				}
 
 				if (projection != null) {
 					log(pc.bold('Projected Usage (if current rate continues):'));
 					log(`  Total Tokens:     ${formatNumber(projection.totalTokens)}`);
-					log(`  Total Cost:       ${formatCurrency(projection.totalCost)}\n`);
+					if (!hideCost) {
+						log(`  Total Cost:       ${formatCurrency(projection.totalCost)}\n`);
+					}
+					else {
+						log('');
+					}
 
 					if (ctx.values.tokenLimit != null) {
 						// Parse token limit
@@ -381,6 +397,7 @@ export const blocksCommand = define({
 
 				// Calculate token limit if "max" is specified
 				const actualTokenLimit = parseTokenLimit(ctx.values.tokenLimit, maxTokensFromAll);
+				const hideCost = Boolean(ctx.values.noCost);
 
 				const tableHeaders = ['Block Start', 'Duration/Status', 'Models', 'Tokens'];
 				const tableAligns: ('left' | 'right' | 'center')[] = ['left', 'left', 'left', 'right'];
@@ -391,8 +408,10 @@ export const blocksCommand = define({
 					tableAligns.push('right');
 				}
 
-				tableHeaders.push('Cost');
-				tableAligns.push('right');
+				if (!hideCost) {
+					tableHeaders.push('Cost');
+					tableAligns.push('right');
+				}
 
 				const table = new ResponsiveTable({
 					head: tableHeaders,
@@ -420,7 +439,9 @@ export const blocksCommand = define({
 						if (actualTokenLimit != null && actualTokenLimit > 0) {
 							gapRow.push(pc.gray('-'));
 						}
-						gapRow.push(pc.gray('-'));
+						if (!hideCost) {
+							gapRow.push(pc.gray('-'));
+						}
 						table.push(gapRow);
 					}
 					else {
@@ -442,7 +463,9 @@ export const blocksCommand = define({
 							row.push(percentage > 100 ? pc.red(percentText) : percentText);
 						}
 
-						row.push(formatCurrency(block.costUSD));
+						if (!hideCost) {
+							row.push(formatCurrency(block.costUSD));
+						}
 						table.push(row);
 
 						// Add REMAINING and PROJECTED rows for active blocks
@@ -461,14 +484,16 @@ export const blocksCommand = define({
 									? `${remainingPercent.toFixed(1)}%`
 									: pc.red('0.0%');
 
-								const remainingRow = [
+								const remainingRow: (string | { content: string; hAlign: 'right' })[] = [
 									{ content: pc.gray(`(assuming ${formatNumber(actualTokenLimit)} token limit)`), hAlign: 'right' as const },
 									pc.blue('REMAINING'),
 									'',
 									remainingText,
 									remainingPercentText,
-									'', // No cost for remaining - it's about token limit, not cost
 								];
+								if (!hideCost) {
+									remainingRow.push(''); // No cost for remaining - it's about token limit, not cost
+								}
 								table.push(remainingRow);
 							}
 
@@ -480,7 +505,7 @@ export const blocksCommand = define({
 									? pc.red(projectedTokens)
 									: projectedTokens;
 
-								const projectedRow = [
+								const projectedRow: (string | { content: string; hAlign: 'right' })[] = [
 									{ content: pc.gray('(assuming current burn rate)'), hAlign: 'right' as const },
 									pc.yellow('PROJECTED'),
 									'',
@@ -494,7 +519,9 @@ export const blocksCommand = define({
 									projectedRow.push(percentText);
 								}
 
-								projectedRow.push(formatCurrency(projection.totalCost));
+								if (!hideCost) {
+									projectedRow.push(formatCurrency(projection.totalCost));
+								}
 								table.push(projectedRow);
 							}
 						}

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -98,13 +98,19 @@ export const monthlyCommand = define({
 			// Print header
 			logger.box('Claude Code Token Usage Report - Monthly');
 
+			const hideCost = Boolean(mergedOptions.noCost);
+
 			// Create table with compact mode support
 			const tableConfig: UsageReportConfig = {
 				firstColumnName: 'Month',
 				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, mergedOptions.timezone, mergedOptions.locale ?? DEFAULT_LOCALE),
 				forceCompact: ctx.values.compact,
+				hideCost,
 			};
 			const table = createUsageReportTable(tableConfig);
+
+			// Calculate column count based on hideCost
+			const columnCount = hideCost ? 7 : 8;
 
 			// Add monthly data
 			for (const data of monthlyData) {
@@ -116,17 +122,17 @@ export const monthlyCommand = define({
 					cacheReadTokens: data.cacheReadTokens,
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
-				});
+				}, { hideCost });
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, hideCost);
 				}
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, columnCount);
 
 			// Add totals
 			const totalsRow = formatTotalsRow({
@@ -135,7 +141,7 @@ export const monthlyCommand = define({
 				cacheCreationTokens: totals.cacheCreationTokens,
 				cacheReadTokens: totals.cacheReadTokens,
 				totalCost: totals.totalCost,
-			});
+			}, { hideCost });
 			table.push(totalsRow);
 
 			log(table.toString());


### PR DESCRIPTION
## Summary

Add `--no-cost` option to all commands (daily, monthly, session, blocks) to hide cost information from table output. This is useful for Claude Pro subscribers who pay a flat rate and don't need cost tracking.

- Add `noCost` flag to shared args
- Update table utilities to support `hideCost` option
- Apply `hideCost` to `formatUsageDataRow`, `formatTotalsRow`, `pushBreakdownRows`
- Update all commands to conditionally hide cost column

Closes #625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new option to hide cost columns from all usage reports and data tables, including daily, monthly, session, and block analysis views. This feature provides a cleaner viewing experience and is specifically designed for Pro subscribers who prefer to focus exclusively on usage metrics without cost information being displayed throughout their reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->