### PR TITLE
chore: migrate to standard engines field and upgrade Bun

### DIFF
--- a/apps/amp/package.json
+++ b/apps/amp/package.json
@@ -29,7 +29,19 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=20.19.4",
+		"runtime": [
+			{
+				"name": "node",
+				"version": "^24.11.0",
+				"onFail": "download"
+			},
+			{
+				"name": "bun",
+				"version": "^1.3.9",
+				"onFail": "download"
+			}
+		]
 	},
 	"scripts": {
 		"build": "tsdown",
@@ -41,6 +53,7 @@
 		"test": "TZ=UTC vitest",
 		"typecheck": "tsgo --noEmit"
 	},
+	"dependencies": {},
 	"devDependencies": {
 		"@ccusage/internal": "workspace:*",
 		"@ccusage/terminal": "workspace:*",
@@ -60,19 +73,5 @@
 		"unplugin-unused": "catalog:build",
 		"valibot": "catalog:runtime",
 		"vitest": "catalog:testing"
-	},
-	"devEngines": {
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.2",
-				"onFail": "download"
-			}
-		]
 	}
 }

--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -47,7 +47,19 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=20.19.4",
+		"runtime": [
+			{
+				"name": "node",
+				"version": "^24.11.0",
+				"onFail": "download"
+			},
+			{
+				"name": "bun",
+				"version": "^1.3.9",
+				"onFail": "download"
+			}
+		]
 	},
 	"scripts": {
 		"build": "pnpm run generate:schema && tsdown",
@@ -66,6 +78,7 @@
 		"test:statusline:sonnet41": "cat test/statusline-test-sonnet41.json | node ./src/index.ts statusline --offline",
 		"typecheck": "tsgo --noEmit"
 	},
+	"dependencies": {},
 	"devDependencies": {
 		"@antfu/utils": "catalog:runtime",
 		"@ccusage/internal": "workspace:*",
@@ -102,19 +115,5 @@
 		"valibot": "catalog:runtime",
 		"vitest": "catalog:testing",
 		"xdg-basedir": "catalog:runtime"
-	},
-	"devEngines": {
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.2",
-				"onFail": "download"
-			}
-		]
 	}
 }

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -29,7 +29,19 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=20.19.4",
+		"runtime": [
+			{
+				"name": "node",
+				"version": "^24.11.0",
+				"onFail": "download"
+			},
+			{
+				"name": "bun",
+				"version": "^1.3.9",
+				"onFail": "download"
+			}
+		]
 	},
 	"scripts": {
 		"build": "tsdown",
@@ -41,6 +53,7 @@
 		"test": "TZ=UTC vitest",
 		"typecheck": "tsgo --noEmit"
 	},
+	"dependencies": {},
 	"devDependencies": {
 		"@ccusage/internal": "workspace:*",
 		"@ccusage/terminal": "workspace:*",
@@ -59,19 +72,5 @@
 		"unplugin-unused": "catalog:build",
 		"valibot": "catalog:runtime",
 		"vitest": "catalog:testing"
-	},
-	"devEngines": {
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.2",
-				"onFail": "download"
-			}
-		]
 	}
 }

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -39,7 +39,19 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=20.19.4",
+		"runtime": [
+			{
+				"name": "node",
+				"version": "^24.11.0",
+				"onFail": "download"
+			},
+			{
+				"name": "bun",
+				"version": "^1.3.9",
+				"onFail": "download"
+			}
+		]
 	},
 	"scripts": {
 		"build": "tsdown",
@@ -73,19 +85,5 @@
 		"publint": "catalog:lint",
 		"tsdown": "catalog:build",
 		"vitest": "catalog:testing"
-	},
-	"devEngines": {
-		"runtime": [
-			{
-				"name": "node",
-				"onFail": "download",
-				"version": "^24.11.0"
-			},
-			{
-				"name": "bun",
-				"onFail": "download",
-				"version": "^1.3.2"
-			}
-		]
 	}
 }

--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -32,7 +32,19 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=20.19.4",
+		"runtime": [
+			{
+				"name": "node",
+				"version": "^24.11.0",
+				"onFail": "download"
+			},
+			{
+				"name": "bun",
+				"version": "^1.3.9",
+				"onFail": "download"
+			}
+		]
 	},
 	"scripts": {
 		"build": "tsdown",
@@ -44,6 +56,7 @@
 		"test": "TZ=UTC vitest",
 		"typecheck": "tsgo --noEmit"
 	},
+	"dependencies": {},
 	"devDependencies": {
 		"@ccusage/internal": "workspace:*",
 		"@ccusage/terminal": "workspace:*",
@@ -64,19 +77,5 @@
 		"unplugin-unused": "catalog:build",
 		"valibot": "catalog:runtime",
 		"vitest": "catalog:testing"
-	},
-	"devEngines": {
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.2",
-				"onFail": "download"
-			}
-		]
 	}
 }

--- a/apps/pi/package.json
+++ b/apps/pi/package.json
@@ -42,7 +42,19 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=20.19.4",
+		"runtime": [
+			{
+				"name": "node",
+				"version": "^24.11.0",
+				"onFail": "download"
+			},
+			{
+				"name": "bun",
+				"version": "^1.3.9",
+				"onFail": "download"
+			}
+		]
 	},
 	"scripts": {
 		"build": "tsdown",
@@ -55,6 +67,7 @@
 		"test": "TZ=UTC vitest",
 		"typecheck": "tsgo --noEmit"
 	},
+	"dependencies": {},
 	"devDependencies": {
 		"@ccusage/internal": "workspace:*",
 		"@ccusage/terminal": "workspace:*",
@@ -73,19 +86,5 @@
 		"tsdown": "catalog:build",
 		"valibot": "catalog:runtime",
 		"vitest": "catalog:testing"
-	},
-	"devEngines": {
-		"runtime": [
-			{
-				"name": "node",
-				"onFail": "download",
-				"version": "^24.11.0"
-			},
-			{
-				"name": "bun",
-				"onFail": "download",
-				"version": "^1.3.2"
-			}
-		]
 	}
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,20 @@
 	"version": "18.0.5",
 	"private": true,
 	"description": "Documentation for ccusage",
+	"engines": {
+		"runtime": [
+			{
+				"name": "node",
+				"version": "^24.11.0",
+				"onFail": "download"
+			},
+			{
+				"name": "bun",
+				"version": "^1.3.9",
+				"onFail": "download"
+			}
+		]
+	},
 	"scripts": {
 		"build": "pnpm run docs:api && cp ../apps/ccusage/config-schema.json public/config-schema.json && vitepress build",
 		"deploy": "wrangler deploy",
@@ -14,6 +28,7 @@
 		"preview": "vitepress preview",
 		"typecheck": "tsgo --noEmit"
 	},
+	"dependencies": {},
 	"devDependencies": {
 		"@ryoppippi/eslint-config": "catalog:lint",
 		"@ryoppippi/vite-plugin-cloudflare-redirect": "catalog:docs",
@@ -31,19 +46,5 @@
 		"vitepress-plugin-group-icons": "catalog:docs",
 		"vitepress-plugin-llms": "catalog:docs",
 		"wrangler": "catalog:docs"
-	},
-	"devEngines": {
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.2",
-				"onFail": "download"
-			}
-		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,20 @@
 		"docs"
 	],
 	"packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
+	"engines": {
+		"runtime": [
+			{
+				"name": "node",
+				"version": "^24.11.0",
+				"onFail": "download"
+			},
+			{
+				"name": "bun",
+				"version": "^1.3.9",
+				"onFail": "download"
+			}
+		]
+	},
 	"scripts": {
 		"build": "pnpm run --filter '*' build",
 		"docs:dev": "pnpm run --filter docs dev",
@@ -28,6 +42,7 @@
 		"test": "pnpm run --filter '*' test",
 		"typecheck": "pnpm run --filter '*' typecheck"
 	},
+	"dependencies": {},
 	"devDependencies": {
 		"@gunshi/docs": "catalog:llm-docs",
 		"@praha/byethrow-docs": "catalog:llm-docs",
@@ -43,20 +58,6 @@
 	"lint-staged": {
 		"*": [
 			"pnpm run format"
-		]
-	},
-	"devEngines": {
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.2",
-				"onFail": "download"
-			}
 		]
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,13 @@ catalogs:
 importers:
 
   .:
+    dependencies:
+      bun:
+        specifier: runtime:^1.3.9
+        version: runtime:1.3.9
+      node:
+        specifier: runtime:^24.11.0
+        version: runtime:24.12.0
     devDependencies:
       '@gunshi/docs':
         specifier: catalog:llm-docs
@@ -198,9 +205,6 @@ importers:
       bumpp:
         specifier: catalog:release
         version: 10.2.3
-      bun:
-        specifier: runtime:^1.3.2
-        version: runtime:1.3.5
       changelogithub:
         specifier: catalog:release
         version: 13.16.1
@@ -210,9 +214,6 @@ importers:
       lint-staged:
         specifier: catalog:release
         version: 16.1.6
-      node:
-        specifier: runtime:^24.11.0
-        version: runtime:24.12.0
       oxfmt:
         specifier: catalog:lint
         version: 0.23.0
@@ -221,6 +222,13 @@ importers:
         version: 0.0.60
 
   apps/amp:
+    dependencies:
+      bun:
+        specifier: runtime:^1.3.9
+        version: runtime:1.3.9
+      node:
+        specifier: runtime:^24.11.0
+        version: runtime:24.12.0
     devDependencies:
       '@ccusage/internal':
         specifier: workspace:*
@@ -237,9 +245,6 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:types
         version: 7.0.0-dev.20260107.1
-      bun:
-        specifier: runtime:^1.3.2
-        version: runtime:1.3.5
       clean-pkg-json:
         specifier: catalog:release
         version: 1.3.0
@@ -255,9 +260,6 @@ importers:
       gunshi:
         specifier: catalog:runtime
         version: 0.26.3
-      node:
-        specifier: runtime:^24.11.0
-        version: runtime:24.12.0
       path-type:
         specifier: catalog:runtime
         version: 6.0.0
@@ -284,6 +286,13 @@ importers:
         version: 4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1)
 
   apps/ccusage:
+    dependencies:
+      bun:
+        specifier: runtime:^1.3.9
+        version: runtime:1.3.9
+      node:
+        specifier: runtime:^24.11.0
+        version: runtime:24.12.0
     devDependencies:
       '@antfu/utils':
         specifier: catalog:runtime
@@ -321,9 +330,6 @@ importers:
       bumpp:
         specifier: catalog:release
         version: 10.2.3
-      bun:
-        specifier: runtime:^1.3.2
-        version: runtime:1.3.5
       clean-pkg-json:
         specifier: catalog:release
         version: 1.3.0
@@ -351,9 +357,6 @@ importers:
       nano-spawn:
         specifier: catalog:runtime
         version: 1.0.3
-      node:
-        specifier: runtime:^24.11.0
-        version: runtime:24.12.0
       p-limit:
         specifier: catalog:runtime
         version: 7.1.1
@@ -398,6 +401,13 @@ importers:
         version: 5.1.0
 
   apps/codex:
+    dependencies:
+      bun:
+        specifier: runtime:^1.3.9
+        version: runtime:1.3.9
+      node:
+        specifier: runtime:^24.11.0
+        version: runtime:24.12.0
     devDependencies:
       '@ccusage/internal':
         specifier: workspace:*
@@ -414,9 +424,6 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:types
         version: 7.0.0-dev.20260107.1
-      bun:
-        specifier: runtime:^1.3.2
-        version: runtime:1.3.5
       clean-pkg-json:
         specifier: catalog:release
         version: 1.3.0
@@ -432,9 +439,6 @@ importers:
       gunshi:
         specifier: catalog:runtime
         version: 0.26.3
-      node:
-        specifier: runtime:^24.11.0
-        version: runtime:24.12.0
       picocolors:
         specifier: catalog:runtime
         version: 1.1.1
@@ -471,6 +475,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: catalog:runtime
         version: 1.24.3(zod@4.1.13)
+      bun:
+        specifier: runtime:^1.3.9
+        version: runtime:1.3.9
       ccusage:
         specifier: workspace:*
         version: link:../ccusage
@@ -483,6 +490,9 @@ importers:
       nano-spawn:
         specifier: catalog:runtime
         version: 1.0.3
+      node:
+        specifier: runtime:^24.11.0
+        version: runtime:24.12.0
       zod:
         specifier: catalog:runtime
         version: 4.1.13
@@ -496,9 +506,6 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:types
         version: 7.0.0-dev.20260107.1
-      bun:
-        specifier: runtime:^1.3.2
-        version: runtime:1.3.5
       clean-pkg-json:
         specifier: catalog:release
         version: 1.3.0
@@ -508,9 +515,6 @@ importers:
       fs-fixture:
         specifier: catalog:testing
         version: 2.8.1
-      node:
-        specifier: runtime:^24.11.0
-        version: runtime:24.12.0
       publint:
         specifier: catalog:lint
         version: 0.3.12
@@ -522,6 +526,13 @@ importers:
         version: 4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1)
 
   apps/opencode:
+    dependencies:
+      bun:
+        specifier: runtime:^1.3.9
+        version: runtime:1.3.9
+      node:
+        specifier: runtime:^24.11.0
+        version: runtime:24.12.0
     devDependencies:
       '@ccusage/internal':
         specifier: workspace:*
@@ -538,9 +549,6 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:types
         version: 7.0.0-dev.20260107.1
-      bun:
-        specifier: runtime:^1.3.2
-        version: runtime:1.3.5
       clean-pkg-json:
         specifier: catalog:release
         version: 1.3.0
@@ -559,9 +567,6 @@ importers:
       gunshi:
         specifier: catalog:runtime
         version: 0.26.3
-      node:
-        specifier: runtime:^24.11.0
-        version: runtime:24.12.0
       path-type:
         specifier: catalog:runtime
         version: 6.0.0
@@ -588,6 +593,13 @@ importers:
         version: 4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1)
 
   apps/pi:
+    dependencies:
+      bun:
+        specifier: runtime:^1.3.9
+        version: runtime:1.3.9
+      node:
+        specifier: runtime:^24.11.0
+        version: runtime:24.12.0
     devDependencies:
       '@ccusage/internal':
         specifier: workspace:*
@@ -604,9 +616,6 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:types
         version: 7.0.0-dev.20260107.1
-      bun:
-        specifier: runtime:^1.3.2
-        version: runtime:1.3.5
       clean-pkg-json:
         specifier: catalog:release
         version: 1.3.0
@@ -622,9 +631,6 @@ importers:
       gunshi:
         specifier: catalog:runtime
         version: 0.26.3
-      node:
-        specifier: runtime:^24.11.0
-        version: runtime:24.12.0
       path-type:
         specifier: catalog:runtime
         version: 6.0.0
@@ -648,6 +654,13 @@ importers:
         version: 4.0.15(@types/node@24.5.1)(happy-dom@16.8.1)(jiti@2.6.1)(yaml@2.8.1)
 
   docs:
+    dependencies:
+      bun:
+        specifier: runtime:^1.3.9
+        version: runtime:1.3.9
+      node:
+        specifier: runtime:^24.11.0
+        version: runtime:24.12.0
     devDependencies:
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
@@ -664,9 +677,6 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:types
         version: 7.0.0-dev.20260107.1
-      bun:
-        specifier: runtime:^1.3.2
-        version: runtime:1.3.5
       ccusage:
         specifier: workspace:^
         version: link:../apps/ccusage
@@ -676,9 +686,6 @@ importers:
       eslint-plugin-format:
         specifier: catalog:lint
         version: 1.0.2(eslint@9.35.0(jiti@2.6.1))
-      node:
-        specifier: runtime:^24.11.0
-        version: runtime:24.12.0
       tinyglobby:
         specifier: catalog:runtime
         version: 0.2.15
@@ -2698,37 +2705,37 @@ packages:
   bun-types@1.3.5:
     resolution: {integrity: sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw==}
 
-  bun@runtime:1.3.5:
+  bun@runtime:1.3.9:
     resolution:
       type: variations
       variants:
         - resolution:
             archive: zip
             bin: bun
-            integrity: sha256-2xdYikrqiASFaCXUvq0/BeHzcnbKYG8342m09y810/s=
+            integrity: sha256-zeak7fGc9kkJFY+lpGShICb9fw15pKlQwQzwrwQmbYU=
             prefix: bun-darwin-aarch64
             type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.5/bun-darwin-aarch64.zip
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-darwin-aarch64.zip
           targets:
             - cpu: arm64
               os: darwin
         - resolution:
             archive: zip
             bin: bun
-            integrity: sha256-9f/AMDD+UnqGKV+1hSuwjF6ZtwdWABHR1QmrAokCvyk=
+            integrity: sha256-WI9KSHQLmgw2agD4eIEKs6teZzTSm3w8vdlIS3SgB94=
             prefix: bun-darwin-x64
             type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.5/bun-darwin-x64.zip
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-darwin-x64.zip
           targets:
             - cpu: x64
               os: darwin
         - resolution:
             archive: zip
             bin: bun
-            integrity: sha256-mAtWe+7Kh1t5d21go1sXgwlYPfPwlzs7rmL3JE3Ehq0=
+            integrity: sha256-QS6bJzLRSMsSenU9Y4mbAzPE9PG9jd55MW7Pt+8XAnA=
             prefix: bun-linux-aarch64-musl
             type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.5/bun-linux-aarch64-musl.zip
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-linux-aarch64-musl.zip
           targets:
             - cpu: arm64
               os: linux
@@ -2736,20 +2743,20 @@ packages:
         - resolution:
             archive: zip
             bin: bun
-            integrity: sha256-7QEAD4W9l3hSKK0oRdySoYYLgFSFaCbXMXaQrI+O50s=
+            integrity: sha256-osKGK8wf0cCzqNzcjH77XirNhx6yDtLxdheITt6ByEQ=
             prefix: bun-linux-aarch64
             type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.5/bun-linux-aarch64.zip
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-linux-aarch64.zip
           targets:
             - cpu: arm64
               os: linux
         - resolution:
             archive: zip
             bin: bun
-            integrity: sha256-cg2I4OX0BFCh2pHAIm9iaxVuqiJIdteU+pX26/dPRrY=
+            integrity: sha256-BLcYQxiTdiPTF95rJegr73v1zOCyQVAcXQSZUTIBxy0=
             prefix: bun-linux-x64-musl
             type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.5/bun-linux-x64-musl.zip
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-linux-x64-musl.zip
           targets:
             - cpu: x64
               os: linux
@@ -2757,24 +2764,24 @@ packages:
         - resolution:
             archive: zip
             bin: bun
-            integrity: sha256-cFHYapJK7+o+C5YhO1/Y95wHk/nK5lNCM+Yn5cPbRmk=
+            integrity: sha256-RoDoDkTjKqcYVgzq6F0i7Pvy77jzZBeC415Lfv1loao=
             prefix: bun-linux-x64
             type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.5/bun-linux-x64.zip
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-linux-x64.zip
           targets:
             - cpu: x64
               os: linux
         - resolution:
             archive: zip
             bin: bun.exe
-            integrity: sha256-kiz/3VFDzRGMbM7Gph389daeAGiwSOoA8KBhUBZTAII=
+            integrity: sha256-9MHPNUn2r5htxlNcQLR4X/Gn54BeWWN+xFD8Ea2wyHQ=
             prefix: bun-windows-x64
             type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.5/bun-windows-x64.zip
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-windows-x64.zip
           targets:
             - cpu: x64
               os: win32
-    version: 1.3.5
+    version: 1.3.9
     hasBin: true
 
   bundle-name@4.1.0:
@@ -7392,7 +7399,7 @@ snapshots:
     dependencies:
       '@types/node': 24.5.1
 
-  bun@runtime:1.3.5: {}
+  bun@runtime:1.3.9: {}
 
   bundle-name@4.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

Migrated from the non-standard `devEngines` field to the standard npm `engines` field across all package.json files. This change aligns with npm conventions and improves compatibility with package manager tooling. Also upgraded Bun runtime from ^1.3.2 to ^1.3.9.

## What Changed

- Moved `devEngines.runtime` → `engines.runtime` in all package.json files:
  - Root package.json
  - apps/amp/package.json
  - apps/ccusage/package.json
  - apps/codex/package.json
  - apps/mcp/package.json
  - apps/opencode/package.json
  - apps/pi/package.json
  - docs/package.json
- Upgraded Bun version specifier from `^1.3.2` to `^1.3.9`
- Updated pnpm-lock.yaml to reflect new structure and version

## Why

The standard `engines` field is the recognised way to declare runtime requirements in npm packages. Using this convention makes the requirements visible to package managers and dependency resolution tools, rather than hiding them in a custom field. This improves discoverability and tooling support.

The Bun upgrade brings performance improvements and bug fixes from the latest minor release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime version requirement to ^24.11.0 and added Bun ^1.3.9 as supported runtime environments across the project.
  * Configured automatic downloads for runtime environment mismatches.
  * Restructured runtime environment configuration management across all project packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->