### PR TITLE
chore: add pnpm security settings for supply chain attack prevention

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"apps/*",
 		"docs"
 	],
-	"packageManager": "pnpm@10.24.0",
+	"packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
 	"scripts": {
 		"build": "pnpm run --filter '*' build",
 		"docs:dev": "pnpm run --filter docs dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,10 +75,17 @@ enablePrePostScripts: true
 
 minimumReleaseAge: 2880
 
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
-  - sqlite3
-  - workerd
+# Security settings for supply chain attack prevention
+strictDepBuilds: true
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
+
+# Explicitly allow build scripts for packages that require them
+# (replaces onlyBuiltDependencies)
+allowBuilds:
+  esbuild: true
+  sharp: true
+  sqlite3: true
+  workerd: true
 
 shellEmulator: true


### PR DESCRIPTION
## Summary

Add pnpm security settings to protect against supply chain attacks, following best practices from the referenced article.

## What Changed

- **strictDepBuilds: true** - Blocks lifecycle scripts (postinstall, etc.) by default. Only packages in `allowBuilds` can run build scripts.
- **blockExoticSubdeps: true** - Blocks dependencies from non-registry sources (Git repos, tarball URLs).
- **trustPolicy: no-downgrade** - Prevents trust level downgrades between versions.
- Migrated from `onlyBuiltDependencies` to the newer `allowBuilds` format
- Updated pnpm to 10.28.2

## Why

Supply chain attacks targeting npm lifecycle scripts (like Shai-Hulud) have become increasingly common. These settings implement a deny-by-default approach where build scripts are blocked unless explicitly allowed.

## Reference

- https://creators.bengo4.com/entry/2026/01/26/080000
- https://github.com/StackOneHQ/disco/pull/463