### PR TITLE
fix(opencode): add Claude model aliases for dot-notation version names

### DIFF
--- a/apps/opencode/src/cost-utils.ts
+++ b/apps/opencode/src/cost-utils.ts
@@ -9,6 +9,13 @@ import { Result } from '@praha/byethrow';
 const MODEL_ALIASES: Record<string, string> = {
 	// OpenCode uses -high suffix for higher tier/thinking mode variants
 	'gemini-3-pro-high': 'gemini-3-pro-preview',
+	// OpenCode uses dot notation for Claude version numbers (e.g. 4.5),
+	// but LiteLLM uses hyphens (e.g. 4-5)
+	'claude-haiku-4.5': 'claude-haiku-4-5',
+	'claude-opus-4.5': 'claude-opus-4-5',
+	'claude-opus-4.6': 'claude-opus-4-6',
+	'claude-sonnet-4.5': 'claude-sonnet-4-5',
+	'claude-sonnet-4.6': 'claude-sonnet-4-6',
 };
 
 function resolveModelName(modelName: string): string {


### PR DESCRIPTION
## Summary

OpenCode uses dot notation for Claude model version numbers (e.g. `claude-opus-4.6`, `claude-sonnet-4.5`), but LiteLLM uses hyphens (e.g. `claude-opus-4-6`, `claude-sonnet-4-5`). This mismatch causes cost calculation to silently fall back to zero for all Claude models used through OpenCode.

## Problem

When OpenCode records usage for Claude models, the `modelID` stored in the database uses dot notation:
- `claude-opus-4.6`
- `claude-sonnet-4.5`
- `claude-sonnet-4.6`
- `claude-opus-4.5`
- `claude-haiku-4.5`

However, LiteLLM's pricing dataset uses hyphen notation (`claude-opus-4-6`, `claude-sonnet-4-5`, etc.). The `LiteLLMPricingFetcher.getModelPricing()` method cannot find a match, so costs are reported as $0.

Note: `github_copilot/claude-opus-4.6` does exist in LiteLLM but with `NaN` pricing — this is a separate upstream issue. The `providerID` field in OpenCode is stored separately and is **not** used in the model name lookup, so `createMatchingCandidates()` never constructs the `github_copilot/` prefixed name. Our aliases correctly map the bare model names.

## Changes

Added 5 Claude model aliases to `MODEL_ALIASES` in `apps/opencode/src/cost-utils.ts`:

| OpenCode name | LiteLLM name | Input ($/M) | Output ($/M) |
|---|---|---|---|
| `claude-haiku-4.5` | `claude-haiku-4-5` | $0.80 | $4.00 |
| `claude-opus-4.5` | `claude-opus-4-5` | $5.00 | $25.00 |
| `claude-opus-4.6` | `claude-opus-4-6` | $5.00 | $25.00 |
| `claude-sonnet-4.5` | `claude-sonnet-4-5` | $3.00 | $15.00 |
| `claude-sonnet-4.6` | `claude-sonnet-4-6` | $3.00 | $15.00 |

## Verification

- [x] Build passes (`pnpm --filter @ccusage/opencode run build`)
- [x] All tests pass (`pnpm --filter @ccusage/opencode run test` — 6/6)
- [x] Lint passes (`pnpm --filter @ccusage/opencode run lint`)
- [x] Verified `modelID` in OpenCode's SQLite DB is stored as bare name without provider prefix
- [x] Confirmed all 5 aliased names exist in LiteLLM with valid (non-NaN) pricing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for additional Claude model naming conventions in pricing lookups, enabling proper translation between variant naming formats for accurate cost calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->