### PR TITLE
fix(opencode): support SQLite database for OpenCode >= 1.2.2

### DIFF
--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -78,5 +78,8 @@
 				"onFail": "download"
 			}
 		]
+	},
+	"dependencies": {
+		"better-sqlite3": "catalog:"
 	}
 }

--- a/apps/opencode/tsdown.config.ts
+++ b/apps/opencode/tsdown.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
 	platform: 'node',
 	target: 'node20',
 	fixedExtension: false,
+	external: ['better-sqlite3'],
 });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,18 @@ packages:
   - docs
   - packages/*
 
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true
+  sharp: true
+  sqlite3: true
+  workerd: true
+
+blockExoticSubdeps: true
+
+catalog:
+  better-sqlite3: ^12.6.2
+
 catalogMode: strict
 
 catalogs:
@@ -75,17 +87,8 @@ enablePrePostScripts: true
 
 minimumReleaseAge: 2880
 
-# Security settings for supply chain attack prevention
-strictDepBuilds: true
-blockExoticSubdeps: true
-trustPolicy: no-downgrade
-
-# Explicitly allow build scripts for packages that require them
-# (replaces onlyBuiltDependencies)
-allowBuilds:
-  esbuild: true
-  sharp: true
-  sqlite3: true
-  workerd: true
-
 shellEmulator: true
+
+strictDepBuilds: true
+
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary

Fixes #845

OpenCode 1.2.2+ migrated from individual JSON files (`storage/message/*.json`) to a SQLite database (`opencode.db`). This PR adds SQLite reading support with automatic fallback to legacy JSON files for older OpenCode versions.

## Changes

- **`apps/opencode/src/data-loader.ts`** — Added `openSqliteDb()` adapter that tries `better-sqlite3` then `bun:sqlite`, plus `loadMessagesFromSqlite()` and `loadSessionsFromSqlite()` functions. Public API (`loadOpenCodeMessages`, `loadOpenCodeSessions`) now tries SQLite first, falls back to JSON.
- **`apps/opencode/package.json`** — Added `better-sqlite3` as a runtime dependency.
- **`apps/opencode/tsdown.config.ts`** — Marked `better-sqlite3` as external (native addon, cannot be bundled).
- **`pnpm-workspace.yaml`** — Added `better-sqlite3` to catalog and `allowBuilds`.

## How it works

1. Check if `opencode.db` exists in the OpenCode data directory
2. If yes → query `message` and `session` tables via SQLite
3. If no (or SQLite fails) → fall back to legacy JSON file globbing

The SQLite `message.data` column contains the same JSON structure as the old files, so the parsing/filtering logic is equivalent.

## Testing

- All 6 existing tests pass
- Verified `daily`, `session`, and `weekly` commands against a real OpenCode 1.2.2+ database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenCode now supports efficient local database loading for improved performance, with automatic fallback to existing formats.
  * Extended token tracking to include reasoning data alongside input and output metrics.

* **Chores**
  * Updated build and workspace configuration for optimized dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->