### PR TITLE
fix(data-loader): keep entry with highest output_tokens during deduplication

### DIFF
--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -4460,36 +4460,30 @@ if (import.meta.vitest != null) {
 			it('should keep entry with highest output_tokens regardless of file order', async () => {
 				await using fixture = await createFixture({
 					projects: {
-						project1: {
-							session1: {
-								'newer.jsonl': JSON.stringify({
-									timestamp: '2025-01-15T10:00:00Z',
-									message: {
-										id: 'msg_123',
-										usage: {
-											input_tokens: 200,
-											output_tokens: 100,
-										},
-									},
-									requestId: 'req_456',
-									costUSD: 0.002,
-								}),
+						'newer.jsonl': JSON.stringify({
+							timestamp: '2025-01-15T10:00:00Z',
+							message: {
+								id: 'msg_123',
+								usage: {
+									input_tokens: 200,
+									output_tokens: 100,
+								},
 							},
-							session2: {
-								'older.jsonl': JSON.stringify({
-									timestamp: '2025-01-10T10:00:00Z',
-									message: {
-										id: 'msg_123',
-										usage: {
-											input_tokens: 100,
-											output_tokens: 50,
-										},
-									},
-									requestId: 'req_456',
-									costUSD: 0.001,
-								}),
+							requestId: 'req_456',
+							costUSD: 0.002,
+						}),
+						'older.jsonl': JSON.stringify({
+							timestamp: '2025-01-10T10:00:00Z',
+							message: {
+								id: 'msg_123',
+								usage: {
+									input_tokens: 100,
+									output_tokens: 50,
+								},
 							},
-						},
+							requestId: 'req_456',
+							costUSD: 0.001,
+						}),
 					},
 				});
 


### PR DESCRIPTION
## Summary

- Fix streaming artifact bug where duplicate transcript entries keep incorrect output_tokens count
- Claude Code creates multiple entries per response during streaming - first entry has real token count, subsequent entries have low delta counts (1-3 tokens)
- Changed deduplication logic to keep entry with highest output_tokens instead of first encountered
- Updated test to reflect new expected behavior

## Problem

When Claude Code streams responses, it creates multiple JSONL entries with the same `messageId:requestId`. The first entry contains the accurate output token count, but later entries contain only the streaming delta (often 1-3 tokens). The previous deduplication logic kept whichever entry was encountered first, which was essentially random.

## Solution

Modified `data-loader.ts` to:
1. Track `output_tokens` for each unique hash during deduplication
2. Keep only the entry with the highest `output_tokens` value
3. Replace previously stored entries if a new entry has higher token count

## Test plan

- [x] All 325 tests pass
- [x] Format and typecheck pass
- [x] Updated "should process files in chronological order" test to "should keep entry with highest output_tokens regardless of file order"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-entry handling during data loading: when duplicates occur, the system now keeps the entry with the highest output-token count and removes lower-priority duplicates consistently across daily, session, and block aggregations.
* **Tests**
  * Added/updated tests to validate deduplication and replacement behavior, including cases where later higher-token entries supersede earlier ones.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->