### PR TITLE
chore: use mkShellNoCC for lighter dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
     in {
       devShells = forAllSystems (pkgs: {
-        default = pkgs.mkShell {
+        default = pkgs.mkShellNoCC {
           buildInputs = with pkgs; [
             # Package manager
             pnpm_10


### PR DESCRIPTION
Replace `mkShell` with `mkShellNoCC` in flake.nix since this project doesn't require a C compiler. This reduces unnecessary dependencies in the development environment.