### PR TITLE
fix(amp): fallback missing model pricing to zero-cost in codex/amp

### DIFF
--- a/apps/amp/src/pricing.ts
+++ b/apps/amp/src/pricing.ts
@@ -7,12 +7,12 @@ import { prefetchAmpPricing } from './_macro.ts' with { type: 'macro' };
 import { logger } from './logger.ts';
 
 const AMP_PROVIDER_PREFIXES = ['anthropic/'];
-const ZERO_MODEL_PRICING: ModelPricing = {
+const ZERO_MODEL_PRICING = {
 	inputCostPerMToken: 0,
 	cachedInputCostPerMToken: 0,
 	cacheCreationCostPerMToken: 0,
 	outputCostPerMToken: 0,
-};
+} as const satisfies ModelPricing;
 
 function toPerMillion(value: number | undefined, fallback?: number): number {
 	const perToken = value ?? fallback ?? 0;

--- a/apps/codex/src/pricing.ts
+++ b/apps/codex/src/pricing.ts
@@ -11,11 +11,11 @@ const CODEX_MODEL_ALIASES_MAP = new Map<string, string>([
 	['gpt-5-codex', 'gpt-5'],
 	['gpt-5.3-codex', 'gpt-5.2-codex'],
 ]);
-const FREE_MODEL_PRICING: ModelPricing = {
+const FREE_MODEL_PRICING = {
 	inputCostPerMToken: 0,
 	cachedInputCostPerMToken: 0,
 	outputCostPerMToken: 0,
-};
+} as const satisfies ModelPricing;
 
 function isOpenRouterFreeModel(model: string): boolean {
 	const normalized = model.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- add zero-cost fallback for missing model pricing in `apps/codex`
- preserve explicit free-route handling for OpenRouter free models in `apps/codex`
- add zero-cost fallback for missing model pricing in `apps/amp`
- add/adjust in-source tests for unknown-model fallback behavior

## Verification
- `pnpm run format`
- `pnpm typecheck`
- `pnpm --filter @ccusage/codex test`
- `pnpm --filter @ccusage/amp test`

## Notes
- when LiteLLM has no pricing entry for a model, reports now continue and assign `0` cost for that model with a warning log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing handling for unknown models — now returns zero cost and logs a warning instead of failing.
  * Recognizes free model offerings and short-circuits to zero pricing where applicable.

* **Tests**
  * Added tests to verify zero-pricing behavior for free and unknown models and to preserve existing alias-based pricing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->