### PR TITLE
docs: add ai-heatmap to Community Projects section

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -47,11 +47,11 @@ Model Context Protocol server that exposes ccusage data to Claude Desktop and ot
 
 ## Community Projects
 
-### 🗓️ [ai-heatmap](https://github.com/seunggabi/ai-heatmap) - GitHub-style Heatmap for AI Usage
+### 🗓️ [ai-heatmap](https://github.com/seunggabi/ai-heatmap) ([npm](https://www.npmjs.com/package/ai-heatmap)) - GitHub-style Heatmap for AI Usage
 
 Visualize your Claude Code spending as a GitHub-style contribution heatmap. Generates interactive dashboards (GitHub Pages) and embeddable SVG images (Vercel) from ccusage data.
 
-![ai-heatmap](https://seunggabi.github.io/ai-heatmap/heatmap.svg)
+![GitHub-style heatmap showing AI usage costs by day](https://seunggabi.github.io/ai-heatmap/heatmap.svg)
 
 ```bash
 npx ai-heatmap@latest init

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -51,6 +51,8 @@ Model Context Protocol server that exposes ccusage data to Claude Desktop and ot
 
 Visualize your Claude Code spending as a GitHub-style contribution heatmap. Generates interactive dashboards (GitHub Pages) and embeddable SVG images (Vercel) from ccusage data.
 
+![ai-heatmap](https://seunggabi.github.io/ai-heatmap/heatmap.svg)
+
 ```bash
 npx ai-heatmap@latest init
 ```

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -45,6 +45,16 @@ Companion tool for analyzing [Amp](https://ampcode.com/) session usage. Track to
 
 Model Context Protocol server that exposes ccusage data to Claude Desktop and other MCP-compatible tools. Enable real-time usage tracking directly in your AI workflows.
 
+## Community Projects
+
+### 🗓️ [ai-heatmap](https://github.com/seunggabi/ai-heatmap) - GitHub-style Heatmap for AI Usage
+
+Visualize your Claude Code spending as a GitHub-style contribution heatmap. Generates interactive dashboards (GitHub Pages) and embeddable SVG images (Vercel) from ccusage data.
+
+```bash
+npx ai-heatmap@latest init
+```
+
 ## Installation
 
 ### Quick Start (Recommended)


### PR DESCRIPTION
## Summary

- Add a new **"Community Projects"** section to the README after the "ccusage Family" section
- List [ai-heatmap](https://github.com/seunggabi/ai-heatmap) as a community project that builds on ccusage data

ai-heatmap generates GitHub-style contribution heatmaps for AI usage costs, powered by ccusage. It supports interactive dashboards (GitHub Pages) and embeddable dynamic SVG images (Vercel).

Closes #852

## Test plan

- [x] Verify README renders correctly with the new section
- [x] Verify links point to the correct repository and npm package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Community Projects" entry for ai-heatmap with a brief description, screenshot, and initialization command.
  * Note: the ai-heatmap section was inadvertently added twice, resulting in duplicated content in the README; one duplicate should be removed in a follow-up cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->