### PR TITLE
fix(opencode): add logger to LiteLLMPricingFetcher

### DIFF
--- a/apps/opencode/src/commands/daily.ts
+++ b/apps/opencode/src/commands/daily.ts
@@ -9,8 +9,9 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
-import { calculateCostForEntry } from '../cost-utils';
-import { loadOpenCodeMessages } from '../data-loader';
+import { calculateCostForEntry } from '../cost-utils.ts';
+import { loadOpenCodeMessages } from '../data-loader.ts';
+import { logger } from '../logger.ts';
 
 const TABLE_COLUMN_COUNT = 8;
 
@@ -42,7 +43,7 @@ export const dailyCommand = define({
 			return;
 		}
 
-		using fetcher = new LiteLLMPricingFetcher({ offline: false });
+		using fetcher = new LiteLLMPricingFetcher({ offline: false, logger });
 
 		const entriesByDate = groupBy(entries, (entry) => entry.timestamp.toISOString().split('T')[0]!);
 

--- a/apps/opencode/src/commands/monthly.ts
+++ b/apps/opencode/src/commands/monthly.ts
@@ -9,8 +9,9 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
-import { calculateCostForEntry } from '../cost-utils';
-import { loadOpenCodeMessages } from '../data-loader';
+import { calculateCostForEntry } from '../cost-utils.ts';
+import { loadOpenCodeMessages } from '../data-loader.ts';
+import { logger } from '../logger.ts';
 
 const TABLE_COLUMN_COUNT = 8;
 
@@ -42,7 +43,7 @@ export const monthlyCommand = define({
 			return;
 		}
 
-		using fetcher = new LiteLLMPricingFetcher({ offline: false });
+		using fetcher = new LiteLLMPricingFetcher({ offline: false, logger });
 
 		const entriesByMonth = groupBy(entries, (entry) => entry.timestamp.toISOString().slice(0, 7));
 

--- a/apps/opencode/src/commands/session.ts
+++ b/apps/opencode/src/commands/session.ts
@@ -9,8 +9,9 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
-import { calculateCostForEntry } from '../cost-utils';
-import { loadOpenCodeMessages, loadOpenCodeSessions } from '../data-loader';
+import { calculateCostForEntry } from '../cost-utils.ts';
+import { loadOpenCodeMessages, loadOpenCodeSessions } from '../data-loader.ts';
+import { logger } from '../logger.ts';
 
 const TABLE_COLUMN_COUNT = 8;
 
@@ -45,7 +46,7 @@ export const sessionCommand = define({
 			return;
 		}
 
-		using fetcher = new LiteLLMPricingFetcher({ offline: false });
+		using fetcher = new LiteLLMPricingFetcher({ offline: false, logger });
 
 		const entriesBySession = groupBy(entries, (entry) => entry.sessionID);
 

--- a/apps/opencode/src/commands/weekly.ts
+++ b/apps/opencode/src/commands/weekly.ts
@@ -9,8 +9,9 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
-import { calculateCostForEntry } from '../cost-utils';
-import { loadOpenCodeMessages } from '../data-loader';
+import { calculateCostForEntry } from '../cost-utils.ts';
+import { loadOpenCodeMessages } from '../data-loader.ts';
+import { logger } from '../logger.ts';
 
 const TABLE_COLUMN_COUNT = 8;
 
@@ -67,7 +68,7 @@ export const weeklyCommand = define({
 			return;
 		}
 
-		using fetcher = new LiteLLMPricingFetcher({ offline: false });
+		using fetcher = new LiteLLMPricingFetcher({ offline: false, logger });
 
 		const entriesByWeek = groupBy(entries, (entry) => getISOWeek(entry.timestamp));
 

--- a/apps/opencode/src/logger.ts
+++ b/apps/opencode/src/logger.ts
@@ -1,0 +1,7 @@
+import { createLogger, log as internalLog } from '@ccusage/internal/logger';
+
+import { name } from '../package.json';
+
+export const logger = createLogger(name);
+
+export const log = internalLog;


### PR DESCRIPTION
## Summary

- Add logger to display "Fetching latest model pricing from LiteLLM..." message when fetching pricing data
- Matches behaviour of other apps (ccusage, codex, amp)

## Test plan

- [x] `pnpm run format` passes
- [x] `pnpm typecheck` passes  
- [x] `pnpm run test` passes in apps/opencode