### PR TITLE
perf: add 3-layer early date filtering to skip irrelevant files and entries

### DIFF
--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -729,6 +729,16 @@ async function filterFilesByMtime(files: string[], since?: string): Promise<stri
 	}
 
 	const sinceDate = parseSinceDate(since);
+	const y = Number(since.slice(0, 4));
+	const m = Number(since.slice(4, 6));
+	const d = Number(since.slice(6, 8));
+	if (
+		sinceDate.getFullYear() !== y ||
+		sinceDate.getMonth() !== m - 1 ||
+		sinceDate.getDate() !== d
+	) {
+		return files;
+	}
 	sinceDate.setDate(sinceDate.getDate() - 1);
 	const sinceMs = sinceDate.getTime();
 
@@ -4893,6 +4903,13 @@ if (import.meta.vitest != null) {
 			const files = ['/a.jsonl', '/b.jsonl'];
 			const result = await filterFilesByMtime(files, 'not-a-date');
 			expect(result).toEqual(files);
+		});
+
+		it('returns all files when since is impossible calendar date', async () => {
+			const files = ['/a.jsonl', '/b.jsonl'];
+			expect(await filterFilesByMtime(files, '20230231')).toEqual(files);
+			expect(await filterFilesByMtime(files, '20231301')).toEqual(files);
+			expect(await filterFilesByMtime(files, '20230000')).toEqual(files);
 		});
 
 		it('keeps files newer than since', async () => {

--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -1041,11 +1041,6 @@ export async function loadSessionData(options?: LoadOptions): Promise<SessionUsa
 
 				const sessionKey = `${projectPath}/${sessionId}`;
 
-				const entryDate = formatDate(data.timestamp, options?.timezone, DEFAULT_LOCALE);
-				if (isOutsideDateRange(entryDate, options?.since, options?.until)) {
-					return;
-				}
-
 				const cost =
 					fetcher != null ? await calculateCostForEntry(data, mode, fetcher) : (data.costUSD ?? 0);
 
@@ -1476,11 +1471,6 @@ export async function loadSessionBlockData(options?: LoadOptions): Promise<Sessi
 				// Mark this combination as processed
 				markAsProcessed(uniqueHash, processedHashes);
 
-				const date = formatDate(data.timestamp, options?.timezone, DEFAULT_LOCALE);
-				if (isOutsideDateRange(date, options?.since, options?.until)) {
-					return;
-				}
-
 				const cost =
 					fetcher != null ? await calculateCostForEntry(data, mode, fetcher) : (data.costUSD ?? 0);
 
@@ -1604,9 +1594,7 @@ if (import.meta.vitest != null) {
 		});
 	});
 
-	describe('loadSessionUsageById', async () => {
-		const { createFixture } = await import('fs-fixture');
-
+	describe('loadSessionUsageById', () => {
 		afterEach(() => {
 			vi.unstubAllEnvs();
 		});
@@ -4795,12 +4783,12 @@ if (import.meta.vitest != null) {
 	});
 
 	// Test for calculateContextTokens
-	describe('calculateContextTokens', async () => {
+	describe('calculateContextTokens', () => {
 		it('returns null when transcript cannot be read', async () => {
 			const result = await calculateContextTokens('/nonexistent/path.jsonl');
 			expect(result).toBeNull();
 		});
-		const { createFixture } = await import('fs-fixture');
+
 		it('parses latest assistant line and excludes output tokens', async () => {
 			await using fixture = await createFixture({
 				'transcript.jsonl': [


### PR DESCRIPTION
## Summary

- Add file-level mtime pre-filter to skip JSONL files that can't contain entries for the requested date range
- Add line-level substring pre-check (`USAGE_LINE_MARKER`) to skip `JSON.parse` on non-usage lines
- Add entry-level early date skip to avoid cost calculation for out-of-range entries
- Apply optimizations to `loadDailyUsageData`, `loadSessionData`, and `loadSessionBlockData`

## Problem

When `--since` / `--until` are provided, ccusage currently:
1. Globs **all** JSONL files
2. Opens **every** file to extract its earliest timestamp (for sorting)
3. Reads and parses **every** line of **every** file
4. Calculates cost for **every** entry
5. Groups and aggregates **all** entries
6. **Then** filters by date range — discarding most of the work

This means a single-day query takes the same time as a full scan.

## Benchmarks

**Machine:** Apple M2 Pro, 32 GB RAM, macOS 15.6
**Dataset:** 4,637 JSONL files, 572 MB total (largest file: 469 MB)

| Query | Before | After | Improvement |
|-------|--------|-------|-------------|
| Today only (`--since 20260227 --until 20260227`) | 36.7s | 0.76s | **98%** |
| Last 7 days (`--since 20260220`) | 36.7s | 3.0s | **92%** |
| Full scan (no filters) | 36.7s | 31.6s | **14%** |

The mtime filter provides the biggest wins for short date ranges (the most common use case for integrations like OpenUsage). The substring pre-check also improves full-scan performance by ~14% by skipping `JSON.parse` on non-usage lines.

## How it works

### 1. File-level mtime pre-filter (`filterFilesByMtime`)
Before reading any file content, checks each file's `mtime` against the `--since` date (with 1-day buffer for timezone safety). Files whose `mtime` is older than `since - 1 day` are skipped entirely.

### 2. Line-level substring pre-check (`USAGE_LINE_MARKER`)
Before calling `JSON.parse` on each line, checks whether the line contains the `"costUSD"` substring (the `USAGE_LINE_MARKER`). In typical JSONL files, ~91.5% of lines are non-usage entries (conversation turns, system messages, etc.) that don't contain cost data. This skips expensive JSON parsing for those lines entirely.

### 3. Entry-level early date skip
Inside the per-line processing loop, after `formatDate` but **before** the expensive `calculateCostForEntry`, compares the entry's date against `since`/`until` and skips out-of-range entries. Uses the same comparison logic as the existing `filterByDateRange` in `_date-utils.ts`.

## Backwards compatibility

This is a **backwards-compatible** change:
- mtime filtering uses a 1-day buffer to account for timezone edge cases
- Substring pre-check only skips lines that can't possibly be usage entries
- Entry-level skip uses identical comparison logic to the existing `filterByDateRange`
- No behavioral change when `--since`/`--until` are not provided
- Files that fail `stat()` are kept (not filtered), ensuring no data loss on permission issues
- All existing tests continue to pass

## Context

Discovered while debugging slow load times in [OpenUsage](https://github.com/robinebers/openusage), a menu bar app that uses ccusage to display Claude Code token usage. With 15-second timeouts per runner, ccusage always times out on machines with heavy usage, causing 60+ second delays. See: robinebers/openusage#249

## Testing

- Added unit tests for `parseSinceDate` (YYYYMMDD parsing, edge cases)
- Added unit tests for `filterFilesByMtime` (mtime edge cases, stat errors, buffer behavior)
- Added tests for `USAGE_LINE_MARKER` substring pre-check (true/false positives, edge cases)
- Added tests for entry-level early skip (correctness parity with existing post-filter)
- Added integration tests with multi-date fixtures and mtime simulation via `utimes()`
- All 269 tests pass: `pnpm run format && pnpm typecheck && pnpm run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date-range (since/until) support added to data loading options.

* **Improvements**
  * Pre-filters files by modification time and applies date-range skipping earlier to reduce work and speed processing.
  * Skips irrelevant lines before parsing and ensures deduplication and cost calculations respect date filters and timezones.

* **Tests**
  * Expanded coverage for date parsing, mtime filtering, line-level skipping, and end-to-end date/time behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->