### PR TITLE
docs: remove unsupported `claude x` execution path

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -25,9 +25,6 @@ bunx ccusage
 pnpm dlx ccusage
 ```
 
-```bash [claude x]
-BUN_BE_BUN=1 claude x ccusage
-```
 
 :::
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -34,7 +34,7 @@ ccusage analyzes the local JSONL files that Claude Code automatically generates 
 
 ### 🚀 Ultra-Small Bundle Size
 
-Unlike other CLI tools, we pay extreme attention to bundle size. ccusage achieves an incredibly small footprint even without minification, which means you can run it directly without installation using `bunx ccusage` or `BUN_BE_BUN=1 claude x ccusage` for instant access.
+Unlike other CLI tools, we pay extreme attention to bundle size. ccusage achieves an incredibly small footprint even without minification, which means you can run it directly without installation using `bunx ccusage` for instant access.
 
 ### 📊 Multiple Report Types
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -33,9 +33,6 @@ pnpm dlx ccusage
 deno run -E -R=$HOME/.claude/projects/ -S=homedir -N='raw.githubusercontent.com:443' npm:ccusage@latest
 ```
 
-```bash [claude x]
-BUN_BE_BUN=1 claude x ccusage
-```
 
 :::
 
@@ -47,32 +44,6 @@ We strongly recommend using `bunx` instead of `npx` due to the massive speed dif
 Consider using `deno run` if you want additional security controls. Deno allows you to specify exact permissions, making it safer to run tools you haven't audited.
 :::
 
-::: details Running with `claude x`
-
-If you have the **native version** of Claude Code installed, you can run ccusage directly using the `claude x` command:
-
-```bash
-BUN_BE_BUN=1 claude x ccusage
-```
-
-**How it works:**
-
-The native Claude Code binary is built with [Bun's standalone executable](https://bun.sh/docs/bundler/executables) feature. When you set `BUN_BE_BUN=1`, the Claude Code executable exposes the full Bun CLI capabilities instead of running its bundled entry point. This allows you to use `claude x` as a drop-in replacement for `bunx`.
-
-**Requirements:**
-
-- **Native Claude Code installation** (installed via `curl -fsSL https://claude.ai/install.sh | bash` or Homebrew/WinGet)
-- This does **NOT** work with the npm version (`npm install -g @anthropic-ai/claude-code`)
-- Run `claude doctor` to verify whether you have the native version installed
-
-**Why use this?**
-
-- No need to install Bun separately
-- Uses the same Bun runtime bundled with Claude Code
-- Convenient for Claude Code users who want to check their usage without additional tools
-
-For more details, see the [Bun documentation on BUN_BE_BUN](https://bun.sh/docs/bundler/executables#act-as-the-bun-cli) and [Claude Code setup guide](https://code.claude.com/docs/en/setup).
-:::
 
 ### Performance Comparison
 

--- a/docs/guide/statusline.md
+++ b/docs/guide/statusline.md
@@ -30,15 +30,6 @@ Add this to your `~/.claude/settings.json` or `~/.config/claude/settings.json`:
 }
 ```
 
-```json [claude x]
-{
-	"statusLine": {
-		"type": "command",
-		"command": "BUN_BE_BUN=1 claude x ccusage statusline",
-		"padding": 0
-	}
-}
-```
 
 ```json [npx]
 {
@@ -52,9 +43,6 @@ Add this to your `~/.claude/settings.json` or `~/.config/claude/settings.json`:
 
 :::
 
-::: tip claude x option
-The `claude x` option requires the native version of Claude Code (not the npm version). If you installed Claude Code via npm, use the `bun x` or `npx` options instead.
-:::
 
 By default, statusline uses **offline mode** with cached pricing data for optimal performance.
 


### PR DESCRIPTION
Fixes #862

## Summary
Remove `BUN_BE_BUN=1 claude x ccusage` from user-facing docs since it is not a valid/working execution path in Claude Code.

## Changes
- Removed `claude x` snippets from:
  - `docs/guide/installation.md`
  - `docs/guide/getting-started.md`
  - `docs/guide/statusline.md`
- Removed the detailed `Running with claude x` section in installation docs
- Updated intro copy in `docs/guide/index.md` to reference supported direct execution (`bunx`) only

## Why
Keeps docs aligned with real CLI behavior and avoids onboarding confusion for new users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified getting started and installation guides by removing legacy environment variable setup instructions.
  * Streamlined code examples in multiple guides to use more direct command invocations.
  * Updated configuration documentation for improved clarity and ease of use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->