### PR TITLE
feat(amp): add Amp CLI usage analysis package

### DIFF
--- a/apps/amp/CLAUDE.md
+++ b/apps/amp/CLAUDE.md
@@ -1,0 +1,104 @@
+# Amp CLI Notes
+
+## Log Sources
+
+- Amp session usage is recorded under `${AMP_DATA_DIR:-~/.local/share/amp}/threads/` (the CLI resolves `AMP_DATA_DIR` and falls back to `~/.local/share/amp`).
+- Each thread is stored as a JSON file (not JSONL) named `T-{uuid}.json`.
+- Token usage is extracted from the `usageLedger.events[]` array in each thread file.
+- Cache token information (creation/read) is extracted from `messages[].usage` for detailed breakdown.
+
+## Token Fields
+
+- `inputTokens`: total input tokens sent to the model.
+- `outputTokens`: output tokens (completion text).
+- `cacheCreationInputTokens`: tokens used for cache creation (from message usage).
+- `cacheReadInputTokens`: tokens read from cache (from message usage).
+- `totalTokens`: sum of input and output tokens.
+
+## Credits
+
+- Amp uses a credits-based billing system in addition to standard token counts.
+- Each usage event includes a `credits` field representing the billing cost in Amp's credit system.
+- Credits are displayed alongside USD cost estimates in reports.
+
+## Cost Calculation
+
+- Pricing is pulled from LiteLLM's public JSON (`model_prices_and_context_window.json`).
+- Amp primarily uses Anthropic Claude models (Haiku, Sonnet, Opus variants).
+- Cost formula per model:
+  - Input: `inputTokens / 1_000_000 * input_cost_per_mtoken`
+  - Cached input read: `cacheReadInputTokens / 1_000_000 * cached_input_cost_per_mtoken`
+  - Cache creation: `cacheCreationInputTokens / 1_000_000 * cache_creation_cost_per_mtoken`
+  - Output: `outputTokens / 1_000_000 * output_cost_per_mtoken`
+
+## CLI Usage
+
+- Treat Amp as a sibling to `apps/ccusage`, `apps/codex`, and `apps/opencode`.
+- Reuse shared packages (`@ccusage/terminal`, `@ccusage/internal`) wherever possible.
+- Amp is packaged as a bundled CLI. Keep every runtime dependency in `devDependencies`.
+- Entry point uses Gunshi framework with subcommands: `daily`, `monthly`, `session`.
+- Data discovery relies on `AMP_DATA_DIR` environment variable.
+- Default path: `~/.local/share/amp`.
+
+## Available Commands
+
+- `ccusage-amp daily` - Show daily usage report
+- `ccusage-amp monthly` - Show monthly usage report
+- `ccusage-amp session` - Show usage by thread (session)
+- Add `--json` flag for JSON output format
+- Add `--compact` flag for compact table mode
+
+## Testing Notes
+
+- Tests rely on `fs-fixture` with `using` to ensure cleanup.
+- All vitest blocks live alongside implementation files via `if (import.meta.vitest != null)`.
+- Vitest globals are enabled - use `describe`, `it`, `expect` directly without imports.
+- **CRITICAL**: NEVER use `await import()` dynamic imports anywhere, especially in test blocks.
+
+## Data Structure
+
+Amp thread files have the following structure:
+
+```json
+{
+	"id": "T-{uuid}",
+	"created": 1700000000000,
+	"title": "Thread Title",
+	"messages": [
+		{
+			"role": "assistant",
+			"messageId": 1,
+			"usage": {
+				"model": "claude-haiku-4-5-20251001",
+				"inputTokens": 100,
+				"outputTokens": 50,
+				"cacheCreationInputTokens": 500,
+				"cacheReadInputTokens": 200,
+				"credits": 1.5
+			}
+		}
+	],
+	"usageLedger": {
+		"events": [
+			{
+				"id": "event-uuid",
+				"timestamp": "2025-11-23T10:00:00.000Z",
+				"model": "claude-haiku-4-5-20251001",
+				"credits": 1.5,
+				"tokens": {
+					"input": 100,
+					"output": 50
+				},
+				"operationType": "inference",
+				"fromMessageId": 0,
+				"toMessageId": 1
+			}
+		]
+	}
+}
+```
+
+## Environment Variables
+
+- `AMP_DATA_DIR` - Custom Amp data directory path (defaults to `~/.local/share/amp`)
+- `LOG_LEVEL` - Control logging verbosity (0=silent, 1=warn, 2=log, 3=info, 4=debug, 5=trace)

--- a/apps/amp/eslint.config.js
+++ b/apps/amp/eslint.config.js
@@ -1,0 +1,12 @@
+import { ryoppippi } from '@ryoppippi/eslint-config';
+
+/** @type {import('eslint').Linter.FlatConfig[]} */
+const config = ryoppippi({
+	type: 'app',
+}, {
+	rules: {
+		'test/no-importing-vitest-globals': 'error',
+	},
+});
+
+export default config;

--- a/apps/amp/package.json
+++ b/apps/amp/package.json
@@ -1,0 +1,78 @@
+{
+	"name": "@ccusage/amp",
+	"type": "module",
+	"version": "0.1.0",
+	"description": "Usage analysis tool for Amp CLI sessions",
+	"author": "ryoppippi",
+	"license": "MIT",
+	"funding": "https://github.com/ryoppippi/ccusage?sponsor=1",
+	"homepage": "https://github.com/ryoppippi/ccusage#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ryoppippi/ccusage.git"
+	},
+	"bugs": {
+		"url": "https://github.com/ryoppippi/ccusage/issues"
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"bin": {
+		"ccusage-amp": "./src/index.ts"
+	},
+	"files": [
+		"dist"
+	],
+	"engines": {
+		"node": ">=20.19.4"
+	},
+	"scripts": {
+		"build": "tsdown",
+		"format": "pnpm run lint --fix",
+		"lint": "eslint --cache .",
+		"prepack": "pnpm run build && clean-pkg-json",
+		"prerelease": "pnpm run lint && pnpm run typecheck && pnpm run build",
+		"start": "bun ./src/index.ts",
+		"test": "TZ=UTC vitest",
+		"typecheck": "tsgo --noEmit"
+	},
+	"devDependencies": {
+		"@ccusage/internal": "workspace:*",
+		"@ccusage/terminal": "workspace:*",
+		"@praha/byethrow": "catalog:runtime",
+		"@ryoppippi/eslint-config": "catalog:lint",
+		"@typescript/native-preview": "catalog:types",
+		"clean-pkg-json": "catalog:release",
+		"eslint": "catalog:lint",
+		"fast-sort": "catalog:runtime",
+		"fs-fixture": "catalog:testing",
+		"gunshi": "catalog:runtime",
+		"path-type": "catalog:runtime",
+		"picocolors": "catalog:runtime",
+		"sort-package-json": "catalog:release",
+		"tinyglobby": "catalog:runtime",
+		"tsdown": "catalog:build",
+		"unplugin-macros": "catalog:build",
+		"unplugin-unused": "catalog:build",
+		"valibot": "catalog:runtime",
+		"vitest": "catalog:testing"
+	},
+	"publishConfig": {
+		"bin": {
+			"ccusage-amp": "./dist/index.js"
+		}
+	},
+	"devEngines": {
+		"runtime": [
+			{
+				"name": "node",
+				"version": "^24.11.0",
+				"onFail": "download"
+			},
+			{
+				"name": "bun",
+				"version": "^1.3.2",
+				"onFail": "download"
+			}
+		]
+	}
+}

--- a/apps/amp/src/_consts.ts
+++ b/apps/amp/src/_consts.ts
@@ -1,0 +1,37 @@
+import path from 'node:path';
+import process from 'node:process';
+
+/**
+ * Environment variable name for custom Amp data directory
+ */
+export const AMP_DATA_DIR_ENV = 'AMP_DATA_DIR';
+
+/**
+ * Default Amp data directory path (~/.local/share/amp)
+ */
+const DEFAULT_AMP_PATH = '.local/share/amp';
+
+/**
+ * User home directory
+ */
+const USER_HOME_DIR = process.env.HOME ?? process.env.USERPROFILE ?? process.cwd();
+
+/**
+ * Default Amp data directory (absolute path)
+ */
+export const DEFAULT_AMP_DIR = path.join(USER_HOME_DIR, DEFAULT_AMP_PATH);
+
+/**
+ * Amp threads subdirectory name
+ */
+export const AMP_THREADS_DIR_NAME = 'threads';
+
+/**
+ * Glob pattern for Amp thread files
+ */
+export const AMP_THREAD_GLOB = '**/*.json';
+
+/**
+ * Million constant for pricing calculations
+ */
+export const MILLION = 1_000_000;

--- a/apps/amp/src/_macro.ts
+++ b/apps/amp/src/_macro.ts
@@ -1,0 +1,26 @@
+import type { LiteLLMModelPricing } from '@ccusage/internal/pricing';
+import {
+	createPricingDataset,
+	fetchLiteLLMPricingDataset,
+	filterPricingDataset,
+} from '@ccusage/internal/pricing-fetch-utils';
+
+const AMP_MODEL_PREFIXES = [
+	'claude-',
+	'anthropic/',
+];
+
+function isAmpModel(modelName: string, _pricing: LiteLLMModelPricing): boolean {
+	return AMP_MODEL_PREFIXES.some(prefix => modelName.startsWith(prefix));
+}
+
+export async function prefetchAmpPricing(): Promise<Record<string, LiteLLMModelPricing>> {
+	try {
+		const dataset = await fetchLiteLLMPricingDataset();
+		return filterPricingDataset(dataset, isAmpModel);
+	}
+	catch (error) {
+		console.warn('Failed to prefetch Amp pricing data, proceeding with empty cache.', error);
+		return createPricingDataset();
+	}
+}

--- a/apps/amp/src/_types.ts
+++ b/apps/amp/src/_types.ts
@@ -1,0 +1,127 @@
+/**
+ * Token usage delta for a single event
+ */
+export type TokenUsageDelta = {
+	inputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+};
+
+/**
+ * Token usage event loaded from Amp thread files
+ */
+export type TokenUsageEvent = TokenUsageDelta & {
+	timestamp: string;
+	threadId: string;
+	model: string;
+	credits: number;
+	operationType: string;
+};
+
+/**
+ * Model usage summary with token counts
+ */
+export type ModelUsage = TokenUsageDelta & {
+	credits: number;
+};
+
+/**
+ * Daily usage summary
+ */
+export type DailyUsageSummary = {
+	date: string;
+	firstTimestamp: string;
+	costUSD: number;
+	credits: number;
+	models: Map<string, ModelUsage>;
+} & TokenUsageDelta;
+
+/**
+ * Monthly usage summary
+ */
+export type MonthlyUsageSummary = {
+	month: string;
+	firstTimestamp: string;
+	costUSD: number;
+	credits: number;
+	models: Map<string, ModelUsage>;
+} & TokenUsageDelta;
+
+/**
+ * Session (thread) usage summary
+ */
+export type SessionUsageSummary = {
+	threadId: string;
+	title: string;
+	firstTimestamp: string;
+	lastTimestamp: string;
+	costUSD: number;
+	credits: number;
+	models: Map<string, ModelUsage>;
+} & TokenUsageDelta;
+
+/**
+ * Model pricing information
+ */
+export type ModelPricing = {
+	inputCostPerMToken: number;
+	cachedInputCostPerMToken: number;
+	cacheCreationCostPerMToken: number;
+	outputCostPerMToken: number;
+};
+
+/**
+ * Pricing source interface
+ */
+export type PricingSource = {
+	getPricing: (model: string) => Promise<ModelPricing>;
+};
+
+/**
+ * Daily report row for JSON output
+ */
+export type DailyReportRow = {
+	date: string;
+	inputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+	costUSD: number;
+	credits: number;
+	models: Record<string, ModelUsage>;
+};
+
+/**
+ * Monthly report row for JSON output
+ */
+export type MonthlyReportRow = {
+	month: string;
+	inputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+	costUSD: number;
+	credits: number;
+	models: Record<string, ModelUsage>;
+};
+
+/**
+ * Session report row for JSON output
+ */
+export type SessionReportRow = {
+	threadId: string;
+	title: string;
+	lastActivity: string;
+	inputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+	costUSD: number;
+	credits: number;
+	models: Record<string, ModelUsage>;
+};

--- a/apps/amp/src/commands/daily.ts
+++ b/apps/amp/src/commands/daily.ts
@@ -1,0 +1,185 @@
+import type { TokenUsageEvent } from '../_types.ts';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { loadAmpUsageEvents } from '../data-loader.ts';
+import { AmpPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 9;
+
+function groupByDate(events: TokenUsageEvent[]): Map<string, TokenUsageEvent[]> {
+	const grouped = new Map<string, TokenUsageEvent[]>();
+	for (const event of events) {
+		const date = event.timestamp.split('T')[0]!;
+		const existing = grouped.get(date);
+		if (existing != null) {
+			existing.push(event);
+		}
+		else {
+			grouped.set(date, [event]);
+		}
+	}
+	return grouped;
+}
+
+export const dailyCommand = define({
+	name: 'daily',
+	description: 'Show Amp token usage grouped by day',
+	args: {
+		json: {
+			type: 'boolean',
+			short: 'j',
+			description: 'Output in JSON format',
+		},
+		compact: {
+			type: 'boolean',
+			description: 'Force compact table mode',
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+
+		const { events } = await loadAmpUsageEvents();
+
+		if (events.length === 0) {
+			const output = jsonOutput ? JSON.stringify({ daily: [], totals: null }) : 'No Amp usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using pricingSource = new AmpPricingSource({ offline: false });
+
+		const eventsByDate = groupByDate(events);
+
+		const dailyData: Array<{
+			date: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationTokens: number;
+			cacheReadTokens: number;
+			totalTokens: number;
+			credits: number;
+			totalCost: number;
+			modelsUsed: string[];
+		}> = [];
+
+		for (const [date, dayEvents] of eventsByDate) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheCreationTokens = 0;
+			let cacheReadTokens = 0;
+			let credits = 0;
+			let totalCost = 0;
+			const modelsSet = new Set<string>();
+
+			for (const event of dayEvents) {
+				inputTokens += event.inputTokens;
+				outputTokens += event.outputTokens;
+				cacheCreationTokens += event.cacheCreationInputTokens;
+				cacheReadTokens += event.cacheReadInputTokens;
+				credits += event.credits;
+
+				const cost = await pricingSource.calculateCost(event.model, {
+					inputTokens: event.inputTokens,
+					outputTokens: event.outputTokens,
+					cacheCreationInputTokens: event.cacheCreationInputTokens,
+					cacheReadInputTokens: event.cacheReadInputTokens,
+				});
+				totalCost += cost;
+				modelsSet.add(event.model);
+			}
+
+			const totalTokens = inputTokens + outputTokens;
+
+			dailyData.push({
+				date,
+				inputTokens,
+				outputTokens,
+				cacheCreationTokens,
+				cacheReadTokens,
+				totalTokens,
+				credits,
+				totalCost,
+				modelsUsed: Array.from(modelsSet),
+			});
+		}
+
+		dailyData.sort((a, b) => a.date.localeCompare(b.date));
+
+		const totals = {
+			inputTokens: dailyData.reduce((sum, d) => sum + d.inputTokens, 0),
+			outputTokens: dailyData.reduce((sum, d) => sum + d.outputTokens, 0),
+			cacheCreationTokens: dailyData.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
+			cacheReadTokens: dailyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
+			totalTokens: dailyData.reduce((sum, d) => sum + d.totalTokens, 0),
+			credits: dailyData.reduce((sum, d) => sum + d.credits, 0),
+			totalCost: dailyData.reduce((sum, d) => sum + d.totalCost, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(JSON.stringify({
+				daily: dailyData,
+				totals,
+			}, null, 2));
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log('\n📊 Amp Token Usage Report - Daily\n');
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: ['Date', 'Models', 'Input', 'Output', 'Cache Create', 'Cache Read', 'Total Tokens', 'Credits', 'Cost (USD)'],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Date', 'Models', 'Input', 'Output', 'Credits', 'Cost (USD)'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+		});
+
+		for (const data of dailyData) {
+			table.push([
+				data.date,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheCreationTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				data.credits.toFixed(2),
+				formatCurrency(data.totalCost),
+			]);
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(totals.credits.toFixed(2)),
+			pc.yellow(formatCurrency(totals.totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/amp/src/commands/index.ts
+++ b/apps/amp/src/commands/index.ts
@@ -1,0 +1,3 @@
+export { dailyCommand } from './daily.ts';
+export { monthlyCommand } from './monthly.ts';
+export { sessionCommand } from './session.ts';

--- a/apps/amp/src/commands/monthly.ts
+++ b/apps/amp/src/commands/monthly.ts
@@ -1,0 +1,185 @@
+import type { TokenUsageEvent } from '../_types.ts';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { loadAmpUsageEvents } from '../data-loader.ts';
+import { AmpPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 9;
+
+function groupByMonth(events: TokenUsageEvent[]): Map<string, TokenUsageEvent[]> {
+	const grouped = new Map<string, TokenUsageEvent[]>();
+	for (const event of events) {
+		const month = event.timestamp.slice(0, 7); // YYYY-MM
+		const existing = grouped.get(month);
+		if (existing != null) {
+			existing.push(event);
+		}
+		else {
+			grouped.set(month, [event]);
+		}
+	}
+	return grouped;
+}
+
+export const monthlyCommand = define({
+	name: 'monthly',
+	description: 'Show Amp token usage grouped by month',
+	args: {
+		json: {
+			type: 'boolean',
+			short: 'j',
+			description: 'Output in JSON format',
+		},
+		compact: {
+			type: 'boolean',
+			description: 'Force compact table mode',
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+
+		const { events } = await loadAmpUsageEvents();
+
+		if (events.length === 0) {
+			const output = jsonOutput ? JSON.stringify({ monthly: [], totals: null }) : 'No Amp usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using pricingSource = new AmpPricingSource({ offline: false });
+
+		const eventsByMonth = groupByMonth(events);
+
+		const monthlyData: Array<{
+			month: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationTokens: number;
+			cacheReadTokens: number;
+			totalTokens: number;
+			credits: number;
+			totalCost: number;
+			modelsUsed: string[];
+		}> = [];
+
+		for (const [month, monthEvents] of eventsByMonth) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheCreationTokens = 0;
+			let cacheReadTokens = 0;
+			let credits = 0;
+			let totalCost = 0;
+			const modelsSet = new Set<string>();
+
+			for (const event of monthEvents) {
+				inputTokens += event.inputTokens;
+				outputTokens += event.outputTokens;
+				cacheCreationTokens += event.cacheCreationInputTokens;
+				cacheReadTokens += event.cacheReadInputTokens;
+				credits += event.credits;
+
+				const cost = await pricingSource.calculateCost(event.model, {
+					inputTokens: event.inputTokens,
+					outputTokens: event.outputTokens,
+					cacheCreationInputTokens: event.cacheCreationInputTokens,
+					cacheReadInputTokens: event.cacheReadInputTokens,
+				});
+				totalCost += cost;
+				modelsSet.add(event.model);
+			}
+
+			const totalTokens = inputTokens + outputTokens;
+
+			monthlyData.push({
+				month,
+				inputTokens,
+				outputTokens,
+				cacheCreationTokens,
+				cacheReadTokens,
+				totalTokens,
+				credits,
+				totalCost,
+				modelsUsed: Array.from(modelsSet),
+			});
+		}
+
+		monthlyData.sort((a, b) => a.month.localeCompare(b.month));
+
+		const totals = {
+			inputTokens: monthlyData.reduce((sum, d) => sum + d.inputTokens, 0),
+			outputTokens: monthlyData.reduce((sum, d) => sum + d.outputTokens, 0),
+			cacheCreationTokens: monthlyData.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
+			cacheReadTokens: monthlyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
+			totalTokens: monthlyData.reduce((sum, d) => sum + d.totalTokens, 0),
+			credits: monthlyData.reduce((sum, d) => sum + d.credits, 0),
+			totalCost: monthlyData.reduce((sum, d) => sum + d.totalCost, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(JSON.stringify({
+				monthly: monthlyData,
+				totals,
+			}, null, 2));
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log('\n📊 Amp Token Usage Report - Monthly\n');
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: ['Month', 'Models', 'Input', 'Output', 'Cache Create', 'Cache Read', 'Total Tokens', 'Credits', 'Cost (USD)'],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Month', 'Models', 'Input', 'Output', 'Credits', 'Cost (USD)'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+		});
+
+		for (const data of monthlyData) {
+			table.push([
+				data.month,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheCreationTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				data.credits.toFixed(2),
+				formatCurrency(data.totalCost),
+			]);
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(totals.credits.toFixed(2)),
+			pc.yellow(formatCurrency(totals.totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/amp/src/commands/session.ts
+++ b/apps/amp/src/commands/session.ts
@@ -1,0 +1,199 @@
+import type { TokenUsageEvent } from '../_types.ts';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { loadAmpUsageEvents } from '../data-loader.ts';
+import { AmpPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 9;
+
+function groupByThread(events: TokenUsageEvent[]): Map<string, TokenUsageEvent[]> {
+	const grouped = new Map<string, TokenUsageEvent[]>();
+	for (const event of events) {
+		const existing = grouped.get(event.threadId);
+		if (existing != null) {
+			existing.push(event);
+		}
+		else {
+			grouped.set(event.threadId, [event]);
+		}
+	}
+	return grouped;
+}
+
+export const sessionCommand = define({
+	name: 'session',
+	description: 'Show Amp token usage grouped by thread (session)',
+	args: {
+		json: {
+			type: 'boolean',
+			short: 'j',
+			description: 'Output in JSON format',
+		},
+		compact: {
+			type: 'boolean',
+			description: 'Force compact table mode',
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+
+		const { events, threads } = await loadAmpUsageEvents();
+
+		if (events.length === 0) {
+			const output = jsonOutput ? JSON.stringify({ sessions: [], totals: null }) : 'No Amp usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using pricingSource = new AmpPricingSource({ offline: false });
+
+		const eventsByThread = groupByThread(events);
+
+		const sessionData: Array<{
+			threadId: string;
+			title: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationTokens: number;
+			cacheReadTokens: number;
+			totalTokens: number;
+			credits: number;
+			totalCost: number;
+			modelsUsed: string[];
+			lastActivity: string;
+		}> = [];
+
+		for (const [threadId, threadEvents] of eventsByThread) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheCreationTokens = 0;
+			let cacheReadTokens = 0;
+			let credits = 0;
+			let totalCost = 0;
+			const modelsSet = new Set<string>();
+			let lastActivity = threadEvents[0]!.timestamp;
+
+			for (const event of threadEvents) {
+				inputTokens += event.inputTokens;
+				outputTokens += event.outputTokens;
+				cacheCreationTokens += event.cacheCreationInputTokens;
+				cacheReadTokens += event.cacheReadInputTokens;
+				credits += event.credits;
+
+				const cost = await pricingSource.calculateCost(event.model, {
+					inputTokens: event.inputTokens,
+					outputTokens: event.outputTokens,
+					cacheCreationInputTokens: event.cacheCreationInputTokens,
+					cacheReadInputTokens: event.cacheReadInputTokens,
+				});
+				totalCost += cost;
+				modelsSet.add(event.model);
+
+				if (event.timestamp > lastActivity) {
+					lastActivity = event.timestamp;
+				}
+			}
+
+			const totalTokens = inputTokens + outputTokens;
+			const threadInfo = threads.get(threadId);
+
+			sessionData.push({
+				threadId,
+				title: threadInfo?.title ?? 'Untitled',
+				inputTokens,
+				outputTokens,
+				cacheCreationTokens,
+				cacheReadTokens,
+				totalTokens,
+				credits,
+				totalCost,
+				modelsUsed: Array.from(modelsSet),
+				lastActivity,
+			});
+		}
+
+		sessionData.sort((a, b) => a.lastActivity.localeCompare(b.lastActivity));
+
+		const totals = {
+			inputTokens: sessionData.reduce((sum, s) => sum + s.inputTokens, 0),
+			outputTokens: sessionData.reduce((sum, s) => sum + s.outputTokens, 0),
+			cacheCreationTokens: sessionData.reduce((sum, s) => sum + s.cacheCreationTokens, 0),
+			cacheReadTokens: sessionData.reduce((sum, s) => sum + s.cacheReadTokens, 0),
+			totalTokens: sessionData.reduce((sum, s) => sum + s.totalTokens, 0),
+			credits: sessionData.reduce((sum, s) => sum + s.credits, 0),
+			totalCost: sessionData.reduce((sum, s) => sum + s.totalCost, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(JSON.stringify({
+				sessions: sessionData,
+				totals,
+			}, null, 2));
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log('\n📊 Amp Token Usage Report - Sessions (Threads)\n');
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: ['Thread', 'Models', 'Input', 'Output', 'Cache Create', 'Cache Read', 'Total Tokens', 'Credits', 'Cost (USD)'],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Thread', 'Models', 'Input', 'Output', 'Credits', 'Cost (USD)'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+		});
+
+		for (const data of sessionData) {
+			// Truncate title for display
+			const displayTitle = data.title.length > 30
+				? `${data.title.slice(0, 27)}...`
+				: data.title;
+
+			table.push([
+				displayTitle,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheCreationTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				data.credits.toFixed(2),
+				formatCurrency(data.totalCost),
+			]);
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(totals.credits.toFixed(2)),
+			pc.yellow(formatCurrency(totals.totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/amp/src/data-loader.ts
+++ b/apps/amp/src/data-loader.ts
@@ -1,0 +1,366 @@
+/**
+ * @fileoverview Data loading utilities for Amp CLI usage analysis
+ *
+ * This module provides functions for loading and parsing Amp usage data
+ * from JSON thread files stored in Amp data directories.
+ * Amp stores usage data in ~/.local/share/amp/threads/
+ *
+ * @module data-loader
+ */
+
+import type { TokenUsageEvent } from './_types.ts';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { Result } from '@praha/byethrow';
+import { createFixture } from 'fs-fixture';
+import { isDirectorySync } from 'path-type';
+import { glob } from 'tinyglobby';
+import * as v from 'valibot';
+import {
+	AMP_DATA_DIR_ENV,
+	AMP_THREAD_GLOB,
+	AMP_THREADS_DIR_NAME,
+	DEFAULT_AMP_DIR,
+} from './_consts.ts';
+import { logger } from './logger.ts';
+
+/**
+ * Amp usageLedger event schema
+ */
+const usageLedgerEventSchema = v.object({
+	id: v.string(),
+	timestamp: v.string(),
+	model: v.string(),
+	credits: v.number(),
+	tokens: v.object({
+		input: v.optional(v.number()),
+		output: v.optional(v.number()),
+	}),
+	operationType: v.optional(v.string()),
+	fromMessageId: v.optional(v.number()),
+	toMessageId: v.optional(v.number()),
+});
+
+/**
+ * Amp message usage schema (for cache tokens)
+ */
+const messageUsageSchema = v.object({
+	model: v.optional(v.string()),
+	inputTokens: v.optional(v.number()),
+	outputTokens: v.optional(v.number()),
+	cacheCreationInputTokens: v.optional(v.number()),
+	cacheReadInputTokens: v.optional(v.number()),
+	totalInputTokens: v.optional(v.number()),
+	credits: v.optional(v.number()),
+});
+
+/**
+ * Amp message schema
+ */
+const messageSchema = v.object({
+	role: v.string(),
+	messageId: v.number(),
+	usage: v.optional(messageUsageSchema),
+});
+
+/**
+ * Amp thread file schema
+ */
+const threadSchema = v.object({
+	id: v.string(),
+	created: v.optional(v.number()),
+	title: v.optional(v.string()),
+	messages: v.optional(v.array(messageSchema)),
+	usageLedger: v.optional(v.object({
+		events: v.optional(v.array(usageLedgerEventSchema)),
+	})),
+});
+
+type ParsedThread = v.InferOutput<typeof threadSchema>;
+type ParsedUsageLedgerEvent = v.InferOutput<typeof usageLedgerEventSchema>;
+type ParsedMessage = v.InferOutput<typeof messageSchema>;
+
+/**
+ * Get Amp data directory
+ * @returns Path to Amp data directory, or null if not found
+ */
+export function getAmpPath(): string | null {
+	// Check environment variable first
+	const envPath = process.env[AMP_DATA_DIR_ENV];
+	if (envPath != null && envPath.trim() !== '') {
+		const normalizedPath = path.resolve(envPath);
+		if (isDirectorySync(normalizedPath)) {
+			return normalizedPath;
+		}
+	}
+
+	// Use default path
+	if (isDirectorySync(DEFAULT_AMP_DIR)) {
+		return DEFAULT_AMP_DIR;
+	}
+
+	return null;
+}
+
+/**
+ * Find cache token information from messages for a specific messageId range
+ */
+function findCacheTokensForEvent(
+	messages: ParsedMessage[] | undefined,
+	fromMessageId: number | undefined,
+	toMessageId: number | undefined,
+): { cacheCreationInputTokens: number; cacheReadInputTokens: number } {
+	if (messages == null || toMessageId == null) {
+		return { cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
+	}
+
+	// Find the assistant message that corresponds to this event
+	const message = messages.find(
+		m => m.role === 'assistant' && m.messageId === toMessageId,
+	);
+
+	if (message?.usage == null) {
+		return { cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
+	}
+
+	return {
+		cacheCreationInputTokens: message.usage.cacheCreationInputTokens ?? 0,
+		cacheReadInputTokens: message.usage.cacheReadInputTokens ?? 0,
+	};
+}
+
+/**
+ * Convert usageLedger event to TokenUsageEvent
+ */
+function convertLedgerEventToUsageEvent(
+	threadId: string,
+	event: ParsedUsageLedgerEvent,
+	messages: ParsedMessage[] | undefined,
+): TokenUsageEvent {
+	const inputTokens = event.tokens.input ?? 0;
+	const outputTokens = event.tokens.output ?? 0;
+
+	const { cacheCreationInputTokens, cacheReadInputTokens } = findCacheTokensForEvent(
+		messages,
+		event.fromMessageId,
+		event.toMessageId,
+	);
+
+	return {
+		timestamp: event.timestamp,
+		threadId,
+		model: event.model,
+		credits: event.credits,
+		operationType: event.operationType ?? 'unknown',
+		inputTokens,
+		outputTokens,
+		cacheCreationInputTokens,
+		cacheReadInputTokens,
+		totalTokens: inputTokens + outputTokens,
+	};
+}
+
+/**
+ * Load and parse a single Amp thread file
+ */
+async function loadThreadFile(filePath: string): Promise<ParsedThread | null> {
+	const readResult = await Result.try({
+		try: readFile(filePath, 'utf-8'),
+		catch: error => error,
+	});
+
+	if (Result.isFailure(readResult)) {
+		logger.debug('Failed to read Amp thread file', { filePath, error: readResult.error });
+		return null;
+	}
+
+	const parseResult = Result.try({
+		try: () => JSON.parse(readResult.value) as unknown,
+		catch: error => error,
+	})();
+
+	if (Result.isFailure(parseResult)) {
+		logger.debug('Failed to parse Amp thread JSON', { filePath, error: parseResult.error });
+		return null;
+	}
+
+	const validationResult = v.safeParse(threadSchema, parseResult.value);
+	if (!validationResult.success) {
+		logger.debug('Failed to validate Amp thread schema', { filePath, issues: validationResult.issues });
+		return null;
+	}
+
+	return validationResult.output;
+}
+
+export type LoadOptions = {
+	threadDirs?: string[];
+};
+
+export type LoadResult = {
+	events: TokenUsageEvent[];
+	threads: Map<string, { title: string; created: number | undefined }>;
+	missingDirectories: string[];
+};
+
+/**
+ * Load all Amp usage events from thread files
+ */
+export async function loadAmpUsageEvents(options: LoadOptions = {}): Promise<LoadResult> {
+	const ampPath = getAmpPath();
+	const providedDirs = options.threadDirs != null && options.threadDirs.length > 0
+		? options.threadDirs.map(dir => path.resolve(dir))
+		: undefined;
+
+	const defaultThreadsDir = ampPath != null
+		? path.join(ampPath, AMP_THREADS_DIR_NAME)
+		: null;
+
+	const threadDirs = providedDirs ?? (defaultThreadsDir != null ? [defaultThreadsDir] : []);
+
+	const events: TokenUsageEvent[] = [];
+	const threads = new Map<string, { title: string; created: number | undefined }>();
+	const missingDirectories: string[] = [];
+
+	for (const dir of threadDirs) {
+		if (!isDirectorySync(dir)) {
+			missingDirectories.push(dir);
+			continue;
+		}
+
+		const files = await glob(AMP_THREAD_GLOB, {
+			cwd: dir,
+			absolute: true,
+		});
+
+		for (const file of files) {
+			const thread = await loadThreadFile(file);
+			if (thread == null) {
+				continue;
+			}
+
+			const threadId = thread.id;
+			threads.set(threadId, {
+				title: thread.title ?? 'Untitled',
+				created: thread.created,
+			});
+
+			const ledgerEvents = thread.usageLedger?.events ?? [];
+			for (const ledgerEvent of ledgerEvents) {
+				const event = convertLedgerEventToUsageEvent(
+					threadId,
+					ledgerEvent,
+					thread.messages,
+				);
+				events.push(event);
+			}
+		}
+	}
+
+	// Sort events by timestamp
+	events.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+	return { events, threads, missingDirectories };
+}
+
+if (import.meta.vitest != null) {
+	describe('loadAmpUsageEvents', () => {
+		it('parses Amp thread files and extracts usage events', async () => {
+			const threadData = {
+				v: 195,
+				id: 'T-test-thread-123',
+				created: 1700000000000,
+				title: 'Test Thread',
+				messages: [
+					{
+						role: 'user',
+						messageId: 0,
+						content: [{ type: 'text', text: 'hi' }],
+					},
+					{
+						role: 'assistant',
+						messageId: 1,
+						content: [{ type: 'text', text: 'Hello!' }],
+						usage: {
+							model: 'claude-haiku-4-5-20251001',
+							inputTokens: 100,
+							outputTokens: 50,
+							cacheCreationInputTokens: 500,
+							cacheReadInputTokens: 200,
+							totalInputTokens: 800,
+							credits: 1.5,
+						},
+					},
+				],
+				usageLedger: {
+					events: [
+						{
+							id: 'event-1',
+							timestamp: '2025-11-23T10:00:00.000Z',
+							model: 'claude-haiku-4-5-20251001',
+							credits: 1.5,
+							tokens: {
+								input: 100,
+								output: 50,
+							},
+							operationType: 'inference',
+							fromMessageId: 0,
+							toMessageId: 1,
+						},
+					],
+				},
+			};
+
+			await using fixture = await createFixture({
+				threads: {
+					'T-test-thread-123.json': JSON.stringify(threadData),
+				},
+			});
+
+			const { events, threads, missingDirectories } = await loadAmpUsageEvents({
+				threadDirs: [fixture.getPath('threads')],
+			});
+
+			expect(missingDirectories).toEqual([]);
+			expect(events).toHaveLength(1);
+
+			const event = events[0]!;
+			expect(event.threadId).toBe('T-test-thread-123');
+			expect(event.model).toBe('claude-haiku-4-5-20251001');
+			expect(event.inputTokens).toBe(100);
+			expect(event.outputTokens).toBe(50);
+			expect(event.cacheCreationInputTokens).toBe(500);
+			expect(event.cacheReadInputTokens).toBe(200);
+			expect(event.credits).toBe(1.5);
+
+			expect(threads.get('T-test-thread-123')).toEqual({
+				title: 'Test Thread',
+				created: 1700000000000,
+			});
+		});
+
+		it('handles missing directories gracefully', async () => {
+			const { events, missingDirectories } = await loadAmpUsageEvents({
+				threadDirs: ['/nonexistent/path'],
+			});
+
+			expect(events).toEqual([]);
+			expect(missingDirectories).toContain('/nonexistent/path');
+		});
+
+		it('handles malformed JSON gracefully', async () => {
+			await using fixture = await createFixture({
+				threads: {
+					'invalid.json': 'not valid json',
+				},
+			});
+
+			const { events } = await loadAmpUsageEvents({
+				threadDirs: [fixture.getPath('threads')],
+			});
+
+			expect(events).toEqual([]);
+		});
+	});
+}

--- a/apps/amp/src/index.ts
+++ b/apps/amp/src/index.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { run } from './run.ts';
+
+// eslint-disable-next-line antfu/no-top-level-await
+await run();

--- a/apps/amp/src/logger.ts
+++ b/apps/amp/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@ccusage/internal/logger';
+
+export const logger = createLogger('@ccusage/amp');

--- a/apps/amp/src/pricing.ts
+++ b/apps/amp/src/pricing.ts
@@ -1,0 +1,132 @@
+import type { LiteLLMModelPricing } from '@ccusage/internal/pricing';
+import type { ModelPricing, PricingSource } from './_types.ts';
+import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
+import { Result } from '@praha/byethrow';
+import { MILLION } from './_consts.ts';
+import { prefetchAmpPricing } from './_macro.ts' with { type: 'macro' };
+import { logger } from './logger.ts';
+
+const AMP_PROVIDER_PREFIXES = ['anthropic/'];
+
+function toPerMillion(value: number | undefined, fallback?: number): number {
+	const perToken = value ?? fallback ?? 0;
+	return perToken * MILLION;
+}
+
+export type AmpPricingSourceOptions = {
+	offline?: boolean;
+	offlineLoader?: () => Promise<Record<string, LiteLLMModelPricing>>;
+};
+
+const PREFETCHED_AMP_PRICING = prefetchAmpPricing();
+
+export class AmpPricingSource implements PricingSource, Disposable {
+	private readonly fetcher: LiteLLMPricingFetcher;
+
+	constructor(options: AmpPricingSourceOptions = {}) {
+		this.fetcher = new LiteLLMPricingFetcher({
+			offline: options.offline ?? false,
+			offlineLoader: options.offlineLoader ?? (async () => PREFETCHED_AMP_PRICING),
+			logger,
+			providerPrefixes: AMP_PROVIDER_PREFIXES,
+		});
+	}
+
+	[Symbol.dispose](): void {
+		this.fetcher[Symbol.dispose]();
+	}
+
+	async getPricing(model: string): Promise<ModelPricing> {
+		const directLookup = await this.fetcher.getModelPricing(model);
+		if (Result.isFailure(directLookup)) {
+			throw directLookup.error;
+		}
+
+		const pricing = directLookup.value;
+		if (pricing == null) {
+			throw new Error(`Pricing not found for model ${model}`);
+		}
+
+		return {
+			inputCostPerMToken: toPerMillion(pricing.input_cost_per_token),
+			cachedInputCostPerMToken: toPerMillion(pricing.cache_read_input_token_cost, pricing.input_cost_per_token),
+			cacheCreationCostPerMToken: toPerMillion(pricing.cache_creation_input_token_cost, pricing.input_cost_per_token),
+			outputCostPerMToken: toPerMillion(pricing.output_cost_per_token),
+		};
+	}
+
+	async calculateCost(
+		model: string,
+		tokens: {
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationInputTokens?: number;
+			cacheReadInputTokens?: number;
+		},
+	): Promise<number> {
+		const result = await this.fetcher.calculateCostFromTokens(
+			{
+				input_tokens: tokens.inputTokens,
+				output_tokens: tokens.outputTokens,
+				cache_creation_input_tokens: tokens.cacheCreationInputTokens,
+				cache_read_input_tokens: tokens.cacheReadInputTokens,
+			},
+			model,
+		);
+
+		if (Result.isFailure(result)) {
+			logger.warn(`Failed to calculate cost for model ${model}:`, result.error);
+			return 0;
+		}
+
+		return result.value;
+	}
+}
+
+if (import.meta.vitest != null) {
+	describe('AmpPricingSource', () => {
+		it('converts LiteLLM pricing to per-million costs', async () => {
+			using source = new AmpPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'claude-haiku-4-5-20251001': {
+						input_cost_per_token: 1e-6,
+						output_cost_per_token: 5e-6,
+						cache_read_input_token_cost: 1e-7,
+						cache_creation_input_token_cost: 1.25e-6,
+					},
+				}),
+			});
+
+			const pricing = await source.getPricing('claude-haiku-4-5-20251001');
+			expect(pricing.inputCostPerMToken).toBeCloseTo(1);
+			expect(pricing.outputCostPerMToken).toBeCloseTo(5);
+			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.1);
+			expect(pricing.cacheCreationCostPerMToken).toBeCloseTo(1.25);
+		});
+
+		it('calculates cost from tokens', async () => {
+			using source = new AmpPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'claude-haiku-4-5-20251001': {
+						input_cost_per_token: 1e-6,
+						output_cost_per_token: 5e-6,
+						cache_read_input_token_cost: 1e-7,
+						cache_creation_input_token_cost: 1.25e-6,
+					},
+				}),
+			});
+
+			const cost = await source.calculateCost('claude-haiku-4-5-20251001', {
+				inputTokens: 1000,
+				outputTokens: 500,
+				cacheReadInputTokens: 200,
+				cacheCreationInputTokens: 100,
+			});
+
+			const expected = (1000 * 1e-6) + (500 * 5e-6) + (200 * 1e-7) + (100 * 1.25e-6);
+			expect(cost).toBeCloseTo(expected);
+		});
+	});
+}

--- a/apps/amp/src/run.ts
+++ b/apps/amp/src/run.ts
@@ -1,0 +1,29 @@
+import process from 'node:process';
+import { cli } from 'gunshi';
+import { description, name, version } from '../package.json';
+import { dailyCommand, monthlyCommand, sessionCommand } from './commands/index.ts';
+
+const subCommands = new Map([
+	['daily', dailyCommand],
+	['monthly', monthlyCommand],
+	['session', sessionCommand],
+]);
+
+const mainCommand = dailyCommand;
+
+export async function run(): Promise<void> {
+	// When invoked through npx, the binary name might be passed as the first argument
+	// Filter it out if it matches the expected binary name
+	let args = process.argv.slice(2);
+	if (args[0] === 'ccusage-amp') {
+		args = args.slice(1);
+	}
+
+	await cli(args, mainCommand, {
+		name,
+		version,
+		description,
+		subCommands,
+		renderHeader: null,
+	});
+}

--- a/apps/amp/tsconfig.json
+++ b/apps/amp/tsconfig.json
@@ -1,0 +1,32 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"lib": [
+			"ESNext"
+		],
+		"moduleDetection": "force",
+		"module": "Preserve",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"types": [
+			"vitest/globals",
+			"vitest/importMeta"
+		],
+		"allowImportingTsExtensions": true,
+		"allowJs": false,
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": false,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noEmit": true,
+		"verbatimModuleSyntax": true,
+		"erasableSyntaxOnly": true,
+		"skipLibCheck": true
+	},
+	"exclude": [
+		"dist"
+	]
+}

--- a/apps/amp/tsdown.config.ts
+++ b/apps/amp/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	format: ['esm'],
+	clean: true,
+	dts: false,
+	shims: true,
+	platform: 'node',
+	target: 'node20',
+});

--- a/apps/amp/vitest.config.ts
+++ b/apps/amp/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		includeSource: ['src/**/*.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+		},
+	},
+	define: {
+		'import.meta.vitest': 'undefined',
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,72 @@ importers:
         specifier: catalog:release
         version: 3.4.0
 
+  apps/amp:
+    devDependencies:
+      '@ccusage/internal':
+        specifier: workspace:*
+        version: link:../../packages/internal
+      '@ccusage/terminal':
+        specifier: workspace:*
+        version: link:../../packages/terminal
+      '@praha/byethrow':
+        specifier: catalog:runtime
+        version: 0.6.3
+      '@ryoppippi/eslint-config':
+        specifier: catalog:lint
+        version: 0.4.0(@vue/compiler-sfc@3.5.21)(eslint-plugin-format@1.0.2(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1))
+      '@typescript/native-preview':
+        specifier: catalog:types
+        version: 7.0.0-dev.20260107.1
+      bun:
+        specifier: runtime:^1.3.2
+        version: runtime:1.3.5
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.3.0
+      eslint:
+        specifier: catalog:lint
+        version: 9.35.0(jiti@2.6.1)
+      fast-sort:
+        specifier: catalog:runtime
+        version: 3.4.1
+      fs-fixture:
+        specifier: catalog:testing
+        version: 2.8.1
+      gunshi:
+        specifier: catalog:runtime
+        version: 0.26.3
+      node:
+        specifier: runtime:^24.11.0
+        version: runtime:24.12.0
+      path-type:
+        specifier: catalog:runtime
+        version: 6.0.0
+      picocolors:
+        specifier: catalog:runtime
+        version: 1.1.1
+      sort-package-json:
+        specifier: catalog:release
+        version: 3.4.0
+      tinyglobby:
+        specifier: catalog:runtime
+        version: 0.2.15
+      tsdown:
+        specifier: catalog:build
+        version: 0.16.6(@typescript/native-preview@7.0.0-dev.20260107.1)(publint@0.3.12)(synckit@0.11.11)(typescript@5.9.2)(unplugin-unused@0.5.3)
+      unplugin-macros:
+        specifier: catalog:build
+        version: 0.18.2(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.1)
+      unplugin-unused:
+        specifier: catalog:build
+        version: 0.5.3
+      valibot:
+        specifier: catalog:runtime
+        version: 1.1.0(typescript@5.9.2)
+      vitest:
+        specifier: catalog:testing
+        version: 4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1)
+
   apps/ccusage:
     devDependencies:
       '@antfu/utils':


### PR DESCRIPTION
## Summary
Adds a new `@ccusage/amp` package for analysing Amp CLI usage data, following the established patterns from codex and opencode packages.

## What Changed
- New `apps/amp` package with full CLI implementation
- Parses Amp thread JSON files from `~/.local/share/amp/threads/`
- Extracts token usage from `usageLedger.events[]` and `messages[].usage`
- Displays Amp credits alongside calculated USD costs using LiteLLM pricing
- Supports three report types: `daily`, `monthly`, `session` (thread-based)
- Includes JSON output (`--json`) and compact table mode (`--compact`)

## Data Structure
Amp stores usage in JSON files (not JSONL) with structure:
- `usageLedger.events[]` - billing events with model, credits, tokens
- `messages[].usage` - detailed cache token information per message

## Testing
- Unit tests pass: `pnpm --filter @ccusage/amp test`
- Build succeeds: `pnpm --filter @ccusage/amp build`
- Manual testing with real Amp data confirmed working