### PR TITLE
refactor(pi): remove ccusage dependency

### DIFF
--- a/apps/pi/package.json
+++ b/apps/pi/package.json
@@ -60,7 +60,6 @@
 		"@praha/byethrow": "catalog:runtime",
 		"@ryoppippi/eslint-config": "catalog:lint",
 		"@typescript/native-preview": "catalog:types",
-		"ccusage": "workspace:*",
 		"clean-pkg-json": "catalog:release",
 		"es-toolkit": "catalog:runtime",
 		"eslint": "catalog:lint",

--- a/apps/pi/src/commands/daily.ts
+++ b/apps/pi/src/commands/daily.ts
@@ -6,9 +6,9 @@ import {
 	formatUsageDataRow,
 	pushBreakdownRows,
 } from '@ccusage/terminal/table';
-import { log, logger } from 'ccusage/logger';
 import { define } from 'gunshi';
 import { loadPiAgentDailyData } from '../data-loader.ts';
+import { log, logger } from '../logger.ts';
 
 export const dailyCommand = define({
 	name: 'daily',

--- a/apps/pi/src/commands/monthly.ts
+++ b/apps/pi/src/commands/monthly.ts
@@ -6,9 +6,9 @@ import {
 	formatUsageDataRow,
 	pushBreakdownRows,
 } from '@ccusage/terminal/table';
-import { log, logger } from 'ccusage/logger';
 import { define } from 'gunshi';
 import { loadPiAgentMonthlyData } from '../data-loader.ts';
+import { log, logger } from '../logger.ts';
 
 export const monthlyCommand = define({
 	name: 'monthly',

--- a/apps/pi/src/commands/session.ts
+++ b/apps/pi/src/commands/session.ts
@@ -7,9 +7,9 @@ import {
 	formatUsageDataRow,
 	pushBreakdownRows,
 } from '@ccusage/terminal/table';
-import { log, logger } from 'ccusage/logger';
 import { define } from 'gunshi';
 import { loadPiAgentSessionData } from '../data-loader.ts';
+import { log, logger } from '../logger.ts';
 
 export const sessionCommand = define({
 	name: 'session',

--- a/apps/pi/src/logger.ts
+++ b/apps/pi/src/logger.ts
@@ -1,0 +1,7 @@
+import { createLogger, log as internalLog } from '@ccusage/internal/logger';
+
+import { name } from '../package.json';
+
+export const logger = createLogger(name);
+
+export const log = internalLog;


### PR DESCRIPTION
## Summary

- Add local logger.ts using `@ccusage/internal/logger` directly
- Remove `ccusage` from devDependencies
- Use same pattern as codex and opencode packages

This reduces the dependency graph and aligns pi with other standalone CLI apps.

## Test plan

- [x] `pnpm run format` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm run test` passes in apps/pi