### PR TITLE
fix(opencode): add model aliases for GitHub Copilot model names

### DIFF
--- a/apps/opencode/src/cost-utils.ts
+++ b/apps/opencode/src/cost-utils.ts
@@ -5,8 +5,28 @@ import { Result } from '@praha/byethrow';
 /**
  * Model aliases for OpenCode-specific model names that don't exist in LiteLLM.
  * Maps OpenCode model names to their LiteLLM equivalents for pricing lookup.
+ *
+ * GitHub Copilot uses dot notation (e.g., claude-opus-4.5) while LiteLLM uses
+ * hyphen notation (e.g., claude-opus-4-5). This mapping handles those differences.
+ *
+ * GitHub Copilot model names are sourced from: https://models.dev/api.json
  */
 const MODEL_ALIASES: Record<string, string> = {
+	// GitHub Copilot uses dots, LiteLLM uses hyphens for Claude 4.5 models
+	'claude-opus-4.5': 'claude-opus-4-5',
+	'claude-sonnet-4.5': 'claude-sonnet-4-5',
+	'claude-haiku-4.5': 'claude-haiku-4-5',
+	// GitHub Copilot shorthand names for Claude 4 models
+	'claude-opus-4': 'claude-opus-4-20250514',
+	'claude-opus-41': 'claude-opus-4-1',
+	'claude-sonnet-4': 'claude-sonnet-4-20250514',
+	// GitHub Copilot Claude 3.x model names
+	'claude-3.5-sonnet': 'claude-3-5-sonnet-latest',
+	'claude-3.7-sonnet': 'claude-3-7-sonnet-latest',
+	// Extended thinking variant uses same pricing as base model
+	'claude-3.7-sonnet-thought': 'claude-3-7-sonnet-latest',
+	// Grok models require provider prefix
+	'grok-code-fast-1': 'xai/grok-code-fast-1',
 	// OpenCode uses -high suffix for higher tier/thinking mode variants
 	'gemini-3-pro-high': 'gemini-3-pro-preview',
 };


### PR DESCRIPTION
## Summary
- map GitHub Copilot model names (dot notation) to LiteLLM pricing IDs
- ensure cost calculations resolve for Copilot logs where cost is 0
- keep existing behavior for other providers unchanged

## Context
- OpenCode fetches model definitions from models.dev: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/provider/models.ts#L88
- GitHub Copilot model names sourced from `https://models.dev/api.json`

## Before/After
- Ran locally to validate the output: 2026-01-15 ran with OpenCode zen, 2026-01-16+ ran with GitHub Copilot subscription using Opus 4.5

### Before
```
📊 OpenCode Token Usage Report - Daily

┌──────────┬─────────────────────────────────────────────────┬──────────┬──────────┬───────────┬──────────┬───────────┬──────────┐
│ Date     │ Models                                          │    Input │   Output │     Cache │    Cache │     Total │     Cost │
│          │                                                 │          │          │    Create │     Read │    Tokens │    (USD) │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ 2026     │ - big-pickle                                    │   14,733 │       18 │         0 │      448 │    15,199 │    $0.00 │
│ 01-10    │                                                 │          │          │           │          │           │          │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ 2026     │ - gpt-5.1-codex-max                             │  573,996 │   60,889 │    56,491 │ 3,780,2… │ 4,471,581 │    $2.30 │
│ 01-14    │ - sonnet-4-5                                    │          │          │           │          │           │          │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ 2026     │ - claude-opus-4.5                               │  667,177 │  133,670 │   947,302 │ 23,721,… │ 25,469,9… │   $17.80 │
│ 01-15    │ - claude-sonnet-4.5                             │          │          │           │          │           │          │
│          │ - gpt-5.1-codex-max                             │          │          │           │          │           │          │
│          │ - opus-4-5                                      │          │          │           │          │           │          │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ 2026     │ - claude-opus-4.5                               │ 2,294,1… │  189,483 │         0 │ 27,108,… │ 29,591,6… │    $0.00 │
│ 01-16    │                                                 │          │          │           │          │           │          │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ 2026     │ - claude-opus-4.5                               │ 7,607,0… │  659,903 │         0 │ 180,860… │ 189,127,… │   $40.67 │
│ 01-17    │ - gpt-5.2-codex                                 │          │          │           │          │           │          │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ Total    │                                                 │ 11,157,… │ 1,043,9… │ 1,003,793 │ 235,470… │ 248,675,… │   $60.78 │
└──────────┴─────────────────────────────────────────────────┴──────────┴──────────┴───────────┴──────────┴───────────┴──────────┘
```

### After
```
📊 OpenCode Token Usage Report - Daily

┌──────────┬─────────────────────────────────────────────────┬──────────┬──────────┬───────────┬──────────┬───────────┬──────────┐
│ Date     │ Models                                          │    Input │   Output │     Cache │    Cache │     Total │     Cost │
│          │                                                 │          │          │    Create │     Read │    Tokens │    (USD) │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ 2026     │ - big-pickle                                    │   14,733 │       18 │         0 │      448 │    15,199 │    $0.00 │
│ 01-10    │                                                 │          │          │           │          │           │          │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ 2026     │ - gpt-5.1-codex-max                             │  573,996 │   60,889 │    56,491 │ 3,780,2… │ 4,471,581 │    $2.30 │
│ 01-14    │ - sonnet-4-5                                    │          │          │           │          │           │          │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ 2026     │ - claude-opus-4.5                               │  667,177 │  133,670 │   947,302 │ 23,721,… │ 25,469,9… │   $20.76 │
│ 01-15    │ - claude-sonnet-4.5                             │          │          │           │          │           │          │
│          │ - gpt-5.1-codex-max                             │          │          │           │          │           │          │
│          │ - opus-4-5                                      │          │          │           │          │           │          │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ 2026     │ - claude-opus-4.5                               │ 2,294,1… │  189,483 │         0 │ 27,108,… │ 29,591,6… │   $29.76 │
│ 01-16    │                                                 │          │          │           │          │           │          │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ 2026     │ - claude-opus-4.5                               │ 7,607,0… │  659,903 │         0 │ 180,860… │ 189,127,… │   $75.86 │
│ 01-17    │ - gpt-5.2-codex                                 │          │          │           │          │           │          │
├──────────┼─────────────────────────────────────────────────┼──────────┼──────────┼───────────┼──────────┼───────────┼──────────┤
│ Total    │                                                 │ 11,157,… │ 1,043,9… │ 1,003,793 │ 235,470… │ 248,675,… │  $128.68 │
└──────────┴─────────────────────────────────────────────────┴──────────┴──────────┴───────────┴──────────┴───────────┴──────────┘
```

## Closes
- Closes #802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded AI model support for cost calculations, now including Claude 4.5, 4.x, 3.x Sonnet variants, Grok models, OpenCode high-tier variants, and Gemini 3 Pro.
  * Enhanced model name resolution system to accurately translate between naming conventions for consistent pricing lookups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->