### PR TITLE
docs: point OpenCode repo to anomalyco

### DIFF
--- a/docs/guide/opencode/index.md
+++ b/docs/guide/opencode/index.md
@@ -1,8 +1,8 @@
 # OpenCode CLI Overview (Beta)
 
-> The OpenCode companion CLI is experimental. Expect breaking changes while both ccusage and [OpenCode](https://github.com/sst/opencode) continue to evolve.
+> The OpenCode companion CLI is experimental. Expect breaking changes while both ccusage and [OpenCode](https://github.com/anomalyco/opencode) continue to evolve.
 
-The `@ccusage/opencode` package reuses ccusage's responsive tables, pricing cache, and token accounting to analyze [OpenCode](https://github.com/sst/opencode) session logs. OpenCode is a terminal-based AI coding assistant that supports multiple AI providers.
+The `@ccusage/opencode` package reuses ccusage's responsive tables, pricing cache, and token accounting to analyze [OpenCode](https://github.com/anomalyco/opencode) session logs. OpenCode is a terminal-based AI coding assistant that supports multiple AI providers.
 
 ## Installation & Launch
 


### PR DESCRIPTION
## Summary
- Update OpenCode documentation links to anomalyco/opencode
- Note that the legacy sst/opencode URL now redirects to the new repo

## Notes
- Preserve existing wording; only switch the GitHub URL

```
❯ curl -I https://github.com/sst/opencode
HTTP/2 301
location: https://github.com/anomalyco/opencode
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenCode reference links in the documentation guide.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->