### PR TITLE
fix(debug): use streaming to handle large JSONL files

### DIFF
--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -535,7 +535,7 @@ export function createUniqueHash(data: UsageData): string | null {
  * @param filePath - Path to the JSONL file
  * @param processLine - Callback function to process each line
  */
-async function processJSONLFileByLine(
+export async function processJSONLFileByLine(
 	filePath: string,
 	processLine: (line: string, lineNumber: number) => void | Promise<void>,
 ): Promise<void> {


### PR DESCRIPTION
## Summary

The debug module was still using the `readFile` + `split('\n')` pattern which can cause `RangeError: Invalid string length` when processing large JSONL files (>512MB).

This is a follow-up to PR #706 which fixed the same issue in `data-loader.ts` but missed the `debug.ts` module.

## Changes

- Export `processJSONLFileByLine` from `data-loader.ts` for reuse
- Refactor `detectMismatches` in `debug.ts` to use streaming instead of `readFile`
- Remove unused `readFile` import from `debug.ts`

## Problem

When users have large usage datasets (1.5GB+ across many files), running debug commands like `ccusage debug` would fail with:

```
RangeError: Invalid string length
    at readFileHandle (node:internal/fs/promises:591:25)
```

## Solution

Reuse the existing `processJSONLFileByLine` helper which uses Node.js streams (`createReadStream` + `readline`) to process files line-by-line without loading the entire file into memory.

## Test Plan

- [x] All existing tests pass (243 tests)
- [x] Verified `processJSONLFileByLine` export doesn't break existing imports
- [x] Debug module tests continue to work with streaming approach

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during file processing — invalid data lines are now gracefully skipped instead of causing failures.

* **Refactor**
  * Optimized large file processing with memory-efficient streaming, reducing memory consumption when handling substantial datasets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->