### PR TITLE
chore: update gunshi and byethrow dependencies

### DIFF
--- a/apps/amp/src/data-loader.ts
+++ b/apps/amp/src/data-loader.ts
@@ -166,8 +166,9 @@ function convertLedgerEventToUsageEvent(
  */
 async function loadThreadFile(filePath: string): Promise<ParsedThread | null> {
 	const readResult = await Result.try({
-		try: readFile(filePath, 'utf-8'),
-		catch: (error) => error,
+		immediate: true,
+		try: async () => readFile(filePath, 'utf-8'),
+		catch: (error: unknown) => error,
 	});
 
 	if (Result.isFailure(readResult)) {

--- a/apps/ccusage/scripts/generate-json-schema.ts
+++ b/apps/ccusage/scripts/generate-json-schema.ts
@@ -190,8 +190,9 @@ function createConfigSchemaJson() {
  */
 async function runFormat(files: string[]) {
 	return Result.try({
-		try: $`pnpm exec oxfmt ${files}`,
-		catch: (error) => error,
+		immediate: true,
+		try: async () => $`pnpm exec oxfmt ${files}`,
+		catch: (error: unknown) => error,
 	});
 }
 
@@ -256,10 +257,7 @@ async function generateJsonSchema() {
 	const schemaJson = JSON.stringify(schemaObject, null, '\t');
 
 	await Result.pipe(
-		Result.try({
-			try: writeFile(SCHEMA_FILENAME, schemaJson),
-			safe: true,
-		}),
+		writeFile(SCHEMA_FILENAME, schemaJson),
 		Result.inspectError((error) => {
 			logger.error(`Failed to write ${SCHEMA_FILENAME}:`, error);
 			process.exit(1);
@@ -272,10 +270,7 @@ async function generateJsonSchema() {
 
 	// Run format on the root schema file that was changed
 	await Result.pipe(
-		Result.try({
-			try: runFormat([SCHEMA_FILENAME]),
-			safe: true,
-		}),
+		runFormat([SCHEMA_FILENAME]),
 		Result.inspectError((error) => {
 			logger.error('Failed to format generated files:', error);
 			process.exit(1);

--- a/apps/ccusage/src/_utils.ts
+++ b/apps/ccusage/src/_utils.ts
@@ -14,8 +14,9 @@ export function unreachable(value: never): never {
 export async function getFileModifiedTime(filePath: string): Promise<number> {
 	return Result.pipe(
 		Result.try({
-			try: stat(filePath),
-			catch: (error) => error,
+			immediate: true,
+			try: async () => stat(filePath),
+			catch: (error: unknown) => error,
 		}),
 		Result.map((stats) => stats.mtime.getTime()),
 		Result.unwrap(0), // Default to 0 if file doesn't exist or can't be accessed

--- a/apps/codex/src/data-loader.ts
+++ b/apps/codex/src/data-loader.ts
@@ -202,8 +202,9 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 	for (const dir of sessionDirs) {
 		const directoryPath = path.resolve(dir);
 		const statResult = await Result.try({
-			try: stat(directoryPath),
-			catch: (error) => error,
+			immediate: true,
+			try: async () => stat(directoryPath),
+			catch: (error: unknown) => error,
 		});
 
 		if (Result.isFailure(statResult)) {
@@ -226,8 +227,9 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 			const normalizedSessionPath = relativeSessionPath.split(path.sep).join('/');
 			const sessionId = normalizedSessionPath.replace(/\.jsonl$/i, '');
 			const fileContentResult = await Result.try({
-				try: readFile(file, 'utf8'),
-				catch: (error) => error,
+				immediate: true,
+				try: async () => readFile(file, 'utf8'),
+				catch: (error: unknown) => error,
 			});
 
 			if (Result.isFailure(fileContentResult)) {

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -155,8 +155,9 @@ export class LiteLLMPricingFetcher implements Disposable {
 				this.logger.warn('Fetching latest model pricing from LiteLLM...');
 				return Result.pipe(
 					Result.try({
-						try: fetch(this.url),
-						catch: (error) =>
+						immediate: true,
+						try: async () => fetch(this.url),
+						catch: (error: unknown) =>
 							new Error('Failed to fetch model pricing from LiteLLM', { cause: error }),
 					}),
 					Result.andThrough((response) => {
@@ -167,8 +168,10 @@ export class LiteLLMPricingFetcher implements Disposable {
 					}),
 					Result.andThen(async (response) =>
 						Result.try({
-							try: response.json() as Promise<Record<string, unknown>>,
-							catch: (error) => new Error('Failed to parse pricing data', { cause: error }),
+							immediate: true,
+							try: async () => response.json() as Promise<Record<string, unknown>>,
+							catch: (error: unknown) =>
+								new Error('Failed to parse pricing data', { cause: error }),
 						}),
 					),
 					Result.map((data) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ catalogs:
       specifier: ^1.24.3
       version: 1.24.3
     '@praha/byethrow':
-      specifier: ^0.6.3
-      version: 0.6.3
+      specifier: ^0.9.0
+      version: 0.9.0
     '@ryoppippi/limo':
       specifier: jsr:^0.2.2
       version: 0.2.3
@@ -123,8 +123,8 @@ catalogs:
       specifier: ^9.0.0
       version: 9.0.0
     gunshi:
-      specifier: ^0.26.3
-      version: 0.26.3
+      specifier: ^0.27.5
+      version: 0.27.5
     hono:
       specifier: ^4.9.2
       version: 4.9.7
@@ -188,7 +188,7 @@ importers:
         version: 0.27.5
       '@praha/byethrow-docs':
         specifier: catalog:llm-docs
-        version: 0.9.0(@praha/byethrow@0.6.3)
+        version: 0.9.0(@praha/byethrow@0.9.0(typescript@5.9.2))
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.21)(eslint-plugin-format@1.0.2(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1))
@@ -230,7 +230,7 @@ importers:
         version: link:../../packages/terminal
       '@praha/byethrow':
         specifier: catalog:runtime
-        version: 0.6.3
+        version: 0.9.0(typescript@5.9.2)
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.21)(eslint-plugin-format@1.0.2(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1))
@@ -254,7 +254,7 @@ importers:
         version: 2.8.1
       gunshi:
         specifier: catalog:runtime
-        version: 0.26.3
+        version: 0.27.5
       node:
         specifier: runtime:^24.11.0
         version: runtime:24.12.0
@@ -299,7 +299,7 @@ importers:
         version: 0.82.3
       '@praha/byethrow':
         specifier: catalog:runtime
-        version: 0.6.3
+        version: 0.9.0(typescript@5.9.2)
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.21)(eslint-plugin-format@1.0.2(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1))
@@ -347,7 +347,7 @@ importers:
         version: 9.0.0
       gunshi:
         specifier: catalog:runtime
-        version: 0.26.3
+        version: 0.27.5
       nano-spawn:
         specifier: catalog:runtime
         version: 1.0.3
@@ -407,7 +407,7 @@ importers:
         version: link:../../packages/terminal
       '@praha/byethrow':
         specifier: catalog:runtime
-        version: 0.6.3
+        version: 0.9.0(typescript@5.9.2)
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.21)(eslint-plugin-format@1.0.2(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1))
@@ -431,7 +431,7 @@ importers:
         version: 2.8.1
       gunshi:
         specifier: catalog:runtime
-        version: 0.26.3
+        version: 0.27.5
       node:
         specifier: runtime:^24.11.0
         version: runtime:24.12.0
@@ -476,7 +476,7 @@ importers:
         version: link:../ccusage
       gunshi:
         specifier: catalog:runtime
-        version: 0.26.3
+        version: 0.27.5
       hono:
         specifier: catalog:runtime
         version: 4.9.7
@@ -531,7 +531,7 @@ importers:
         version: link:../../packages/terminal
       '@praha/byethrow':
         specifier: catalog:runtime
-        version: 0.6.3
+        version: 0.9.0(typescript@5.9.2)
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.21)(eslint-plugin-format@1.0.2(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1))
@@ -558,7 +558,7 @@ importers:
         version: 2.8.1
       gunshi:
         specifier: catalog:runtime
-        version: 0.26.3
+        version: 0.27.5
       node:
         specifier: runtime:^24.11.0
         version: runtime:24.12.0
@@ -597,7 +597,7 @@ importers:
         version: link:../../packages/terminal
       '@praha/byethrow':
         specifier: catalog:runtime
-        version: 0.6.3
+        version: 0.9.0(typescript@5.9.2)
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.21)(eslint-plugin-format@1.0.2(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1))
@@ -621,7 +621,7 @@ importers:
         version: 2.8.1
       gunshi:
         specifier: catalog:runtime
-        version: 0.26.3
+        version: 0.27.5
       node:
         specifier: runtime:^24.11.0
         version: runtime:24.12.0
@@ -708,7 +708,7 @@ importers:
     dependencies:
       '@praha/byethrow':
         specifier: catalog:runtime
-        version: 0.6.3
+        version: 0.9.0(typescript@5.9.2)
       consola:
         specifier: catalog:runtime
         version: 3.4.2
@@ -1926,8 +1926,10 @@ packages:
     peerDependencies:
       '@praha/byethrow': 0.9.0
 
-  '@praha/byethrow@0.6.3':
-    resolution: {integrity: sha512-WeHnDRzan8Zx4Lj3wCKy88K0zFZqnGKBho2QuTAM94yutkLDOsDSIYDbu/OXgnc+bQnnomCOteJNtE53o7l+Zw==}
+  '@praha/byethrow@0.9.0':
+    resolution: {integrity: sha512-D8XhQ40RsGkwcJdKYqoQ2RUfoqgzztHWXZNpMaRE5P5U+D1c1YboFPc8hysJWQhqloQ32kCXB0XPwM3dFiNyIg==}
+    peerDependencies:
+      typescript: '>=5.0.0'
 
   '@publint/pack@0.1.2':
     resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
@@ -2621,8 +2623,8 @@ packages:
   args-tokenizer@0.3.0:
     resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
 
-  args-tokens@0.20.1:
-    resolution: {integrity: sha512-pQ5R5TsJyx94zsgSCCQ9kzOgUfMmI4bkqNjgSSt2C92mzPCvovoUMMW6HqR+35mHZ0cb1++MD2uAOLm62sGC+Q==}
+  args-tokens@0.23.0:
+    resolution: {integrity: sha512-VZETsQmpEGO7A9adjfIOTyZuxKzurUas9kh1Hm0WGhFq8dOyw50P6OjiTwKyURwnmDabw0DbFjI+BUucJfCtnQ==}
     engines: {node: '>= 20'}
 
   ast-kit@2.2.0:
@@ -3684,8 +3686,8 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
-  gunshi@0.26.3:
-    resolution: {integrity: sha512-x/CaxovzDA3KMkrjqow7M1dnsO1CxGMNabBaeGTGdVNtjOMN1G/eK7vjKeJ+zHdFIsWHmo47YQ2DQIESUut2+A==}
+  gunshi@0.27.5:
+    resolution: {integrity: sha512-ExdnmI90hQ/eR1wnUc5rVom+K16F1hSpbYrplpt6rrJhXLprVGK9/E63bk7Rju27hAqc3WvpCa8PeY95R165fw==}
     engines: {node: '>= 20'}
 
   happy-dom@16.8.1:
@@ -6602,9 +6604,9 @@ snapshots:
 
   '@poppinss/exception@1.2.2': {}
 
-  '@praha/byethrow-docs@0.9.0(@praha/byethrow@0.6.3)':
+  '@praha/byethrow-docs@0.9.0(@praha/byethrow@0.9.0(typescript@5.9.2))':
     dependencies:
-      '@praha/byethrow': 0.6.3
+      '@praha/byethrow': 0.9.0(typescript@5.9.2)
       citty: 0.1.6
       find-up: 8.0.0
       flexsearch: 0.8.212
@@ -6615,9 +6617,10 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@praha/byethrow@0.6.3':
+  '@praha/byethrow@0.9.0(typescript@5.9.2)':
     dependencies:
       '@standard-schema/spec': 1.0.0
+      typescript: 5.9.2
 
   '@publint/pack@0.1.2': {}
 
@@ -7295,7 +7298,7 @@ snapshots:
 
   args-tokenizer@0.3.0: {}
 
-  args-tokens@0.20.1: {}
+  args-tokens@0.23.0: {}
 
   ast-kit@2.2.0:
     dependencies:
@@ -8455,9 +8458,9 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  gunshi@0.26.3:
+  gunshi@0.27.5:
     dependencies:
-      args-tokens: 0.20.1
+      args-tokens: 0.23.0
 
   happy-dom@16.8.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ catalogs:
     '@hono/mcp': ^0.1.5
     '@hono/node-server': ^1.19.7
     '@modelcontextprotocol/sdk': ^1.24.3
-    '@praha/byethrow': ^0.6.3
+    '@praha/byethrow': ^0.9.0
     '@ryoppippi/limo': jsr:^0.2.2
     '@std/async': jsr:^1.0.14
     ansi-escapes: ^7.0.0
@@ -49,7 +49,7 @@ catalogs:
     es-toolkit: ^1.39.10
     fast-sort: ^3.4.1
     get-stdin: ^9.0.0
-    gunshi: ^0.26.3
+    gunshi: ^0.27.5
     hono: ^4.9.2
     nano-spawn: ^1.0.3
     p-limit: ^7.1.0


### PR DESCRIPTION
## Summary

- Update `gunshi` from ^0.26.3 to ^0.27.5
- Update `@praha/byethrow` from ^0.6.3 to ^0.9.0
- Adapt code to byethrow 0.9.0 API changes

## What Changed

The byethrow 0.9.0 release introduced breaking changes to the `Result.try` API:
- The `try` field now requires a function instead of a direct Promise
- `immediate: true` must be set for immediate execution

Updated all affected files to use the new API signature:
- `packages/internal/src/pricing.ts`
- `apps/ccusage/src/_utils.ts`
- `apps/ccusage/scripts/generate-json-schema.ts`
- `apps/codex/src/data-loader.ts`
- `apps/amp/src/data-loader.ts`

## Testing

- All typecheck passes
- All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions (@praha/byethrow and gunshi) to latest compatible versions.
  * Enhanced error handling across data loading and utility modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->