### PR TITLE
docs: fix OpenCode description in documentation

### DIFF
--- a/docs/guide/opencode/index.md
+++ b/docs/guide/opencode/index.md
@@ -2,7 +2,7 @@
 
 > The OpenCode companion CLI is experimental. Expect breaking changes while both ccusage and [OpenCode](https://github.com/sst/opencode) continue to evolve.
 
-The `@ccusage/opencode` package reuses ccusage's responsive tables, pricing cache, and token accounting to analyze [OpenCode](https://github.com/sst/opencode) session logs. OpenCode is a fork of Claude Code that supports multiple AI providers.
+The `@ccusage/opencode` package reuses ccusage's responsive tables, pricing cache, and token accounting to analyze [OpenCode](https://github.com/sst/opencode) session logs. OpenCode is a terminal-based AI coding assistant that supports multiple AI providers.
 
 ## Installation & Launch
 


### PR DESCRIPTION
Fixes incorrect description stating OpenCode is a fork of Claude Code. OpenCode is a terminal-based AI coding assistant that supports multiple providers.

This was missed in the previous README fixes (6ef7f52).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenCode description to accurately reflect its nature as a terminal-based AI coding assistant supporting multiple AI providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->