### PR TITLE
docs: add BUN_BE_BUN=1 claude x / opencode x execution method

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -25,6 +25,10 @@ bunx ccusage
 pnpm dlx ccusage
 ```
 
+```bash [claude x]
+BUN_BE_BUN=1 claude x ccusage
+```
+
 :::
 
 This will show your daily usage report by default.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -34,7 +34,7 @@ ccusage analyzes the local JSONL files that Claude Code automatically generates 
 
 ### 🚀 Ultra-Small Bundle Size
 
-Unlike other CLI tools, we pay extreme attention to bundle size. ccusage achieves an incredibly small footprint even without minification, which means you can run it directly without installation using `bunx ccusage` for instant access.
+Unlike other CLI tools, we pay extreme attention to bundle size. ccusage achieves an incredibly small footprint even without minification, which means you can run it directly without installation using `bunx ccusage` or `BUN_BE_BUN=1 claude x ccusage` for instant access.
 
 ### 📊 Multiple Report Types
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -33,6 +33,10 @@ pnpm dlx ccusage
 deno run -E -R=$HOME/.claude/projects/ -S=homedir -N='raw.githubusercontent.com:443' npm:ccusage@latest
 ```
 
+```bash [claude x]
+BUN_BE_BUN=1 claude x ccusage
+```
+
 :::
 
 ::: tip Speed Recommendation
@@ -41,6 +45,33 @@ We strongly recommend using `bunx` instead of `npx` due to the massive speed dif
 
 ::: info Deno Security
 Consider using `deno run` if you want additional security controls. Deno allows you to specify exact permissions, making it safer to run tools you haven't audited.
+:::
+
+::: details Running with `claude x`
+
+If you have the **native version** of Claude Code installed, you can run ccusage directly using the `claude x` command:
+
+```bash
+BUN_BE_BUN=1 claude x ccusage
+```
+
+**How it works:**
+
+The native Claude Code binary is built with [Bun's standalone executable](https://bun.sh/docs/bundler/executables) feature. When you set `BUN_BE_BUN=1`, the Claude Code executable exposes the full Bun CLI capabilities instead of running its bundled entry point. This allows you to use `claude x` as a drop-in replacement for `bunx`.
+
+**Requirements:**
+
+- **Native Claude Code installation** (installed via `curl -fsSL https://claude.ai/install.sh | bash` or Homebrew/WinGet)
+- This does **NOT** work with the npm version (`npm install -g @anthropic-ai/claude-code`)
+- Run `claude doctor` to verify whether you have the native version installed
+
+**Why use this?**
+
+- No need to install Bun separately
+- Uses the same Bun runtime bundled with Claude Code
+- Convenient for Claude Code users who want to check their usage without additional tools
+
+For more details, see the [Bun documentation on BUN_BE_BUN](https://bun.sh/docs/bundler/executables#act-as-the-bun-cli) and [Claude Code setup guide](https://code.claude.com/docs/en/setup).
 :::
 
 ### Performance Comparison

--- a/docs/guide/opencode/index.md
+++ b/docs/guide/opencode/index.md
@@ -6,14 +6,29 @@ The `@ccusage/opencode` package reuses ccusage's responsive tables, pricing cach
 
 ## Installation & Launch
 
-```bash
-# Recommended - always include @latest
-npx @ccusage/opencode@latest --help
-bunx @ccusage/opencode@latest --help
+::: code-group
 
-# Alternative package runners
+```bash [bunx (Recommended)]
+bunx @ccusage/opencode@latest --help
+```
+
+```bash [npx]
+npx @ccusage/opencode@latest --help
+```
+
+```bash [pnpm]
 pnpm dlx @ccusage/opencode --help
 ```
+
+```bash [opencode x]
+BUN_BE_BUN=1 opencode x @ccusage/opencode@latest --help
+```
+
+:::
+
+::: tip opencode x option
+The `opencode x` option requires the native version of OpenCode. If you installed OpenCode via npm, use the `bunx` or `npx` options instead.
+:::
 
 ### Recommended: Shell Alias
 

--- a/docs/guide/statusline.md
+++ b/docs/guide/statusline.md
@@ -18,15 +18,43 @@ The `statusline` command provides a compact, real-time view of your Claude Code 
 
 Add this to your `~/.claude/settings.json` or `~/.config/claude/settings.json`:
 
-```json
+::: code-group
+
+```json [bun x (Recommended)]
 {
 	"statusLine": {
 		"type": "command",
-		"command": "bun x ccusage statusline", // Use "npx -y ccusage statusline" if you prefer npm
-		"padding": 0 // Optional: set to 0 to let status line go to edge
+		"command": "bun x ccusage statusline",
+		"padding": 0
 	}
 }
 ```
+
+```json [claude x]
+{
+	"statusLine": {
+		"type": "command",
+		"command": "BUN_BE_BUN=1 claude x ccusage statusline",
+		"padding": 0
+	}
+}
+```
+
+```json [npx]
+{
+	"statusLine": {
+		"type": "command",
+		"command": "npx -y ccusage statusline",
+		"padding": 0
+	}
+}
+```
+
+:::
+
+::: tip claude x option
+The `claude x` option requires the native version of Claude Code (not the npm version). If you installed Claude Code via npm, use the `bun x` or `npx` options instead.
+:::
 
 By default, statusline uses **offline mode** with cached pricing data for optimal performance.
 


### PR DESCRIPTION
## Summary

Add documentation for running ccusage and @ccusage/opencode via native Claude Code and OpenCode CLIs using `BUN_BE_BUN=1` environment variable.

## What Changed

- **installation.md**: Add detailed "Running with `claude x`" section (collapsible) explaining how it works, requirements (native version only), and links to Bun/Claude Code docs
- **getting-started.md**: Add `claude x` option to Quick Start code group
- **index.md**: Mention `claude x` in Ultra-Small Bundle Size feature description
- **statusline.md**: Add `claude x` option to settings.json configuration examples with native version note
- **opencode/index.md**: Add `opencode x` option with native version requirement tip

## Why

This leverages Bun's standalone executable feature (`BUN_BE_BUN=1`) which exposes full Bun CLI capabilities from native Claude Code/OpenCode binaries. Users with native installations can run ccusage without installing Bun separately.

References:
- [Bun docs: Act as the Bun CLI](https://bun.sh/docs/bundler/executables#act-as-the-bun-cli)
- [Claude Code setup](https://code.claude.com/docs/en/setup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added code examples and guidance for the new `claude x` invocation method across multiple setup guides.
  * Expanded installation documentation with alternative invocation approaches (bunx, npx, pnpm options).
  * Provided detailed configuration examples for statusline setup, cost source options, and visual burn rate features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->