### PR TITLE
feat(opencode): add modelBreakdowns to JSON output

### DIFF
--- a/apps/opencode/src/commands/daily.ts
+++ b/apps/opencode/src/commands/daily.ts
@@ -16,6 +16,27 @@ import { logger } from '../logger.ts';
 
 const TABLE_COLUMN_COUNT = 8;
 
+type TokenStats = {
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationTokens: number;
+	cacheReadTokens: number;
+	cost: number;
+};
+
+type ModelBreakdown = TokenStats & {
+	modelName: string;
+};
+
+function createModelBreakdowns(modelAggregates: Map<string, TokenStats>): ModelBreakdown[] {
+	return Array.from(modelAggregates.entries())
+		.map(([modelName, stats]) => ({
+			modelName,
+			...stats,
+		}))
+		.sort((a, b) => b.cost - a.cost);
+}
+
 export const dailyCommand = define({
 	name: 'daily',
 	description: 'Show OpenCode token usage grouped by day',
@@ -57,6 +78,7 @@ export const dailyCommand = define({
 			totalTokens: number;
 			totalCost: number;
 			modelsUsed: string[];
+			modelBreakdowns: ModelBreakdown[];
 		}> = [];
 
 		for (const [date, dayEntries] of Object.entries(entriesByDate)) {
@@ -66,17 +88,47 @@ export const dailyCommand = define({
 			let cacheReadTokens = 0;
 			let totalCost = 0;
 			const modelsSet = new Set<string>();
+			const modelAggregates = new Map<string, TokenStats>();
+			const defaultStats: TokenStats = {
+				inputTokens: 0,
+				outputTokens: 0,
+				cacheCreationTokens: 0,
+				cacheReadTokens: 0,
+				cost: 0,
+			};
 
 			for (const entry of dayEntries) {
-				inputTokens += entry.usage.inputTokens;
-				outputTokens += entry.usage.outputTokens;
-				cacheCreationTokens += entry.usage.cacheCreationInputTokens;
-				cacheReadTokens += entry.usage.cacheReadInputTokens;
-				totalCost += await calculateCostForEntry(entry, fetcher);
-				modelsSet.add(entry.model);
+				const modelName = entry.model ?? 'unknown';
+				if (modelName === '<synthetic>') {
+					continue;
+				}
+
+				const entryInputTokens = entry.usage.inputTokens;
+				const entryOutputTokens = entry.usage.outputTokens;
+				const entryCacheCreation = entry.usage.cacheCreationInputTokens;
+				const entryCacheRead = entry.usage.cacheReadInputTokens;
+				const entryCost = await calculateCostForEntry(entry, fetcher);
+
+				inputTokens += entryInputTokens;
+				outputTokens += entryOutputTokens;
+				cacheCreationTokens += entryCacheCreation;
+				cacheReadTokens += entryCacheRead;
+				totalCost += entryCost;
+				modelsSet.add(modelName);
+
+				const existing = modelAggregates.get(modelName) ?? defaultStats;
+
+				modelAggregates.set(modelName, {
+					inputTokens: existing.inputTokens + entryInputTokens,
+					outputTokens: existing.outputTokens + entryOutputTokens,
+					cacheCreationTokens: existing.cacheCreationTokens + entryCacheCreation,
+					cacheReadTokens: existing.cacheReadTokens + entryCacheRead,
+					cost: existing.cost + entryCost,
+				});
 			}
 
 			const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
+			const modelBreakdowns = createModelBreakdowns(modelAggregates);
 
 			dailyData.push({
 				date,
@@ -87,6 +139,7 @@ export const dailyCommand = define({
 				totalTokens,
 				totalCost,
 				modelsUsed: Array.from(modelsSet),
+				modelBreakdowns,
 			});
 		}
 

--- a/apps/opencode/src/commands/monthly.ts
+++ b/apps/opencode/src/commands/monthly.ts
@@ -16,6 +16,27 @@ import { logger } from '../logger.ts';
 
 const TABLE_COLUMN_COUNT = 8;
 
+type TokenStats = {
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationTokens: number;
+	cacheReadTokens: number;
+	cost: number;
+};
+
+type ModelBreakdown = TokenStats & {
+	modelName: string;
+};
+
+function createModelBreakdowns(modelAggregates: Map<string, TokenStats>): ModelBreakdown[] {
+	return Array.from(modelAggregates.entries())
+		.map(([modelName, stats]) => ({
+			modelName,
+			...stats,
+		}))
+		.sort((a, b) => b.cost - a.cost);
+}
+
 export const monthlyCommand = define({
 	name: 'monthly',
 	description: 'Show OpenCode token usage grouped by month',
@@ -57,6 +78,7 @@ export const monthlyCommand = define({
 			totalTokens: number;
 			totalCost: number;
 			modelsUsed: string[];
+			modelBreakdowns: ModelBreakdown[];
 		}> = [];
 
 		for (const [month, monthEntries] of Object.entries(entriesByMonth)) {
@@ -66,17 +88,47 @@ export const monthlyCommand = define({
 			let cacheReadTokens = 0;
 			let totalCost = 0;
 			const modelsSet = new Set<string>();
+			const modelAggregates = new Map<string, TokenStats>();
+			const defaultStats: TokenStats = {
+				inputTokens: 0,
+				outputTokens: 0,
+				cacheCreationTokens: 0,
+				cacheReadTokens: 0,
+				cost: 0,
+			};
 
 			for (const entry of monthEntries) {
-				inputTokens += entry.usage.inputTokens;
-				outputTokens += entry.usage.outputTokens;
-				cacheCreationTokens += entry.usage.cacheCreationInputTokens;
-				cacheReadTokens += entry.usage.cacheReadInputTokens;
-				totalCost += await calculateCostForEntry(entry, fetcher);
-				modelsSet.add(entry.model);
+				const modelName = entry.model ?? 'unknown';
+				if (modelName === '<synthetic>') {
+					continue;
+				}
+
+				const entryInputTokens = entry.usage.inputTokens;
+				const entryOutputTokens = entry.usage.outputTokens;
+				const entryCacheCreation = entry.usage.cacheCreationInputTokens;
+				const entryCacheRead = entry.usage.cacheReadInputTokens;
+				const entryCost = await calculateCostForEntry(entry, fetcher);
+
+				inputTokens += entryInputTokens;
+				outputTokens += entryOutputTokens;
+				cacheCreationTokens += entryCacheCreation;
+				cacheReadTokens += entryCacheRead;
+				totalCost += entryCost;
+				modelsSet.add(modelName);
+
+				const existing = modelAggregates.get(modelName) ?? defaultStats;
+
+				modelAggregates.set(modelName, {
+					inputTokens: existing.inputTokens + entryInputTokens,
+					outputTokens: existing.outputTokens + entryOutputTokens,
+					cacheCreationTokens: existing.cacheCreationTokens + entryCacheCreation,
+					cacheReadTokens: existing.cacheReadTokens + entryCacheRead,
+					cost: existing.cost + entryCost,
+				});
 			}
 
 			const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
+			const modelBreakdowns = createModelBreakdowns(modelAggregates);
 
 			monthlyData.push({
 				month,
@@ -87,6 +139,7 @@ export const monthlyCommand = define({
 				totalTokens,
 				totalCost,
 				modelsUsed: Array.from(modelsSet),
+				modelBreakdowns,
 			});
 		}
 


### PR DESCRIPTION
## Summary
Add `modelBreakdowns` field to `@ccusage/opencode` JSON output for feature parity with `ccusage` (Claude Code).
Currently `@ccusage/opencode` only provides `modelsUsed` (model name array), while `ccusage` provides detailed `modelBreakdowns` with per-model token counts and costs. 
## Changes
- Add `modelBreakdowns` array to JSON output in daily, weekly, monthly, and session reports
- Each breakdown includes: `modelName`, `inputTokens`, `outputTokens`, `cacheCreationTokens`, `cacheReadTokens`, `cost`
- Backward compatible - `modelsUsed` array is preserved
## Before/After
### Before
```json
{
  "daily": [{
    "date": "2026-01-20",
    "inputTokens": 228,
    "outputTokens": 346277,
    "totalCost": 95.38,
    "modelsUsed": ["claude-opus-4-5", "gpt-5.2-codex"]
  }]
}
```
### After
```json
{
  "daily": [{
    "date": "2026-01-20",
    "inputTokens": 228,
    "outputTokens": 346277,
    "totalCost": 95.38,
    "modelsUsed": ["claude-opus-4-5", "gpt-5.2-codex"],
    "modelBreakdowns": [
      {
        "modelName": "claude-opus-4-5",
        "inputTokens": 200,
        "outputTokens": 340000,
        "cacheCreationTokens": 7268400,
        "cacheReadTokens": 82593000,
        "cost": 94.50
      },
      {
        "modelName": "gpt-5.2-codex",
        "inputTokens": 28,
        "outputTokens": 6277,
        "cacheCreationTokens": 0,
        "cacheReadTokens": 0,
        "cost": 0.88
      }
    ]
  }]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All reports enhanced with per-model breakdowns. Daily, weekly, monthly, and session reports now display comprehensive metrics for each AI model used, including input tokens, output tokens, cache tokens, and associated costs. Breakdowns are sorted by cost for easier identification of resource allocation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->