### PR TITLE
fix: replace non-standard engines.runtime array with standard engines fields

### DIFF
--- a/apps/amp/package.json
+++ b/apps/amp/package.json
@@ -29,19 +29,8 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4",
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.9",
-				"onFail": "download"
-			}
-		]
+		"bun": ">=1.3.9",
+		"node": ">=20.19.4"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -47,19 +47,8 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4",
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.9",
-				"onFail": "download"
-			}
-		]
+		"bun": ">=1.3.9",
+		"node": ">=20.19.4"
 	},
 	"scripts": {
 		"build": "pnpm run generate:schema && tsdown",

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -29,19 +29,8 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4",
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.9",
-				"onFail": "download"
-			}
-		]
+		"bun": ">=1.3.9",
+		"node": ">=20.19.4"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -39,19 +39,8 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4",
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.9",
-				"onFail": "download"
-			}
-		]
+		"bun": ">=1.3.9",
+		"node": ">=20.19.4"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -32,19 +32,8 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4",
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.9",
-				"onFail": "download"
-			}
-		]
+		"bun": ">=1.3.9",
+		"node": ">=20.19.4"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/apps/pi/package.json
+++ b/apps/pi/package.json
@@ -42,19 +42,8 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4",
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.9",
-				"onFail": "download"
-			}
-		]
+		"bun": ">=1.3.9",
+		"node": ">=20.19.4"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,18 +5,8 @@
 	"private": true,
 	"description": "Documentation for ccusage",
 	"engines": {
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.11.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.9",
-				"onFail": "download"
-			}
-		]
+		"bun": ">=1.3.9",
+		"node": ">=20.19.4"
 	},
 	"scripts": {
 		"build": "pnpm run docs:api && cp ../apps/ccusage/config-schema.json public/config-schema.json && vitepress build",


### PR DESCRIPTION
## Summary

- Fixes `EUNSUPPORTEDPROTOCOL` error when installing via `npx ccusage@latest` (closes #861)
- Removes the non-standard `engines.runtime` array introduced by #851 across all packages

## Root Cause

PR #851 migrated from `devEngines` to `engines` but kept the `devEngines` array-of-objects format inside `engines.runtime`. This is not a valid npm `engines` field — the only valid values are runtime name keys with semver strings (e.g. `"node"`, `"bun"`).

During publish, the `engines.runtime[].version` value (`^24.11.0`) gets written as a `runtime:^24.11.0` dependency entry in the final package, which npm rejects with `EUNSUPPORTEDPROTOCOL`.

## Fix

Replace the invalid array format with standard string fields in all 7 package.json files (root + 6 apps + docs):

```json
// Before (broken)
"engines": {
  "node": ">=20.19.4",
  "runtime": [
    { "name": "node", "version": "^24.11.0", "onFail": "download" },
    { "name": "bun",  "version": "^1.3.9",   "onFail": "download" }
  ]
}

// After (standard)
"engines": {
  "node": ">=20.19.4",
  "bun": ">=1.3.9"
}
```

## Testing

Packed the fixed package and installed via npm — no `EUNSUPPORTEDPROTOCOL` error:

```bash
pnpm pack
mkdir /tmp/test-ccusage && cd /tmp/test-ccusage
npm install /path/to/ccusage-18.0.6.tgz
# added 1 package in 128ms ✅

./node_modules/.bin/ccusage --version
# 18.0.6 ✅
```

Workaround for affected users until a new release is cut: `npx ccusage@18.0.5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified runtime engine configuration across multiple packages. Engine requirements for Node (>=20.19.4) and Bun (>=1.3.9) are now declared more straightforwardly without complex runtime metadata structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->