### PR TITLE
fix(ccusage): improve project name handling on windows

### DIFF
--- a/apps/ccusage/src/_project-names.ts
+++ b/apps/ccusage/src/_project-names.ts
@@ -47,6 +47,24 @@ function parseProjectName(projectName: string): string {
 		}
 	}
 
+	// Handle Windows-style arbitrary paths: C:\work\projectd
+	if (cleaned.match(/^[A-Z]:/) != null) {
+		const segments = cleaned.split('\\');
+		const projectIndex = segments.length - 1;
+		if (projectIndex >= 0) {
+			cleaned = segments.slice(projectIndex).join('-');
+		}
+	}
+
+	// Handle Windows-style arbitrary paths: C--src--data--db
+	if (cleaned.match(/^[A-Z]--/) != null) {
+		const segments = cleaned.split('--');
+		const projectIndex = segments.length - 1;
+		if (projectIndex >= 0) {
+			cleaned = segments.slice(projectIndex).join('-');
+		}
+	}
+
 	// Handle Unix-style paths: /Users/... or -Users-...
 	if (cleaned.startsWith('-Users-') || cleaned.startsWith('/Users/')) {
 		const separator = cleaned.startsWith('-Users-') ? '-' : '/';
@@ -185,6 +203,16 @@ if (import.meta.vitest != null) {
 			it('returns original name for simple names', () => {
 				expect(formatProjectName('simple-project')).toBe('simple-project');
 				expect(formatProjectName('project')).toBe('project');
+			});
+
+			it('handles windows project names in C:\\Users\\Projects dir', () => {
+				expect(formatProjectName('C:\\Users\\user\\Projects\\project')).toBe('project');
+				expect(formatProjectName('D--Users--user--Projects--project')).toBe('project');
+			});
+
+			it('handles windows project names in arbitrary dir', () => {
+				expect(formatProjectName('C:\\work\\project')).toBe('project');
+				expect(formatProjectName('Z--src--data--project')).toBe('project');
 			});
 		});
 


### PR DESCRIPTION
  Fixes #818                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                     
  **Problem:**                                                                                                                                                                                                                                       
  Windows project names were incorrectly shortened from `C--src--delete--ansible` to just `C`, losing the actual project name.                                                                                                                       
                                                                                                                                                                                                                                                     
  **Solution:**                                                                                                                                                                                                                                      
  Added proper handling for Windows-style paths in two formats:                                                                                                                                                                                      
  - Direct paths: `C:\work\project` → `project`                                                                                                                                                                                                      
  - Escaped paths: `C--src--data--project` → `project`                                                                                                                                                                                               
                                                                                                                                                                                                                                                     
  Both cases now extract the last segment as the project name, matching the behavior for Unix-style paths.                                                                                                                                           
                                                                                                                                                                                                                                                     
  **Tests:**                                                                                                                                                                                                                                         
  Added test cases covering both Windows path formats in arbitrary directories.    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced project name extraction and normalization from Windows-style file paths, including backslash-separated paths and double-dash segment handling
  * Improved compatibility for Windows directory paths to ensure consistent project name formatting across different path formats

* **Tests**
  * Expanded test suite with comprehensive coverage for Windows path scenarios and directory structure variations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->