### PR TITLE
fix(codex): fallback when gpt-5.3-codex pricing entry is zero

### DIFF
--- a/apps/codex/src/pricing.ts
+++ b/apps/codex/src/pricing.ts
@@ -7,7 +7,18 @@ import { prefetchCodexPricing } from './_macro.ts' with { type: 'macro' };
 import { logger } from './logger.ts';
 
 const CODEX_PROVIDER_PREFIXES = ['openai/', 'azure/', 'openrouter/openai/'];
-const CODEX_MODEL_ALIASES_MAP = new Map<string, string>([['gpt-5-codex', 'gpt-5']]);
+const CODEX_MODEL_ALIASES_MAP = new Map<string, string>([
+	['gpt-5-codex', 'gpt-5'],
+	['gpt-5.3-codex', 'gpt-5.2-codex'],
+]);
+
+function hasNonZeroTokenPricing(pricing: LiteLLMModelPricing): boolean {
+	return (
+		(pricing.input_cost_per_token ?? 0) > 0 ||
+		(pricing.output_cost_per_token ?? 0) > 0 ||
+		(pricing.cache_read_input_token_cost ?? 0) > 0
+	);
+}
 
 function toPerMillion(value: number | undefined, fallback?: number): number {
 	const perToken = value ?? fallback ?? 0;
@@ -44,13 +55,13 @@ export class CodexPricingSource implements PricingSource, Disposable {
 		}
 
 		let pricing = directLookup.value;
-		if (pricing == null) {
-			const alias = CODEX_MODEL_ALIASES_MAP.get(model);
-			if (alias != null) {
-				const aliasLookup = await this.fetcher.getModelPricing(alias);
-				if (Result.isFailure(aliasLookup)) {
-					throw aliasLookup.error;
-				}
+		const alias = CODEX_MODEL_ALIASES_MAP.get(model);
+		if (alias != null && (pricing == null || !hasNonZeroTokenPricing(pricing))) {
+			const aliasLookup = await this.fetcher.getModelPricing(alias);
+			if (Result.isFailure(aliasLookup)) {
+				throw aliasLookup.error;
+			}
+			if (aliasLookup.value != null && hasNonZeroTokenPricing(aliasLookup.value)) {
 				pricing = aliasLookup.value;
 			}
 		}
@@ -88,6 +99,52 @@ if (import.meta.vitest != null) {
 			expect(pricing.inputCostPerMToken).toBeCloseTo(1.25);
 			expect(pricing.outputCostPerMToken).toBeCloseTo(10);
 			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.125);
+		});
+
+		it('falls back to alias pricing when direct model pricing is all zeros', async () => {
+			using source = new CodexPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'gpt-5.3-codex': {
+						input_cost_per_token: 0,
+						output_cost_per_token: 0,
+						cache_read_input_token_cost: 0,
+					},
+					'gpt-5.2-codex': {
+						input_cost_per_token: 1.75e-6,
+						output_cost_per_token: 1.4e-5,
+						cache_read_input_token_cost: 1.75e-7,
+					},
+				}),
+			});
+
+			const pricing = await source.getPricing('gpt-5.3-codex');
+			expect(pricing.inputCostPerMToken).toBeCloseTo(1.75);
+			expect(pricing.outputCostPerMToken).toBeCloseTo(14);
+			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.175);
+		});
+
+		it('prefers direct pricing when non-zero pricing is available', async () => {
+			using source = new CodexPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'gpt-5.3-codex': {
+						input_cost_per_token: 1.9e-6,
+						output_cost_per_token: 1.5e-5,
+						cache_read_input_token_cost: 1.9e-7,
+					},
+					'gpt-5.2-codex': {
+						input_cost_per_token: 1.75e-6,
+						output_cost_per_token: 1.4e-5,
+						cache_read_input_token_cost: 1.75e-7,
+					},
+				}),
+			});
+
+			const pricing = await source.getPricing('gpt-5.3-codex');
+			expect(pricing.inputCostPerMToken).toBeCloseTo(1.9);
+			expect(pricing.outputCostPerMToken).toBeCloseTo(15);
+			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.19);
 		});
 	});
 }


### PR DESCRIPTION
## Summary
- add a Codex alias fallback `gpt-5.3-codex -> gpt-5.2-codex`
- trigger alias fallback not only when pricing is missing, but also when direct model pricing is present but all token rates are zero
- keep direct model pricing when non-zero rates are available

## Why
When LiteLLM publishes a temporary `gpt-5.3-codex` entry with zero costs, `@ccusage/codex` currently accepts it as valid and reports `$0.00` despite non-zero token usage. This makes cost reporting misleading.

Upstream tracking:
- LiteLLM fix PR: https://github.com/BerriAI/litellm/pull/21522
- LiteLLM issue: https://github.com/BerriAI/litellm/issues/21562

This change provides a safe fallback for the known Codex path while preserving normal behavior once upstream pricing is corrected.

## Testing
- `pnpm --filter @ccusage/codex test -- --run src/pricing.ts`
- added tests in `apps/codex/src/pricing.ts` for:
  - zero-priced direct entry falls back to alias
  - non-zero direct entry remains preferred


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced pricing resolution to intelligently fall back to alias pricing when direct pricing is unavailable or all token costs are zero. Only replaces direct pricing if alias pricing is non-zero.
  * Expanded model alias mappings to support additional model variants in pricing configuration.

* **Tests**
  * Added comprehensive tests for pricing fallback scenarios, alias resolution preferences, and pricing prioritization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->