### PR TITLE
codex: make pricing resolution strict by default and add explicit fallback controls

### DIFF
--- a/apps/codex/src/_shared-args.ts
+++ b/apps/codex/src/_shared-args.ts
@@ -37,6 +37,17 @@ export const sharedArgs = {
 		default: false,
 		negatable: true,
 	},
+	allowFuzzyPricing: {
+		type: 'boolean',
+		description:
+			'Allow fuzzy pricing model matching when direct or alias match fails (default: false)',
+		default: false,
+	},
+	unknownModelFallback: {
+		type: 'string',
+		description:
+			'Fallback model to use when pricing for a model cannot be resolved (e.g. gpt-5.2-codex)',
+	},
 	compact: {
 		type: 'boolean',
 		description: 'Force compact table layout for narrow terminals',

--- a/apps/codex/src/_types.ts
+++ b/apps/codex/src/_types.ts
@@ -15,7 +15,11 @@ export type TokenUsageEvent = TokenUsageDelta & {
 
 export type ModelUsage = TokenUsageDelta & {
 	isFallback?: boolean;
+	pricingResolution?: PricingResolution;
+	pricingModel?: string;
 };
+
+export type PricingResolution = 'direct' | 'alias' | 'fuzzy' | 'fallback';
 
 export type DailyUsageSummary = {
 	date: string;
@@ -43,6 +47,8 @@ export type ModelPricing = {
 	inputCostPerMToken: number;
 	cachedInputCostPerMToken: number;
 	outputCostPerMToken: number;
+	pricingResolution: PricingResolution;
+	pricingModel: string;
 };
 
 export type PricingLookupResult = {

--- a/apps/codex/src/commands/daily.ts
+++ b/apps/codex/src/commands/daily.ts
@@ -54,6 +54,8 @@ export const dailyCommand = define({
 
 		const pricingSource = new CodexPricingSource({
 			offline: ctx.values.offline,
+			allowFuzzyPricing: ctx.values.allowFuzzyPricing,
+			unknownModelFallback: ctx.values.unknownModelFallback,
 		});
 		try {
 			const rows = await buildDailyReport(events, {

--- a/apps/codex/src/commands/monthly.ts
+++ b/apps/codex/src/commands/monthly.ts
@@ -56,6 +56,8 @@ export const monthlyCommand = define({
 
 		const pricingSource = new CodexPricingSource({
 			offline: ctx.values.offline,
+			allowFuzzyPricing: ctx.values.allowFuzzyPricing,
+			unknownModelFallback: ctx.values.unknownModelFallback,
 		});
 		try {
 			const rows = await buildMonthlyReport(events, {

--- a/apps/codex/src/commands/session.ts
+++ b/apps/codex/src/commands/session.ts
@@ -61,6 +61,8 @@ export const sessionCommand = define({
 
 		const pricingSource = new CodexPricingSource({
 			offline: ctx.values.offline,
+			allowFuzzyPricing: ctx.values.allowFuzzyPricing,
+			unknownModelFallback: ctx.values.unknownModelFallback,
 		});
 		try {
 			const rows = await buildSessionReport(events, {

--- a/apps/codex/src/daily-report.ts
+++ b/apps/codex/src/daily-report.ts
@@ -103,7 +103,12 @@ export async function buildDailyReport(
 
 		const rowModels: Record<string, ModelUsage> = {};
 		for (const [modelName, usage] of summary.models) {
-			rowModels[modelName] = { ...usage };
+			const pricing = modelPricing.get(modelName);
+			rowModels[modelName] = {
+				...usage,
+				pricingResolution: pricing?.pricingResolution,
+				pricingModel: pricing?.pricingModel,
+			};
 		}
 
 		rows.push({
@@ -127,11 +132,23 @@ if (import.meta.vitest != null) {
 			const pricing = new Map([
 				[
 					'gpt-5',
-					{ inputCostPerMToken: 1.25, cachedInputCostPerMToken: 0.125, outputCostPerMToken: 10 },
+					{
+						inputCostPerMToken: 1.25,
+						cachedInputCostPerMToken: 0.125,
+						outputCostPerMToken: 10,
+						pricingResolution: 'direct' as const,
+						pricingModel: 'gpt-5',
+					},
 				],
 				[
 					'gpt-5-mini',
-					{ inputCostPerMToken: 0.6, cachedInputCostPerMToken: 0.06, outputCostPerMToken: 2 },
+					{
+						inputCostPerMToken: 0.6,
+						cachedInputCostPerMToken: 0.06,
+						outputCostPerMToken: 2,
+						pricingResolution: 'direct' as const,
+						pricingModel: 'gpt-5-mini',
+					},
 				],
 			]);
 			const stubPricingSource: PricingSource = {

--- a/apps/codex/src/monthly-report.ts
+++ b/apps/codex/src/monthly-report.ts
@@ -104,7 +104,12 @@ export async function buildMonthlyReport(
 
 		const rowModels: Record<string, ModelUsage> = {};
 		for (const [modelName, usage] of summary.models) {
-			rowModels[modelName] = { ...usage };
+			const pricing = modelPricing.get(modelName);
+			rowModels[modelName] = {
+				...usage,
+				pricingResolution: pricing?.pricingResolution,
+				pricingModel: pricing?.pricingModel,
+			};
 		}
 
 		rows.push({
@@ -128,11 +133,23 @@ if (import.meta.vitest != null) {
 			const pricing = new Map([
 				[
 					'gpt-5',
-					{ inputCostPerMToken: 1.25, cachedInputCostPerMToken: 0.125, outputCostPerMToken: 10 },
+					{
+						inputCostPerMToken: 1.25,
+						cachedInputCostPerMToken: 0.125,
+						outputCostPerMToken: 10,
+						pricingResolution: 'direct' as const,
+						pricingModel: 'gpt-5',
+					},
 				],
 				[
 					'gpt-5-mini',
-					{ inputCostPerMToken: 0.6, cachedInputCostPerMToken: 0.06, outputCostPerMToken: 2 },
+					{
+						inputCostPerMToken: 0.6,
+						cachedInputCostPerMToken: 0.06,
+						outputCostPerMToken: 2,
+						pricingResolution: 'direct' as const,
+						pricingModel: 'gpt-5-mini',
+					},
 				],
 			]);
 			const stubPricingSource: PricingSource = {

--- a/apps/codex/src/pricing.ts
+++ b/apps/codex/src/pricing.ts
@@ -1,5 +1,5 @@
 import type { LiteLLMModelPricing } from '@ccusage/internal/pricing';
-import type { ModelPricing, PricingSource } from './_types.ts';
+import type { ModelPricing, PricingResolution, PricingSource } from './_types.ts';
 import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
 import { Result } from '@praha/byethrow';
 import { MILLION } from './_consts.ts';
@@ -9,20 +9,27 @@ import { logger } from './logger.ts';
 const CODEX_PROVIDER_PREFIXES = ['openai/', 'azure/', 'openrouter/openai/'];
 const CODEX_MODEL_ALIASES_MAP = new Map<string, string>([['gpt-5-codex', 'gpt-5']]);
 
-function toPerMillion(value: number | undefined, fallback?: number): number {
-	const perToken = value ?? fallback ?? 0;
+function toPerMillion(value: number, fallback?: number): number {
+	const perToken = value ?? fallback;
+	if (perToken == null) {
+		throw new Error('Missing required pricing value');
+	}
 	return perToken * MILLION;
 }
 
 export type CodexPricingSourceOptions = {
 	offline?: boolean;
 	offlineLoader?: () => Promise<Record<string, LiteLLMModelPricing>>;
+	allowFuzzyPricing?: boolean;
+	unknownModelFallback?: string;
 };
 
 const PREFETCHED_CODEX_PRICING = prefetchCodexPricing();
 
 export class CodexPricingSource implements PricingSource, Disposable {
 	private readonly fetcher: LiteLLMPricingFetcher;
+	private readonly allowFuzzyPricing: boolean;
+	private readonly unknownModelFallback?: string;
 
 	constructor(options: CodexPricingSourceOptions = {}) {
 		this.fetcher = new LiteLLMPricingFetcher({
@@ -31,42 +38,155 @@ export class CodexPricingSource implements PricingSource, Disposable {
 			logger,
 			providerPrefixes: CODEX_PROVIDER_PREFIXES,
 		});
+		this.allowFuzzyPricing = options.allowFuzzyPricing ?? false;
+		this.unknownModelFallback = options.unknownModelFallback;
 	}
 
 	[Symbol.dispose](): void {
 		this.fetcher[Symbol.dispose]();
 	}
 
-	async getPricing(model: string): Promise<ModelPricing> {
-		const directLookup = await this.fetcher.getModelPricing(model);
-		if (Result.isFailure(directLookup)) {
-			throw directLookup.error;
+	private async getPricingMap(): Promise<Map<string, LiteLLMModelPricing>> {
+		const pricingLookup = await this.fetcher.fetchModelPricing();
+		if (Result.isFailure(pricingLookup)) {
+			throw pricingLookup.error;
 		}
+		return pricingLookup.value;
+	}
 
-		let pricing = directLookup.value;
-		if (pricing == null) {
-			const alias = CODEX_MODEL_ALIASES_MAP.get(model);
-			if (alias != null) {
-				const aliasLookup = await this.fetcher.getModelPricing(alias);
-				if (Result.isFailure(aliasLookup)) {
-					throw aliasLookup.error;
-				}
-				pricing = aliasLookup.value;
+	private createResolvedPricing(
+		key: string,
+		pricing: LiteLLMModelPricing,
+		resolution: PricingResolution,
+	): { key: string; pricing: LiteLLMModelPricing; resolution: PricingResolution } {
+		return { key, pricing, resolution };
+	}
+
+	private findDirectPricing(
+		pricingMap: Map<string, LiteLLMModelPricing>,
+		model: string,
+	): { key: string; pricing: LiteLLMModelPricing; resolution: PricingResolution } | null {
+		const candidates = [model, ...CODEX_PROVIDER_PREFIXES.map((prefix) => `${prefix}${model}`)];
+		for (const candidate of candidates) {
+			const pricing = pricingMap.get(candidate);
+			if (pricing != null) {
+				return this.createResolvedPricing(candidate, pricing, 'direct');
+			}
+		}
+		return null;
+	}
+
+	private findAliasPricing(
+		pricingMap: Map<string, LiteLLMModelPricing>,
+		model: string,
+	): { key: string; pricing: LiteLLMModelPricing; resolution: PricingResolution } | null {
+		const alias = CODEX_MODEL_ALIASES_MAP.get(model);
+		if (alias == null) {
+			return null;
+		}
+		const aliasPricing = this.findDirectPricing(pricingMap, alias);
+		if (aliasPricing == null) {
+			return null;
+		}
+		return this.createResolvedPricing(aliasPricing.key, aliasPricing.pricing, 'alias');
+	}
+
+	private findFuzzyPricing(
+		pricingMap: Map<string, LiteLLMModelPricing>,
+		model: string,
+	): { key: string; pricing: LiteLLMModelPricing; resolution: PricingResolution } | null {
+		const lower = model.toLowerCase();
+		const matches: Array<{ key: string; pricing: LiteLLMModelPricing }> = [];
+		for (const [key, value] of pricingMap) {
+			const comparison = key.toLowerCase();
+			if (comparison.includes(lower) || lower.includes(comparison)) {
+				matches.push({ key, pricing: value });
 			}
 		}
 
-		if (pricing == null) {
-			throw new Error(`Pricing not found for model ${model}`);
+		if (matches.length === 0) {
+			return null;
+		}
+		if (matches.length > 1) {
+			throw new Error(
+				`Ambiguous fuzzy pricing resolution for model ${model}; ${matches.length} candidates found: ${matches
+					.map((x) => x.key)
+					.join(', ')}`,
+			);
+		}
+		const match = matches[0];
+		if (match == null) {
+			return null;
+		}
+		return this.createResolvedPricing(match.key, match.pricing, 'fuzzy');
+	}
+
+	private normalizeModelPricing(
+		model: string,
+		resolved: { key: string; pricing: LiteLLMModelPricing; resolution: PricingResolution },
+	): ModelPricing {
+		const { pricing, key, resolution } = resolved;
+		const inputCostPerToken = pricing.input_cost_per_token;
+		const outputCostPerToken = pricing.output_cost_per_token;
+		if (inputCostPerToken == null || outputCostPerToken == null) {
+			throw new Error(
+				`Pricing for model ${model} is incomplete: input_cost_per_token and output_cost_per_token are required`,
+			);
 		}
 
 		return {
-			inputCostPerMToken: toPerMillion(pricing.input_cost_per_token),
+			inputCostPerMToken: toPerMillion(inputCostPerToken),
 			cachedInputCostPerMToken: toPerMillion(
-				pricing.cache_read_input_token_cost,
-				pricing.input_cost_per_token,
+				pricing.cache_read_input_token_cost ?? inputCostPerToken,
 			),
-			outputCostPerMToken: toPerMillion(pricing.output_cost_per_token),
+			outputCostPerMToken: toPerMillion(outputCostPerToken),
+			pricingResolution: resolution,
+			pricingModel: key,
 		};
+	}
+
+	async getPricing(model: string): Promise<ModelPricing> {
+		const pricingMap = await this.getPricingMap();
+
+		let resolvedPricing = this.findDirectPricing(pricingMap, model);
+		if (resolvedPricing == null) {
+			resolvedPricing = this.findAliasPricing(pricingMap, model);
+		}
+
+		if (resolvedPricing == null && this.allowFuzzyPricing) {
+			resolvedPricing = this.findFuzzyPricing(pricingMap, model);
+		}
+
+		if (resolvedPricing == null && this.unknownModelFallback != null) {
+			const fallbackModel = this.unknownModelFallback.trim();
+			if (fallbackModel !== '') {
+				const fallbackPricing =
+					this.findDirectPricing(pricingMap, fallbackModel) ??
+					this.findAliasPricing(pricingMap, fallbackModel);
+				if (fallbackPricing == null) {
+					throw new Error(
+						`Configured fallback model ${fallbackModel} could not be resolved for ${model}`,
+					);
+				}
+				logger.warn(`Using fallback model pricing: ${model} -> ${fallbackModel}`);
+				resolvedPricing = this.createResolvedPricing(
+					fallbackPricing.key,
+					fallbackPricing.pricing,
+					'fallback',
+				);
+			}
+		}
+
+		if (resolvedPricing == null) {
+			if (!this.allowFuzzyPricing) {
+				throw new Error(
+					`Pricing not found for model ${model}. Fuzzy matching is disabled; pass --allow-fuzzy-pricing to enable it.`,
+				);
+			}
+			throw new Error(`Pricing not found for model ${model}`);
+		}
+
+		return this.normalizeModelPricing(model, resolvedPricing);
 	}
 }
 
@@ -88,6 +208,57 @@ if (import.meta.vitest != null) {
 			expect(pricing.inputCostPerMToken).toBeCloseTo(1.25);
 			expect(pricing.outputCostPerMToken).toBeCloseTo(10);
 			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.125);
+		});
+
+		it('fails when required pricing fields are missing', async () => {
+			using source = new CodexPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'gpt-5.3-codex': {
+						max_tokens: 128_000,
+					},
+				}),
+			});
+
+			await expect(source.getPricing('gpt-5.3-codex')).rejects.toThrow(
+				'incomplete: input_cost_per_token and output_cost_per_token are required',
+			);
+		});
+
+		it('fails when unknown model has no fallback and fuzzy is disabled', async () => {
+			using source = new CodexPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'gpt-5.2-codex': {
+						input_cost_per_token: 1.75e-6,
+						output_cost_per_token: 1.4e-5,
+						cache_read_input_token_cost: 1.75e-7,
+					},
+				}),
+			});
+
+			await expect(source.getPricing('gpt-5.3-codex')).rejects.toThrow(
+				'Fuzzy matching is disabled',
+			);
+		});
+
+		it('uses configured unknown model fallback when resolution fails', async () => {
+			using source = new CodexPricingSource({
+				offline: true,
+				unknownModelFallback: 'gpt-5.2-codex',
+				offlineLoader: async () => ({
+					'gpt-5.2-codex': {
+						input_cost_per_token: 1.75e-6,
+						output_cost_per_token: 1.4e-5,
+						cache_read_input_token_cost: 1.75e-7,
+					},
+				}),
+			});
+
+			const pricing = await source.getPricing('gpt-5.3-codex');
+			expect(pricing.inputCostPerMToken).toBeCloseTo(1.75);
+			expect(pricing.outputCostPerMToken).toBeCloseTo(14);
+			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.175);
 		});
 	});
 }

--- a/apps/codex/src/session-report.ts
+++ b/apps/codex/src/session-report.ts
@@ -124,7 +124,12 @@ export async function buildSessionReport(
 
 		const rowModels: Record<string, ModelUsage> = {};
 		for (const [modelName, usage] of summary.models) {
-			rowModels[modelName] = { ...usage };
+			const pricing = modelPricing.get(modelName);
+			rowModels[modelName] = {
+				...usage,
+				pricingResolution: pricing?.pricingResolution,
+				pricingModel: pricing?.pricingModel,
+			};
 		}
 
 		const separatorIndex = summary.sessionId.lastIndexOf('/');
@@ -156,11 +161,23 @@ if (import.meta.vitest != null) {
 			const pricing = new Map([
 				[
 					'gpt-5',
-					{ inputCostPerMToken: 1.25, cachedInputCostPerMToken: 0.125, outputCostPerMToken: 10 },
+					{
+						inputCostPerMToken: 1.25,
+						cachedInputCostPerMToken: 0.125,
+						outputCostPerMToken: 10,
+						pricingResolution: 'direct' as const,
+						pricingModel: 'gpt-5',
+					},
 				],
 				[
 					'gpt-5-mini',
-					{ inputCostPerMToken: 0.6, cachedInputCostPerMToken: 0.06, outputCostPerMToken: 2 },
+					{
+						inputCostPerMToken: 0.6,
+						cachedInputCostPerMToken: 0.06,
+						outputCostPerMToken: 2,
+						pricingResolution: 'direct' as const,
+						pricingModel: 'gpt-5-mini',
+					},
 				],
 			]);
 			const stubPricingSource: PricingSource = {


### PR DESCRIPTION
## Summary
- make model pricing resolution strict by default
  - fail on incomplete pricing fields
  - fail when unresolved model pricing and fuzzy matching is disabled
- add explicit opt-in controls:
  - --allow-fuzzy-pricing
  - --unknown-model-fallback <model>
- add pricing provenance metadata to JSON model entries:
  - pricingResolution (direct|alias|fuzzy|fallback)
  - pricingModel (resolved pricing key)

## Why
Recent pricing datasets can include model keys without required cost fields. Previous behavior could silently produce 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line options for fuzzy pricing and fallback model configuration, enabling more flexible pricing resolution for unknown models.
  * Reports now include pricing resolution metadata, showing how pricing was determined for each model (direct match, alias, fuzzy, or fallback).
  * Enhanced pricing resolution with multiple lookup strategies to handle unknown models gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->