### PR TITLE
feat(ccusage): improve statusline labels, add setup command & 2x usage countdown and indicator

### DIFF
--- a/apps/ccusage/src/_promotions.ts
+++ b/apps/ccusage/src/_promotions.ts
@@ -111,6 +111,31 @@ function getMinutesToOffPeak(promotion: Promotion, now: Date = new Date()): numb
 }
 
 /**
+ * Calculates minutes until peak hours start (i.e., until 2x off-peak window ends)
+ * Returns null if currently in peak hours or no peak hours defined
+ */
+function getMinutesToPeak(promotion: Promotion, now: Date = new Date()): number | null {
+	if (promotion.peakHours == null) {
+		return null;
+	}
+	if (!isOffPeakHours(promotion, now)) {
+		return null;
+	}
+	const tz = promotion.peakHours.timezone;
+	const currentHour = getHourInTimezone(now, tz);
+	const currentMinute = getMinuteInTimezone(now, tz);
+	const startHour = promotion.peakHours.startHour;
+
+	// If before peak start today (e.g. 2 AM, peak starts at 5 AM)
+	if (currentHour < startHour) {
+		return (startHour - currentHour) * 60 - currentMinute;
+	}
+
+	// After peak end (e.g. 3 PM, next peak starts at 5 AM tomorrow)
+	return (24 - currentHour + startHour) * 60 - currentMinute;
+}
+
+/**
  * Calculates days remaining until promotion ends (inclusive of end date)
  */
 function getDaysUntilPromotionEnd(promotion: Promotion, now: Date = new Date()): number {
@@ -163,8 +188,13 @@ function getEnhancedPromotionSegment(now: Date = new Date()): string {
 	const daysStr = daysLeft > 0 ? pc.dim(` · ${daysLeft}d left`) : '';
 
 	if (isOffPeakHours(promotion, now)) {
-		// Green = 2x is active right now
-		return `${pc.bold(pc.green(promotion.statuslineLabel))} ${pc.bold(pc.green('ON'))}${daysStr}`;
+		// Green = 2x is active right now, show countdown until peak starts
+		const minutesToPeak = getMinutesToPeak(promotion, now);
+		const countdownStr =
+			minutesToPeak != null && minutesToPeak > 0
+				? ` ${pc.bold(pc.green(formatCompactDuration(minutesToPeak)))}`
+				: '';
+		return `${pc.bold(pc.green(promotion.statuslineLabel))} ${pc.bold(pc.green('ON'))}${countdownStr}${daysStr}`;
 	}
 
 	// During peak hours — dim to signal 2x is not active, show countdown
@@ -182,6 +212,7 @@ export {
 	getDaysUntilPromotionEnd,
 	getEnhancedPromotionSegment,
 	getMinutesToOffPeak,
+	getMinutesToPeak,
 	getPromotionStatuslineSegment,
 	isOffPeakHours,
 };
@@ -337,8 +368,37 @@ if (import.meta.vitest != null) {
 		});
 	});
 
+	describe('getMinutesToPeak', () => {
+		const promo = ACTIVE_PROMOTIONS[0]!;
+
+		it('should return null during peak hours', () => {
+			// 8 AM PT (peak)
+			const date = new Date('2026-03-15T15:00:00Z');
+			expect(getMinutesToPeak(promo, date)).toBeNull();
+		});
+
+		it('should return minutes until peak when before peak start same day', () => {
+			// 2 AM PT → 3h until 5 AM peak start
+			const date = new Date('2026-03-15T10:00:00Z'); // 3 AM UTC = 2 AM PT (PDT -7)
+			const minutes = getMinutesToPeak(promo, date);
+			expect(minutes).toBeGreaterThan(0);
+		});
+
+		it('should return minutes until next peak when after peak end', () => {
+			// 8 PM PT → 9h until 5 AM peak start next day
+			const date = new Date('2026-03-16T03:00:00Z'); // 8 PM PT
+			const minutes = getMinutesToPeak(promo, date);
+			expect(minutes).toBeGreaterThan(0);
+		});
+
+		it('should return null when peakHours is undefined', () => {
+			const nopeakPromo: Promotion = { ...promo, peakHours: undefined };
+			expect(getMinutesToPeak(nopeakPromo)).toBeNull();
+		});
+	});
+
 	describe('getEnhancedPromotionSegment', () => {
-		it('should return label with ON and days during off-peak', () => {
+		it('should return label with ON, countdown, and days during off-peak', () => {
 			// Off-peak: 8 PM PT on March 15 (12 days left)
 			const date = new Date('2026-03-16T03:00:00Z');
 			const segment = getEnhancedPromotionSegment(date);

--- a/apps/ccusage/src/_promotions.ts
+++ b/apps/ccusage/src/_promotions.ts
@@ -1,0 +1,362 @@
+import pc from 'picocolors';
+
+/**
+ * Promotion definition for time-limited usage multipliers
+ */
+type Promotion = {
+	id: string;
+	name: string;
+	startDate: string;
+	endDate: string;
+	endTimezone: string;
+	peakHours?: {
+		startHour: number;
+		endHour: number;
+		timezone: string;
+	};
+	multiplier: string;
+	statuslineLabel: string;
+};
+
+/**
+ * Active promotions list — add new promotions here
+ */
+const ACTIVE_PROMOTIONS: Promotion[] = [
+	{
+		id: 'claude-march-2026-2x',
+		name: 'Claude March 2026 2x Off-Peak',
+		startDate: '2026-03-13',
+		endDate: '2026-03-27',
+		endTimezone: 'America/Los_Angeles',
+		peakHours: { startHour: 5, endHour: 11, timezone: 'America/Los_Angeles' },
+		multiplier: '2x',
+		statuslineLabel: '\u26A12x',
+	},
+];
+
+/**
+ * Gets the current hour in a given timezone using Intl.DateTimeFormat
+ */
+function getHourInTimezone(date: Date, timezone: string): number {
+	const formatter = new Intl.DateTimeFormat('en-US', {
+		hour: 'numeric',
+		hour12: false,
+		timeZone: timezone,
+	});
+	return Number.parseInt(formatter.format(date), 10);
+}
+
+/**
+ * Gets a YYYY-MM-DD date string in a given timezone
+ */
+function getDateStringInTimezone(date: Date, timezone: string): string {
+	const formatter = new Intl.DateTimeFormat('en-CA', {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		timeZone: timezone,
+	});
+	return formatter.format(date);
+}
+
+/**
+ * Finds the first active promotion within the date range
+ */
+function getActivePromotion(now: Date = new Date()): Promotion | undefined {
+	return ACTIVE_PROMOTIONS.find((promo) => {
+		const dateStr = getDateStringInTimezone(now, promo.endTimezone);
+		return dateStr >= promo.startDate && dateStr <= promo.endDate;
+	});
+}
+
+/**
+ * Checks if the current time is outside peak hours for a promotion
+ * If no peakHours are defined, always returns true (always off-peak)
+ */
+function isOffPeakHours(promotion: Promotion, now: Date = new Date()): boolean {
+	if (promotion.peakHours == null) {
+		return true;
+	}
+	const hour = getHourInTimezone(now, promotion.peakHours.timezone);
+	return hour < promotion.peakHours.startHour || hour >= promotion.peakHours.endHour;
+}
+
+/**
+ * Gets the current minute in a given timezone using Intl.DateTimeFormat
+ */
+function getMinuteInTimezone(date: Date, timezone: string): number {
+	const formatter = new Intl.DateTimeFormat('en-US', {
+		minute: 'numeric',
+		timeZone: timezone,
+	});
+	return Number.parseInt(formatter.format(date), 10);
+}
+
+/**
+ * Calculates minutes until off-peak hours start for a promotion
+ * Returns null if already off-peak or no peak hours defined
+ */
+function getMinutesToOffPeak(promotion: Promotion, now: Date = new Date()): number | null {
+	if (promotion.peakHours == null) {
+		return null;
+	}
+	if (isOffPeakHours(promotion, now)) {
+		return null;
+	}
+	const tz = promotion.peakHours.timezone;
+	const currentHour = getHourInTimezone(now, tz);
+	const currentMinute = getMinuteInTimezone(now, tz);
+	const endHour = promotion.peakHours.endHour;
+	return (endHour - currentHour) * 60 - currentMinute;
+}
+
+/**
+ * Calculates days remaining until promotion ends (inclusive of end date)
+ */
+function getDaysUntilPromotionEnd(promotion: Promotion, now: Date = new Date()): number {
+	const todayStr = getDateStringInTimezone(now, promotion.endTimezone);
+	const todayMs = new Date(`${todayStr}T00:00:00`).getTime();
+	const endMs = new Date(`${promotion.endDate}T00:00:00`).getTime();
+	return Math.max(0, Math.ceil((endMs - todayMs) / (1000 * 60 * 60 * 24)));
+}
+
+/**
+ * Formats minutes into compact time string (e.g., "2h15m", "45m")
+ */
+function formatCompactDuration(totalMinutes: number): string {
+	const hours = Math.floor(totalMinutes / 60);
+	const mins = totalMinutes % 60;
+	if (hours > 0) {
+		return `${hours}h${mins}m`;
+	}
+	return `${mins}m`;
+}
+
+/**
+ * Returns the formatted promotion segment for the statusline,
+ * or an empty string if no promotion is active or it's peak hours
+ */
+function getPromotionStatuslineSegment(now: Date = new Date()): string {
+	const promotion = getActivePromotion(now);
+	if (promotion == null) {
+		return '';
+	}
+	if (!isOffPeakHours(promotion, now)) {
+		return '';
+	}
+	return pc.bold(pc.yellow(promotion.statuslineLabel));
+}
+
+/**
+ * Returns an enhanced promotion segment that shows status during both peak and off-peak:
+ * - Off-peak: "⚡2x" (bold yellow) with optional days remaining
+ * - Peak: "⚡2x in 2h15m" (yellow, showing countdown to off-peak)
+ * - No promotion: empty string
+ */
+function getEnhancedPromotionSegment(now: Date = new Date()): string {
+	const promotion = getActivePromotion(now);
+	if (promotion == null) {
+		return '';
+	}
+
+	const daysLeft = getDaysUntilPromotionEnd(promotion, now);
+	const daysStr = daysLeft > 0 ? pc.dim(` · ${daysLeft}d left`) : '';
+
+	if (isOffPeakHours(promotion, now)) {
+		return `${pc.bold(pc.yellow(promotion.statuslineLabel))}${daysStr}`;
+	}
+
+	// During peak hours — show countdown to off-peak
+	const minutesToOffPeak = getMinutesToOffPeak(promotion, now);
+	if (minutesToOffPeak != null && minutesToOffPeak > 0) {
+		const countdown = formatCompactDuration(minutesToOffPeak);
+		return `${pc.yellow(promotion.statuslineLabel)} ${pc.dim(`in ${countdown}`)}${daysStr}`;
+	}
+
+	return pc.bold(pc.yellow(promotion.statuslineLabel));
+}
+
+export {
+	getActivePromotion,
+	getDaysUntilPromotionEnd,
+	getEnhancedPromotionSegment,
+	getMinutesToOffPeak,
+	getPromotionStatuslineSegment,
+	isOffPeakHours,
+};
+
+if (import.meta.vitest != null) {
+	describe('getActivePromotion', () => {
+		it('should return promotion when date is within range', () => {
+			const date = new Date('2026-03-15T12:00:00Z');
+			const promo = getActivePromotion(date);
+			expect(promo).toBeDefined();
+			expect(promo?.id).toBe('claude-march-2026-2x');
+		});
+
+		it('should return undefined when date is before range', () => {
+			const date = new Date('2026-03-12T12:00:00Z');
+			const promo = getActivePromotion(date);
+			expect(promo).toBeUndefined();
+		});
+
+		it('should return undefined when date is after range', () => {
+			const date = new Date('2026-03-28T12:00:00Z');
+			const promo = getActivePromotion(date);
+			expect(promo).toBeUndefined();
+		});
+
+		it('should return promotion on start date', () => {
+			// 2026-03-13 in PT
+			const date = new Date('2026-03-13T20:00:00Z');
+			const promo = getActivePromotion(date);
+			expect(promo).toBeDefined();
+		});
+
+		it('should return promotion on end date', () => {
+			// 2026-03-27 in PT
+			const date = new Date('2026-03-27T12:00:00Z');
+			const promo = getActivePromotion(date);
+			expect(promo).toBeDefined();
+		});
+	});
+
+	describe('isOffPeakHours', () => {
+		const promo = ACTIVE_PROMOTIONS[0]!;
+
+		it('should return true during off-peak hours (before 5 AM PT)', () => {
+			// 3 AM PT = 11 AM UTC
+			const date = new Date('2026-03-15T11:00:00Z');
+			expect(isOffPeakHours(promo, date)).toBe(true);
+		});
+
+		it('should return false during peak hours (5 AM PT)', () => {
+			// 5 AM PT = 1 PM UTC (during PDT)
+			const date = new Date('2026-03-15T12:00:00Z');
+			expect(isOffPeakHours(promo, date)).toBe(false);
+		});
+
+		it('should return false during peak hours (10 AM PT)', () => {
+			// 10 AM PT = 6 PM UTC (during PDT)
+			const date = new Date('2026-03-15T17:00:00Z');
+			expect(isOffPeakHours(promo, date)).toBe(false);
+		});
+
+		it('should return true at 11 AM PT (end of peak)', () => {
+			// 11 AM PT = 7 PM UTC (during PDT)
+			const date = new Date('2026-03-15T18:00:00Z');
+			expect(isOffPeakHours(promo, date)).toBe(true);
+		});
+
+		it('should return true during off-peak hours (evening PT)', () => {
+			// 8 PM PT = 4 AM UTC+1 (during PDT)
+			const date = new Date('2026-03-16T03:00:00Z');
+			expect(isOffPeakHours(promo, date)).toBe(true);
+		});
+
+		it('should return true when peakHours is undefined', () => {
+			const nopeakPromo: Promotion = {
+				...promo,
+				peakHours: undefined,
+			};
+			expect(isOffPeakHours(nopeakPromo)).toBe(true);
+		});
+	});
+
+	describe('getPromotionStatuslineSegment', () => {
+		it('should return formatted string during off-peak within promo dates', () => {
+			// Off-peak: 8 PM PT on March 15
+			const date = new Date('2026-03-16T03:00:00Z');
+			const segment = getPromotionStatuslineSegment(date);
+			expect(segment).not.toBe('');
+			expect(segment).toContain('2x');
+		});
+
+		it('should return empty string during peak hours', () => {
+			// Peak: 8 AM PT on March 15
+			const date = new Date('2026-03-15T15:00:00Z');
+			const segment = getPromotionStatuslineSegment(date);
+			expect(segment).toBe('');
+		});
+
+		it('should return empty string outside promotion dates', () => {
+			const date = new Date('2026-04-01T03:00:00Z');
+			const segment = getPromotionStatuslineSegment(date);
+			expect(segment).toBe('');
+		});
+	});
+
+	describe('getMinutesToOffPeak', () => {
+		const promo = ACTIVE_PROMOTIONS[0]!;
+
+		it('should return null during off-peak hours', () => {
+			// 8 PM PT (off-peak)
+			const date = new Date('2026-03-16T03:00:00Z');
+			expect(getMinutesToOffPeak(promo, date)).toBeNull();
+		});
+
+		it('should return minutes remaining during peak hours', () => {
+			// 8 AM PT → 3 hours until 11 AM = 180 minutes
+			const date = new Date('2026-03-15T15:00:00Z');
+			const minutes = getMinutesToOffPeak(promo, date);
+			expect(minutes).toBe(180);
+		});
+
+		it('should return minutes including partial hour', () => {
+			// 10:30 AM PT → 30 minutes until 11 AM
+			const date = new Date('2026-03-15T17:30:00Z');
+			const minutes = getMinutesToOffPeak(promo, date);
+			expect(minutes).toBe(30);
+		});
+
+		it('should return null when peakHours is undefined', () => {
+			const nopeakPromo: Promotion = { ...promo, peakHours: undefined };
+			expect(getMinutesToOffPeak(nopeakPromo)).toBeNull();
+		});
+	});
+
+	describe('getDaysUntilPromotionEnd', () => {
+		const promo = ACTIVE_PROMOTIONS[0]!;
+
+		it('should return days remaining on start date', () => {
+			// March 13 → March 27 = 14 days
+			const date = new Date('2026-03-13T20:00:00Z');
+			expect(getDaysUntilPromotionEnd(promo, date)).toBe(14);
+		});
+
+		it('should return 0 on end date', () => {
+			// March 27 in PT
+			const date = new Date('2026-03-27T20:00:00Z');
+			expect(getDaysUntilPromotionEnd(promo, date)).toBe(0);
+		});
+
+		it('should return 0 after promotion ends', () => {
+			const date = new Date('2026-03-28T12:00:00Z');
+			expect(getDaysUntilPromotionEnd(promo, date)).toBe(0);
+		});
+	});
+
+	describe('getEnhancedPromotionSegment', () => {
+		it('should return label with days during off-peak', () => {
+			// Off-peak: 8 PM PT on March 15 (12 days left)
+			const date = new Date('2026-03-16T03:00:00Z');
+			const segment = getEnhancedPromotionSegment(date);
+			expect(segment).toContain('2x');
+			expect(segment).toContain('12d left');
+		});
+
+		it('should return countdown during peak hours', () => {
+			// Peak: 8 AM PT on March 15 → 3h to off-peak
+			const date = new Date('2026-03-15T15:00:00Z');
+			const segment = getEnhancedPromotionSegment(date);
+			expect(segment).toContain('2x');
+			expect(segment).toContain('in 3h0m');
+		});
+
+		it('should return empty string outside promotion dates', () => {
+			const date = new Date('2026-04-01T03:00:00Z');
+			const segment = getEnhancedPromotionSegment(date);
+			expect(segment).toBe('');
+		});
+	});
+}

--- a/apps/ccusage/src/_promotions.ts
+++ b/apps/ccusage/src/_promotions.ts
@@ -149,8 +149,8 @@ function getPromotionStatuslineSegment(now: Date = new Date()): string {
 
 /**
  * Returns an enhanced promotion segment that shows status during both peak and off-peak:
- * - Off-peak: "⚡2x" (bold yellow) with optional days remaining
- * - Peak: "⚡2x in 2h15m" (yellow, showing countdown to off-peak)
+ * - Off-peak (2x active): "⚡2x ON" (bold green) with optional days remaining
+ * - Peak (2x inactive): "⚡2x in 2h15m" (dim, showing countdown to off-peak)
  * - No promotion: empty string
  */
 function getEnhancedPromotionSegment(now: Date = new Date()): string {
@@ -163,17 +163,18 @@ function getEnhancedPromotionSegment(now: Date = new Date()): string {
 	const daysStr = daysLeft > 0 ? pc.dim(` · ${daysLeft}d left`) : '';
 
 	if (isOffPeakHours(promotion, now)) {
-		return `${pc.bold(pc.yellow(promotion.statuslineLabel))}${daysStr}`;
+		// Green = 2x is active right now
+		return `${pc.bold(pc.green(promotion.statuslineLabel))} ${pc.bold(pc.green('ON'))}${daysStr}`;
 	}
 
-	// During peak hours — show countdown to off-peak
+	// During peak hours — dim to signal 2x is not active, show countdown
 	const minutesToOffPeak = getMinutesToOffPeak(promotion, now);
 	if (minutesToOffPeak != null && minutesToOffPeak > 0) {
 		const countdown = formatCompactDuration(minutesToOffPeak);
-		return `${pc.yellow(promotion.statuslineLabel)} ${pc.dim(`in ${countdown}`)}${daysStr}`;
+		return `${pc.dim(promotion.statuslineLabel)} ${pc.dim(`in ${countdown}`)}${daysStr}`;
 	}
 
-	return pc.bold(pc.yellow(promotion.statuslineLabel));
+	return pc.bold(pc.green(promotion.statuslineLabel));
 }
 
 export {
@@ -337,20 +338,22 @@ if (import.meta.vitest != null) {
 	});
 
 	describe('getEnhancedPromotionSegment', () => {
-		it('should return label with days during off-peak', () => {
+		it('should return label with ON and days during off-peak', () => {
 			// Off-peak: 8 PM PT on March 15 (12 days left)
 			const date = new Date('2026-03-16T03:00:00Z');
 			const segment = getEnhancedPromotionSegment(date);
 			expect(segment).toContain('2x');
+			expect(segment).toContain('ON');
 			expect(segment).toContain('12d left');
 		});
 
-		it('should return countdown during peak hours', () => {
+		it('should return dim countdown during peak hours', () => {
 			// Peak: 8 AM PT on March 15 → 3h to off-peak
 			const date = new Date('2026-03-15T15:00:00Z');
 			const segment = getEnhancedPromotionSegment(date);
 			expect(segment).toContain('2x');
 			expect(segment).toContain('in 3h0m');
+			expect(segment).not.toContain('ON');
 		});
 
 		it('should return empty string outside promotion dates', () => {

--- a/apps/ccusage/src/commands/index.ts
+++ b/apps/ccusage/src/commands/index.ts
@@ -5,6 +5,7 @@ import { blocksCommand } from './blocks.ts';
 import { dailyCommand } from './daily.ts';
 import { monthlyCommand } from './monthly.ts';
 import { sessionCommand } from './session.ts';
+import { setupStatuslineCommand } from './setup-statusline.ts';
 import { statuslineCommand } from './statusline.ts';
 import { weeklyCommand } from './weekly.ts';
 
@@ -14,6 +15,7 @@ export {
 	dailyCommand,
 	monthlyCommand,
 	sessionCommand,
+	setupStatuslineCommand,
 	statuslineCommand,
 	weeklyCommand,
 };
@@ -28,6 +30,7 @@ export const subCommandUnion = [
 	['session', sessionCommand],
 	['blocks', blocksCommand],
 	['statusline', statuslineCommand],
+	['setup-statusline', setupStatuslineCommand],
 ] as const;
 
 /**

--- a/apps/ccusage/src/commands/setup-statusline.ts
+++ b/apps/ccusage/src/commands/setup-statusline.ts
@@ -1,0 +1,236 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { Result } from '@praha/byethrow';
+import { define } from 'gunshi';
+import nanoSpawn from 'nano-spawn';
+import pc from 'picocolors';
+import { DEFAULT_CLAUDE_CODE_PATH, DEFAULT_CLAUDE_CONFIG_PATH, USER_HOME_DIR } from '../_consts.ts';
+import { log } from '../logger.ts';
+
+const runnerChoices = ['auto', 'bun', 'npx'] as const;
+const visualBurnRateChoices = ['off', 'emoji', 'text', 'emoji-text'] as const;
+const costSourceChoices = ['auto', 'ccusage', 'cc', 'both'] as const;
+const promotionDisplayChoices = ['auto', 'active-only', 'off'] as const;
+
+/**
+ * Detects whether bun is available on the system
+ */
+async function detectBun(): Promise<boolean> {
+	return Result.pipe(
+		await Result.try({
+			try: async () => {
+				await nanoSpawn('bun', ['--version']);
+				return true;
+			},
+			catch: () => false,
+		})(),
+		Result.unwrap(false),
+	);
+}
+
+/**
+ * Finds the Claude Code settings.json path
+ * Prefers XDG config path, falls back to legacy path
+ */
+function findSettingsPath(): { settingsPath: string; isXdg: boolean } {
+	const xdgSettingsPath = path.join(DEFAULT_CLAUDE_CONFIG_PATH, 'settings.json');
+	const legacySettingsPath = path.join(USER_HOME_DIR, DEFAULT_CLAUDE_CODE_PATH, 'settings.json');
+
+	// Prefer XDG path if it exists, otherwise check legacy
+	if (existsSync(xdgSettingsPath)) {
+		return { settingsPath: xdgSettingsPath, isXdg: true };
+	}
+	if (existsSync(legacySettingsPath)) {
+		return { settingsPath: legacySettingsPath, isXdg: false };
+	}
+
+	// Default to XDG path for new installations
+	return { settingsPath: xdgSettingsPath, isXdg: true };
+}
+
+/**
+ * Builds the statusline command string from options
+ */
+function buildCommand(
+	runner: string,
+	options: {
+		visualBurnRate: string;
+		showPromotions: boolean;
+		promotionDisplay: string;
+		costSource: string;
+		showSessionDuration: boolean;
+		showLinesChanged: boolean;
+	},
+): string {
+	const prefix = runner === 'bun' ? 'bun x' : 'npx -y';
+	const parts = [`${prefix} ccusage statusline`];
+
+	if (options.visualBurnRate !== 'off') {
+		parts.push(`--visual-burn-rate ${options.visualBurnRate}`);
+	}
+
+	if (!options.showPromotions) {
+		parts.push('--no-show-promotions');
+	}
+
+	if (options.promotionDisplay !== 'auto') {
+		parts.push(`--promotion-display ${options.promotionDisplay}`);
+	}
+
+	if (options.costSource !== 'auto') {
+		parts.push(`--cost-source ${options.costSource}`);
+	}
+
+	if (!options.showSessionDuration) {
+		parts.push('--no-show-session-duration');
+	}
+
+	if (!options.showLinesChanged) {
+		parts.push('--no-show-lines-changed');
+	}
+
+	return parts.join(' ');
+}
+
+export const setupStatuslineCommand = define({
+	name: 'setup-statusline',
+	description: 'Auto-configure Claude Code statusline integration',
+	toKebab: true,
+	args: {
+		runner: {
+			type: 'enum',
+			choices: runnerChoices,
+			description: 'Package runner: auto (detect bun), bun, or npx',
+			default: 'auto',
+			negatable: false,
+		},
+		force: {
+			type: 'boolean',
+			short: 'f',
+			description: 'Overwrite existing statusLine configuration',
+			default: false,
+		},
+		dryRun: {
+			type: 'boolean',
+			description: 'Show what would be written without making changes',
+			default: false,
+			toKebab: true,
+		},
+		visualBurnRate: {
+			type: 'enum',
+			choices: visualBurnRateChoices,
+			description: 'Burn rate visualization style',
+			default: 'off',
+			negatable: false,
+			toKebab: true,
+		},
+		showPromotions: {
+			type: 'boolean',
+			description: 'Enable promotion display in statusline (default: true)',
+			negatable: true,
+			default: true,
+			toKebab: true,
+		},
+		costSource: {
+			type: 'enum',
+			choices: costSourceChoices,
+			description: 'Session cost source: auto, ccusage, cc, or both',
+			default: 'auto',
+			negatable: false,
+			toKebab: true,
+		},
+		promotionDisplay: {
+			type: 'enum',
+			choices: promotionDisplayChoices,
+			description: 'Promotion display: auto (with countdown), active-only (off-peak only), off',
+			default: 'auto',
+			negatable: false,
+			toKebab: true,
+		},
+		showSessionDuration: {
+			type: 'boolean',
+			description: 'Show session duration in statusline (default: true)',
+			negatable: true,
+			default: true,
+			toKebab: true,
+		},
+		showLinesChanged: {
+			type: 'boolean',
+			description: 'Show lines added/removed in statusline (default: true)',
+			negatable: true,
+			default: true,
+			toKebab: true,
+		},
+	},
+	async run(ctx) {
+		// Detect runner
+		const resolvedRunner = await (async (): Promise<'bun' | 'npx'> => {
+			if (ctx.values.runner === 'bun') {
+				return 'bun';
+			}
+			if (ctx.values.runner === 'npx') {
+				return 'npx';
+			}
+			// auto detection
+			const hasBun = await detectBun();
+			return hasBun ? 'bun' : 'npx';
+		})();
+
+		log(`${pc.dim('Runner:')} ${pc.bold(resolvedRunner)}`);
+
+		// Find settings path
+		const { settingsPath } = findSettingsPath();
+		log(`${pc.dim('Settings:')} ${settingsPath}`);
+
+		// Read existing settings
+		const existingSettings: Record<string, unknown> = existsSync(settingsPath)
+			? (JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>)
+			: {};
+
+		// Check if statusLine already exists
+		if ('statusLine' in existingSettings && !ctx.values.force) {
+			log(`\n${pc.yellow('⚠')} statusLine is already configured in ${settingsPath}`);
+			log(`  Use ${pc.bold('--force')} to overwrite the existing configuration.`);
+			return;
+		}
+
+		// Build command
+		const command = buildCommand(resolvedRunner, {
+			visualBurnRate: ctx.values.visualBurnRate,
+			showPromotions: ctx.values.showPromotions,
+			promotionDisplay: ctx.values.promotionDisplay,
+			costSource: ctx.values.costSource,
+			showSessionDuration: ctx.values.showSessionDuration,
+			showLinesChanged: ctx.values.showLinesChanged,
+		});
+
+		// Build new settings
+		const newSettings = {
+			...existingSettings,
+			statusLine: {
+				type: 'command',
+				command,
+				padding: 0,
+			},
+		};
+
+		const settingsJson = JSON.stringify(newSettings, null, '\t');
+
+		// Dry run mode
+		if (ctx.values.dryRun) {
+			log(`\n${pc.dim('--- dry run ---')}`);
+			log(`${pc.dim('Would write to:')} ${settingsPath}`);
+			log(settingsJson);
+			log(pc.dim('--- end dry run ---'));
+			return;
+		}
+
+		// Write settings
+		mkdirSync(path.dirname(settingsPath), { recursive: true });
+		writeFileSync(settingsPath, `${settingsJson}\n`, 'utf-8');
+
+		log(`\n${pc.green('✓')} Statusline configured successfully!`);
+		log(`  ${pc.dim('Command:')} ${command}`);
+		log(`\n  ${pc.dim('Restart Claude Code to activate the statusline.')}`);
+	},
+});

--- a/apps/ccusage/src/commands/setup-statusline.ts
+++ b/apps/ccusage/src/commands/setup-statusline.ts
@@ -183,9 +183,24 @@ export const setupStatuslineCommand = define({
 		log(`${pc.dim('Settings:')} ${settingsPath}`);
 
 		// Read existing settings
-		const existingSettings: Record<string, unknown> = existsSync(settingsPath)
-			? (JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>)
+		const existingSettings: Record<string, unknown> | null = existsSync(settingsPath)
+			? Result.pipe(
+					Result.try({
+						try: () => JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>,
+						catch: (error) => error,
+					})(),
+					Result.inspectError((error) => {
+						log(`\n${pc.red('✗')} Malformed settings.json at ${settingsPath}`);
+						log(`  ${error instanceof Error ? error.message : String(error)}`);
+						log(`  Please fix or remove the file and try again.`);
+					}),
+					Result.unwrap(null),
+				)
 			: {};
+
+		if (existingSettings == null) {
+			return;
+		}
 
 		// Check if statusLine already exists
 		if ('statusLine' in existingSettings && !ctx.values.force) {

--- a/apps/ccusage/src/commands/setup-statusline.ts
+++ b/apps/ccusage/src/commands/setup-statusline.ts
@@ -186,7 +186,13 @@ export const setupStatuslineCommand = define({
 		const existingSettings: Record<string, unknown> | null = existsSync(settingsPath)
 			? Result.pipe(
 					Result.try({
-						try: () => JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>,
+						try: () => {
+							const parsed: unknown = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+							if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+								throw new Error('settings.json must contain a JSON object at the root');
+							}
+							return parsed as Record<string, unknown>;
+						},
 						catch: (error) => error,
 					})(),
 					Result.inspectError((error) => {

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -3,7 +3,7 @@ import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import process from 'node:process';
-import { formatCurrency } from '@ccusage/terminal/table';
+import { formatCompactTokens, formatCurrency } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { createLimoJson } from '@ryoppippi/limo';
 import getStdin from 'get-stdin';
@@ -12,6 +12,7 @@ import pc from 'picocolors';
 import * as v from 'valibot';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { DEFAULT_CONTEXT_USAGE_THRESHOLDS, DEFAULT_REFRESH_INTERVAL_SECONDS } from '../_consts.ts';
+import { getEnhancedPromotionSegment, getPromotionStatuslineSegment } from '../_promotions.ts';
 import { calculateBurnRate } from '../_session-blocks.ts';
 import { sharedArgs } from '../_shared-args.ts';
 import { statuslineHookJsonSchema } from '../_types.ts';
@@ -26,18 +27,18 @@ import {
 import { log, logger } from '../logger.ts';
 
 /**
- * Formats the remaining time for display
+ * Formats the remaining time for compact display
  * @param remaining - Remaining minutes
- * @returns Formatted time string
+ * @returns Compact time string (e.g., "4h30m")
  */
 function formatRemainingTime(remaining: number): string {
 	const remainingHours = Math.floor(remaining / 60);
 	const remainingMins = remaining % 60;
 
 	if (remainingHours > 0) {
-		return `${remainingHours}h ${remainingMins}m left`;
+		return `${remainingHours}h${remainingMins}m`;
 	}
-	return `${remainingMins}m left`;
+	return `${remainingMins}m`;
 }
 
 /**
@@ -80,6 +81,7 @@ type SemaphoreType = {
 
 const visualBurnRateChoices = ['off', 'emoji', 'text', 'emoji-text'] as const;
 const costSourceChoices = ['auto', 'ccusage', 'cc', 'both'] as const;
+const promotionDisplayChoices = ['auto', 'active-only', 'off'] as const;
 
 // Valibot schema for context threshold validation
 const contextThresholdSchema = v.pipe(
@@ -153,6 +155,36 @@ export const statuslineCommand = define({
 			description: 'Context usage percentage below which status is shown in yellow (0-100)',
 			parse: (value) => parseContextThreshold(value),
 			default: DEFAULT_CONTEXT_USAGE_THRESHOLDS.MEDIUM,
+		},
+		showPromotions: {
+			type: 'boolean',
+			description: 'Show active promotions in statusline (default: true)',
+			negatable: true,
+			default: true,
+			toKebab: true,
+		},
+		promotionDisplay: {
+			type: 'enum',
+			choices: promotionDisplayChoices,
+			description:
+				'Promotion display mode: auto (always show with countdown during peak), active-only (only during off-peak), off (disable)',
+			default: 'auto',
+			negatable: false,
+			toKebab: true,
+		},
+		showSessionDuration: {
+			type: 'boolean',
+			description: 'Show session duration in statusline (default: true)',
+			negatable: true,
+			default: true,
+			toKebab: true,
+		},
+		showLinesChanged: {
+			type: 'boolean',
+			description: 'Show lines added/removed in statusline (default: true)',
+			negatable: true,
+			default: true,
+			toKebab: true,
 		},
 		config: sharedArgs.config,
 		debug: sharedArgs.debug,
@@ -359,7 +391,7 @@ export const statuslineCommand = define({
 					);
 
 					// Load session block data to find active block
-					const { blockInfo, burnRateInfo } = await Result.pipe(
+					const { blockCostStr, blockTimeStr, burnRateInfo } = await Result.pipe(
 						Result.try({
 							try: async () =>
 								loadSessionBlockData({
@@ -371,29 +403,19 @@ export const statuslineCommand = define({
 						Result.map((blocks) => {
 							// Only identify blocks if we have data
 							if (blocks.length === 0) {
-								return { blockInfo: 'No active block', burnRateInfo: '' };
+								return { blockCostStr: '$0.00', blockTimeStr: '', burnRateInfo: '' };
 							}
 
-							// Find active block that contains our session
-							const activeBlock = blocks.find((block) => {
-								if (!block.isActive) {
-									return false;
-								}
-
-								// Check if any entry in this block matches our session
-								// Since we don't have direct session mapping in entries,
-								// we use the active block that's currently running
-								return true;
-							});
+							// Find active block
+							const activeBlock = blocks.find((block) => block.isActive);
 
 							if (activeBlock != null) {
 								const now = new Date();
 								const remaining = Math.round(
 									(activeBlock.endTime.getTime() - now.getTime()) / (1000 * 60),
 								);
-								const blockCost = activeBlock.costUSD;
-
-								const blockInfo = `${formatCurrency(blockCost)} block (${formatRemainingTime(remaining)})`;
+								const blockCostStr = formatCurrency(activeBlock.costUSD);
+								const blockTimeStr = formatRemainingTime(remaining);
 
 								// Calculate burn rate
 								const burnRate = calculateBurnRate(activeBlock);
@@ -443,21 +465,21 @@ export const statuslineCommand = define({
 													burnRateOutputSegments.push(coloredString(`(${textValue})`));
 												}
 
-												return ` | 🔥 ${burnRateOutputSegments.join(' ')}`;
+												return ` ${burnRateOutputSegments.join(' ')}`;
 											})()
 										: '';
 
-								return { blockInfo, burnRateInfo };
+								return { blockCostStr, blockTimeStr, burnRateInfo };
 							}
 
-							return { blockInfo: 'No active block', burnRateInfo: '' };
+							return { blockCostStr: '$0.00', blockTimeStr: '', burnRateInfo: '' };
 						}),
 						Result.inspectError((error) => logger.error('Failed to load block data:', error)),
-						Result.unwrap({ blockInfo: 'No active block', burnRateInfo: '' }),
+						Result.unwrap({ blockCostStr: '$0.00', blockTimeStr: '', burnRateInfo: '' }),
 					);
 
-					// Helper function to format context info with color coding
-					const formatContextInfo = (inputTokens: number, contextLimit: number): string => {
+					// Helper function to format context percentage with color coding
+					const formatContextPercentage = (inputTokens: number, contextLimit: number): string => {
 						const percentage = Math.round((inputTokens / contextLimit) * 100);
 						const color =
 							percentage < ctx.values.contextLowThreshold
@@ -465,9 +487,7 @@ export const statuslineCommand = define({
 								: percentage < ctx.values.contextMediumThreshold
 									? pc.yellow
 									: pc.red;
-						const coloredPercentage = color(`${percentage}%`);
-						const tokenDisplay = inputTokens.toLocaleString();
-						return `${tokenDisplay} (${coloredPercentage})`;
+						return `${color(`${percentage}%`)} ${pc.dim('ctx')}`;
 					};
 
 					// Get context tokens from Claude Code hook data, or fall back to calculating from transcript
@@ -476,51 +496,113 @@ export const statuslineCommand = define({
 							? // Prefer context_window data from Claude Code hook if available
 								Result.succeed({
 									inputTokens: hookData.context_window.total_input_tokens,
+									outputTokens: hookData.context_window.total_output_tokens ?? 0,
 									contextLimit: hookData.context_window.context_window_size,
 								})
 							: // Fall back to calculating context tokens from transcript
 								await Result.try({
-									try: async () =>
-										calculateContextTokens(
+									try: async () => {
+										const result = await calculateContextTokens(
 											hookData.transcript_path,
 											hookData.model.id,
 											mergedOptions.offline,
-										),
+										);
+										return result != null ? { ...result, outputTokens: 0 } : null;
+									},
 									catch: (error) => error,
 								})();
 
-					const contextInfo = Result.pipe(
+					const contextData = Result.pipe(
 						contextDataResult,
 						Result.inspectError((error) =>
 							logger.debug(
 								`Failed to calculate context tokens: ${error instanceof Error ? error.message : String(error)}`,
 							),
 						),
-						Result.map((contextResult) => {
-							if (contextResult == null) {
-								return undefined;
-							}
-							return formatContextInfo(contextResult.inputTokens, contextResult.contextLimit);
-						}),
-						Result.unwrap(undefined),
+						Result.unwrap(null),
 					);
+
+					// Build token breakdown segment: ↑35K ↓2.5K
+					const tokenSegment =
+						contextData != null
+							? `${pc.green(`\u2191${formatCompactTokens(contextData.inputTokens)}`)} ${pc.magenta(`\u2193${formatCompactTokens(contextData.outputTokens)}`)}`
+							: '';
+
+					// Build context percentage segment: 17% ctx
+					const contextSegment =
+						contextData != null
+							? formatContextPercentage(contextData.inputTokens, contextData.contextLimit)
+							: '';
 
 					// Get model display name
 					const modelName = hookData.model.display_name;
 
-					// Format and output the status line
-					// Format: 🤖 model | 💰 session / today / block | 🔥 burn | 🧠 context
+					// Build session cost display
 					const sessionDisplay = (() => {
-						// If both costs are available, show them side by side
 						if (ccCost != null || ccusageCost != null) {
 							const ccDisplay = ccCost != null ? formatCurrency(ccCost) : 'N/A';
 							const ccusageDisplay = ccusageCost != null ? formatCurrency(ccusageCost) : 'N/A';
-							return `(${ccDisplay} cc / ${ccusageDisplay} ccusage)`;
+							return `(${pc.cyan(ccDisplay)} ${pc.dim('cc')} / ${pc.cyan(ccusageDisplay)} ${pc.dim('ccusage')})`;
 						}
-						// Single cost display
-						return sessionCost != null ? formatCurrency(sessionCost) : 'N/A';
+						return sessionCost != null ? pc.cyan(formatCurrency(sessionCost)) : 'N/A';
 					})();
-					const statusLine = `🤖 ${modelName} | 💰 ${sessionDisplay} session / ${formatCurrency(todayCost)} today / ${blockInfo}${burnRateInfo} | 🧠 ${contextInfo ?? 'N/A'}`;
+
+					// Build cost segment with burn rate separated by pipe
+					const dot = pc.dim(' · ');
+					const costParts = `${sessionDisplay} ${pc.dim('session')}${dot}${pc.cyan(formatCurrency(todayCost))} ${pc.dim('today')}${dot}${pc.cyan(blockCostStr)} ${pc.dim('block')} ${pc.dim(blockTimeStr)}`;
+					const costSegment =
+						burnRateInfo !== '' ? `${costParts} ${pc.dim('|')}${burnRateInfo}` : costParts;
+
+					// Build session activity segment: duration + lines changed
+					const sessionActivityParts: string[] = [];
+					if (ctx.values.showSessionDuration && hookData.cost?.total_duration_ms != null) {
+						const durationMin = Math.round(hookData.cost.total_duration_ms / 60_000);
+						if (durationMin > 0) {
+							sessionActivityParts.push(pc.dim(formatRemainingTime(durationMin)));
+						}
+					}
+					if (ctx.values.showLinesChanged) {
+						const added = hookData.cost?.total_lines_added;
+						const removed = hookData.cost?.total_lines_removed;
+						if (added != null || removed != null) {
+							const parts: string[] = [];
+							if (added != null && added > 0) {
+								parts.push(pc.green(`+${added}`));
+							}
+							if (removed != null && removed > 0) {
+								parts.push(pc.red(`-${removed}`));
+							}
+							if (parts.length > 0) {
+								sessionActivityParts.push(parts.join(' '));
+							}
+						}
+					}
+					const sessionActivitySegment = sessionActivityParts.join(' ');
+
+					// Build promotion segment with configurable display mode
+					const promotionSegment = (() => {
+						if (!ctx.values.showPromotions || ctx.values.promotionDisplay === 'off') {
+							return '';
+						}
+						if (ctx.values.promotionDisplay === 'active-only') {
+							return getPromotionStatuslineSegment();
+						}
+						// 'auto' mode — show enhanced promotion with countdown during peak
+						return getEnhancedPromotionSegment();
+					})();
+
+					// Assemble status line from segments
+					const segments = [
+						pc.bold(modelName),
+						costSegment,
+						tokenSegment,
+						contextSegment,
+						sessionActivitySegment,
+						promotionSegment,
+					].filter((s) => s !== '');
+
+					const pipe = pc.dim(' | ');
+					const statusLine = segments.join(pipe);
 					return statusLine;
 				},
 				catch: (error) => error,

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -507,7 +507,7 @@ export const statuslineCommand = define({
 											hookData.model.id,
 											mergedOptions.offline,
 										);
-										return result != null ? { ...result, outputTokens: 0 } : null;
+										return result != null ? { ...result, outputTokens: undefined } : null;
 									},
 									catch: (error) => error,
 								})();
@@ -525,7 +525,14 @@ export const statuslineCommand = define({
 					// Build token breakdown segment: ↑35K ↓2.5K
 					const tokenSegment =
 						contextData != null
-							? `${pc.green(`\u2191${formatCompactTokens(contextData.inputTokens)}`)} ${pc.magenta(`\u2193${formatCompactTokens(contextData.outputTokens)}`)}`
+							? [
+									pc.green(`\u2191${formatCompactTokens(contextData.inputTokens)}`),
+									contextData.outputTokens != null && contextData.outputTokens > 0
+										? pc.magenta(`\u2193${formatCompactTokens(contextData.outputTokens)}`)
+										: '',
+								]
+									.filter(Boolean)
+									.join(' ')
 							: '';
 
 					// Build context percentage segment: 17% ctx
@@ -555,13 +562,13 @@ export const statuslineCommand = define({
 
 					// Build session activity segment: duration + lines changed
 					const sessionActivityParts: string[] = [];
-					if (ctx.values.showSessionDuration && hookData.cost?.total_duration_ms != null) {
+					if (mergedOptions.showSessionDuration && hookData.cost?.total_duration_ms != null) {
 						const durationMin = Math.round(hookData.cost.total_duration_ms / 60_000);
 						if (durationMin > 0) {
 							sessionActivityParts.push(pc.dim(formatRemainingTime(durationMin)));
 						}
 					}
-					if (ctx.values.showLinesChanged) {
+					if (mergedOptions.showLinesChanged) {
 						const added = hookData.cost?.total_lines_added;
 						const removed = hookData.cost?.total_lines_removed;
 						if (added != null || removed != null) {
@@ -581,10 +588,10 @@ export const statuslineCommand = define({
 
 					// Build promotion segment with configurable display mode
 					const promotionSegment = (() => {
-						if (!ctx.values.showPromotions || ctx.values.promotionDisplay === 'off') {
+						if (!mergedOptions.showPromotions || mergedOptions.promotionDisplay === 'off') {
 							return '';
 						}
-						if (ctx.values.promotionDisplay === 'active-only') {
+						if (mergedOptions.promotionDisplay === 'active-only') {
 							return getPromotionStatuslineSegment();
 						}
 						// 'auto' mode — show enhanced promotion with countdown during peak

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -352,14 +352,14 @@ export const statuslineCommand = define({
 							return { sessionCost: cost };
 						}
 
-						// If 'auto' mode (default), prefer Claude Code cost, fallback to ccusage
+						// If 'auto' mode (default), prefer ccusage calculation for consistency
+						// with today/block costs (same pricing engine), fallback to Claude Code cost
 						if (costSource === 'auto') {
-							if (hookData.cost?.total_cost_usd != null) {
-								return { sessionCost: hookData.cost.total_cost_usd };
-							}
-							// Fallback to ccusage calculation
 							const cost = await getCcusageCost();
-							return { sessionCost: cost };
+							if (cost != null) {
+								return { sessionCost: cost };
+							}
+							return { sessionCost: hookData.cost?.total_cost_usd };
 						}
 						unreachable(costSource);
 						return {}; // This line should never be reached

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -32,11 +32,12 @@ import { log, logger } from '../logger.ts';
  * @returns Compact time string (e.g., "4h30m")
  */
 function formatRemainingTime(remaining: number): string {
-	const remainingHours = Math.floor(remaining / 60);
-	const remainingMins = remaining % 60;
+	const safeRemaining = Math.max(0, remaining);
+	const remainingHours = Math.floor(safeRemaining / 60);
+	const remainingMins = safeRemaining % 60;
 
 	if (remainingHours > 0) {
-		return `${remainingHours}h${remainingMins}m`;
+		return remainingMins === 0 ? `${remainingHours}h` : `${remainingHours}h${remainingMins}m`;
 	}
 	return `${remainingMins}m`;
 }
@@ -193,16 +194,16 @@ export const statuslineCommand = define({
 		// Set logger to silent for statusline output
 		logger.level = 0;
 
-		// Validate threshold ordering constraint: LOW must be less than MEDIUM
-		if (ctx.values.contextLowThreshold >= ctx.values.contextMediumThreshold) {
-			throw new Error(
-				`Context low threshold (${ctx.values.contextLowThreshold}) must be less than medium threshold (${ctx.values.contextMediumThreshold})`,
-			);
-		}
-
 		// Load configuration and merge with CLI args
 		const config = loadConfig(ctx.values.config, ctx.values.debug);
 		const mergedOptions = mergeConfigWithArgs(ctx, config, ctx.values.debug);
+
+		// Validate threshold ordering constraint: LOW must be less than MEDIUM (after merge)
+		if (mergedOptions.contextLowThreshold >= mergedOptions.contextMediumThreshold) {
+			throw new Error(
+				`Context low threshold (${mergedOptions.contextLowThreshold}) must be less than medium threshold (${mergedOptions.contextMediumThreshold})`,
+			);
+		}
 
 		// Use refresh interval from merged options
 		const refreshInterval = mergedOptions.refreshInterval;
@@ -482,9 +483,9 @@ export const statuslineCommand = define({
 					const formatContextPercentage = (inputTokens: number, contextLimit: number): string => {
 						const percentage = Math.round((inputTokens / contextLimit) * 100);
 						const color =
-							percentage < ctx.values.contextLowThreshold
+							percentage < mergedOptions.contextLowThreshold
 								? pc.green
-								: percentage < ctx.values.contextMediumThreshold
+								: percentage < mergedOptions.contextMediumThreshold
 									? pc.yellow
 									: pc.red;
 						return `${color(`${percentage}%`)} ${pc.dim('ctx')}`;

--- a/docs/guide/statusline.md
+++ b/docs/guide/statusline.md
@@ -1,4 +1,4 @@
-# Statusline Integration (Beta) 🚀
+# Statusline Integration (Beta)
 
 Display real-time usage statistics in your Claude Code status line.
 
@@ -6,15 +6,47 @@ Display real-time usage statistics in your Claude Code status line.
 
 The `statusline` command provides a compact, real-time view of your Claude Code usage, designed to integrate with Claude Code's status line hooks. It shows:
 
-- 💬 **Current session cost** - Cost for your active conversation session
-- 💰 **Today's total cost** - Your cumulative spending for the current day
-- 🚀 **Current session block** - Cost and time remaining in your active 5-hour billing block
-- 🔥 **Burn rate** - Token consumption rate with visual indicators
-- 🤖 **Active model** - The Claude model you're currently using
+- **Active model** - The Claude model you're currently using
+- **Current session cost** - Cost for your active conversation session
+- **Today's total cost** - Your cumulative spending for the current day
+- **Current session block** - Cost and time remaining in your active 5-hour billing block
+- **Token breakdown** - Input/output tokens in compact format
+- **Context usage** - Percentage of context window used with color coding
+- **Promotion indicator** - Active promotions (e.g., 2x off-peak)
 
 ## Setup
 
-### Configure settings.json
+### Quick Setup (Recommended)
+
+Run the setup command to automatically configure your Claude Code settings:
+
+```bash
+npx -y ccusage setup-statusline
+```
+
+This will:
+
+- Detect the best package runner (`bun` or `npx`)
+- Find your Claude Code settings file
+- Write the statusline configuration automatically
+
+**Options:**
+
+```bash
+# Preview changes without writing
+npx -y ccusage setup-statusline --dry-run
+
+# Overwrite existing configuration
+npx -y ccusage setup-statusline --force
+
+# Specify runner explicitly
+npx -y ccusage setup-statusline --runner bun
+
+# Configure options during setup
+npx -y ccusage setup-statusline --visual-burn-rate emoji --cost-source both
+```
+
+### Manual Configuration
 
 Add this to your `~/.claude/settings.json` or `~/.config/claude/settings.json`:
 
@@ -109,37 +141,66 @@ See [Cost Source Options](#cost-source-options) section for all available modes.
 The statusline displays a compact, single-line summary:
 
 ```
-🤖 Opus | 💰 $0.23 session / $1.23 today / $0.45 block (2h 45m left) | 🔥 $0.12/hr | 🧠 25,000 (12%)
+Opus 4 | $0.23 session · $1.23 today · $0.45 block 2h45m | $8.50/hr | ↑25K ↓3.2K | 12% ctx | 45m +23 -5 | ⚡2x
+```
+
+During peak hours, a countdown to off-peak is shown instead:
+
+```
+Opus 4 | $0.23 session · $1.23 today · $0.45 block 2h45m | $8.50/hr | ↑25K ↓3.2K | 12% ctx | 45m +23 -5 | ⚡2x in 2h15m 12d
 ```
 
 When using `--cost-source both`, the session cost shows both Claude Code and ccusage calculations:
 
 ```
-🤖 Opus | 💰 ($0.25 cc / $0.23 ccusage) session / $1.23 today / $0.45 block (2h 45m left) | 🔥 $0.12/hr | 🧠 25,000 (12%)
+Opus 4 | ($0.25 cc / $0.23 ccusage) session · $1.23 today · $0.45 block 2h45m | ↑25K ↓3.2K | 12% ctx
 ```
 
 ### Components Explained
 
-- **Model** (`🤖 Opus`): Currently active Claude model
-- **Session Cost** (`💰 $0.23 session`): Cost for the current conversation session (see [Cost Source Options](#cost-source-options) for different calculation modes)
-- **Today's Cost** (`$1.23 today`): Total cost for the current day across all sessions
-- **Session Block** (`$0.45 block (2h 45m left)`): Current 5-hour block cost with remaining time
-- **Burn Rate** (`🔥 $0.12/hr`): Cost burn rate per hour with color-coded indicators:
-  - Green text: Normal (< 2,000 tokens/min)
-  - Yellow text: Moderate (2,000-5,000 tokens/min)
-  - Red text: High (> 5,000 tokens/min)
-  - Optional visual status indicators (see [Visual Burn Rate](#visual-burn-rate))
-- **Context Usage** (`🧠 25,000 (12%)`): Shows input tokens with percentage of context limit:
+- **Model** (`Opus 4`): Currently active Claude model (bold)
+- **Session Cost** (`$0.23 session`): Cost for the current conversation session in cyan (see [Cost Source Options](#cost-source-options) for different calculation modes)
+- **Today's Cost** (`$1.23 today`): Total cost for the current day across all sessions in cyan
+- **Session Block** (`$0.45 block 2h45m`): Current 5-hour block cost with remaining time
+- **Burn Rate** (`$8.50/hr`): Current spending rate, separated by pipe for visual clarity
+- **Input Tokens** (`↑25K`): Input tokens sent to the model in green, compact format (K/M)
+- **Output Tokens** (`↓3.2K`): Output tokens from the model in magenta, compact format (K/M)
+- **Context Usage** (`12% ctx`): Percentage of context window used:
   - Green text: Low usage (< 50% by default)
   - Yellow text: Medium usage (50-80% by default)
   - Red text: High usage (> 80% by default)
   - Uses Claude Code's [`context_window` data](https://code.claude.com/docs/en/statusline) when available for accurate token counts
+- **Session Duration** (`45m`): How long the current session has been running (dim)
+- **Lines Changed** (`+23 -5`): Lines added (green) and removed (red) during the session
+- **Promotion** (`⚡2x`): Active promotion indicator — bold yellow during off-peak, with countdown during peak hours (`⚡2x in 2h15m`), and days remaining (`12d`)
 
 When no active block exists:
 
 ```
-🤖 Opus | 💰 $0.00 session / $0.00 today / No active block
+Opus 4 | $0.00 session · $0.00 today · $0.00 block | ↑0 ↓0 | 0% ctx
 ```
+
+### Color Scheme
+
+| Element                      | Color       | Purpose                         |
+| ---------------------------- | ----------- | ------------------------------- |
+| Model name                   | Bold        | Visual anchor                   |
+| Pipe separator               | Dim         | Reduces visual noise            |
+| Cost values                  | Cyan        | Standard info color             |
+| Labels (session/today/block) | Dim         | Secondary info                  |
+| Dot separator (·)            | Dim         | Visual separation between costs |
+| Remaining time               | Dim         | Supplementary info              |
+| Input tokens (↑)             | Green       | Data flowing to model           |
+| Output tokens (↓)            | Magenta     | Contrast to input               |
+| Context (low)                | Green       | < 50%                           |
+| Context (medium)             | Yellow      | 50-80%                          |
+| Context (high)               | Red         | > 80%                           |
+| Session duration             | Dim         | Background metric               |
+| Lines added (+N)             | Green       | Matches git convention          |
+| Lines removed (-N)           | Red         | Matches git convention          |
+| Promotion (off-peak)         | Bold yellow | Active promotion                |
+| Promotion (peak)             | Yellow      | Countdown to off-peak           |
+| Promotion days remaining     | Dim         | Days until promotion ends       |
 
 ## Technical Details
 
@@ -154,7 +215,7 @@ The statusline command:
 
 ## Beta Notice
 
-⚠️ This feature is currently in **beta**. More customization options and features are coming soon:
+This feature is currently in **beta**. More customization options and features are coming soon:
 
 - Custom format templates
 - Configurable burn rate thresholds
@@ -209,8 +270,8 @@ bun x ccusage statusline --cost-source both
 
 **Output differences:**
 
-- **Single cost modes** (`auto`, `ccusage`, `cc`): `💰 $0.23 session`
-- **Both mode**: `💰 ($0.25 cc / $0.23 ccusage) session`
+- **Single cost modes** (`auto`, `ccusage`, `cc`): `$0.23 session`
+- **Both mode**: `($0.25 cc / $0.23 ccusage) session`
 
 ## Configuration
 
@@ -262,32 +323,54 @@ bun x ccusage statusline --visual-burn-rate emoji
 
 **Available options:**
 
-- `off` (default): No visual indicators, only colored text
-- `emoji`: Add emoji indicators (🟢/⚠️/🚨)
+- `off` (default): No visual indicators, only colored cost/hr in cost section
+- `emoji`: Add emoji indicators
 - `text`: Add text status in parentheses (Normal/Moderate/High)
 - `emoji-text`: Combine both emoji and text indicators
 
-**Examples:**
+**Status thresholds:**
+
+- Normal (green): < 2,000 tokens/min
+- Moderate (yellow): 2,000-5,000 tokens/min
+- High (red): > 5,000 tokens/min
+
+### Promotion Display
+
+The statusline shows active Claude usage promotions (e.g., 2x off-peak capacity). By default (`--promotion-display auto`), it shows:
+
+- **Off-peak hours**: `⚡2x 12d` — promotion active, with days remaining
+- **Peak hours**: `⚡2x in 2h15m 12d` — countdown to when off-peak starts
+
+**Promotion display modes (`--promotion-display`):**
+
+- `auto` (default): Always show promotion when active, with countdown during peak hours
+- `active-only`: Only show during off-peak hours (no countdown)
+- `off`: Disable promotion display entirely
 
 ```bash
-# Default (off)
-🔥 $0.12/hr
+# Show countdown during peak (default)
+bun x ccusage statusline --promotion-display auto
 
-# With emoji
-🔥 $0.12/hr 🟢
+# Only show when off-peak is active
+bun x ccusage statusline --promotion-display active-only
 
-# With text
-🔥 $0.12/hr (Normal)
-
-# With both emoji and text
-🔥 $0.12/hr 🟢 (Normal)
+# Disable promotions
+bun x ccusage statusline --no-show-promotions
 ```
 
-**Status Indicators:**
+### Session Activity
 
-- 🟢 Normal (Green)
-- ⚠️ Moderate (Yellow)
-- 🚨 High (Red)
+The statusline can display session duration and lines changed from Claude Code hook data.
+
+**Session duration** shows how long the current session has been active (e.g., `45m`, `2h15m`).
+
+**Lines changed** shows lines added and removed during the session in git-style format (e.g., `+23 -5`).
+
+Both are enabled by default. To disable:
+
+```bash
+bun x ccusage statusline --no-show-session-duration --no-show-lines-changed
+```
 
 ## Troubleshooting
 

--- a/docs/guide/statusline.md
+++ b/docs/guide/statusline.md
@@ -140,19 +140,19 @@ See [Cost Source Options](#cost-source-options) section for all available modes.
 
 The statusline displays a compact, single-line summary:
 
-```
-Opus 4 | $0.23 session · $1.23 today · $0.45 block 2h45m | $8.50/hr | ↑25K ↓3.2K | 12% ctx | 45m +23 -5 | ⚡2x
+```text
+Opus 4 | $0.23 session · $1.23 today · $0.45 block 2h45m | $8.50/hr | ↑25K ↓3.2K | 12% ctx | 45m +23 -5 | ⚡2x · 12d left
 ```
 
 During peak hours, a countdown to off-peak is shown instead:
 
-```
-Opus 4 | $0.23 session · $1.23 today · $0.45 block 2h45m | $8.50/hr | ↑25K ↓3.2K | 12% ctx | 45m +23 -5 | ⚡2x in 2h15m 12d
+```text
+Opus 4 | $0.23 session · $1.23 today · $0.45 block 2h45m | $8.50/hr | ↑25K ↓3.2K | 12% ctx | 45m +23 -5 | ⚡2x in 2h15m · 12d left
 ```
 
 When using `--cost-source both`, the session cost shows both Claude Code and ccusage calculations:
 
-```
+```text
 Opus 4 | ($0.25 cc / $0.23 ccusage) session · $1.23 today · $0.45 block 2h45m | ↑25K ↓3.2K | 12% ctx
 ```
 
@@ -172,11 +172,11 @@ Opus 4 | ($0.25 cc / $0.23 ccusage) session · $1.23 today · $0.45 block 2h45m 
   - Uses Claude Code's [`context_window` data](https://code.claude.com/docs/en/statusline) when available for accurate token counts
 - **Session Duration** (`45m`): How long the current session has been running (dim)
 - **Lines Changed** (`+23 -5`): Lines added (green) and removed (red) during the session
-- **Promotion** (`⚡2x`): Active promotion indicator — bold yellow during off-peak, with countdown during peak hours (`⚡2x in 2h15m`), and days remaining (`12d`)
+- **Promotion** (`⚡2x · 12d left`): Active promotion indicator — bold yellow during off-peak with days remaining, with countdown during peak hours (`⚡2x in 2h15m · 12d left`)
 
 When no active block exists:
 
-```
+```text
 Opus 4 | $0.00 session · $0.00 today · $0.00 block | ↑0 ↓0 | 0% ctx
 ```
 
@@ -338,8 +338,8 @@ bun x ccusage statusline --visual-burn-rate emoji
 
 The statusline shows active Claude usage promotions (e.g., 2x off-peak capacity). By default (`--promotion-display auto`), it shows:
 
-- **Off-peak hours**: `⚡2x 12d` — promotion active, with days remaining
-- **Peak hours**: `⚡2x in 2h15m 12d` — countdown to when off-peak starts
+- **Off-peak hours**: `⚡2x · 12d left` — promotion active, with days remaining
+- **Peak hours**: `⚡2x in 2h15m · 12d left` — countdown to when off-peak starts
 
 **Promotion display modes (`--promotion-display`):**
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,48 @@
+$repo   = "https://github.com/r1di/ccusage.git"
+$branch = "feat/statusline-improvements"
+$dir    = "$env:USERPROFILE\.ccusage-fork"
+$pkg    = "$dir\apps\ccusage"
+$dist   = "$pkg\dist\index.js"
+
+Write-Host "ccusage statusline installer (r1di fork)"
+
+foreach ($cmd in @("node","git")) {
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        Write-Host "ERROR: '$cmd' not found." -ForegroundColor Red; exit 1
+    }
+}
+
+if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing pnpm..."
+    npm install -g pnpm --loglevel=error
+}
+
+if (Test-Path "$dir\.git") {
+    Write-Host "Updating repo..."
+    git -C $dir fetch origin
+    git -C $dir checkout $branch
+    git -C $dir reset --hard "origin/$branch"
+} else {
+    Write-Host "Cloning repo..."
+    git clone --branch $branch --depth 1 $repo $dir
+}
+
+Write-Host "Building..."
+Set-Location $pkg
+pnpm install --frozen-lockfile=false
+pnpm run build
+
+Write-Host "Configuring Claude Code settings.json..."
+$settings_path = "$env:USERPROFILE\.claude\settings.json"
+if (-not (Test-Path "$env:USERPROFILE\.claude")) { New-Item -ItemType Directory -Path "$env:USERPROFILE\.claude" | Out-Null }
+if (Test-Path $settings_path) {
+    try { $s = (Get-Content $settings_path -Raw -Encoding UTF8) | ConvertFrom-Json }
+    catch { $s = [PSCustomObject]@{} }
+} else { $s = [PSCustomObject]@{} }
+$s | Add-Member -MemberType NoteProperty -Name "statusLine" -Value ([PSCustomObject]@{
+    type    = "command"
+    command = "node `"$dist`" statusline"
+}) -Force
+$s | ConvertTo-Json -Depth 20 | Set-Content $settings_path -Encoding UTF8
+
+Write-Host "Done. Restart Claude Code to activate the statusline." -ForegroundColor Green

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e
+
+REPO="https://github.com/r1di/ccusage.git"
+BRANCH="feat/statusline-improvements"
+DIR="$HOME/.ccusage-fork"
+PKG="$DIR/apps/ccusage"
+DIST="$PKG/dist/index.js"
+
+echo "ccusage statusline installer (r1di fork)"
+
+for cmd in node git; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd not found."; exit 1; }
+done
+
+if ! command -v pnpm >/dev/null 2>&1; then
+    echo "Installing pnpm..."
+    npm install -g pnpm --loglevel=error
+fi
+
+if [ -d "$DIR/.git" ]; then
+    echo "Updating repo..."
+    git -C "$DIR" fetch origin
+    git -C "$DIR" checkout "$BRANCH"
+    git -C "$DIR" reset --hard "origin/$BRANCH"
+else
+    echo "Cloning repo..."
+    git clone --branch "$BRANCH" --depth 1 "$REPO" "$DIR"
+fi
+
+echo "Building..."
+cd "$PKG"
+pnpm install --frozen-lockfile=false
+pnpm run build
+
+echo "Configuring Claude Code settings.json..."
+CLAUDE_DIR="$HOME/.claude"
+SETTINGS="$CLAUDE_DIR/settings.json"
+mkdir -p "$CLAUDE_DIR"
+[ -f "$SETTINGS" ] || echo '{}' > "$SETTINGS"
+
+node - "$SETTINGS" "$DIST" <<'EOF'
+const fs = require('fs')
+const p = process.argv[2], dist = process.argv[3]
+let s = {}
+try { s = JSON.parse(fs.readFileSync(p, 'utf8')) } catch {}
+s.statusLine = { type: 'command', command: `node "${dist}" statusline` }
+fs.writeFileSync(p, JSON.stringify(s, null, 2))
+EOF
+
+echo "Done. Restart Claude Code to activate the statusline."

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
 		"pkg-pr-new": "catalog:release"
 	},
 	"lint-staged": {
-		"*": [
-			"pnpm run format"
+		"*.{js,ts,json,md}": [
+			"npx --no-install eslint --fix --cache"
 		]
 	}
 }

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -366,12 +366,12 @@ export function formatNumber(num: number): string {
  * @returns Compact token string
  */
 export function formatCompactTokens(tokens: number): string {
-	if (tokens >= 1_000_000) {
-		const m = tokens / 1_000_000;
+	if (tokens >= 999_950) {
+		const m = Number((tokens / 1_000_000).toFixed(1));
 		return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`;
 	}
 	if (tokens >= 1_000) {
-		const k = tokens / 1_000;
+		const k = Number((tokens / 1_000).toFixed(1));
 		return k % 1 === 0 ? `${k}K` : `${k.toFixed(1)}K`;
 	}
 	return `${tokens}`;

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -361,6 +361,23 @@ export function formatNumber(num: number): string {
 }
 
 /**
+ * Formats a token count into a compact string (e.g., 35000 → "35K", 2500 → "2.5K")
+ * @param tokens - The number of tokens
+ * @returns Compact token string
+ */
+export function formatCompactTokens(tokens: number): string {
+	if (tokens >= 1_000_000) {
+		const m = tokens / 1_000_000;
+		return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`;
+	}
+	if (tokens >= 1_000) {
+		const k = tokens / 1_000;
+		return k % 1 === 0 ? `${k}K` : `${k.toFixed(1)}K`;
+	}
+	return `${tokens}`;
+}
+
+/**
  * Formats a number as USD currency with dollar sign and 2 decimal places
  * @param amount - The amount to format
  * @returns Formatted currency string (e.g., "$12.34")


### PR DESCRIPTION
## Summary

- Replace cryptic labels (`ses`/`day`/`blk`) with full words (`session`/`today`/`block`)
- Add dot separator between cost segments for visual clarity
- Separate burn rate from cost block with pipe separator
- Add `setup-statusline` command for auto-configuring Claude Code `settings.json`
- Fix `mkdirSync` before `writeFileSync` to prevent ENOENT crash on fresh installs
- Show promotion countdown during peak hours with clear separator (12d left)
- Display session duration and lines changed from hook data
- Add `formatCompactTokens` utility for compact token count display
- Add `--promotion-display`, `--show-session-duration`, `--show-lines-changed` options

## Test plan

- [x] `pnpm run format` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm run test` 274 passed (2 pre-existing failures: Windows path bug + 600MB timeout)
- [x] `setup-statusline --dry-run` verified
- [x] Promotion countdown updates correctly between invocations

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time-bound, timezone-aware promotions with off-peak detection, countdowns, and statusline indicators.
  * New setup-statusline command to auto-configure statusline integration (dry-run, force, runner).
  * Enhanced statusline: promotion display modes (auto/active-only/off), session duration, lines-changed, and compact token formatting.

* **Documentation**
  * Expanded statusline guide with quick setup flow, examples, component explanations, color scheme, and troubleshooting.

* **Chores**
  * PowerShell and Bash installer scripts; tightened lint-staged configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->