### PR TITLE
docs(pi): fix pi-agent repository link

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -35,7 +35,7 @@ Companion tool for analyzing [OpenCode](https://github.com/opencode-ai/opencode)
 
 ### 🥧 [@ccusage/pi](https://www.npmjs.com/package/@ccusage/pi) - Pi-agent Usage Analyzer
 
-Companion tool for analyzing [pi-agent](https://github.com/nicobailon/pi-agent) session usage. Track token usage and costs from your pi-agent sessions with daily, monthly, and session-based reports.
+Companion tool for analyzing [pi-agent](https://github.com/badlogic/pi-mono) session usage. Track token usage and costs from your pi-agent sessions with daily, monthly, and session-based reports.
 
 ### ⚡ [@ccusage/amp](https://www.npmjs.com/package/@ccusage/amp) - Amp Usage Analyzer
 

--- a/apps/pi/README.md
+++ b/apps/pi/README.md
@@ -11,7 +11,7 @@
     <a href="https://deepwiki.com/ryoppippi/ccusage"><img src="https://img.shields.io/badge/DeepWiki-ryoppippi%2Fccusage-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==" alt="DeepWiki"></a>
 </p>
 
-> Analyze [pi-agent](https://github.com/nicobailon/pi-agent) session usage with the same reporting experience as <code>ccusage</code>.
+> Analyze [pi-agent](https://github.com/badlogic/pi-mono) session usage with the same reporting experience as <code>ccusage</code>.
 
 ## Quick Start
 
@@ -69,7 +69,7 @@ Useful environment variables:
 
 ## What is pi-agent?
 
-[Pi-agent](https://github.com/nicobailon/pi-agent) is an alternative Claude coding agent. It stores usage data in a similar JSONL format to Claude Code but in a different directory structure.
+[Pi-agent](https://github.com/badlogic/pi-mono) is an alternative Claude coding agent. It stores usage data in a similar JSONL format to Claude Code but in a different directory structure.
 
 ## Features
 


### PR DESCRIPTION
Fix broken pi-agent repository links in apps/pi/README.md.

The links were incorrectly changed from `badlogic/pi-mono` to `nicobailon/pi-agent` (non-existent) in f86d0f3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository references and project attributions throughout documentation.
  * Clarified documentation to highlight credits alongside usage and cost information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->