### PR TITLE
chore: add repository directory field to app packages

### DIFF
--- a/apps/amp/package.json
+++ b/apps/amp/package.json
@@ -9,7 +9,8 @@
 	"homepage": "https://github.com/ryoppippi/ccusage#readme",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/ryoppippi/ccusage.git"
+		"url": "git+https://github.com/ryoppippi/ccusage.git",
+		"directory": "apps/amp"
 	},
 	"bugs": {
 		"url": "https://github.com/ryoppippi/ccusage/issues"

--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -9,7 +9,8 @@
 	"homepage": "https://github.com/ryoppippi/ccusage#readme",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/ryoppippi/ccusage.git"
+		"url": "git+https://github.com/ryoppippi/ccusage.git",
+		"directory": "apps/ccusage"
 	},
 	"bugs": {
 		"url": "https://github.com/ryoppippi/ccusage/issues"

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -9,7 +9,8 @@
 	"homepage": "https://github.com/ryoppippi/ccusage#readme",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/ryoppippi/ccusage.git"
+		"url": "git+https://github.com/ryoppippi/ccusage.git",
+		"directory": "apps/codex"
 	},
 	"bugs": {
 		"url": "https://github.com/ryoppippi/ccusage/issues"

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -9,7 +9,8 @@
 	"homepage": "https://github.com/ryoppippi/ccusage#readme",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/ryoppippi/ccusage.git"
+		"url": "git+https://github.com/ryoppippi/ccusage.git",
+		"directory": "apps/mcp"
 	},
 	"bugs": {
 		"url": "https://github.com/ryoppippi/ccusage/issues"

--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/ryoppippi/ccusage#readme",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/ryoppippi/ccusage.git"
+		"url": "git+https://github.com/ryoppippi/ccusage.git",
+		"directory": "apps/opencode"
 	},
 	"bugs": {
 		"url": "https://github.com/ryoppippi/ccusage/issues"

--- a/apps/pi/package.json
+++ b/apps/pi/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/ryoppippi/ccusage#readme",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/ryoppippi/ccusage.git"
+		"url": "git+https://github.com/ryoppippi/ccusage.git",
+		"directory": "apps/pi"
 	},
 	"bugs": {
 		"url": "https://github.com/ryoppippi/ccusage/issues"


### PR DESCRIPTION
## Summary

Add the `directory` field to the `repository` object in each app's package.json to help npm and GitHub generate correct links to source code locations within the monorepo.

## What Changed

- Added `directory` field to repository configuration in:
  - `apps/amp/package.json`
  - `apps/ccusage/package.json`
  - `apps/codex/package.json`
  - `apps/mcp/package.json`
  - `apps/opencode/package.json`
  - `apps/pi/package.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository metadata across all applications to include directory references, enhancing monorepo structure configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->