### PR TITLE
`agent` command — hierarchical team grouping, resumable session IDs, AI titles

### DIFF
--- a/apps/ccusage/CLAUDE.md
+++ b/apps/ccusage/CLAUDE.md
@@ -62,6 +62,12 @@ This package contains the core ccusage functionality:
 3. Calculates costs using LiteLLM pricing database
 4. Outputs formatted tables or JSON
 
+## Agent Command Notes
+
+- **Pre-filter files by mtime**: The agent command scans session JSONL files. When a date filter is active (e.g., today only), check file modification time before parsing — avoids loading 3800+ files when only a handful are relevant.
+- **Lead identifiability**: `lead-xxxx` entries (4-char session hash) are unidentifiable without project/directory context. Include the project name or working directory so users can map each lead to what they were working on.
+- **Agent column width**: Must accommodate `team/agent-name` format (e.g., `ccusage-fork/cli-dev`) — test with realistic team names, not just short placeholders.
+
 ## Testing Guidelines
 
 - **In-Source Testing**: Tests are written in the same files using `if (import.meta.vitest != null)` blocks

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -503,6 +503,125 @@
 							},
 							"additionalProperties": false
 						},
+						"agent": {
+							"type": "object",
+							"properties": {
+								"since": {
+									"type": "string",
+									"description": "Filter from date (YYYYMMDD format)",
+									"markdownDescription": "Filter from date (YYYYMMDD format)"
+								},
+								"until": {
+									"type": "string",
+									"description": "Filter until date (YYYYMMDD format)",
+									"markdownDescription": "Filter until date (YYYYMMDD format)"
+								},
+								"json": {
+									"type": "boolean",
+									"description": "Output in JSON format",
+									"markdownDescription": "Output in JSON format",
+									"default": false
+								},
+								"mode": {
+									"type": "string",
+									"enum": ["auto", "calculate", "display"],
+									"description": "Cost calculation mode: auto (use costUSD if exists, otherwise calculate), calculate (always calculate), display (always use costUSD)",
+									"markdownDescription": "Cost calculation mode: auto (use costUSD if exists, otherwise calculate), calculate (always calculate), display (always use costUSD)",
+									"default": "auto"
+								},
+								"debug": {
+									"type": "boolean",
+									"description": "Show pricing mismatch information for debugging",
+									"markdownDescription": "Show pricing mismatch information for debugging",
+									"default": false
+								},
+								"debugSamples": {
+									"type": "number",
+									"description": "Number of sample discrepancies to show in debug output (default: 5)",
+									"markdownDescription": "Number of sample discrepancies to show in debug output (default: 5)",
+									"default": 5
+								},
+								"order": {
+									"type": "string",
+									"enum": ["desc", "asc"],
+									"description": "Sort order: desc (newest first) or asc (oldest first)",
+									"markdownDescription": "Sort order: desc (newest first) or asc (oldest first)",
+									"default": "asc"
+								},
+								"breakdown": {
+									"type": "boolean",
+									"description": "Show per-model cost breakdown",
+									"markdownDescription": "Show per-model cost breakdown",
+									"default": false
+								},
+								"offline": {
+									"type": "boolean",
+									"description": "Use cached pricing data for Claude models instead of fetching from API",
+									"markdownDescription": "Use cached pricing data for Claude models instead of fetching from API",
+									"default": false
+								},
+								"color": {
+									"type": "boolean",
+									"description": "Enable colored output (default: auto). FORCE_COLOR=1 has the same effect.",
+									"markdownDescription": "Enable colored output (default: auto). FORCE_COLOR=1 has the same effect."
+								},
+								"noColor": {
+									"type": "boolean",
+									"description": "Disable colored output (default: auto). NO_COLOR=1 has the same effect.",
+									"markdownDescription": "Disable colored output (default: auto). NO_COLOR=1 has the same effect."
+								},
+								"timezone": {
+									"type": "string",
+									"description": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone",
+									"markdownDescription": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone"
+								},
+								"locale": {
+									"type": "string",
+									"description": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
+									"markdownDescription": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
+									"default": "en-CA"
+								},
+								"jq": {
+									"type": "string",
+									"description": "Process JSON output with jq command (requires jq binary, implies --json)",
+									"markdownDescription": "Process JSON output with jq command (requires jq binary, implies --json)"
+								},
+								"compact": {
+									"type": "boolean",
+									"description": "Force compact mode for narrow displays (better for screenshots)",
+									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+									"default": false
+								},
+								"team": {
+									"type": "string",
+									"description": "Filter to a specific team name",
+									"markdownDescription": "Filter to a specific team name"
+								},
+								"session": {
+									"type": "string",
+									"description": "Filter to a specific session ID",
+									"markdownDescription": "Filter to a specific session ID"
+								},
+								"all": {
+									"type": "boolean",
+									"description": "Show all-time data instead of today only",
+									"markdownDescription": "Show all-time data instead of today only",
+									"default": false
+								},
+								"days": {
+									"type": "number",
+									"description": "Show data from the last N days",
+									"markdownDescription": "Show data from the last N days"
+								},
+								"instances": {
+									"type": "boolean",
+									"description": "Show per-instance breakdown instead of role grouping",
+									"markdownDescription": "Show per-instance breakdown instead of role grouping",
+									"default": false
+								}
+							},
+							"additionalProperties": false
+						},
 						"blocks": {
 							"type": "object",
 							"properties": {

--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -17,6 +17,7 @@
 	},
 	"exports": {
 		".": "./src/index.ts",
+		"./agent-id": "./src/agent-id.ts",
 		"./calculate-cost": "./src/calculate-cost.ts",
 		"./data-loader": "./src/data-loader.ts",
 		"./debug": "./src/debug.ts",
@@ -39,6 +40,7 @@
 		},
 		"exports": {
 			".": "./dist/index.js",
+			"./agent-id": "./dist/agent-id.js",
 			"./calculate-cost": "./dist/calculate-cost.js",
 			"./data-loader": "./dist/data-loader.js",
 			"./debug": "./dist/debug.js",

--- a/apps/ccusage/src/agent-id.ts
+++ b/apps/ccusage/src/agent-id.ts
@@ -1,0 +1,181 @@
+/**
+ * @fileoverview Utility for deriving human-readable agent IDs from usage data
+ *
+ * Produces IDs like "my-team/researcher-a1b2", "coder-c3d4", or "lead-e5f6"
+ * based on the teamName, agentName, and sessionId fields in JSONL entries.
+ *
+ * @module agent-id
+ */
+
+type AgentEntry = {
+	teamName?: string | undefined;
+	agentName?: string | undefined;
+	sessionId?: string | undefined;
+};
+
+/**
+ * Derives a human-readable agent ID from a usage entry's metadata.
+ *
+ * - teamName + agentName + sessionId → `{teamName}/{agentName}-{sessionId[0:4]}`
+ * - only agentName + sessionId → `{agentName}-{sessionId[0:4]}`
+ * - neither (main agent) → `lead-{sessionId[0:4]}`
+ * - no sessionId → just `lead`, `{agentName}`, or `{teamName}/{agentName}`
+ */
+export function deriveAgentId(entry: AgentEntry): string {
+	const { teamName, agentName, sessionId } = entry;
+	const suffix = sessionId != null ? `-${sessionId.slice(0, 4)}` : '';
+
+	if (teamName != null && agentName != null) {
+		return `${teamName}/${agentName}${suffix}`;
+	}
+	if (agentName != null) {
+		return `${agentName}${suffix}`;
+	}
+	return `lead${suffix}`;
+}
+
+/**
+ * Derives a role name (without session hash suffix) for grouping agent instances.
+ *
+ * - teamName + agentName → `{teamName}/{agentName}`
+ * - only agentName → `{agentName}`
+ * - neither → `lead`
+ */
+export function deriveAgentRole(entry: AgentEntry): string {
+	const { teamName, agentName } = entry;
+
+	if (teamName != null && agentName != null) {
+		return `${teamName}/${agentName}`;
+	}
+	if (agentName != null) {
+		return agentName;
+	}
+	return 'lead';
+}
+
+// Common parent/container directories that don't identify a specific project
+const CONTAINER_DIRS = new Set([
+	'IdeaProjects',
+	'Projects',
+	'projects',
+	'repos',
+	'Repos',
+	'repositories',
+	'src',
+	'code',
+	'Code',
+	'workspace',
+	'Workspace',
+	'workspaces',
+	'Documents',
+	'Desktop',
+	'Downloads',
+	'dev',
+	'Dev',
+	'development',
+]);
+
+/**
+ * Extracts a short human-readable project name from an encoded project path.
+ * The encoded path uses '-' as a path separator (e.g. '-Users-thomas-IdeaProjects-diana').
+ * Returns the last non-container segment, skipping generic directory names like 'IdeaProjects'.
+ */
+export function shortProjectName(encoded: string): string {
+	const parts = encoded.split('-').filter(Boolean);
+	for (let i = parts.length - 1; i >= 0; i--) {
+		if (!CONTAINER_DIRS.has(parts[i]!)) {
+			return parts[i]!;
+		}
+	}
+	return parts.at(-1) ?? encoded;
+}
+
+if (import.meta.vitest != null) {
+	const { describe, it, expect } = import.meta.vitest;
+
+	describe('deriveAgentRole', () => {
+		it('returns teamName/agentName when both present', () => {
+			expect(
+				deriveAgentRole({
+					teamName: 'ccusage-fork',
+					agentName: 'researcher',
+					sessionId: 'a1b2c3d4',
+				}),
+			).toBe('ccusage-fork/researcher');
+		});
+
+		it('returns agentName when no teamName', () => {
+			expect(deriveAgentRole({ agentName: 'coder', sessionId: 'deadbeef' })).toBe('coder');
+		});
+
+		it('returns lead for main agent', () => {
+			expect(deriveAgentRole({ sessionId: 'e5f6a7b8' })).toBe('lead');
+		});
+
+		it('returns lead when no fields present', () => {
+			expect(deriveAgentRole({})).toBe('lead');
+		});
+	});
+
+	describe('deriveAgentId', () => {
+		it('returns teamName/agentName-sessionPrefix when all fields present', () => {
+			expect(
+				deriveAgentId({ teamName: 'ccusage-fork', agentName: 'researcher', sessionId: 'a1b2c3d4' }),
+			).toBe('ccusage-fork/researcher-a1b2');
+		});
+
+		it('returns agentName-sessionPrefix when no teamName', () => {
+			expect(deriveAgentId({ agentName: 'coder', sessionId: 'deadbeef' })).toBe('coder-dead');
+		});
+
+		it('returns lead-sessionPrefix for main agent (no teamName/agentName)', () => {
+			expect(deriveAgentId({ sessionId: 'e5f6a7b8' })).toBe('lead-e5f6');
+		});
+
+		it('returns lead when no fields present', () => {
+			expect(deriveAgentId({})).toBe('lead');
+		});
+
+		it('returns teamName/agentName without suffix when no sessionId', () => {
+			expect(deriveAgentId({ teamName: 'my-team', agentName: 'worker' })).toBe('my-team/worker');
+		});
+
+		it('returns agentName without suffix when no sessionId or teamName', () => {
+			expect(deriveAgentId({ agentName: 'solo' })).toBe('solo');
+		});
+
+		it('handles short sessionId gracefully', () => {
+			expect(deriveAgentId({ sessionId: 'ab' })).toBe('lead-ab');
+		});
+	});
+
+	describe('shortProjectName', () => {
+		it('returns last segment for normal project path', () => {
+			expect(shortProjectName('-Users-thomas-IdeaProjects-diana')).toBe('diana');
+		});
+
+		it('skips container directory IdeaProjects', () => {
+			expect(shortProjectName('-Users-thomas-IdeaProjects')).toBe('thomas');
+		});
+
+		it('skips container directory Projects', () => {
+			expect(shortProjectName('-Users-thomas-Projects')).toBe('thomas');
+		});
+
+		it('skips container directory Desktop', () => {
+			expect(shortProjectName('-home-user-Desktop')).toBe('user');
+		});
+
+		it('returns last segment when not a container', () => {
+			expect(shortProjectName('-Users-thomas-myapp')).toBe('myapp');
+		});
+
+		it('falls back to last segment when all are containers', () => {
+			expect(shortProjectName('-Projects')).toBe('Projects');
+		});
+
+		it('returns encoded string for empty input', () => {
+			expect(shortProjectName('')).toBe('');
+		});
+	});
+}

--- a/apps/ccusage/src/agent-id.ts
+++ b/apps/ccusage/src/agent-id.ts
@@ -55,7 +55,6 @@ export function deriveAgentRole(entry: AgentEntry): string {
 
 // Common parent/container directories that don't identify a specific project
 const CONTAINER_DIRS = new Set([
-	'IdeaProjects',
 	'Projects',
 	'projects',
 	'repos',
@@ -154,8 +153,8 @@ if (import.meta.vitest != null) {
 			expect(shortProjectName('-Users-thomas-IdeaProjects-diana')).toBe('diana');
 		});
 
-		it('skips container directory IdeaProjects', () => {
-			expect(shortProjectName('-Users-thomas-IdeaProjects')).toBe('thomas');
+		it('returns IdeaProjects as a normal directory name', () => {
+			expect(shortProjectName('-Users-thomas-IdeaProjects')).toBe('IdeaProjects');
 		});
 
 		it('skips container directory Projects', () => {

--- a/apps/ccusage/src/agent-id.ts
+++ b/apps/ccusage/src/agent-id.ts
@@ -55,8 +55,11 @@ export function deriveAgentRole(entry: AgentEntry): string {
 
 // Common parent/container directories that don't identify a specific project
 const CONTAINER_DIRS = new Set([
+	'Users',
+	'home',
 	'Projects',
 	'projects',
+	'IdeaProjects',
 	'repos',
 	'Repos',
 	'repositories',
@@ -81,8 +84,13 @@ const CONTAINER_DIRS = new Set([
  */
 export function shortProjectName(encoded: string): string {
 	const parts = encoded.split('-').filter(Boolean);
+	// Find the last non-container segment
 	for (let i = parts.length - 1; i >= 0; i--) {
 		if (!CONTAINER_DIRS.has(parts[i]!)) {
+			// Include the preceding non-container segment for disambiguation
+			if (i > 0 && !CONTAINER_DIRS.has(parts[i - 1]!)) {
+				return `${parts[i - 1]}-${parts[i]}`;
+			}
 			return parts[i]!;
 		}
 	}
@@ -153,8 +161,8 @@ if (import.meta.vitest != null) {
 			expect(shortProjectName('-Users-thomas-IdeaProjects-diana')).toBe('diana');
 		});
 
-		it('returns IdeaProjects as a normal directory name', () => {
-			expect(shortProjectName('-Users-thomas-IdeaProjects')).toBe('IdeaProjects');
+		it('skips container directory IdeaProjects', () => {
+			expect(shortProjectName('-Users-thomas-IdeaProjects')).toBe('thomas');
 		});
 
 		it('skips container directory Projects', () => {
@@ -166,7 +174,11 @@ if (import.meta.vitest != null) {
 		});
 
 		it('returns last segment when not a container', () => {
-			expect(shortProjectName('-Users-thomas-myapp')).toBe('myapp');
+			expect(shortProjectName('-Users-thomas-myapp')).toBe('thomas-myapp');
+		});
+
+		it('joins last two non-container segments for disambiguation', () => {
+			expect(shortProjectName('-Users-me-IdeaProjects-ccusage-fork')).toBe('ccusage-fork');
 		});
 
 		it('falls back to last segment when all are containers', () => {

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -575,7 +575,14 @@ async function resolveSessionTitle(
 						if (textContent == null) {
 							continue;
 						}
-						const firstLine = textContent.split('\n')[0]!.trim();
+						// Find first non-empty line that isn't a bare UUID/hash
+						const uuidPattern = /^[\da-f-]{8,}$/i;
+						const firstLine =
+							textContent
+								.split('\n')
+								.map((l) => l.trim())
+								.find((l) => l.length > 0 && !uuidPattern.test(l)) ??
+							textContent.split('\n')[0]!.trim();
 						if (firstLine.length > 0) {
 							// Only set deterministic title from substantive messages
 							if (firstLine.length >= 10 && firstLine.includes(' ') && userMessageTitle == null) {

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -356,7 +356,12 @@ async function generateAITitlesBatch(
 		return result;
 	}
 
-	const numbered = sessions.map((s) => `${s.index}. ${s.messages.join(' | ')}`).join('\n');
+	const numbered = sessions
+		.map((s) => {
+			const joined = s.messages.join(' | ');
+			return `${s.index}. ${joined.length > 1000 ? `${joined.slice(0, 1000)}…` : joined}`;
+		})
+		.join('\n');
 
 	const prompt = `Generate a short noun-phrase title (max 30 characters, 3-5 words) for each Claude Code session below.
 
@@ -589,7 +594,7 @@ async function resolveSessionTitle(
 								userMessageTitle = firstLine;
 							}
 							// Collect ALL non-empty messages for AI title generation
-							if (userMessages.length < 3) {
+							if (userMessages.length < 5) {
 								userMessages.push(truncateAtWord(firstLine, 120));
 							}
 						}
@@ -763,7 +768,8 @@ async function resolveLeadDisplayNames(
 			} else {
 				// No AI title (no substantive messages) — show truncated ID + time + hint
 				const shortId = agent.sessionId?.slice(0, 8) ?? 'Untitled';
-				const firstMsg = item.messages[0];
+				const uuidLike = /^[\da-f-]{8,}$/i;
+				const firstMsg = item.messages.find((m) => !uuidLike.test(m));
 				const hint =
 					firstMsg != null
 						? ` ("${firstMsg.length > 30 ? `${firstMsg.slice(0, 30)}…` : firstMsg}")`
@@ -777,7 +783,8 @@ async function resolveLeadDisplayNames(
 		for (const item of needsAI) {
 			const agent = agents[item.agentIdx]!;
 			const shortId = agent.sessionId?.slice(0, 8) ?? 'Untitled';
-			const firstMsg = item.messages[0];
+			const uuidLike = /^[\da-f-]{8,}$/i;
+			const firstMsg = item.messages.find((m) => !uuidLike.test(m));
 			const hint =
 				firstMsg != null
 					? ` ("${firstMsg.length > 30 ? `${firstMsg.slice(0, 30)}…` : firstMsg}")`

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -571,9 +571,9 @@ async function resolveSessionTitle(
 		return { title: null, startTime, userMessages };
 	}
 
-	// Absolute fallback: truncated sessionId (no user messages to generate from)
+	// Absolute fallback: no user messages to generate from
 	if (startTime != null) {
-		return { title: sessionId.slice(0, 8), startTime };
+		return { title: null, startTime, userMessages: [] };
 	}
 
 	return null;
@@ -646,22 +646,27 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 		for (const item of needsAI) {
 			const agent = agents[item.agentIdx]!;
 			const aiTitle = aiTitles.get(needsAI.indexOf(item) + 1);
-			const finalTitle = aiTitle ?? agent.sessionId?.slice(0, 8) ?? 'Untitled';
 
-			agent.agentId = `${finalTitle} · ${formatStartTime(item.startTime, timezone)}${agent.sessionId != null ? ` · ${agent.sessionId}` : ''}`;
+			if (aiTitle != null) {
+				agent.agentId = `${aiTitle} · ${formatStartTime(item.startTime, timezone)}${agent.sessionId != null ? ` · ${agent.sessionId}` : ''}`;
 
-			// Cache the AI-generated title
-			if (agent.sessionId != null) {
-				try {
-					await mkdir(cacheDir, { recursive: true });
-					await writeFile(
-						path.join(cacheDir, agent.sessionId),
-						`${CACHE_VERSION}\n${finalTitle}\n${item.startTime}`,
-						'utf-8',
-					);
-				} catch {
-					// Cache write failure is non-fatal
+				// Cache only real AI-generated titles
+				if (agent.sessionId != null) {
+					try {
+						await mkdir(cacheDir, { recursive: true });
+						await writeFile(
+							path.join(cacheDir, agent.sessionId),
+							`${CACHE_VERSION}\n${aiTitle}\n${item.startTime}`,
+							'utf-8',
+						);
+					} catch {
+						// Cache write failure is non-fatal
+					}
 				}
+			} else {
+				// No AI title (no substantive messages) — show truncated ID + time only
+				const shortId = agent.sessionId?.slice(0, 8) ?? 'Untitled';
+				agent.agentId = `${shortId} · ${formatStartTime(item.startTime, timezone)}`;
 			}
 		}
 	}

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -15,12 +15,12 @@ import {
 import { Result } from '@praha/byethrow';
 import { uniq } from 'es-toolkit';
 import { define } from 'gunshi';
-
+import spawn from 'nano-spawn';
 import pc from 'picocolors';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
-import { deriveAgentRole } from '../agent-id.ts';
+import { deriveAgentId, deriveAgentRole, shortProjectName } from '../agent-id.ts';
 import { createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
 import { getClaudePaths, loadAgentUsageData } from '../data-loader.ts';
 import { log, logger } from '../logger.ts';
@@ -211,22 +211,196 @@ function extractCompactionTitle(text: string): string | null {
 	return null;
 }
 
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const OAUTH_REFRESH_URL = 'https://console.anthropic.com/v1/oauth/token';
+
+/**
+ * Reads Claude Code credentials from macOS Keychain (preferred) or file fallback.
+ * Handles token refresh for expired OAuth tokens.
+ */
+async function getClaudeAuthHeaders(): Promise<Record<string, string> | null> {
+	// Try ANTHROPIC_API_KEY first (API subscribers)
+	const apiKey = process.env.ANTHROPIC_API_KEY;
+	if (apiKey != null && apiKey !== '') {
+		return {
+			'x-api-key': apiKey,
+			'anthropic-version': '2023-06-01',
+		};
+	}
+
+	// Read credentials: Keychain first, then file
+	let creds: Record<string, unknown> | null = null;
+
+	// macOS Keychain (has the freshest tokens)
+	for (const service of ['Claude Code-credentials', 'Claude Code - credentials', 'Claude Code']) {
+		try {
+			const proc = await spawn('security', ['find-generic-password', '-s', service, '-w']);
+			const raw = proc.stdout.trim();
+			if (raw !== '') {
+				creds = JSON.parse(raw) as Record<string, unknown>;
+				break;
+			}
+		} catch {
+			// Keychain entry not found
+		}
+	}
+
+	// File fallback
+	if (creds == null) {
+		try {
+			const credsPath = path.join(os.homedir(), '.claude', '.credentials.json');
+			const raw = await readFile(credsPath, 'utf-8');
+			creds = JSON.parse(raw) as Record<string, unknown>;
+		} catch {
+			// File not available
+		}
+	}
+
+	if (creds == null) {
+		return null;
+	}
+
+	const oauth = creds.claudeAiOauth as Record<string, unknown> | undefined;
+	if (oauth == null) {
+		return null;
+	}
+
+	// Direct API key stored by Claude Code
+	if (typeof oauth.apiKey === 'string' && oauth.apiKey !== '') {
+		return {
+			'x-api-key': oauth.apiKey,
+			'anthropic-version': '2023-06-01',
+		};
+	}
+
+	let accessToken = typeof oauth.accessToken === 'string' ? oauth.accessToken : null;
+	const expiresAt = typeof oauth.expiresAt === 'number' ? oauth.expiresAt : 0;
+	const refreshToken = typeof oauth.refreshToken === 'string' ? oauth.refreshToken : null;
+
+	// Refresh if expired or expiring within 5 minutes
+	if (expiresAt > 0 && expiresAt / 1000 < Date.now() / 1000 + 300 && refreshToken != null) {
+		try {
+			const response = await fetch(OAUTH_REFRESH_URL, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					grant_type: 'refresh_token',
+					refresh_token: refreshToken,
+					client_id: OAUTH_CLIENT_ID,
+				}),
+			});
+			const res = response as unknown as { ok: boolean; json: () => Promise<unknown> };
+			if (res.ok) {
+				const data = (await res.json()) as { access_token?: string };
+				if (typeof data.access_token === 'string') {
+					accessToken = data.access_token;
+				}
+			}
+		} catch {
+			// Refresh failed — try with existing token anyway
+		}
+	}
+
+	if (accessToken != null && accessToken !== '') {
+		return {
+			Authorization: `Bearer ${accessToken}`,
+			'anthropic-version': '2023-06-01',
+			'anthropic-beta': 'oauth-2025-04-20',
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Generates AI titles for multiple sessions in a single API call.
+ * Auth: Claude Code OAuth credentials > ANTHROPIC_API_KEY > claude CLI fallback.
+ */
+async function generateAITitlesBatch(
+	sessions: Array<{ index: number; messages: string[] }>,
+): Promise<Map<number, string>> {
+	const result = new Map<number, string>();
+	if (sessions.length === 0) {
+		return result;
+	}
+
+	const numbered = sessions.map((s) => `${s.index}. ${s.messages.join(' | ')}`).join('\n');
+
+	const prompt = `Generate concise titles (max 8 words each) for these ${sessions.length} Claude Code sessions. Output ONLY numbered titles matching the input numbers, one per line. No other text.\n\n${numbered}`;
+
+	let output: string | null = null;
+
+	// Try direct API with OAuth/API key (no session pollution)
+	const authHeaders = await getClaudeAuthHeaders();
+	if (authHeaders != null) {
+		try {
+			const response = await fetch('https://api.anthropic.com/v1/messages', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					...authHeaders,
+				},
+				body: JSON.stringify({
+					model: 'claude-haiku-4-5-20251001',
+					max_tokens: 1024,
+					messages: [{ role: 'user', content: prompt }],
+				}),
+			});
+			const res = response as unknown as { ok: boolean; json: () => Promise<unknown> };
+			if (res.ok) {
+				const data = (await res.json()) as { content?: Array<{ text?: string }> };
+				output = data.content?.[0]?.text ?? null;
+			}
+		} catch {
+			// API call failed — fall through to CLI
+		}
+	}
+
+	// Fallback: claude CLI (creates a session entry but works without credentials file)
+	if (output == null) {
+		try {
+			const proc = await spawn('claude', ['-p', prompt, '--model', 'haiku']);
+			output = proc.stdout.trim();
+		} catch {
+			// CLI not available
+		}
+	}
+
+	if (output != null) {
+		for (const line of output.split('\n')) {
+			const match = line.match(/^(\d+)\.\s*(.+)/);
+			if (match != null) {
+				const idx = Number.parseInt(match[1]!, 10);
+				const title = match[2]!.trim();
+				if (title.length > 0 && title.length <= 80) {
+					result.set(idx, title);
+				}
+			}
+		}
+	}
+
+	return result;
+}
+
 /**
  * Resolves a session title from JSONL file content.
- * Priority: cached title > compaction summary > legacy summary.
- * Returns null when no title can be derived — caller shows UUID only.
+ * Priority: cached title > compaction summary (isCompactSummary user entry)
+ * > legacy summary > AI-generated title > truncated sessionId (last resort).
  */
 async function resolveSessionTitle(
 	sessionId: string,
 	project: string | undefined,
 	claudePaths: string[],
-): Promise<{ title: string; startTime: string } | { title: null; startTime: string } | null> {
+): Promise<
+	| { title: string; startTime: string }
+	| { title: null; startTime: string; userMessages: string[] }
+	| null
+> {
 	const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
 	const cachePath = path.join(cacheDir, sessionId);
 
-	// Check cache — versioned format: "v11\n<title>\n<startTime>"
-	// v11: invalidate AI-generated title caches from v10
-	const CACHE_VERSION = 'v11';
+	// Check cache — versioned format: "v8\n<title>\n<startTime>"
+	const CACHE_VERSION = 'v10';
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
 		const lines = cached.trim().split('\n');
@@ -266,6 +440,8 @@ async function resolveSessionTitle(
 
 	let compactionTitle: string | null = null;
 	let summaryTitle: string | null = null;
+	let userMessageTitle: string | null = null;
+	const userMessages: string[] = [];
 	let startTime: string | null = null;
 
 	// Phase 1: quick scan of first 50 lines for startTime, userMessages, and early compaction
@@ -300,6 +476,37 @@ async function resolveSessionTitle(
 			}
 			if (summaryTitle == null && parsed.type === 'summary' && typeof parsed.summary === 'string') {
 				summaryTitle = parsed.summary.slice(0, 60).trim();
+			}
+			if (parsed.type === 'user' && parsed.isCompactSummary !== true && parsed.isMeta !== true) {
+				const msg = parsed.message as Record<string, unknown> | undefined;
+				if (msg?.role === 'user') {
+					const content = msg.content;
+					// Extract text from string or array content (multimodal messages use [{type:"text",text:"..."}])
+					let textContent: string | undefined;
+					if (typeof content === 'string') {
+						textContent = content;
+					} else if (Array.isArray(content)) {
+						const textBlock = content.find(
+							(b: unknown) =>
+								typeof b === 'object' &&
+								b != null &&
+								(b as Record<string, unknown>).type === 'text',
+						) as Record<string, unknown> | undefined;
+						if (typeof textBlock?.text === 'string') {
+							textContent = textBlock.text;
+						}
+					}
+					if (textContent != null && !/^<[a-z]/i.test(textContent)) {
+						// Collect first user message as title fallback
+						if (userMessageTitle == null) {
+							userMessageTitle = truncateAtWord(textContent.split('\n')[0]!.trim(), 60);
+						}
+						// Collect up to 3 user messages for AI title generation
+						if (userMessages.length < 3) {
+							userMessages.push(truncateAtWord(textContent.split('\n')[0]!.trim(), 120));
+						}
+					}
+				}
 			}
 		} catch {
 			// Skip unparseable lines
@@ -355,9 +562,14 @@ async function resolveSessionTitle(
 		return { title, startTime };
 	}
 
-	// No title available — return startTime so caller can show UUID with timestamp
+	// No deterministic title — return messages for AI generation
+	if (startTime != null && userMessages.length > 0) {
+		return { title: null, startTime, userMessages };
+	}
+
+	// Absolute fallback: truncated sessionId (no user messages to generate from)
 	if (startTime != null) {
-		return { title: null, startTime };
+		return { title: sessionId.slice(0, 8), startTime };
 	}
 
 	return null;
@@ -376,10 +588,16 @@ function formatStartTime(timestamp: string, timezone?: string): string {
 
 /**
  * Replaces temporary `lead:sessionId` agentIds with meaningful session titles.
- * Falls back to UUID-only display when no compaction summary exists.
+ * Falls back to project/lead-hash when title can't be derived.
+ * Batches all AI title requests into a single API call.
  */
 async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string): Promise<void> {
 	let claudePaths: string[] | null = null;
+	const needsAI: Array<{
+		agentIdx: number;
+		startTime: string;
+		messages: string[];
+	}> = [];
 
 	for (let i = 0; i < agents.length; i++) {
 		const agent = agents[i]!;
@@ -397,14 +615,50 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 
 		const titleInfo = await resolveSessionTitle(agent.sessionId, agent.project, claudePaths);
 		if (titleInfo == null) {
-			// No data at all — show UUID only
-			agent.agentId = agent.sessionId;
+			// No data at all — fallback to project/lead-hash
+			const prefix = agent.project != null ? `${shortProjectName(agent.project)}/` : '';
+			agent.agentId = `${prefix}${deriveAgentId({ sessionId: agent.sessionId })}`;
 		} else if (titleInfo.title != null) {
-			// Got a resolved title (cached, compaction, or summary)
+			// Got a resolved title (cached, compaction, or user message)
 			agent.agentId = `${titleInfo.title} · ${formatStartTime(titleInfo.startTime, timezone)} · ${agent.sessionId}`;
 		} else {
-			// No title — show UUID with timestamp
-			agent.agentId = `${formatStartTime(titleInfo.startTime, timezone)} · ${agent.sessionId}`;
+			// Needs AI title generation — collect for batch
+			needsAI.push({
+				agentIdx: i,
+				startTime: titleInfo.startTime,
+				messages: titleInfo.userMessages,
+			});
+		}
+	}
+
+	// Batch AI title generation in a single claude call
+	if (needsAI.length > 0) {
+		const batchInput = needsAI.map((item, idx) => ({ index: idx + 1, messages: item.messages }));
+		const aiTitles = await generateAITitlesBatch(batchInput);
+
+		const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
+		const CACHE_VERSION = 'v10';
+
+		for (const item of needsAI) {
+			const agent = agents[item.agentIdx]!;
+			const aiTitle = aiTitles.get(needsAI.indexOf(item) + 1);
+			const finalTitle = aiTitle ?? agent.sessionId?.slice(0, 8) ?? 'Untitled';
+
+			agent.agentId = `${finalTitle} · ${formatStartTime(item.startTime, timezone)}${agent.sessionId != null ? ` · ${agent.sessionId}` : ''}`;
+
+			// Cache the AI-generated title
+			if (agent.sessionId != null) {
+				try {
+					await mkdir(cacheDir, { recursive: true });
+					await writeFile(
+						path.join(cacheDir, agent.sessionId),
+						`${CACHE_VERSION}\n${finalTitle}\n${item.startTime}`,
+						'utf-8',
+					);
+				} catch {
+					// Cache write failure is non-fatal
+				}
+			}
 		}
 	}
 }

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -341,7 +341,7 @@ async function generateAITitlesBatch(
 
 	const numbered = sessions.map((s) => `${s.index}. ${s.messages.join(' | ')}`).join('\n');
 
-	const prompt = `Generate concise titles (max 8 words each) for these ${sessions.length} Claude Code sessions based on what the user asked for. Focus on the TASK or GOAL, not greetings. Output ONLY numbered titles matching the input numbers, one per line. No other text.\n\n${numbered}`;
+	const prompt = `Generate concise titles (max 40 characters each) for these ${sessions.length} Claude Code sessions based on what the user asked for. Focus on the TASK or GOAL, not greetings. Output ONLY numbered titles matching the input numbers, one per line. No other text.\n\n${numbered}`;
 
 	let output: string | null = null;
 
@@ -387,7 +387,7 @@ async function generateAITitlesBatch(
 			if (match != null) {
 				const idx = Number.parseInt(match[1]!, 10);
 				const title = match[2]!.trim();
-				if (title.length > 0 && title.length <= 80 && !/^\[.*\]$/.test(title)) {
+				if (title.length > 0 && title.length <= 50 && !/^\[.*\]$/.test(title)) {
 					result.set(idx, title);
 				}
 			}
@@ -416,7 +416,7 @@ async function resolveSessionTitle(
 
 	// Check cache — versioned format: "v12\n<title>\n<startTime>"
 	// v12: invalidate caches from v11 (filter bracketed AI placeholders)
-	const CACHE_VERSION = 'v12';
+	const CACHE_VERSION = 'v13';
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
 		const lines = cached.trim().split('\n');
@@ -532,12 +532,12 @@ async function resolveSessionTitle(
 							continue;
 						}
 						const firstLine = textContent.split('\n')[0]!.trim();
-						// Skip trivially short messages ("hello", "ok", "yes", etc.)
-						const isSubstantive = firstLine.length >= 10 && firstLine.includes(' ');
-						if (isSubstantive) {
-							if (userMessageTitle == null) {
+						if (firstLine.length > 0) {
+							// Only set deterministic title from substantive messages
+							if (firstLine.length >= 10 && firstLine.includes(' ') && userMessageTitle == null) {
 								userMessageTitle = truncateAtWord(firstLine, 60);
 							}
+							// Collect ALL non-empty messages for AI title generation
 							if (userMessages.length < 3) {
 								userMessages.push(truncateAtWord(firstLine, 120));
 							}
@@ -678,7 +678,7 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 		const aiTitles = await generateAITitlesBatch(batchInput);
 
 		const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
-		const CACHE_VERSION = 'v12';
+		const CACHE_VERSION = 'v13';
 
 		for (const item of needsAI) {
 			const agent = agents[item.agentIdx]!;
@@ -703,9 +703,15 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 					}
 				}
 			} else {
-				// No AI title (no substantive messages) — show truncated ID + time only
+				// No AI title (no substantive messages) — show truncated ID + time + hint
 				const shortId = agent.sessionId?.slice(0, 8) ?? 'Untitled';
-				agent.agentId = joinParts([shortId, formatStartTime(item.startTime, timezone)]);
+				const firstMsg = item.messages[0];
+				const hint =
+					firstMsg != null
+						? ` ("${firstMsg.length > 30 ? `${firstMsg.slice(0, 30)}…` : firstMsg}")`
+						: '';
+				const line1 = joinParts([shortId, formatStartTime(item.startTime, timezone)]) + hint;
+				agent.agentId = agent.sessionId != null ? `${line1}\n${agent.sessionId}` : line1;
 			}
 		}
 	}

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -1,6 +1,6 @@
 import type { AgentUsage, ModelBreakdown } from '../data-loader.ts';
 import { createReadStream } from 'node:fs';
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -648,6 +648,167 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 	}
 }
 
+/**
+ * Loads team configs from ~/.claude/teams/ to build a teamName → leadSessionId map.
+ */
+async function loadTeamLeadMap(claudePaths: string[]): Promise<Map<string, string>> {
+	const map = new Map<string, string>();
+	for (const cp of claudePaths) {
+		const teamsDir = path.join(cp, 'teams');
+		let entries: string[];
+		try {
+			entries = await readdir(teamsDir);
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			if (map.has(entry)) {
+				continue;
+			}
+			try {
+				const raw = await readFile(path.join(teamsDir, entry, 'config.json'), 'utf-8');
+				const config = JSON.parse(raw) as { leadSessionId?: string };
+				if (typeof config.leadSessionId === 'string') {
+					map.set(entry, config.leadSessionId);
+				}
+			} catch {
+				// Skip invalid configs
+			}
+		}
+	}
+	return map;
+}
+
+type DisplayRow = {
+	data: AgentUsage;
+	isLeadHeader: boolean; // header-only row for orphan leads (no usage data in current range)
+	indent: boolean; // team member indented under lead
+};
+
+/**
+ * Groups team members under their lead sessions using tree-style display.
+ * Leads with members appear first (sorted by total group cost), then ungrouped entries.
+ */
+function groupByTeamLead(
+	displayData: AgentUsage[],
+	teamLeadMap: Map<string, string>,
+	leadTitleCache: Map<string, string>,
+): DisplayRow[] {
+	// Map leadSessionId → lead entry (if present in data)
+	const leadBySession = new Map<string, AgentUsage>();
+	for (const d of displayData) {
+		if (d.agentId.startsWith('lead:') || d.sessionId != null) {
+			// After resolveLeadDisplayNames, leads no longer start with "lead:" —
+			// they have resolved titles. Identify leads by having sessionId + no teamName.
+			if (d.teamName == null && d.sessionId != null) {
+				leadBySession.set(d.sessionId, d);
+			}
+		}
+	}
+
+	// Group team members under leads
+	const leadGroups = new Map<string, { lead: AgentUsage | null; members: AgentUsage[] }>();
+	const ungrouped: AgentUsage[] = [];
+
+	for (const d of displayData) {
+		if (d.teamName != null && d.agentName != null) {
+			// Team member — find its lead
+			const leadSessionId = teamLeadMap.get(d.teamName);
+			if (leadSessionId != null) {
+				const group = leadGroups.get(leadSessionId);
+				if (group != null) {
+					group.members.push(d);
+				} else {
+					const lead = leadBySession.get(leadSessionId) ?? null;
+					leadGroups.set(leadSessionId, { lead, members: [d] });
+				}
+			} else {
+				ungrouped.push(d);
+			}
+		} else if (d.teamName == null && d.sessionId != null) {
+			// Lead entry — ensure group exists
+			const existingGroup = leadGroups.get(d.sessionId);
+			if (existingGroup != null) {
+				existingGroup.lead = d;
+			} else {
+				leadGroups.set(d.sessionId, { lead: d, members: [] });
+			}
+		} else {
+			ungrouped.push(d);
+		}
+	}
+
+	// Build sorted output: groups by total cost (lead + members), then ungrouped
+	const sortedGroups = Array.from(leadGroups.entries())
+		.map(([sessionId, group]) => {
+			const leadCost = group.lead?.totalCost ?? 0;
+			const memberCost = group.members.reduce((sum, m) => sum + m.totalCost, 0);
+			return { sessionId, ...group, totalCost: leadCost + memberCost };
+		})
+		.sort((a, b) => b.totalCost - a.totalCost);
+
+	const rows: DisplayRow[] = [];
+
+	for (const group of sortedGroups) {
+		if (group.lead != null) {
+			rows.push({ data: group.lead, isLeadHeader: false, indent: false });
+		} else {
+			// Orphan lead — create header-only row from cached title
+			const title = leadTitleCache.get(group.sessionId) ?? group.sessionId.slice(0, 8);
+			rows.push({
+				data: {
+					agentId: title,
+					agentName: undefined,
+					teamName: undefined,
+					sessionId: group.sessionId,
+					inputTokens: 0,
+					outputTokens: 0,
+					cacheCreationTokens: 0,
+					cacheReadTokens: 0,
+					totalCost: 0,
+					modelsUsed: [],
+					modelBreakdowns: [],
+				},
+				isLeadHeader: true,
+				indent: false,
+			});
+		}
+		// Sort members by cost descending
+		group.members.sort((a, b) => b.totalCost - a.totalCost);
+		for (const m of group.members) {
+			rows.push({ data: m, isLeadHeader: false, indent: true });
+		}
+	}
+
+	// Ungrouped entries (no team, or team not in config)
+	ungrouped.sort((a, b) => b.totalCost - a.totalCost);
+	for (const d of ungrouped) {
+		rows.push({ data: d, isLeadHeader: false, indent: false });
+	}
+
+	return rows;
+}
+
+/**
+ * Loads cached session titles for lead sessions (used for orphan lead headers).
+ */
+async function loadLeadTitleCache(teamLeadMap: Map<string, string>): Promise<Map<string, string>> {
+	const cache = new Map<string, string>();
+	const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
+	for (const sessionId of new Set(teamLeadMap.values())) {
+		try {
+			const raw = await readFile(path.join(cacheDir, sessionId), 'utf-8');
+			const lines = raw.trim().split('\n');
+			if (lines.length >= 2 && lines[1] != null && lines[1] !== '') {
+				cache.set(sessionId, lines[1]);
+			}
+		} catch {
+			// No cached title
+		}
+	}
+	return cache;
+}
+
 export const agentCommand = define({
 	name: 'agent',
 	description: 'Show usage report grouped by agent identity',
@@ -743,7 +904,23 @@ export const agentCommand = define({
 		// Sort by cost descending (top spenders first)
 		displayData.sort((a, b) => b.totalCost - a.totalCost);
 
-		// Calculate totals
+		// Group team members under their lead sessions
+		let groupedRows: DisplayRow[] | null = null;
+		if (!ctx.values.instances) {
+			let claudePaths: string[];
+			try {
+				claudePaths = getClaudePaths();
+			} catch {
+				claudePaths = [];
+			}
+			const teamLeadMap = await loadTeamLeadMap(claudePaths);
+			if (teamLeadMap.size > 0) {
+				const leadTitleCache = await loadLeadTitleCache(teamLeadMap);
+				groupedRows = groupByTeamLead(displayData, teamLeadMap, leadTitleCache);
+			}
+		}
+
+		// Calculate totals (from original data, not grouped rows which may include header-only rows)
 		const totals = displayData.reduce(
 			(acc, item) => ({
 				inputTokens: acc.inputTokens + item.inputTokens,
@@ -828,13 +1005,31 @@ export const agentCommand = define({
 				forceCompact: ctx.values.compact,
 			});
 
-			for (const data of displayData) {
+			const rows =
+				groupedRows ?? displayData.map((d) => ({ data: d, isLeadHeader: false, indent: false }));
+
+			for (const row of rows) {
+				const { data, isLeadHeader, indent } = row;
+
+				if (isLeadHeader) {
+					// Orphan lead header — title only, no usage columns
+					table.push([pc.dim(data.agentId), '', '', '', '', '', '', '']);
+					continue;
+				}
+
 				const totalTokens =
 					data.inputTokens + data.outputTokens + data.cacheCreationTokens + data.cacheReadTokens;
-				// Insert newline after '/' so team/member names wrap at semantic boundary
-				const displayName = data.agentId.includes('/')
-					? data.agentId.replace('/', '/\n')
-					: data.agentId;
+				let displayName: string;
+				if (indent) {
+					// Team member — show just the agent name with tree prefix
+					const name = data.agentName ?? data.agentId;
+					displayName = `  └─ ${name}`;
+				} else if (data.agentId.includes('/')) {
+					// Ungrouped team/member — wrap at '/' boundary
+					displayName = data.agentId.replace('/', '/\n');
+				} else {
+					displayName = data.agentId;
+				}
 				table.push([
 					displayName,
 					data.modelsUsed.length > 0 ? formatModelsDisplayMultiline(data.modelsUsed) : '',

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -580,22 +580,25 @@ async function resolveSessionTitle(
 						if (textContent == null) {
 							continue;
 						}
-						// Find first non-empty line that isn't a bare UUID/hash
+						// Filter out bare UUIDs/hashes and bare URLs, keep substantive lines
 						const uuidPattern = /^[\da-f-]{8,}$/i;
-						const firstLine =
-							textContent
-								.split('\n')
-								.map((l) => l.trim())
-								.find((l) => l.length > 0 && !uuidPattern.test(l)) ??
-							textContent.split('\n')[0]!.trim();
-						if (firstLine.length > 0) {
+						const bareUrlPattern = /^https?:\/\/\S+$/i;
+						const substantiveLines = textContent
+							.split('\n')
+							.map((l) => l.trim())
+							.filter((l) => l.length > 0 && !uuidPattern.test(l) && !bareUrlPattern.test(l));
+						const condensed =
+							substantiveLines.length > 0
+								? substantiveLines.join(' ')
+								: textContent.split('\n')[0]!.trim();
+						if (condensed.length > 0) {
 							// Only set deterministic title from substantive messages
-							if (firstLine.length >= 10 && firstLine.includes(' ') && userMessageTitle == null) {
-								userMessageTitle = firstLine;
+							if (condensed.length >= 10 && condensed.includes(' ') && userMessageTitle == null) {
+								userMessageTitle = truncateAtWord(condensed, 120);
 							}
-							// Collect ALL non-empty messages for AI title generation
+							// Collect full message content for AI title generation
 							if (userMessages.length < 5) {
-								userMessages.push(truncateAtWord(firstLine, 120));
+								userMessages.push(truncateAtWord(condensed, 200));
 							}
 						}
 					}

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -492,7 +492,9 @@ async function resolveSessionTitle(
 								b != null &&
 								(b as Record<string, unknown>).type === 'text',
 						) as Record<string, unknown> | undefined;
-						if (typeof textBlock?.text === 'string') {textContent = textBlock.text;}
+						if (typeof textBlock?.text === 'string') {
+							textContent = textBlock.text;
+						}
 					}
 					if (textContent != null && !/^<[a-z]/i.test(textContent)) {
 						// Collect first user message as title fallback
@@ -719,13 +721,15 @@ function groupByTeamLead(
 		}
 	}
 
-	// Group team members under leads
+	// Group team members under leads (by leadSessionId) or by teamName (when no config exists)
 	const leadGroups = new Map<string, { lead: AgentUsage | null; members: AgentUsage[] }>();
+	// Teams without a config — group by teamName directly
+	const teamNameGroups = new Map<string, AgentUsage[]>();
 	const ungrouped: AgentUsage[] = [];
 
 	for (const d of displayData) {
 		if (d.teamName != null && d.agentName != null) {
-			// Team member — find its lead
+			// Team member — find its lead via config
 			const leadSessionId = teamLeadMap.get(d.teamName);
 			if (leadSessionId != null) {
 				const group = leadGroups.get(leadSessionId);
@@ -736,7 +740,13 @@ function groupByTeamLead(
 					leadGroups.set(leadSessionId, { lead, members: [d] });
 				}
 			} else {
-				ungrouped.push(d);
+				// No config for this team — group by teamName
+				const existing = teamNameGroups.get(d.teamName);
+				if (existing != null) {
+					existing.push(d);
+				} else {
+					teamNameGroups.set(d.teamName, [d]);
+				}
 			}
 		} else if (d.teamName == null && d.sessionId != null) {
 			// Lead entry — ensure group exists
@@ -751,13 +761,21 @@ function groupByTeamLead(
 		}
 	}
 
-	// Build sorted output: groups by total cost (lead + members), then ungrouped
+	// Build sorted output: groups by total cost (lead + members), then teamName groups, then ungrouped
 	const sortedGroups = Array.from(leadGroups.entries())
 		.map(([sessionId, group]) => {
 			const leadCost = group.lead?.totalCost ?? 0;
 			const memberCost = group.members.reduce((sum, m) => sum + m.totalCost, 0);
 			return { sessionId, ...group, totalCost: leadCost + memberCost };
 		})
+		.sort((a, b) => b.totalCost - a.totalCost);
+
+	const sortedTeamNameGroups = Array.from(teamNameGroups.entries())
+		.map(([teamName, members]) => ({
+			teamName,
+			members,
+			totalCost: members.reduce((sum, m) => sum + m.totalCost, 0),
+		}))
 		.sort((a, b) => b.totalCost - a.totalCost);
 
 	const rows: DisplayRow[] = [];
@@ -793,7 +811,32 @@ function groupByTeamLead(
 		}
 	}
 
-	// Ungrouped entries (no team, or team not in config)
+	// Teams without configs — use teamName as header
+	for (const group of sortedTeamNameGroups) {
+		rows.push({
+			data: {
+				agentId: group.teamName,
+				agentName: undefined,
+				teamName: undefined,
+				sessionId: undefined,
+				inputTokens: 0,
+				outputTokens: 0,
+				cacheCreationTokens: 0,
+				cacheReadTokens: 0,
+				totalCost: 0,
+				modelsUsed: [],
+				modelBreakdowns: [],
+			},
+			isLeadHeader: true,
+			indent: false,
+		});
+		group.members.sort((a, b) => b.totalCost - a.totalCost);
+		for (const m of group.members) {
+			rows.push({ data: m, isLeadHeader: false, indent: true });
+		}
+	}
+
+	// Ungrouped entries (no team at all)
 	ungrouped.sort((a, b) => b.totalCost - a.totalCost);
 	for (const d of ungrouped) {
 		rows.push({ data: d, isLeadHeader: false, indent: false });
@@ -993,8 +1036,9 @@ export const agentCommand = define({
 				'Cache Read',
 				'Total',
 				'Cost (USD)',
+				'%',
 			];
-			const compactHeaders = ['Agent', 'Models', 'Input', 'Output', 'Cost (USD)'];
+			const compactHeaders = ['Agent', 'Models', 'Input', 'Output', 'Cost (USD)', '%'];
 			const aligns: Array<'left' | 'right'> = [
 				'left',
 				'left',
@@ -1004,8 +1048,16 @@ export const agentCommand = define({
 				'right',
 				'right',
 				'right',
+				'right',
 			];
-			const compactAligns: Array<'left' | 'right'> = ['left', 'left', 'right', 'right', 'right'];
+			const compactAligns: Array<'left' | 'right'> = [
+				'left',
+				'left',
+				'right',
+				'right',
+				'right',
+				'right',
+			];
 
 			const table = new ResponsiveTable({
 				head: headers,
@@ -1026,7 +1078,7 @@ export const agentCommand = define({
 
 				if (isLeadHeader) {
 					// Orphan lead header — title only, no usage columns
-					table.push([pc.dim(data.agentId), '', '', '', '', '', '', '']);
+					table.push([pc.dim(data.agentId), '', '', '', '', '', '', '', '']);
 					continue;
 				}
 
@@ -1043,6 +1095,8 @@ export const agentCommand = define({
 				} else {
 					displayName = data.agentId;
 				}
+				const pct = totals.totalCost > 0 ? (data.totalCost / totals.totalCost) * 100 : 0;
+				const pctStr = pct < 0.1 ? '<0.1' : pct.toFixed(1);
 				table.push([
 					displayName,
 					data.modelsUsed.length > 0 ? formatModelsDisplayMultiline(data.modelsUsed) : '',
@@ -1052,6 +1106,7 @@ export const agentCommand = define({
 					formatCompact(data.cacheReadTokens),
 					formatCompact(totalTokens),
 					formatCurrency(data.totalCost),
+					pctStr,
 				]);
 
 				if (ctx.values.breakdown) {
@@ -1059,7 +1114,7 @@ export const agentCommand = define({
 				}
 			}
 
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, 9);
 
 			const grandTotal =
 				totals.inputTokens +
@@ -1075,6 +1130,7 @@ export const agentCommand = define({
 				pc.yellow(formatCompact(totals.cacheReadTokens)),
 				pc.yellow(formatCompact(grandTotal)),
 				pc.yellow(formatCurrency(totals.totalCost)),
+				pc.yellow('100'),
 			]);
 
 			log(table.toString());

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -326,7 +326,7 @@ async function generateAITitlesBatch(
 
 	const numbered = sessions.map((s) => `${s.index}. ${s.messages.join(' | ')}`).join('\n');
 
-	const prompt = `Generate concise titles (max 8 words each) for these ${sessions.length} Claude Code sessions. Output ONLY numbered titles matching the input numbers, one per line. No other text.\n\n${numbered}`;
+	const prompt = `Generate concise titles (max 8 words each) for these ${sessions.length} Claude Code sessions based on what the user asked for. Focus on the TASK or GOAL, not greetings. Output ONLY numbered titles matching the input numbers, one per line. No other text.\n\n${numbered}`;
 
 	let output: string | null = null;
 
@@ -399,8 +399,9 @@ async function resolveSessionTitle(
 	const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
 	const cachePath = path.join(cacheDir, sessionId);
 
-	// Check cache — versioned format: "v8\n<title>\n<startTime>"
-	const CACHE_VERSION = 'v10';
+	// Check cache — versioned format: "v11\n<title>\n<startTime>"
+	// v11: invalidate caches from v10 (fixed trivial message filtering)
+	const CACHE_VERSION = 'v11';
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
 		const lines = cached.trim().split('\n');
@@ -497,13 +498,16 @@ async function resolveSessionTitle(
 						}
 					}
 					if (textContent != null && !/^<[a-z]/i.test(textContent)) {
-						// Collect first user message as title fallback
-						if (userMessageTitle == null) {
-							userMessageTitle = truncateAtWord(textContent.split('\n')[0]!.trim(), 60);
-						}
-						// Collect up to 3 user messages for AI title generation
-						if (userMessages.length < 3) {
-							userMessages.push(truncateAtWord(textContent.split('\n')[0]!.trim(), 120));
+						const firstLine = textContent.split('\n')[0]!.trim();
+						// Skip trivially short messages ("hello", "ok", "yes", etc.)
+						const isSubstantive = firstLine.length >= 10 && firstLine.includes(' ');
+						if (isSubstantive) {
+							if (userMessageTitle == null) {
+								userMessageTitle = truncateAtWord(firstLine, 60);
+							}
+							if (userMessages.length < 3) {
+								userMessages.push(truncateAtWord(firstLine, 120));
+							}
 						}
 					}
 				}
@@ -637,7 +641,7 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 		const aiTitles = await generateAITitlesBatch(batchInput);
 
 		const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
-		const CACHE_VERSION = 'v10';
+		const CACHE_VERSION = 'v11';
 
 		for (const item of needsAI) {
 			const agent = agents[item.agentIdx]!;

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -15,6 +15,7 @@ import {
 import { Result } from '@praha/byethrow';
 import { uniq } from 'es-toolkit';
 import { define } from 'gunshi';
+import spawn from 'nano-spawn';
 import pc from 'picocolors';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { processWithJq } from '../_jq-processor.ts';
@@ -210,21 +211,196 @@ function extractCompactionTitle(text: string): string | null {
 	return null;
 }
 
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const OAUTH_REFRESH_URL = 'https://console.anthropic.com/v1/oauth/token';
+
+/**
+ * Reads Claude Code credentials from macOS Keychain (preferred) or file fallback.
+ * Handles token refresh for expired OAuth tokens.
+ */
+async function getClaudeAuthHeaders(): Promise<Record<string, string> | null> {
+	// Try ANTHROPIC_API_KEY first (API subscribers)
+	const apiKey = process.env.ANTHROPIC_API_KEY;
+	if (apiKey != null && apiKey !== '') {
+		return {
+			'x-api-key': apiKey,
+			'anthropic-version': '2023-06-01',
+		};
+	}
+
+	// Read credentials: Keychain first, then file
+	let creds: Record<string, unknown> | null = null;
+
+	// macOS Keychain (has the freshest tokens)
+	for (const service of ['Claude Code-credentials', 'Claude Code - credentials', 'Claude Code']) {
+		try {
+			const proc = await spawn('security', ['find-generic-password', '-s', service, '-w']);
+			const raw = proc.stdout.trim();
+			if (raw !== '') {
+				creds = JSON.parse(raw) as Record<string, unknown>;
+				break;
+			}
+		} catch {
+			// Keychain entry not found
+		}
+	}
+
+	// File fallback
+	if (creds == null) {
+		try {
+			const credsPath = path.join(os.homedir(), '.claude', '.credentials.json');
+			const raw = await readFile(credsPath, 'utf-8');
+			creds = JSON.parse(raw) as Record<string, unknown>;
+		} catch {
+			// File not available
+		}
+	}
+
+	if (creds == null) {
+		return null;
+	}
+
+	const oauth = creds.claudeAiOauth as Record<string, unknown> | undefined;
+	if (oauth == null) {
+		return null;
+	}
+
+	// Direct API key stored by Claude Code
+	if (typeof oauth.apiKey === 'string' && oauth.apiKey !== '') {
+		return {
+			'x-api-key': oauth.apiKey,
+			'anthropic-version': '2023-06-01',
+		};
+	}
+
+	let accessToken = typeof oauth.accessToken === 'string' ? oauth.accessToken : null;
+	const expiresAt = typeof oauth.expiresAt === 'number' ? oauth.expiresAt : 0;
+	const refreshToken = typeof oauth.refreshToken === 'string' ? oauth.refreshToken : null;
+
+	// Refresh if expired or expiring within 5 minutes
+	if (expiresAt > 0 && expiresAt / 1000 < Date.now() / 1000 + 300 && refreshToken != null) {
+		try {
+			const response = await fetch(OAUTH_REFRESH_URL, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					grant_type: 'refresh_token',
+					refresh_token: refreshToken,
+					client_id: OAUTH_CLIENT_ID,
+				}),
+			});
+			const res = response as unknown as { ok: boolean; json: () => Promise<unknown> };
+			if (res.ok) {
+				const data = (await res.json()) as { access_token?: string };
+				if (typeof data.access_token === 'string') {
+					accessToken = data.access_token;
+				}
+			}
+		} catch {
+			// Refresh failed — try with existing token anyway
+		}
+	}
+
+	if (accessToken != null && accessToken !== '') {
+		return {
+			Authorization: `Bearer ${accessToken}`,
+			'anthropic-version': '2023-06-01',
+			'anthropic-beta': 'oauth-2025-04-20',
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Generates AI titles for multiple sessions in a single API call.
+ * Auth: Claude Code OAuth credentials > ANTHROPIC_API_KEY > claude CLI fallback.
+ */
+async function generateAITitlesBatch(
+	sessions: Array<{ index: number; messages: string[] }>,
+): Promise<Map<number, string>> {
+	const result = new Map<number, string>();
+	if (sessions.length === 0) {
+		return result;
+	}
+
+	const numbered = sessions.map((s) => `${s.index}. ${s.messages.join(' | ')}`).join('\n');
+
+	const prompt = `Generate concise titles (max 8 words each) for these ${sessions.length} Claude Code sessions. Output ONLY numbered titles matching the input numbers, one per line. No other text.\n\n${numbered}`;
+
+	let output: string | null = null;
+
+	// Try direct API with OAuth/API key (no session pollution)
+	const authHeaders = await getClaudeAuthHeaders();
+	if (authHeaders != null) {
+		try {
+			const response = await fetch('https://api.anthropic.com/v1/messages', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					...authHeaders,
+				},
+				body: JSON.stringify({
+					model: 'claude-haiku-4-5-20251001',
+					max_tokens: 1024,
+					messages: [{ role: 'user', content: prompt }],
+				}),
+			});
+			const res = response as unknown as { ok: boolean; json: () => Promise<unknown> };
+			if (res.ok) {
+				const data = (await res.json()) as { content?: Array<{ text?: string }> };
+				output = data.content?.[0]?.text ?? null;
+			}
+		} catch {
+			// API call failed — fall through to CLI
+		}
+	}
+
+	// Fallback: claude CLI (creates a session entry but works without credentials file)
+	if (output == null) {
+		try {
+			const proc = await spawn('claude', ['-p', prompt, '--model', 'haiku']);
+			output = proc.stdout.trim();
+		} catch {
+			// CLI not available
+		}
+	}
+
+	if (output != null) {
+		for (const line of output.split('\n')) {
+			const match = line.match(/^(\d+)\.\s*(.+)/);
+			if (match != null) {
+				const idx = Number.parseInt(match[1]!, 10);
+				const title = match[2]!.trim();
+				if (title.length > 0 && title.length <= 80) {
+					result.set(idx, title);
+				}
+			}
+		}
+	}
+
+	return result;
+}
+
 /**
  * Resolves a session title from JSONL file content.
  * Priority: cached title > compaction summary (isCompactSummary user entry)
- * > legacy summary > slug > first user message.
+ * > legacy summary > AI-generated title > slug (last resort).
  */
 async function resolveSessionTitle(
 	sessionId: string,
 	project: string | undefined,
 	claudePaths: string[],
-): Promise<{ title: string; startTime: string } | null> {
+): Promise<
+	| { title: string; startTime: string }
+	| { title: null; startTime: string; userMessages: string[]; slug: string | null }
+	| null
+> {
 	const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
 	const cachePath = path.join(cacheDir, sessionId);
 
-	// Check cache — versioned format: "v6\n<title>\n<startTime>"
-	const CACHE_VERSION = 'v6';
+	// Check cache — versioned format: "v8\n<title>\n<startTime>"
+	const CACHE_VERSION = 'v9';
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
 		const lines = cached.trim().split('\n');
@@ -266,9 +442,10 @@ async function resolveSessionTitle(
 	let compactionTitle: string | null = null;
 	let summaryTitle: string | null = null;
 	let userMessageTitle: string | null = null;
+	const userMessages: string[] = [];
 	let startTime: string | null = null;
 
-	// Phase 1: quick scan of first 50 lines for slug, startTime, userMessage, and early compaction
+	// Phase 1: quick scan of first 50 lines for slug, startTime, userMessages, and early compaction
 	const fileStream1 = createReadStream(jsonlPath, { encoding: 'utf-8' });
 	const rl1 = createInterface({
 		input: fileStream1,
@@ -304,12 +481,19 @@ async function resolveSessionTitle(
 			if (summaryTitle == null && parsed.type === 'summary' && typeof parsed.summary === 'string') {
 				summaryTitle = parsed.summary.slice(0, 60).trim();
 			}
-			if (userMessageTitle == null && parsed.type === 'user') {
+			if (parsed.type === 'user' && parsed.isCompactSummary !== true) {
 				const msg = parsed.message as Record<string, unknown> | undefined;
 				if (msg?.role === 'user') {
 					const content = msg.content;
 					if (typeof content === 'string' && !/^<[a-z]/i.test(content)) {
-						userMessageTitle = content.split('\n')[0]!.slice(0, 60).trim();
+						// Collect first user message as title fallback
+						if (userMessageTitle == null) {
+							userMessageTitle = truncateAtWord(content.split('\n')[0]!.trim(), 60);
+						}
+						// Collect up to 3 user messages for AI title generation
+						if (userMessages.length < 3) {
+							userMessages.push(truncateAtWord(content.split('\n')[0]!.trim(), 120));
+						}
 					}
 				}
 			}
@@ -354,21 +538,30 @@ async function resolveSessionTitle(
 		fileStream2.destroy();
 	}
 
-	// Pick best title: compaction summary > legacy summary > slug > user message
-	const title = compactionTitle ?? summaryTitle ?? slug ?? userMessageTitle;
-	if (title == null || startTime == null) {
-		return null;
+	// Only compaction/summary titles are deterministic — use directly
+	const title = compactionTitle ?? summaryTitle;
+
+	if (title != null && startTime != null) {
+		try {
+			await mkdir(cacheDir, { recursive: true });
+			await writeFile(cachePath, `${CACHE_VERSION}\n${title}\n${startTime}`, 'utf-8');
+		} catch {
+			// Cache write failure is non-fatal
+		}
+		return { title, startTime };
 	}
 
-	// Cache the derived title (versioned format)
-	try {
-		await mkdir(cacheDir, { recursive: true });
-		await writeFile(cachePath, `${CACHE_VERSION}\n${title}\n${startTime}`, 'utf-8');
-	} catch {
-		// Cache write failure is non-fatal
+	// No deterministic title — return messages for AI generation
+	if (startTime != null && userMessages.length > 0) {
+		return { title: null, startTime, userMessages, slug };
 	}
 
-	return { title, startTime };
+	// Absolute fallback: slug only (no user messages to generate from)
+	if (slug != null && startTime != null) {
+		return { title: slug, startTime };
+	}
+
+	return null;
 }
 
 function formatStartTime(timestamp: string, timezone?: string): string {
@@ -385,16 +578,23 @@ function formatStartTime(timestamp: string, timezone?: string): string {
 /**
  * Replaces temporary `lead:sessionId` agentIds with meaningful session titles.
  * Falls back to project/lead-hash when title can't be derived.
+ * Batches all AI title requests into a single `claude -p` call.
  */
 async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string): Promise<void> {
 	let claudePaths: string[] | null = null;
+	const needsAI: Array<{
+		agentIdx: number;
+		startTime: string;
+		messages: string[];
+		slug: string | null;
+	}> = [];
 
-	for (const agent of agents) {
+	for (let i = 0; i < agents.length; i++) {
+		const agent = agents[i]!;
 		if (!agent.agentId.startsWith('lead:') || agent.sessionId == null) {
 			continue;
 		}
 
-		// Lazy-load claude paths
 		if (claudePaths == null) {
 			try {
 				claudePaths = getClaudePaths();
@@ -404,12 +604,52 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 		}
 
 		const titleInfo = await resolveSessionTitle(agent.sessionId, agent.project, claudePaths);
-		if (titleInfo != null) {
-			agent.agentId = `${titleInfo.title} · ${formatStartTime(titleInfo.startTime, timezone)}`;
-		} else {
-			// Fallback: project/lead-hash
+		if (titleInfo == null) {
+			// No data at all — fallback to project/lead-hash
 			const prefix = agent.project != null ? `${shortProjectName(agent.project)}/` : '';
 			agent.agentId = `${prefix}${deriveAgentId({ sessionId: agent.sessionId })}`;
+		} else if (titleInfo.title != null) {
+			// Got a resolved title (cached, compaction, or user message)
+			agent.agentId = `${titleInfo.title} · ${formatStartTime(titleInfo.startTime, timezone)}`;
+		} else {
+			// Needs AI title generation — collect for batch
+			needsAI.push({
+				agentIdx: i,
+				startTime: titleInfo.startTime,
+				messages: titleInfo.userMessages,
+				slug: titleInfo.slug,
+			});
+		}
+	}
+
+	// Batch AI title generation in a single claude call
+	if (needsAI.length > 0) {
+		const batchInput = needsAI.map((item, idx) => ({ index: idx + 1, messages: item.messages }));
+		const aiTitles = await generateAITitlesBatch(batchInput);
+
+		const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
+		const CACHE_VERSION = 'v9';
+
+		for (const item of needsAI) {
+			const agent = agents[item.agentIdx]!;
+			const aiTitle = aiTitles.get(needsAI.indexOf(item) + 1);
+			const finalTitle = aiTitle ?? item.slug ?? 'Untitled session';
+
+			agent.agentId = `${finalTitle} · ${formatStartTime(item.startTime, timezone)}`;
+
+			// Cache the AI-generated title
+			if (agent.sessionId != null) {
+				try {
+					await mkdir(cacheDir, { recursive: true });
+					await writeFile(
+						path.join(cacheDir, agent.sessionId),
+						`${CACHE_VERSION}\n${finalTitle}\n${item.startTime}`,
+						'utf-8',
+					);
+				} catch {
+					// Cache write failure is non-fatal
+				}
+			}
 		}
 	}
 }

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -15,12 +15,12 @@ import {
 import { Result } from '@praha/byethrow';
 import { uniq } from 'es-toolkit';
 import { define } from 'gunshi';
-import spawn from 'nano-spawn';
+
 import pc from 'picocolors';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
-import { deriveAgentId, deriveAgentRole, shortProjectName } from '../agent-id.ts';
+import { deriveAgentRole } from '../agent-id.ts';
 import { createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
 import { getClaudePaths, loadAgentUsageData } from '../data-loader.ts';
 import { log, logger } from '../logger.ts';
@@ -211,196 +211,22 @@ function extractCompactionTitle(text: string): string | null {
 	return null;
 }
 
-const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
-const OAUTH_REFRESH_URL = 'https://console.anthropic.com/v1/oauth/token';
-
-/**
- * Reads Claude Code credentials from macOS Keychain (preferred) or file fallback.
- * Handles token refresh for expired OAuth tokens.
- */
-async function getClaudeAuthHeaders(): Promise<Record<string, string> | null> {
-	// Try ANTHROPIC_API_KEY first (API subscribers)
-	const apiKey = process.env.ANTHROPIC_API_KEY;
-	if (apiKey != null && apiKey !== '') {
-		return {
-			'x-api-key': apiKey,
-			'anthropic-version': '2023-06-01',
-		};
-	}
-
-	// Read credentials: Keychain first, then file
-	let creds: Record<string, unknown> | null = null;
-
-	// macOS Keychain (has the freshest tokens)
-	for (const service of ['Claude Code-credentials', 'Claude Code - credentials', 'Claude Code']) {
-		try {
-			const proc = await spawn('security', ['find-generic-password', '-s', service, '-w']);
-			const raw = proc.stdout.trim();
-			if (raw !== '') {
-				creds = JSON.parse(raw) as Record<string, unknown>;
-				break;
-			}
-		} catch {
-			// Keychain entry not found
-		}
-	}
-
-	// File fallback
-	if (creds == null) {
-		try {
-			const credsPath = path.join(os.homedir(), '.claude', '.credentials.json');
-			const raw = await readFile(credsPath, 'utf-8');
-			creds = JSON.parse(raw) as Record<string, unknown>;
-		} catch {
-			// File not available
-		}
-	}
-
-	if (creds == null) {
-		return null;
-	}
-
-	const oauth = creds.claudeAiOauth as Record<string, unknown> | undefined;
-	if (oauth == null) {
-		return null;
-	}
-
-	// Direct API key stored by Claude Code
-	if (typeof oauth.apiKey === 'string' && oauth.apiKey !== '') {
-		return {
-			'x-api-key': oauth.apiKey,
-			'anthropic-version': '2023-06-01',
-		};
-	}
-
-	let accessToken = typeof oauth.accessToken === 'string' ? oauth.accessToken : null;
-	const expiresAt = typeof oauth.expiresAt === 'number' ? oauth.expiresAt : 0;
-	const refreshToken = typeof oauth.refreshToken === 'string' ? oauth.refreshToken : null;
-
-	// Refresh if expired or expiring within 5 minutes
-	if (expiresAt > 0 && expiresAt / 1000 < Date.now() / 1000 + 300 && refreshToken != null) {
-		try {
-			const response = await fetch(OAUTH_REFRESH_URL, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					grant_type: 'refresh_token',
-					refresh_token: refreshToken,
-					client_id: OAUTH_CLIENT_ID,
-				}),
-			});
-			const res = response as unknown as { ok: boolean; json: () => Promise<unknown> };
-			if (res.ok) {
-				const data = (await res.json()) as { access_token?: string };
-				if (typeof data.access_token === 'string') {
-					accessToken = data.access_token;
-				}
-			}
-		} catch {
-			// Refresh failed — try with existing token anyway
-		}
-	}
-
-	if (accessToken != null && accessToken !== '') {
-		return {
-			Authorization: `Bearer ${accessToken}`,
-			'anthropic-version': '2023-06-01',
-			'anthropic-beta': 'oauth-2025-04-20',
-		};
-	}
-
-	return null;
-}
-
-/**
- * Generates AI titles for multiple sessions in a single API call.
- * Auth: Claude Code OAuth credentials > ANTHROPIC_API_KEY > claude CLI fallback.
- */
-async function generateAITitlesBatch(
-	sessions: Array<{ index: number; messages: string[] }>,
-): Promise<Map<number, string>> {
-	const result = new Map<number, string>();
-	if (sessions.length === 0) {
-		return result;
-	}
-
-	const numbered = sessions.map((s) => `${s.index}. ${s.messages.join(' | ')}`).join('\n');
-
-	const prompt = `Generate concise titles (max 8 words each) for these ${sessions.length} Claude Code sessions. Output ONLY numbered titles matching the input numbers, one per line. No other text.\n\n${numbered}`;
-
-	let output: string | null = null;
-
-	// Try direct API with OAuth/API key (no session pollution)
-	const authHeaders = await getClaudeAuthHeaders();
-	if (authHeaders != null) {
-		try {
-			const response = await fetch('https://api.anthropic.com/v1/messages', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					...authHeaders,
-				},
-				body: JSON.stringify({
-					model: 'claude-haiku-4-5-20251001',
-					max_tokens: 1024,
-					messages: [{ role: 'user', content: prompt }],
-				}),
-			});
-			const res = response as unknown as { ok: boolean; json: () => Promise<unknown> };
-			if (res.ok) {
-				const data = (await res.json()) as { content?: Array<{ text?: string }> };
-				output = data.content?.[0]?.text ?? null;
-			}
-		} catch {
-			// API call failed — fall through to CLI
-		}
-	}
-
-	// Fallback: claude CLI (creates a session entry but works without credentials file)
-	if (output == null) {
-		try {
-			const proc = await spawn('claude', ['-p', prompt, '--model', 'haiku']);
-			output = proc.stdout.trim();
-		} catch {
-			// CLI not available
-		}
-	}
-
-	if (output != null) {
-		for (const line of output.split('\n')) {
-			const match = line.match(/^(\d+)\.\s*(.+)/);
-			if (match != null) {
-				const idx = Number.parseInt(match[1]!, 10);
-				const title = match[2]!.trim();
-				if (title.length > 0 && title.length <= 80) {
-					result.set(idx, title);
-				}
-			}
-		}
-	}
-
-	return result;
-}
-
 /**
  * Resolves a session title from JSONL file content.
- * Priority: cached title > compaction summary (isCompactSummary user entry)
- * > legacy summary > AI-generated title > truncated sessionId (last resort).
+ * Priority: cached title > compaction summary > legacy summary.
+ * Returns null when no title can be derived — caller shows UUID only.
  */
 async function resolveSessionTitle(
 	sessionId: string,
 	project: string | undefined,
 	claudePaths: string[],
-): Promise<
-	| { title: string; startTime: string }
-	| { title: null; startTime: string; userMessages: string[] }
-	| null
-> {
+): Promise<{ title: string; startTime: string } | { title: null; startTime: string } | null> {
 	const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
 	const cachePath = path.join(cacheDir, sessionId);
 
-	// Check cache — versioned format: "v8\n<title>\n<startTime>"
-	const CACHE_VERSION = 'v10';
+	// Check cache — versioned format: "v11\n<title>\n<startTime>"
+	// v11: invalidate AI-generated title caches from v10
+	const CACHE_VERSION = 'v11';
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
 		const lines = cached.trim().split('\n');
@@ -440,8 +266,6 @@ async function resolveSessionTitle(
 
 	let compactionTitle: string | null = null;
 	let summaryTitle: string | null = null;
-	let userMessageTitle: string | null = null;
-	const userMessages: string[] = [];
 	let startTime: string | null = null;
 
 	// Phase 1: quick scan of first 50 lines for startTime, userMessages, and early compaction
@@ -476,37 +300,6 @@ async function resolveSessionTitle(
 			}
 			if (summaryTitle == null && parsed.type === 'summary' && typeof parsed.summary === 'string') {
 				summaryTitle = parsed.summary.slice(0, 60).trim();
-			}
-			if (parsed.type === 'user' && parsed.isCompactSummary !== true && parsed.isMeta !== true) {
-				const msg = parsed.message as Record<string, unknown> | undefined;
-				if (msg?.role === 'user') {
-					const content = msg.content;
-					// Extract text from string or array content (multimodal messages use [{type:"text",text:"..."}])
-					let textContent: string | undefined;
-					if (typeof content === 'string') {
-						textContent = content;
-					} else if (Array.isArray(content)) {
-						const textBlock = content.find(
-							(b: unknown) =>
-								typeof b === 'object' &&
-								b != null &&
-								(b as Record<string, unknown>).type === 'text',
-						) as Record<string, unknown> | undefined;
-						if (typeof textBlock?.text === 'string') {
-							textContent = textBlock.text;
-						}
-					}
-					if (textContent != null && !/^<[a-z]/i.test(textContent)) {
-						// Collect first user message as title fallback
-						if (userMessageTitle == null) {
-							userMessageTitle = truncateAtWord(textContent.split('\n')[0]!.trim(), 60);
-						}
-						// Collect up to 3 user messages for AI title generation
-						if (userMessages.length < 3) {
-							userMessages.push(truncateAtWord(textContent.split('\n')[0]!.trim(), 120));
-						}
-					}
-				}
 			}
 		} catch {
 			// Skip unparseable lines
@@ -562,14 +355,9 @@ async function resolveSessionTitle(
 		return { title, startTime };
 	}
 
-	// No deterministic title — return messages for AI generation
-	if (startTime != null && userMessages.length > 0) {
-		return { title: null, startTime, userMessages };
-	}
-
-	// Absolute fallback: truncated sessionId (no user messages to generate from)
+	// No title available — return startTime so caller can show UUID with timestamp
 	if (startTime != null) {
-		return { title: sessionId.slice(0, 8), startTime };
+		return { title: null, startTime };
 	}
 
 	return null;
@@ -588,16 +376,10 @@ function formatStartTime(timestamp: string, timezone?: string): string {
 
 /**
  * Replaces temporary `lead:sessionId` agentIds with meaningful session titles.
- * Falls back to project/lead-hash when title can't be derived.
- * Batches all AI title requests into a single API call.
+ * Falls back to UUID-only display when no compaction summary exists.
  */
 async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string): Promise<void> {
 	let claudePaths: string[] | null = null;
-	const needsAI: Array<{
-		agentIdx: number;
-		startTime: string;
-		messages: string[];
-	}> = [];
 
 	for (let i = 0; i < agents.length; i++) {
 		const agent = agents[i]!;
@@ -615,50 +397,14 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 
 		const titleInfo = await resolveSessionTitle(agent.sessionId, agent.project, claudePaths);
 		if (titleInfo == null) {
-			// No data at all — fallback to project/lead-hash
-			const prefix = agent.project != null ? `${shortProjectName(agent.project)}/` : '';
-			agent.agentId = `${prefix}${deriveAgentId({ sessionId: agent.sessionId })}`;
+			// No data at all — show UUID only
+			agent.agentId = agent.sessionId;
 		} else if (titleInfo.title != null) {
-			// Got a resolved title (cached, compaction, or user message)
+			// Got a resolved title (cached, compaction, or summary)
 			agent.agentId = `${titleInfo.title} · ${formatStartTime(titleInfo.startTime, timezone)} · ${agent.sessionId}`;
 		} else {
-			// Needs AI title generation — collect for batch
-			needsAI.push({
-				agentIdx: i,
-				startTime: titleInfo.startTime,
-				messages: titleInfo.userMessages,
-			});
-		}
-	}
-
-	// Batch AI title generation in a single claude call
-	if (needsAI.length > 0) {
-		const batchInput = needsAI.map((item, idx) => ({ index: idx + 1, messages: item.messages }));
-		const aiTitles = await generateAITitlesBatch(batchInput);
-
-		const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
-		const CACHE_VERSION = 'v10';
-
-		for (const item of needsAI) {
-			const agent = agents[item.agentIdx]!;
-			const aiTitle = aiTitles.get(needsAI.indexOf(item) + 1);
-			const finalTitle = aiTitle ?? agent.sessionId?.slice(0, 8) ?? 'Untitled';
-
-			agent.agentId = `${finalTitle} · ${formatStartTime(item.startTime, timezone)}${agent.sessionId != null ? ` · ${agent.sessionId}` : ''}`;
-
-			// Cache the AI-generated title
-			if (agent.sessionId != null) {
-				try {
-					await mkdir(cacheDir, { recursive: true });
-					await writeFile(
-						path.join(cacheDir, agent.sessionId),
-						`${CACHE_VERSION}\n${finalTitle}\n${item.startTime}`,
-						'utf-8',
-					);
-				} catch {
-					// Cache write failure is non-fatal
-				}
-			}
+			// No title — show UUID with timestamp
+			agent.agentId = `${formatStartTime(titleInfo.startTime, timezone)} · ${agent.sessionId}`;
 		}
 	}
 }

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -513,7 +513,24 @@ async function resolveSessionTitle(
 							textContent = textBlock.text;
 						}
 					}
-					if (textContent != null && !/^<[a-z]/i.test(textContent)) {
+					if (textContent != null) {
+						// Extract inner text from <teammate-message> blocks
+						if (/^<teammate-message\b/i.test(textContent)) {
+							const innerMatch = textContent.match(
+								/<teammate-message[^>]*>([\s\S]*?)<\/teammate-message>/i,
+							);
+							if (innerMatch?.[1] != null) {
+								textContent = innerMatch[1].trim();
+							} else {
+								textContent = undefined;
+							}
+						} else if (/^<[a-z]/i.test(textContent)) {
+							// Skip other XML/HTML system content
+							textContent = undefined;
+						}
+						if (textContent == null) {
+							continue;
+						}
 						const firstLine = textContent.split('\n')[0]!.trim();
 						// Skip trivially short messages ("hello", "ok", "yes", etc.)
 						const isSubstantive = firstLine.length >= 10 && firstLine.includes(' ');
@@ -642,11 +659,9 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 			agent.agentId = `${prefix}${deriveAgentId({ sessionId: agent.sessionId })}`;
 		} else if (titleInfo.title != null) {
 			// Got a resolved title (cached, compaction, or user message)
-			agent.agentId = joinParts([
-				titleInfo.title,
-				formatStartTime(titleInfo.startTime, timezone),
-				agent.sessionId,
-			]);
+			// Line 1: title · timestamp, Line 2: full UUID
+			const line1 = joinParts([titleInfo.title, formatStartTime(titleInfo.startTime, timezone)]);
+			agent.agentId = agent.sessionId != null ? `${line1}\n${agent.sessionId}` : line1;
 		} else {
 			// Needs AI title generation — collect for batch
 			needsAI.push({
@@ -670,11 +685,9 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 			const aiTitle = aiTitles.get(needsAI.indexOf(item) + 1);
 
 			if (aiTitle != null) {
-				agent.agentId = joinParts([
-					aiTitle,
-					formatStartTime(item.startTime, timezone),
-					agent.sessionId,
-				]);
+				// Line 1: title · timestamp, Line 2: full UUID
+				const line1 = joinParts([aiTitle, formatStartTime(item.startTime, timezone)]);
+				agent.agentId = agent.sessionId != null ? `${line1}\n${agent.sessionId}` : line1;
 
 				// Cache only real AI-generated titles
 				if (agent.sessionId != null) {
@@ -945,14 +958,12 @@ function groupByTeamLead(
 	leadTitleCache: Map<string, string>,
 ): DisplayRow[] {
 	// Map leadSessionId → lead entry (if present in data)
+	// Leads are identified by having sessionId set. They may have teamName set (team-aware leads)
+	// or teamName null (standalone leads). Both are valid lead entries.
 	const leadBySession = new Map<string, AgentUsage>();
 	for (const d of displayData) {
-		if (d.agentId.startsWith('lead:') || d.sessionId != null) {
-			// After resolveLeadDisplayNames, leads no longer start with "lead:" —
-			// they have resolved titles. Identify leads by having sessionId + no teamName.
-			if (d.teamName == null && d.sessionId != null) {
-				leadBySession.set(d.sessionId, d);
-			}
+		if (d.sessionId != null && d.agentName == null) {
+			leadBySession.set(d.sessionId, d);
 		}
 	}
 
@@ -983,8 +994,8 @@ function groupByTeamLead(
 					teamNameGroups.set(d.teamName, [d]);
 				}
 			}
-		} else if (d.teamName == null && d.sessionId != null) {
-			// Lead entry — ensure group exists
+		} else if (d.sessionId != null && d.agentName == null) {
+			// Lead entry (with or without teamName) — ensure group exists
 			const existingGroup = leadGroups.get(d.sessionId);
 			if (existingGroup != null) {
 				existingGroup.lead = d;

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -1264,7 +1264,7 @@ export const agentCommand = define({
 				head: headers,
 				style: { head: ['cyan'] },
 				colAligns: aligns,
-				colWidthOverrides: { 0: 36 },
+				colWidthOverrides: { 0: 46 },
 				compactHead: compactHeaders,
 				compactColAligns: compactAligns,
 				compactThreshold: 100,

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -25,7 +25,7 @@ import { createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
 import { getClaudePaths, loadAgentUsageData } from '../data-loader.ts';
 import { log, logger } from '../logger.ts';
 
-const CACHE_VERSION = 'v15';
+const CACHE_VERSION = 'v16';
 
 /**
  * Formats a number in compact form: 999, 1.2K, 12.4K, 1.2M, 12.4M, 1.2B
@@ -358,7 +358,21 @@ async function generateAITitlesBatch(
 
 	const numbered = sessions.map((s) => `${s.index}. ${s.messages.join(' | ')}`).join('\n');
 
-	const prompt = `Generate a short noun-phrase title (max 30 characters, 3-5 words) for each Claude Code session below. Focus on the task or goal. No verbs at the start, no "User asked to..." framing. Output ONLY numbered titles matching the input numbers, one per line.\n\n${numbered}`;
+	const prompt = `Generate a short noun-phrase title (max 30 characters, 3-5 words) for each Claude Code session below.
+
+Rules:
+- Start with a NOUN, not a verb or gerund. "Investigate", "Fix", "Debugging", "Add" are NOT valid starts.
+- Valid starts: "PR Review", "API Key Setup", "Configuration Update", "Bug Fix for X", etc.
+- No "User asked to..." framing.
+
+Examples of BAD → GOOD:
+- "Investigate and fix" → "Bug Investigation"
+- "Debugging the API" → "API Debug Session"
+- "Add new feature" → "New Feature Addition"
+
+Output ONLY numbered titles matching the input numbers, one per line.
+
+${numbered}`;
 
 	let output: string | null = null;
 

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -620,7 +620,8 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 			agent.agentId = `${prefix}${deriveAgentId({ sessionId: agent.sessionId })}`;
 		} else if (titleInfo.title != null) {
 			// Got a resolved title (cached, compaction, or user message)
-			agent.agentId = `${titleInfo.title} · ${formatStartTime(titleInfo.startTime, timezone)}`;
+			const sid = agent.sessionId.slice(0, 8);
+			agent.agentId = `${titleInfo.title} · ${formatStartTime(titleInfo.startTime, timezone)} · ${sid}`;
 		} else {
 			// Needs AI title generation — collect for batch
 			needsAI.push({
@@ -644,7 +645,8 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 			const aiTitle = aiTitles.get(needsAI.indexOf(item) + 1);
 			const finalTitle = aiTitle ?? agent.sessionId?.slice(0, 8) ?? 'Untitled';
 
-			agent.agentId = `${finalTitle} · ${formatStartTime(item.startTime, timezone)}`;
+			const sid = agent.sessionId?.slice(0, 8) ?? '';
+			agent.agentId = `${finalTitle} · ${formatStartTime(item.startTime, timezone)}${sid !== '' ? ` · ${sid}` : ''}`;
 
 			// Cache the AI-generated title
 			if (agent.sessionId != null) {
@@ -985,7 +987,9 @@ function groupByTeamLead(
 			rows.push({ data: group.lead, isLeadHeader: false, indent: false });
 		} else {
 			// Orphan lead — create header-only row from cached title
-			const title = leadTitleCache.get(group.sessionId) ?? group.sessionId.slice(0, 8);
+			const cachedTitle = leadTitleCache.get(group.sessionId);
+			const sid = group.sessionId.slice(0, 8);
+			const title = cachedTitle != null ? `${cachedTitle} · ${sid}` : sid;
 			rows.push({
 				data: {
 					agentId: title,

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -1,0 +1,349 @@
+import type { AgentUsage, ModelBreakdown } from '../data-loader.ts';
+import process from 'node:process';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatModelsDisplayMultiline,
+	pushBreakdownRows,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
+import { uniq } from 'es-toolkit';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
+import { processWithJq } from '../_jq-processor.ts';
+import { sharedCommandConfig } from '../_shared-args.ts';
+import { deriveAgentId, deriveAgentRole, shortProjectName } from '../agent-id.ts';
+import { createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
+import { loadAgentUsageData } from '../data-loader.ts';
+import { log, logger } from '../logger.ts';
+
+/**
+ * Formats a number in compact form: 999, 1.2K, 12.4K, 1.2M, 12.4M, 1.2B
+ * Keeps output short (max ~6 chars) so table columns don't overflow.
+ */
+function formatCompact(num: number): string {
+	if (num < 1_000) {
+		return String(num);
+	}
+	if (num < 1_000_000) {
+		const k = num / 1_000;
+		return k < 10 ? `${k.toFixed(1)}K` : `${Math.round(k)}K`;
+	}
+	if (num < 1_000_000_000) {
+		const m = num / 1_000_000;
+		return m < 10 ? `${m.toFixed(1)}M` : `${Math.round(m)}M`;
+	}
+	const b = num / 1_000_000_000;
+	return b < 10 ? `${b.toFixed(1)}B` : `${Math.round(b)}B`;
+}
+
+/**
+ * Formats a Date to YYYYMMDD string in local time (or specified timezone)
+ */
+function formatLocalDateYYYYMMDD(date: Date, timezone?: string): string {
+	const formatter = new Intl.DateTimeFormat('en-CA', {
+		...(timezone != null ? { timeZone: timezone } : {}),
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	});
+	return formatter.format(date).replace(/-/g, '');
+}
+
+/**
+ * Merges two arrays of model breakdowns, summing tokens/cost for matching models
+ */
+function mergeModelBreakdowns(a: ModelBreakdown[], b: ModelBreakdown[]): ModelBreakdown[] {
+	const map = new Map<string, ModelBreakdown>();
+
+	for (const bd of [...a, ...b]) {
+		const existing = map.get(bd.modelName);
+		if (existing != null) {
+			existing.inputTokens += bd.inputTokens;
+			existing.outputTokens += bd.outputTokens;
+			existing.cacheCreationTokens += bd.cacheCreationTokens;
+			existing.cacheReadTokens += bd.cacheReadTokens;
+			existing.cost += bd.cost;
+		} else {
+			map.set(bd.modelName, { ...bd });
+		}
+	}
+
+	return Array.from(map.values()).sort((x, y) => y.cost - x.cost);
+}
+
+/**
+ * Aggregates per-instance agent data into role-level summaries.
+ * Strips the session hash suffix so all instances of the same role merge.
+ * Lead agents are kept separate per session since they represent distinct work.
+ */
+function aggregateByRole(agentData: AgentUsage[]): AgentUsage[] {
+	const roleMap = new Map<string, AgentUsage>();
+
+	for (const agent of agentData) {
+		const role = deriveAgentRole({
+			teamName: agent.teamName,
+			agentName: agent.agentName,
+		});
+
+		// Lead agents represent distinct sessions — keep them separate
+		const isLead = role === 'lead';
+		const key = isLead
+			? `${agent.project != null ? `${shortProjectName(agent.project)}/` : ''}${deriveAgentId({ teamName: agent.teamName, agentName: agent.agentName, sessionId: agent.sessionId })}`
+			: role;
+
+		const existing = roleMap.get(key);
+		if (existing != null) {
+			existing.inputTokens += agent.inputTokens;
+			existing.outputTokens += agent.outputTokens;
+			existing.cacheCreationTokens += agent.cacheCreationTokens;
+			existing.cacheReadTokens += agent.cacheReadTokens;
+			existing.totalCost += agent.totalCost;
+			existing.modelsUsed = uniq([...existing.modelsUsed, ...agent.modelsUsed]);
+			existing.modelBreakdowns = mergeModelBreakdowns(
+				existing.modelBreakdowns,
+				agent.modelBreakdowns,
+			);
+		} else {
+			roleMap.set(key, {
+				agentId: key,
+				agentName: agent.agentName,
+				teamName: agent.teamName,
+				sessionId: isLead ? agent.sessionId : undefined,
+				project: isLead ? agent.project : undefined,
+				inputTokens: agent.inputTokens,
+				outputTokens: agent.outputTokens,
+				cacheCreationTokens: agent.cacheCreationTokens,
+				cacheReadTokens: agent.cacheReadTokens,
+				totalCost: agent.totalCost,
+				modelsUsed: [...agent.modelsUsed],
+				modelBreakdowns: [...agent.modelBreakdowns],
+			});
+		}
+	}
+
+	return Array.from(roleMap.values());
+}
+
+export const agentCommand = define({
+	name: 'agent',
+	description: 'Show usage report grouped by agent identity',
+	...sharedCommandConfig,
+	args: {
+		...sharedCommandConfig.args,
+		team: {
+			type: 'string',
+			short: 't',
+			description: 'Filter to a specific team name',
+		},
+		session: {
+			type: 'string',
+			description: 'Filter to a specific session ID',
+		},
+		all: {
+			type: 'boolean',
+			short: 'a',
+			description: 'Show all-time data instead of today only',
+			default: false,
+		},
+		days: {
+			type: 'number',
+			short: 'D',
+			description: 'Show data from the last N days',
+		},
+		instances: {
+			type: 'boolean',
+			short: 'i',
+			description: 'Show per-instance breakdown instead of role grouping',
+			default: false,
+		},
+	},
+	async run(ctx) {
+		const config = loadConfig(ctx.values.config, ctx.values.debug);
+		const mergedOptions: typeof ctx.values = mergeConfigWithArgs(ctx, config, ctx.values.debug);
+
+		// --jq implies --json
+		const useJson = Boolean(mergedOptions.json) || mergedOptions.jq != null;
+		if (useJson) {
+			logger.level = 0;
+		}
+
+		// Resolve date range: explicit --since/--until > --days > --all > default (today)
+		let since = ctx.values.since;
+		const until = ctx.values.until;
+
+		if (since == null && until == null) {
+			if (ctx.values.days != null) {
+				const now = new Date();
+				const daysAgo = new Date(now);
+				daysAgo.setDate(daysAgo.getDate() - (ctx.values.days - 1));
+				since = formatLocalDateYYYYMMDD(daysAgo, ctx.values.timezone);
+			} else if (!ctx.values.all) {
+				// Default: today only
+				since = formatLocalDateYYYYMMDD(new Date(), ctx.values.timezone);
+			}
+		}
+
+		logger.start('Loading agent usage data...');
+
+		const agentData = await loadAgentUsageData({
+			since,
+			until,
+			mode: ctx.values.mode,
+			offline: ctx.values.offline,
+			timezone: ctx.values.timezone,
+			locale: ctx.values.locale,
+			teamFilter: ctx.values.team,
+			sessionFilter: ctx.values.session,
+			onProgress: (step) => logger.start(step),
+		});
+
+		logger.success('Data loaded.');
+
+		if (agentData.length === 0) {
+			if (useJson) {
+				log(JSON.stringify([]));
+			} else {
+				logger.warn('No agent usage data found.');
+			}
+			process.exit(0);
+		}
+
+		// Role-level grouping (default) vs per-instance view
+		const displayData = ctx.values.instances ? agentData : aggregateByRole(agentData);
+
+		// Sort by cost descending (top spenders first)
+		displayData.sort((a, b) => b.totalCost - a.totalCost);
+
+		// Calculate totals
+		const totals = displayData.reduce(
+			(acc, item) => ({
+				inputTokens: acc.inputTokens + item.inputTokens,
+				outputTokens: acc.outputTokens + item.outputTokens,
+				cacheCreationTokens: acc.cacheCreationTokens + item.cacheCreationTokens,
+				cacheReadTokens: acc.cacheReadTokens + item.cacheReadTokens,
+				totalCost: acc.totalCost + item.totalCost,
+			}),
+			{
+				inputTokens: 0,
+				outputTokens: 0,
+				cacheCreationTokens: 0,
+				cacheReadTokens: 0,
+				totalCost: 0,
+			},
+		);
+
+		if (useJson) {
+			const jsonOutput = {
+				agents: displayData.map((data) => ({
+					agentId: data.agentId,
+					agentName: data.agentName,
+					teamName: data.teamName,
+					sessionId: data.sessionId,
+					project: data.project,
+					inputTokens: data.inputTokens,
+					outputTokens: data.outputTokens,
+					cacheCreationTokens: data.cacheCreationTokens,
+					cacheReadTokens: data.cacheReadTokens,
+					totalTokens: getTotalTokens(data),
+					totalCost: data.totalCost,
+					modelsUsed: data.modelsUsed,
+					modelBreakdowns: data.modelBreakdowns,
+				})),
+				totals: createTotalsObject(totals),
+			};
+
+			if (ctx.values.jq != null) {
+				const jqResult = await processWithJq(jsonOutput, ctx.values.jq);
+				if (Result.isFailure(jqResult)) {
+					logger.error(jqResult.error.message);
+					process.exit(1);
+				}
+				log(jqResult.value);
+			} else {
+				log(JSON.stringify(jsonOutput, null, 2));
+			}
+		} else {
+			logger.box('Claude Code Token Usage Report - By Agent');
+
+			const headers = [
+				'Agent',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Write',
+				'Cache Read',
+				'Total',
+				'Cost (USD)',
+			];
+			const compactHeaders = ['Agent', 'Models', 'Input', 'Output', 'Cost (USD)'];
+			const aligns: Array<'left' | 'right'> = [
+				'left',
+				'left',
+				'right',
+				'right',
+				'right',
+				'right',
+				'right',
+				'right',
+			];
+			const compactAligns: Array<'left' | 'right'> = ['left', 'left', 'right', 'right', 'right'];
+
+			const table = new ResponsiveTable({
+				head: headers,
+				style: { head: ['cyan'] },
+				colAligns: aligns,
+				compactHead: compactHeaders,
+				compactColAligns: compactAligns,
+				compactThreshold: 100,
+				forceCompact: ctx.values.compact,
+			});
+
+			for (const data of displayData) {
+				const totalTokens =
+					data.inputTokens + data.outputTokens + data.cacheCreationTokens + data.cacheReadTokens;
+				table.push([
+					data.agentId,
+					data.modelsUsed.length > 0 ? formatModelsDisplayMultiline(data.modelsUsed) : '',
+					formatCompact(data.inputTokens),
+					formatCompact(data.outputTokens),
+					formatCompact(data.cacheCreationTokens),
+					formatCompact(data.cacheReadTokens),
+					formatCompact(totalTokens),
+					formatCurrency(data.totalCost),
+				]);
+
+				if (ctx.values.breakdown) {
+					pushBreakdownRows(table, data.modelBreakdowns);
+				}
+			}
+
+			addEmptySeparatorRow(table, 8);
+
+			const grandTotal =
+				totals.inputTokens +
+				totals.outputTokens +
+				totals.cacheCreationTokens +
+				totals.cacheReadTokens;
+			table.push([
+				pc.yellow('Total'),
+				'',
+				pc.yellow(formatCompact(totals.inputTokens)),
+				pc.yellow(formatCompact(totals.outputTokens)),
+				pc.yellow(formatCompact(totals.cacheCreationTokens)),
+				pc.yellow(formatCompact(totals.cacheReadTokens)),
+				pc.yellow(formatCompact(grandTotal)),
+				pc.yellow(formatCurrency(totals.totalCost)),
+			]);
+
+			log(table.toString());
+
+			if (table.isCompactMode()) {
+				logger.info('\nRunning in Compact Mode');
+				logger.info('Expand terminal width to see cache metrics and total tokens');
+			}
+		}
+	},
+});

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -1,5 +1,10 @@
 import type { AgentUsage, ModelBreakdown } from '../data-loader.ts';
+import { createReadStream } from 'node:fs';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import process from 'node:process';
+import { createInterface } from 'node:readline';
 import {
 	addEmptySeparatorRow,
 	formatCurrency,
@@ -16,7 +21,7 @@ import { processWithJq } from '../_jq-processor.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
 import { deriveAgentId, deriveAgentRole, shortProjectName } from '../agent-id.ts';
 import { createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
-import { loadAgentUsageData } from '../data-loader.ts';
+import { getClaudePaths, loadAgentUsageData } from '../data-loader.ts';
 import { log, logger } from '../logger.ts';
 
 /**
@@ -76,10 +81,23 @@ function mergeModelBreakdowns(a: ModelBreakdown[], b: ModelBreakdown[]): ModelBr
 
 /**
  * Aggregates per-instance agent data into role-level summaries.
- * Strips the session hash suffix so all instances of the same role merge.
- * Lead agents are kept separate per session since they represent distinct work.
+ * Two-pass approach: first identifies named members by sessionId,
+ * then resolves lead entries to their named roles when possible.
+ * Unresolved leads get a temporary key for later title resolution.
  */
 function aggregateByRole(agentData: AgentUsage[]): AgentUsage[] {
+	// Pass 1: map sessionId → named role from entries with agentName
+	const namedSessionMap = new Map<string, { teamName: string | undefined; agentName: string }>();
+	for (const agent of agentData) {
+		if (agent.agentName != null && agent.sessionId != null) {
+			namedSessionMap.set(agent.sessionId, {
+				teamName: agent.teamName,
+				agentName: agent.agentName,
+			});
+		}
+	}
+
+	// Pass 2: aggregate, resolving leads to named roles when possible
 	const roleMap = new Map<string, AgentUsage>();
 
 	for (const agent of agentData) {
@@ -88,11 +106,29 @@ function aggregateByRole(agentData: AgentUsage[]): AgentUsage[] {
 			agentName: agent.agentName,
 		});
 
-		// Lead agents represent distinct sessions — keep them separate
 		const isLead = role === 'lead';
-		const key = isLead
-			? `${agent.project != null ? `${shortProjectName(agent.project)}/` : ''}${deriveAgentId({ teamName: agent.teamName, agentName: agent.agentName, sessionId: agent.sessionId })}`
-			: role;
+		let key: string;
+		let entryAgentName = agent.agentName;
+		let entryTeamName = agent.teamName;
+		let entrySessionId: string | undefined;
+		let entryProject: string | undefined;
+
+		if (isLead) {
+			// Check if this lead's session has a named team member
+			const named = agent.sessionId != null ? namedSessionMap.get(agent.sessionId) : undefined;
+			if (named != null) {
+				key = deriveAgentRole({ teamName: named.teamName, agentName: named.agentName });
+				entryAgentName = named.agentName;
+				entryTeamName = named.teamName;
+			} else {
+				// Unresolvable lead — temporary key, title resolved in post-processing
+				key = `lead:${agent.sessionId ?? 'unknown'}`;
+				entrySessionId = agent.sessionId;
+				entryProject = agent.project;
+			}
+		} else {
+			key = role;
+		}
 
 		const existing = roleMap.get(key);
 		if (existing != null) {
@@ -109,10 +145,10 @@ function aggregateByRole(agentData: AgentUsage[]): AgentUsage[] {
 		} else {
 			roleMap.set(key, {
 				agentId: key,
-				agentName: agent.agentName,
-				teamName: agent.teamName,
-				sessionId: isLead ? agent.sessionId : undefined,
-				project: isLead ? agent.project : undefined,
+				agentName: entryAgentName,
+				teamName: entryTeamName,
+				sessionId: entrySessionId,
+				project: entryProject,
 				inputTokens: agent.inputTokens,
 				outputTokens: agent.outputTokens,
 				cacheCreationTokens: agent.cacheCreationTokens,
@@ -125,6 +161,239 @@ function aggregateByRole(agentData: AgentUsage[]): AgentUsage[] {
 	}
 
 	return Array.from(roleMap.values());
+}
+
+/**
+ * Extracts a short descriptive title from a compaction summary text.
+ * Looks for content between <summary> tags, then extracts the first meaningful
+ * line after "Primary Request and Intent:" or the first ~50 chars.
+ */
+function extractCompactionTitle(text: string): string | null {
+	// Extract content between <summary> tags
+	const summaryMatch = text.match(/<summary>([\s\S]*?)<\/summary>/);
+	if (summaryMatch?.[1] == null) {
+		return null;
+	}
+
+	const summaryContent = summaryMatch[1].trim();
+	if (summaryContent.length === 0) {
+		return null;
+	}
+
+	// Look for "Primary Request and Intent:" section and grab the line after it
+	const primaryMatch = summaryContent.match(/Primary Request and Intent[:\s]*\n(.+)/i);
+	if (primaryMatch?.[1] != null) {
+		const line = primaryMatch[1].replace(/^[-\s*]+/, '').trim();
+		if (line.length > 0) {
+			return line.slice(0, 60).trim();
+		}
+	}
+
+	// Fallback: first non-header line with meaningful content
+	const lines = summaryContent.split('\n');
+	for (const rawLine of lines) {
+		const line = rawLine.replace(/^[\d.)\-*\s#]+/, '').trim();
+		// Skip headers, numbered section titles, and empty lines
+		if (line.length === 0) {
+			continue;
+		}
+		if (/^(?:Primary|Key|Current|Important)\s/i.test(line)) {
+			continue;
+		}
+		return line.slice(0, 60).trim();
+	}
+
+	return summaryContent.slice(0, 60).trim();
+}
+
+/**
+ * Resolves a session title from JSONL file content.
+ * Priority: cached title > slug > compaction summary (acompact- assistant entry)
+ * > legacy summary > first user message.
+ */
+async function resolveSessionTitle(
+	sessionId: string,
+	project: string | undefined,
+	claudePaths: string[],
+): Promise<{ title: string; startTime: string } | null> {
+	const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
+	const cachePath = path.join(cacheDir, sessionId);
+
+	// Check cache — versioned format: "v3\n<title>\n<startTime>"
+	const CACHE_VERSION = 'v3';
+	try {
+		const cached = await readFile(cachePath, 'utf-8');
+		const lines = cached.trim().split('\n');
+		if (
+			lines[0] === CACHE_VERSION &&
+			lines.length >= 3 &&
+			lines[1] != null &&
+			lines[1] !== '' &&
+			lines[2] != null &&
+			lines[2] !== ''
+		) {
+			return { title: lines[1], startTime: lines[2] };
+		}
+		// Stale cache (old format) — fall through to re-derive
+	} catch {
+		// No cache — continue to derive
+	}
+
+	// Find the JSONL file
+	let jsonlPath: string | null = null;
+	for (const cp of claudePaths) {
+		if (project != null) {
+			const candidate = path.join(cp, 'projects', project, `${sessionId}.jsonl`);
+			try {
+				await stat(candidate);
+				jsonlPath = candidate;
+				break;
+			} catch {
+				// File not found at this path
+			}
+		}
+	}
+
+	if (jsonlPath == null) {
+		return null;
+	}
+
+	let slug: string | null = null;
+	let compactionTitle: string | null = null;
+	let summaryTitle: string | null = null;
+	let userMessageTitle: string | null = null;
+	let startTime: string | null = null;
+
+	const fileStream = createReadStream(jsonlPath, { encoding: 'utf-8' });
+	const rl = createInterface({
+		input: fileStream,
+		crlfDelay: Number.POSITIVE_INFINITY,
+	});
+
+	let lineCount = 0;
+	for await (const line of rl) {
+		if (line.trim().length === 0) {
+			continue;
+		}
+		lineCount++;
+
+		// Early exit: compaction summary is top priority — if found with startTime, done
+		if (compactionTitle != null && startTime != null) {
+			break;
+		}
+		// Cap scan: stop after 500 lines (compaction summaries can appear deep in the file)
+		if (lineCount > 500) {
+			break;
+		}
+
+		try {
+			const parsed = JSON.parse(line) as Record<string, unknown>;
+
+			// Start time from first entry with a timestamp
+			if (startTime == null && typeof parsed.timestamp === 'string') {
+				startTime = parsed.timestamp;
+			}
+
+			// Slug field — Claude Code's session name (highest priority)
+			if (slug == null && typeof parsed.slug === 'string') {
+				slug = parsed.slug;
+			}
+
+			// Compaction summary from assistant entries with acompact- agentId
+			if (compactionTitle == null && parsed.type === 'assistant') {
+				const agentId = parsed.agentId;
+				if (typeof agentId === 'string' && agentId.startsWith('acompact-')) {
+					const msg = parsed.message as Record<string, unknown> | undefined;
+					if (msg?.role === 'assistant' && Array.isArray(msg.content)) {
+						const firstBlock = msg.content[0] as Record<string, unknown> | undefined;
+						if (firstBlock?.type === 'text' && typeof firstBlock.text === 'string') {
+							compactionTitle = extractCompactionTitle(firstBlock.text);
+						}
+					}
+				}
+			}
+
+			// Legacy summary type (third priority)
+			if (summaryTitle == null && parsed.type === 'summary' && typeof parsed.summary === 'string') {
+				summaryTitle = parsed.summary.slice(0, 60).trim();
+			}
+
+			// First real user message (last resort)
+			if (userMessageTitle == null && parsed.type === 'user') {
+				const msg = parsed.message as Record<string, unknown> | undefined;
+				if (msg?.role === 'user') {
+					const content = msg.content;
+					if (typeof content === 'string' && !/^<[a-z]/i.test(content)) {
+						userMessageTitle = content.split('\n')[0]!.slice(0, 60).trim();
+					}
+				}
+			}
+		} catch {
+			// Skip unparseable lines
+		}
+	}
+
+	rl.close();
+	fileStream.destroy();
+
+	// Pick best title: compaction summary > legacy summary > slug > user message
+	const title = compactionTitle ?? summaryTitle ?? slug ?? userMessageTitle;
+	if (title == null || startTime == null) {
+		return null;
+	}
+
+	// Cache the derived title (versioned format)
+	try {
+		await mkdir(cacheDir, { recursive: true });
+		await writeFile(cachePath, `${CACHE_VERSION}\n${title}\n${startTime}`, 'utf-8');
+	} catch {
+		// Cache write failure is non-fatal
+	}
+
+	return { title, startTime };
+}
+
+function formatStartTime(timestamp: string, timezone?: string): string {
+	const date = new Date(timestamp);
+	const formatter = new Intl.DateTimeFormat('en-GB', {
+		...(timezone != null ? { timeZone: timezone } : {}),
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false,
+	});
+	return formatter.format(date);
+}
+
+/**
+ * Replaces temporary `lead:sessionId` agentIds with meaningful session titles.
+ * Falls back to project/lead-hash when title can't be derived.
+ */
+async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string): Promise<void> {
+	let claudePaths: string[] | null = null;
+
+	for (const agent of agents) {
+		if (!agent.agentId.startsWith('lead:') || agent.sessionId == null) {
+			continue;
+		}
+
+		// Lazy-load claude paths
+		if (claudePaths == null) {
+			try {
+				claudePaths = getClaudePaths();
+			} catch {
+				claudePaths = [];
+			}
+		}
+
+		const titleInfo = await resolveSessionTitle(agent.sessionId, agent.project, claudePaths);
+		if (titleInfo != null) {
+			agent.agentId = `${titleInfo.title} · ${formatStartTime(titleInfo.startTime, timezone)}`;
+		} else {
+			// Fallback: project/lead-hash
+			const prefix = agent.project != null ? `${shortProjectName(agent.project)}/` : '';
+			agent.agentId = `${prefix}${deriveAgentId({ sessionId: agent.sessionId })}`;
+		}
+	}
 }
 
 export const agentCommand = define({
@@ -214,6 +483,11 @@ export const agentCommand = define({
 		// Role-level grouping (default) vs per-instance view
 		const displayData = ctx.values.instances ? agentData : aggregateByRole(agentData);
 
+		// Resolve lead display names (session titles) for aggregated view
+		if (!ctx.values.instances) {
+			await resolveLeadDisplayNames(displayData, ctx.values.timezone);
+		}
+
 		// Sort by cost descending (top spenders first)
 		displayData.sort((a, b) => b.totalCost - a.totalCost);
 
@@ -295,6 +569,7 @@ export const agentCommand = define({
 				head: headers,
 				style: { head: ['cyan'] },
 				colAligns: aligns,
+				colWidthOverrides: { 0: 36 },
 				compactHead: compactHeaders,
 				compactColAligns: compactAligns,
 				compactThreshold: 100,
@@ -304,8 +579,12 @@ export const agentCommand = define({
 			for (const data of displayData) {
 				const totalTokens =
 					data.inputTokens + data.outputTokens + data.cacheCreationTokens + data.cacheReadTokens;
+				// Insert newline after '/' so team/member names wrap at semantic boundary
+				const displayName = data.agentId.includes('/')
+					? data.agentId.replace('/', '/\n')
+					: data.agentId;
 				table.push([
-					data.agentId,
+					displayName,
 					data.modelsUsed.length > 0 ? formatModelsDisplayMultiline(data.modelsUsed) : '',
 					formatCompact(data.inputTokens),
 					formatCompact(data.outputTokens),

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -620,8 +620,7 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 			agent.agentId = `${prefix}${deriveAgentId({ sessionId: agent.sessionId })}`;
 		} else if (titleInfo.title != null) {
 			// Got a resolved title (cached, compaction, or user message)
-			const sid = agent.sessionId.slice(0, 8);
-			agent.agentId = `${titleInfo.title} · ${formatStartTime(titleInfo.startTime, timezone)} · ${sid}`;
+			agent.agentId = `${titleInfo.title} · ${formatStartTime(titleInfo.startTime, timezone)} · ${agent.sessionId}`;
 		} else {
 			// Needs AI title generation — collect for batch
 			needsAI.push({
@@ -645,8 +644,7 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 			const aiTitle = aiTitles.get(needsAI.indexOf(item) + 1);
 			const finalTitle = aiTitle ?? agent.sessionId?.slice(0, 8) ?? 'Untitled';
 
-			const sid = agent.sessionId?.slice(0, 8) ?? '';
-			agent.agentId = `${finalTitle} · ${formatStartTime(item.startTime, timezone)}${sid !== '' ? ` · ${sid}` : ''}`;
+			agent.agentId = `${finalTitle} · ${formatStartTime(item.startTime, timezone)}${agent.sessionId != null ? ` · ${agent.sessionId}` : ''}`;
 
 			// Cache the AI-generated title
 			if (agent.sessionId != null) {
@@ -988,8 +986,7 @@ function groupByTeamLead(
 		} else {
 			// Orphan lead — create header-only row from cached title
 			const cachedTitle = leadTitleCache.get(group.sessionId);
-			const sid = group.sessionId.slice(0, 8);
-			const title = cachedTitle != null ? `${cachedTitle} · ${sid}` : sid;
+			const title = cachedTitle != null ? `${cachedTitle} · ${group.sessionId}` : group.sessionId;
 			rows.push({
 				data: {
 					agentId: title,

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -694,6 +694,206 @@ async function loadTeamLeadMap(claudePaths: string[]): Promise<Map<string, strin
 	return map;
 }
 
+/**
+ * Reads the first few lines of a JSONL file to extract the teamName field.
+ */
+async function peekTeamName(filePath: string): Promise<string | null> {
+	const fileStream = createReadStream(filePath, { encoding: 'utf-8' });
+	const rl = createInterface({ input: fileStream, crlfDelay: Number.POSITIVE_INFINITY });
+	let lineCount = 0;
+	let teamName: string | null = null;
+
+	for await (const line of rl) {
+		if (line.trim().length === 0) {
+			continue;
+		}
+		lineCount++;
+		if (lineCount > 5) {
+			break;
+		}
+
+		try {
+			const parsed = JSON.parse(line) as Record<string, unknown>;
+			if (typeof parsed.teamName === 'string') {
+				teamName = parsed.teamName;
+				break;
+			}
+		} catch {
+			// skip unparseable lines
+		}
+	}
+
+	rl.close();
+	fileStream.destroy();
+	return teamName;
+}
+
+/**
+ * Discovers team→lead mappings for teams without configs by scanning subagent directories.
+ * Files in {project}/{leadSessionId}/subagents/*.jsonl contain team member data
+ * whose teamName may not have a ~/.claude/teams/ config entry.
+ */
+async function discoverOrphanTeams(
+	displayData: AgentUsage[],
+	teamLeadMap: Map<string, string>,
+	claudePaths: string[],
+): Promise<void> {
+	// Find teams not in the config-based map
+	const orphanTeams = new Set<string>();
+	for (const d of displayData) {
+		if (d.teamName != null && !teamLeadMap.has(d.teamName)) {
+			orphanTeams.add(d.teamName);
+		}
+	}
+	if (orphanTeams.size === 0) {
+		return;
+	}
+
+	// Phase 0: Load cached team→lead mappings (survives JSONL compaction)
+	const cacheDir = path.join(os.homedir(), '.claude', 'team-lead-cache');
+	try {
+		const cacheFiles = await readdir(cacheDir);
+		for (const file of cacheFiles) {
+			if (!orphanTeams.has(file)) {
+				continue;
+			}
+			try {
+				const leadSessionId = (await readFile(path.join(cacheDir, file), 'utf-8')).trim();
+				if (leadSessionId !== '') {
+					teamLeadMap.set(file, leadSessionId);
+					orphanTeams.delete(file);
+				}
+			} catch {
+				// skip unreadable cache entries
+			}
+		}
+	} catch {
+		// cache dir doesn't exist yet
+	}
+	if (orphanTeams.size === 0) {
+		return;
+	}
+
+	const leads = displayData.filter(
+		(d) => d.teamName == null && d.sessionId != null && d.project != null,
+	);
+	const newlyDiscovered = new Map<string, string>();
+
+	// Phase 1: Scan subagent directories of known lead sessions
+	for (const lead of leads) {
+		if (orphanTeams.size === 0) {
+			break;
+		}
+		for (const cp of claudePaths) {
+			const subagentsDir = path.join(cp, 'projects', lead.project!, lead.sessionId!, 'subagents');
+			let files: string[];
+			try {
+				files = await readdir(subagentsDir);
+			} catch {
+				continue;
+			}
+
+			for (const file of files) {
+				if (!file.endsWith('.jsonl')) {
+					continue;
+				}
+				const teamName = await peekTeamName(path.join(subagentsDir, file));
+				if (teamName != null && orphanTeams.has(teamName) && !teamLeadMap.has(teamName)) {
+					teamLeadMap.set(teamName, lead.sessionId!);
+					newlyDiscovered.set(teamName, lead.sessionId!);
+					orphanTeams.delete(teamName);
+					if (orphanTeams.size === 0) {
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	if (orphanTeams.size > 0) {
+		// Phase 2: Scan lead JSONL files for TeamCreate tool uses referencing orphan teams.
+		// Some teams (e.g. spawned via TeamCreate) have no subagent files under the lead —
+		// the only link is the TeamCreate tool_use entry in the lead's conversation.
+		// After compaction, these entries are lost — that's why Phase 0 caches discoveries.
+		for (const lead of leads) {
+			if (orphanTeams.size === 0) {
+				break;
+			}
+			for (const cp of claudePaths) {
+				if (lead.project == null) {
+					continue;
+				}
+				const jsonlPath = path.join(cp, 'projects', lead.project, `${lead.sessionId}.jsonl`);
+				try {
+					await stat(jsonlPath);
+				} catch {
+					continue;
+				}
+
+				const fileStream = createReadStream(jsonlPath, { encoding: 'utf-8' });
+				const rl = createInterface({
+					input: fileStream,
+					crlfDelay: Number.POSITIVE_INFINITY,
+				});
+
+				for await (const line of rl) {
+					// Cheap string check before JSON parse
+					if (!line.includes('TeamCreate')) {
+						continue;
+					}
+
+					try {
+						const parsed = JSON.parse(line) as Record<string, unknown>;
+						if (parsed.type !== 'assistant') {
+							continue;
+						}
+						const msg = parsed.message as Record<string, unknown> | undefined;
+						const content = msg?.content;
+						if (!Array.isArray(content)) {
+							continue;
+						}
+
+						for (const block of content) {
+							const b = block as Record<string, unknown>;
+							if (b.type !== 'tool_use' || b.name !== 'TeamCreate') {
+								continue;
+							}
+							const input = b.input as Record<string, unknown> | undefined;
+							const tn = input?.team_name;
+							if (typeof tn === 'string' && orphanTeams.has(tn) && !teamLeadMap.has(tn)) {
+								teamLeadMap.set(tn, lead.sessionId!);
+								newlyDiscovered.set(tn, lead.sessionId!);
+								orphanTeams.delete(tn);
+							}
+						}
+					} catch {
+						// skip unparseable lines
+					}
+
+					if (orphanTeams.size === 0) {
+						break;
+					}
+				}
+
+				rl.close();
+				fileStream.destroy();
+			}
+		}
+	}
+
+	// Persist newly discovered mappings so they survive JSONL compaction
+	if (newlyDiscovered.size > 0) {
+		try {
+			await mkdir(cacheDir, { recursive: true });
+			for (const [teamName, leadSessionId] of newlyDiscovered) {
+				await writeFile(path.join(cacheDir, teamName), leadSessionId, 'utf-8');
+			}
+		} catch {
+			// cache write failure is non-fatal
+		}
+	}
+}
+
 type DisplayRow = {
 	data: AgentUsage;
 	isLeadHeader: boolean; // header-only row for orphan leads (no usage data in current range)
@@ -970,10 +1170,10 @@ export const agentCommand = define({
 				claudePaths = [];
 			}
 			const teamLeadMap = await loadTeamLeadMap(claudePaths);
-			if (teamLeadMap.size > 0) {
-				const leadTitleCache = await loadLeadTitleCache(teamLeadMap);
-				groupedRows = groupByTeamLead(displayData, teamLeadMap, leadTitleCache);
-			}
+			// Discover orphan teams (no config) by scanning subagent directories
+			await discoverOrphanTeams(displayData, teamLeadMap, claudePaths);
+			const leadTitleCache = await loadLeadTitleCache(teamLeadMap);
+			groupedRows = groupByTeamLead(displayData, teamLeadMap, leadTitleCache);
 		}
 
 		// Calculate totals (from original data, not grouped rows which may include header-only rows)

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -385,7 +385,7 @@ async function generateAITitlesBatch(
 /**
  * Resolves a session title from JSONL file content.
  * Priority: cached title > compaction summary (isCompactSummary user entry)
- * > legacy summary > AI-generated title > slug (last resort).
+ * > legacy summary > AI-generated title > truncated sessionId (last resort).
  */
 async function resolveSessionTitle(
 	sessionId: string,
@@ -393,14 +393,14 @@ async function resolveSessionTitle(
 	claudePaths: string[],
 ): Promise<
 	| { title: string; startTime: string }
-	| { title: null; startTime: string; userMessages: string[]; slug: string | null }
+	| { title: null; startTime: string; userMessages: string[] }
 	| null
 > {
 	const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
 	const cachePath = path.join(cacheDir, sessionId);
 
 	// Check cache — versioned format: "v8\n<title>\n<startTime>"
-	const CACHE_VERSION = 'v9';
+	const CACHE_VERSION = 'v10';
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
 		const lines = cached.trim().split('\n');
@@ -438,14 +438,13 @@ async function resolveSessionTitle(
 		return null;
 	}
 
-	let slug: string | null = null;
 	let compactionTitle: string | null = null;
 	let summaryTitle: string | null = null;
 	let userMessageTitle: string | null = null;
 	const userMessages: string[] = [];
 	let startTime: string | null = null;
 
-	// Phase 1: quick scan of first 50 lines for slug, startTime, userMessages, and early compaction
+	// Phase 1: quick scan of first 50 lines for startTime, userMessages, and early compaction
 	const fileStream1 = createReadStream(jsonlPath, { encoding: 'utf-8' });
 	const rl1 = createInterface({
 		input: fileStream1,
@@ -467,9 +466,6 @@ async function resolveSessionTitle(
 
 			if (startTime == null && typeof parsed.timestamp === 'string') {
 				startTime = parsed.timestamp;
-			}
-			if (slug == null && typeof parsed.slug === 'string') {
-				slug = parsed.slug;
 			}
 			// Check for compaction summary in early lines too
 			if (compactionTitle == null && parsed.type === 'user' && parsed.isCompactSummary === true) {
@@ -553,12 +549,12 @@ async function resolveSessionTitle(
 
 	// No deterministic title — return messages for AI generation
 	if (startTime != null && userMessages.length > 0) {
-		return { title: null, startTime, userMessages, slug };
+		return { title: null, startTime, userMessages };
 	}
 
-	// Absolute fallback: slug only (no user messages to generate from)
-	if (slug != null && startTime != null) {
-		return { title: slug, startTime };
+	// Absolute fallback: truncated sessionId (no user messages to generate from)
+	if (startTime != null) {
+		return { title: sessionId.slice(0, 8), startTime };
 	}
 
 	return null;
@@ -578,7 +574,7 @@ function formatStartTime(timestamp: string, timezone?: string): string {
 /**
  * Replaces temporary `lead:sessionId` agentIds with meaningful session titles.
  * Falls back to project/lead-hash when title can't be derived.
- * Batches all AI title requests into a single `claude -p` call.
+ * Batches all AI title requests into a single API call.
  */
 async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string): Promise<void> {
 	let claudePaths: string[] | null = null;
@@ -586,7 +582,6 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 		agentIdx: number;
 		startTime: string;
 		messages: string[];
-		slug: string | null;
 	}> = [];
 
 	for (let i = 0; i < agents.length; i++) {
@@ -617,7 +612,6 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 				agentIdx: i,
 				startTime: titleInfo.startTime,
 				messages: titleInfo.userMessages,
-				slug: titleInfo.slug,
 			});
 		}
 	}
@@ -628,12 +622,12 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 		const aiTitles = await generateAITitlesBatch(batchInput);
 
 		const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
-		const CACHE_VERSION = 'v9';
+		const CACHE_VERSION = 'v10';
 
 		for (const item of needsAI) {
 			const agent = agents[item.agentIdx]!;
 			const aiTitle = aiTitles.get(needsAI.indexOf(item) + 1);
-			const finalTitle = aiTitle ?? item.slug ?? 'Untitled session';
+			const finalTitle = aiTitle ?? agent.sessionId?.slice(0, 8) ?? 'Untitled';
 
 			agent.agentId = `${finalTitle} · ${formatStartTime(item.startTime, timezone)}`;
 

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -25,6 +25,8 @@ import { createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
 import { getClaudePaths, loadAgentUsageData } from '../data-loader.ts';
 import { log, logger } from '../logger.ts';
 
+const CACHE_VERSION = 'v15';
+
 /**
  * Formats a number in compact form: 999, 1.2K, 12.4K, 1.2M, 12.4M, 1.2B
  * Keeps output short (max ~6 chars) so table columns don't overflow.
@@ -43,6 +45,14 @@ function formatCompact(num: number): string {
 	}
 	const b = num / 1_000_000_000;
 	return b < 10 ? `${b.toFixed(1)}B` : `${Math.round(b)}B`;
+}
+
+/**
+ * Sanitizes a string for safe use as a filesystem path component.
+ * Strips path traversal sequences and replaces invalid characters.
+ */
+function sanitizePathComponent(name: string): string {
+	return path.basename(name.replace(/[^\w-]/g, '_'));
 }
 
 /**
@@ -260,14 +270,20 @@ async function getClaudeAuthHeaders(): Promise<Record<string, string> | null> {
 		}
 	}
 
-	// File fallback
+	// File fallback — try both config locations
 	if (creds == null) {
-		try {
-			const credsPath = path.join(os.homedir(), '.claude', '.credentials.json');
-			const raw = await readFile(credsPath, 'utf-8');
-			creds = JSON.parse(raw) as Record<string, unknown>;
-		} catch {
-			// File not available
+		const credsDirs = [
+			path.join(os.homedir(), '.claude'),
+			path.join(os.homedir(), '.config', 'claude'),
+		];
+		for (const dir of credsDirs) {
+			try {
+				const raw = await readFile(path.join(dir, '.credentials.json'), 'utf-8');
+				creds = JSON.parse(raw) as Record<string, unknown>;
+				break;
+			} catch {
+				// File not available
+			}
 		}
 	}
 
@@ -303,6 +319,7 @@ async function getClaudeAuthHeaders(): Promise<Record<string, string> | null> {
 					refresh_token: refreshToken,
 					client_id: OAUTH_CLIENT_ID,
 				}),
+				signal: AbortSignal.timeout(10_000),
 			});
 			const res = response as unknown as { ok: boolean; json: () => Promise<unknown> };
 			if (res.ok) {
@@ -360,6 +377,7 @@ async function generateAITitlesBatch(
 					max_tokens: 1024,
 					messages: [{ role: 'user', content: prompt }],
 				}),
+				signal: AbortSignal.timeout(30_000),
 			});
 			const res = response as unknown as { ok: boolean; json: () => Promise<unknown> };
 			if (res.ok) {
@@ -414,9 +432,7 @@ async function resolveSessionTitle(
 	const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
 	const cachePath = path.join(cacheDir, sessionId);
 
-	// Check cache — versioned format: "v12\n<title>\n<startTime>"
-	// v12: invalidate caches from v11 (filter bracketed AI placeholders)
-	const CACHE_VERSION = 'v15';
+	// Check cache — versioned format: "v15\n<title>\n<startTime>"
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
 		const lines = cached.trim().split('\n');
@@ -640,10 +656,14 @@ function formatStartTime(timestamp: string, timezone?: string): string {
 
 /**
  * Replaces temporary `lead:sessionId` agentIds with meaningful session titles.
- * Falls back to project/lead-hash when title can't be derived.
+ * Falls back to project/lead-xxxx (4-char session prefix) when title can't be derived.
  * Batches all AI title requests into a single API call.
  */
-async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string): Promise<void> {
+async function resolveLeadDisplayNames(
+	agents: AgentUsage[],
+	timezone?: string,
+	offline = false,
+): Promise<void> {
 	let claudePaths: string[] | null = null;
 	const needsAI: Array<{
 		agentIdx: number;
@@ -665,9 +685,14 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 			}
 		}
 
-		const titleInfo = await resolveSessionTitle(agent.sessionId, agent.project, claudePaths);
+		let titleInfo: Awaited<ReturnType<typeof resolveSessionTitle>> = null;
+		try {
+			titleInfo = await resolveSessionTitle(agent.sessionId, agent.project, claudePaths);
+		} catch {
+			// Skip unreadable JSONL files — don't abort the whole report
+		}
 		if (titleInfo == null) {
-			// No data at all — fallback to project/lead-hash
+			// No data at all — fallback to project/lead-xxxx (4-char session prefix)
 			const prefix = agent.project != null ? `${shortProjectName(agent.project)}/` : '';
 			agent.agentId = `${prefix}${deriveAgentId({ sessionId: agent.sessionId })}`;
 		} else if (titleInfo.title != null) {
@@ -685,13 +710,12 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 		}
 	}
 
-	// Batch AI title generation in a single claude call
-	if (needsAI.length > 0) {
+	// Batch AI title generation in a single claude call (skip in offline mode)
+	if (needsAI.length > 0 && !offline) {
 		const batchInput = needsAI.map((item, idx) => ({ index: idx + 1, messages: item.messages }));
 		const aiTitles = await generateAITitlesBatch(batchInput);
 
 		const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
-		const CACHE_VERSION = 'v15';
 
 		for (const item of needsAI) {
 			const agent = agents[item.agentIdx]!;
@@ -726,6 +750,19 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 				const line1 = joinParts([shortId, formatStartTime(item.startTime, timezone)]) + hint;
 				agent.agentId = agent.sessionId != null ? `${line1}\n${agent.sessionId}` : line1;
 			}
+		}
+	} else if (needsAI.length > 0) {
+		// Offline mode — use fallback display for sessions that need AI
+		for (const item of needsAI) {
+			const agent = agents[item.agentIdx]!;
+			const shortId = agent.sessionId?.slice(0, 8) ?? 'Untitled';
+			const firstMsg = item.messages[0];
+			const hint =
+				firstMsg != null
+					? ` ("${firstMsg.length > 30 ? `${firstMsg.slice(0, 30)}…` : firstMsg}")`
+					: '';
+			const line1 = joinParts([shortId, formatStartTime(item.startTime, timezone)]) + hint;
+			agent.agentId = agent.sessionId != null ? `${line1}\n${agent.sessionId}` : line1;
 		}
 	}
 }
@@ -953,7 +990,11 @@ async function discoverOrphanTeams(
 		try {
 			await mkdir(cacheDir, { recursive: true });
 			for (const [teamName, leadSessionId] of newlyDiscovered) {
-				await writeFile(path.join(cacheDir, teamName), leadSessionId, 'utf-8');
+				await writeFile(
+					path.join(cacheDir, sanitizePathComponent(teamName)),
+					leadSessionId,
+					'utf-8',
+				);
 			}
 		} catch {
 			// cache write failure is non-fatal
@@ -1133,7 +1174,13 @@ async function loadLeadTitleCache(teamLeadMap: Map<string, string>): Promise<Map
 		try {
 			const raw = await readFile(path.join(cacheDir, sessionId), 'utf-8');
 			const lines = raw.trim().split('\n');
-			if (lines.length >= 2 && lines[1] != null && lines[1] !== '' && isValidTitle(lines[1])) {
+			if (
+				lines[0] === CACHE_VERSION &&
+				lines.length >= 2 &&
+				lines[1] != null &&
+				lines[1] !== '' &&
+				isValidTitle(lines[1])
+			) {
 				cache.set(sessionId, lines[1]);
 			}
 		} catch {
@@ -1187,18 +1234,19 @@ export const agentCommand = define({
 		}
 
 		// Resolve date range: explicit --since/--until > --days > --all > default (today)
-		let since = ctx.values.since;
-		const until = ctx.values.until;
+		let since = mergedOptions.since;
+		const until = mergedOptions.until;
 
 		if (since == null && until == null) {
-			if (ctx.values.days != null) {
+			if (mergedOptions.days != null) {
+				const days = Math.max(1, Math.floor(mergedOptions.days));
 				const now = new Date();
 				const daysAgo = new Date(now);
-				daysAgo.setDate(daysAgo.getDate() - (ctx.values.days - 1));
-				since = formatLocalDateYYYYMMDD(daysAgo, ctx.values.timezone);
-			} else if (!ctx.values.all) {
+				daysAgo.setDate(daysAgo.getDate() - (days - 1));
+				since = formatLocalDateYYYYMMDD(daysAgo, mergedOptions.timezone);
+			} else if (!mergedOptions.all) {
 				// Default: today only
-				since = formatLocalDateYYYYMMDD(new Date(), ctx.values.timezone);
+				since = formatLocalDateYYYYMMDD(new Date(), mergedOptions.timezone);
 			}
 		}
 
@@ -1207,12 +1255,12 @@ export const agentCommand = define({
 		const agentData = await loadAgentUsageData({
 			since,
 			until,
-			mode: ctx.values.mode,
-			offline: ctx.values.offline,
-			timezone: ctx.values.timezone,
-			locale: ctx.values.locale,
-			teamFilter: ctx.values.team,
-			sessionFilter: ctx.values.session,
+			mode: mergedOptions.mode,
+			offline: mergedOptions.offline,
+			timezone: mergedOptions.timezone,
+			locale: mergedOptions.locale,
+			teamFilter: mergedOptions.team,
+			sessionFilter: mergedOptions.session,
 			onProgress: (step) => logger.start(step),
 		});
 
@@ -1228,11 +1276,11 @@ export const agentCommand = define({
 		}
 
 		// Role-level grouping (default) vs per-instance view
-		const displayData = ctx.values.instances ? agentData : aggregateByRole(agentData);
+		const displayData = mergedOptions.instances ? agentData : aggregateByRole(agentData);
 
 		// Resolve lead display names (session titles) for aggregated view
-		if (!ctx.values.instances) {
-			await resolveLeadDisplayNames(displayData, ctx.values.timezone);
+		if (!mergedOptions.instances) {
+			await resolveLeadDisplayNames(displayData, mergedOptions.timezone, mergedOptions.offline);
 		}
 
 		// Sort by cost descending (top spenders first)
@@ -1240,7 +1288,7 @@ export const agentCommand = define({
 
 		// Group team members under their lead sessions
 		let groupedRows: DisplayRow[] | null = null;
-		if (!ctx.values.instances) {
+		if (!mergedOptions.instances) {
 			let claudePaths: string[];
 			try {
 				claudePaths = getClaudePaths();
@@ -1292,8 +1340,8 @@ export const agentCommand = define({
 				totals: createTotalsObject(totals),
 			};
 
-			if (ctx.values.jq != null) {
-				const jqResult = await processWithJq(jsonOutput, ctx.values.jq);
+			if (mergedOptions.jq != null) {
+				const jqResult = await processWithJq(jsonOutput, mergedOptions.jq);
 				if (Result.isFailure(jqResult)) {
 					logger.error(jqResult.error.message);
 					process.exit(1);
@@ -1345,7 +1393,7 @@ export const agentCommand = define({
 				compactHead: compactHeaders,
 				compactColAligns: compactAligns,
 				compactThreshold: 100,
-				forceCompact: ctx.values.compact,
+				forceCompact: mergedOptions.compact,
 			});
 
 			const rows =
@@ -1374,7 +1422,7 @@ export const agentCommand = define({
 					displayName = data.agentId;
 				}
 				const pct = totals.totalCost > 0 ? (data.totalCost / totals.totalCost) * 100 : 0;
-				const pctStr = pct < 0.1 ? '<0.1' : pct.toFixed(1);
+				const pctStr = data.totalCost === 0 ? '-' : pct < 0.1 ? '<0.1' : pct.toFixed(1);
 				table.push([
 					displayName,
 					data.modelsUsed.length > 0 ? formatModelsDisplayMultiline(data.modelsUsed) : '',
@@ -1387,7 +1435,7 @@ export const agentCommand = define({
 					pctStr,
 				]);
 
-				if (ctx.values.breakdown) {
+				if (mergedOptions.breakdown) {
 					pushBreakdownRows(table, data.modelBreakdowns);
 				}
 			}
@@ -1408,7 +1456,7 @@ export const agentCommand = define({
 				pc.yellow(formatCompact(totals.cacheReadTokens)),
 				pc.yellow(formatCompact(grandTotal)),
 				pc.yellow(formatCurrency(totals.totalCost)),
-				pc.yellow('100'),
+				pc.yellow(totals.totalCost > 0 ? '100' : '-'),
 			]);
 
 			log(table.toString());

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -477,18 +477,31 @@ async function resolveSessionTitle(
 			if (summaryTitle == null && parsed.type === 'summary' && typeof parsed.summary === 'string') {
 				summaryTitle = parsed.summary.slice(0, 60).trim();
 			}
-			if (parsed.type === 'user' && parsed.isCompactSummary !== true) {
+			if (parsed.type === 'user' && parsed.isCompactSummary !== true && parsed.isMeta !== true) {
 				const msg = parsed.message as Record<string, unknown> | undefined;
 				if (msg?.role === 'user') {
 					const content = msg.content;
-					if (typeof content === 'string' && !/^<[a-z]/i.test(content)) {
+					// Extract text from string or array content (multimodal messages use [{type:"text",text:"..."}])
+					let textContent: string | undefined;
+					if (typeof content === 'string') {
+						textContent = content;
+					} else if (Array.isArray(content)) {
+						const textBlock = content.find(
+							(b: unknown) =>
+								typeof b === 'object' &&
+								b != null &&
+								(b as Record<string, unknown>).type === 'text',
+						) as Record<string, unknown> | undefined;
+						if (typeof textBlock?.text === 'string') {textContent = textBlock.text;}
+					}
+					if (textContent != null && !/^<[a-z]/i.test(textContent)) {
 						// Collect first user message as title fallback
 						if (userMessageTitle == null) {
-							userMessageTitle = truncateAtWord(content.split('\n')[0]!.trim(), 60);
+							userMessageTitle = truncateAtWord(textContent.split('\n')[0]!.trim(), 60);
 						}
 						// Collect up to 3 user messages for AI title generation
 						if (userMessages.length < 3) {
-							userMessages.push(truncateAtWord(content.split('\n')[0]!.trim(), 120));
+							userMessages.push(truncateAtWord(textContent.split('\n')[0]!.trim(), 120));
 						}
 					}
 				}

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -195,13 +195,13 @@ function joinParts(parts: (string | undefined)[]): string {
  * Compaction summaries are plain text starting with "This session is being continued..."
  * followed by "Summary:\n1. Primary Request and Intent:\n   - <description>".
  */
-function extractCompactionTitle(text: string): string | null {
+function extractCompactionSummary(text: string): string | null {
 	// Look for "Primary Request and Intent:" section and grab the first content line after it
 	const primaryMatch = text.match(/Primary Request and Intent[:\s]*\n(.+)/i);
 	if (primaryMatch?.[1] != null) {
 		const line = primaryMatch[1].replace(/^[-\s*]+/, '').trim();
 		if (line.length > 0) {
-			return truncateAtWord(line, 60);
+			return line;
 		}
 	}
 
@@ -219,7 +219,7 @@ function extractCompactionTitle(text: string): string | null {
 			if (/^(?:Primary|Key|Current|Important)\s/i.test(line)) {
 				continue;
 			}
-			return truncateAtWord(line, 60);
+			return line;
 		}
 	}
 
@@ -341,7 +341,7 @@ async function generateAITitlesBatch(
 
 	const numbered = sessions.map((s) => `${s.index}. ${s.messages.join(' | ')}`).join('\n');
 
-	const prompt = `Generate concise titles (max 40 characters each) for these ${sessions.length} Claude Code sessions based on what the user asked for. Focus on the TASK or GOAL, not greetings. Output ONLY numbered titles matching the input numbers, one per line. No other text.\n\n${numbered}`;
+	const prompt = `Generate a short noun-phrase title (max 30 characters, 3-5 words) for each Claude Code session below. Focus on the task or goal. No verbs at the start, no "User asked to..." framing. Output ONLY numbered titles matching the input numbers, one per line.\n\n${numbered}`;
 
 	let output: string | null = null;
 
@@ -387,7 +387,7 @@ async function generateAITitlesBatch(
 			if (match != null) {
 				const idx = Number.parseInt(match[1]!, 10);
 				const title = match[2]!.trim();
-				if (title.length > 0 && title.length <= 50 && !/^\[.*\]$/.test(title)) {
+				if (title.length > 0 && !/^\[.*\]$/.test(title)) {
 					result.set(idx, title);
 				}
 			}
@@ -416,7 +416,7 @@ async function resolveSessionTitle(
 
 	// Check cache — versioned format: "v12\n<title>\n<startTime>"
 	// v12: invalidate caches from v11 (filter bracketed AI placeholders)
-	const CACHE_VERSION = 'v13';
+	const CACHE_VERSION = 'v15';
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
 		const lines = cached.trim().split('\n');
@@ -455,7 +455,7 @@ async function resolveSessionTitle(
 		return null;
 	}
 
-	let compactionTitle: string | null = null;
+	let hasCompactionSummary = false;
 	let summaryTitle: string | null = null;
 	let userMessageTitle: string | null = null;
 	const userMessages: string[] = [];
@@ -484,11 +484,15 @@ async function resolveSessionTitle(
 			if (startTime == null && typeof parsed.timestamp === 'string') {
 				startTime = parsed.timestamp;
 			}
-			// Check for compaction summary in early lines too
-			if (compactionTitle == null && parsed.type === 'user' && parsed.isCompactSummary === true) {
+			// Check for compaction summary — feed to AI as high-quality input
+			if (!hasCompactionSummary && parsed.type === 'user' && parsed.isCompactSummary === true) {
 				const msg = parsed.message as Record<string, unknown> | undefined;
 				if (msg?.role === 'user' && typeof msg.content === 'string') {
-					compactionTitle = extractCompactionTitle(msg.content);
+					const summary = extractCompactionSummary(msg.content);
+					if (summary != null) {
+						userMessages.unshift(summary);
+						hasCompactionSummary = true;
+					}
 				}
 			}
 			if (summaryTitle == null && parsed.type === 'summary' && typeof parsed.summary === 'string') {
@@ -521,6 +525,16 @@ async function resolveSessionTitle(
 							);
 							if (innerMatch?.[1] != null) {
 								textContent = innerMatch[1].trim();
+								// Strip "You are a ... on team ..." preamble
+								textContent = textContent.replace(/^You are\b[^.]+\bon team [\w-]+\.\s*/i, '');
+							} else {
+								textContent = undefined;
+							}
+						} else if (/^<command-message\b/i.test(textContent)) {
+							// Extract user's actual input from <command-args>
+							const argsMatch = textContent.match(/<command-args>([\s\S]*?)<\/command-args>/i);
+							if (argsMatch?.[1] != null) {
+								textContent = argsMatch[1].trim();
 							} else {
 								textContent = undefined;
 							}
@@ -535,7 +549,7 @@ async function resolveSessionTitle(
 						if (firstLine.length > 0) {
 							// Only set deterministic title from substantive messages
 							if (firstLine.length >= 10 && firstLine.includes(' ') && userMessageTitle == null) {
-								userMessageTitle = truncateAtWord(firstLine, 60);
+								userMessageTitle = firstLine;
 							}
 							// Collect ALL non-empty messages for AI title generation
 							if (userMessages.length < 3) {
@@ -553,8 +567,8 @@ async function resolveSessionTitle(
 	rl1.close();
 	fileStream1.destroy();
 
-	// Phase 2: if no compaction title yet, fast-scan the whole file for isCompactSummary lines
-	if (compactionTitle == null) {
+	// Phase 2: if no compaction summary yet, fast-scan the whole file for isCompactSummary lines
+	if (!hasCompactionSummary) {
 		const fileStream2 = createReadStream(jsonlPath, { encoding: 'utf-8' });
 		const rl2 = createInterface({
 			input: fileStream2,
@@ -571,8 +585,10 @@ async function resolveSessionTitle(
 				if (parsed.type === 'user' && parsed.isCompactSummary === true) {
 					const msg = parsed.message as Record<string, unknown> | undefined;
 					if (msg?.role === 'user' && typeof msg.content === 'string') {
-						compactionTitle = extractCompactionTitle(msg.content);
-						if (compactionTitle != null) {
+						const summary = extractCompactionSummary(msg.content);
+						if (summary != null) {
+							userMessages.unshift(summary);
+							hasCompactionSummary = true;
 							break;
 						}
 					}
@@ -586,19 +602,16 @@ async function resolveSessionTitle(
 		fileStream2.destroy();
 	}
 
-	// Only compaction/summary titles are deterministic — use directly
+	// Legacy summary titles are deterministic — use directly
 	// Filter out bracketed placeholders like "[No content provided]"
-	const rawTitle = compactionTitle ?? summaryTitle;
-	const title = rawTitle != null && isValidTitle(rawTitle) ? rawTitle : null;
-
-	if (title != null && startTime != null) {
+	if (summaryTitle != null && isValidTitle(summaryTitle) && startTime != null) {
 		try {
 			await mkdir(cacheDir, { recursive: true });
-			await writeFile(cachePath, `${CACHE_VERSION}\n${title}\n${startTime}`, 'utf-8');
+			await writeFile(cachePath, `${CACHE_VERSION}\n${summaryTitle}\n${startTime}`, 'utf-8');
 		} catch {
 			// Cache write failure is non-fatal
 		}
-		return { title, startTime };
+		return { title: summaryTitle, startTime };
 	}
 
 	// No deterministic title — return messages for AI generation
@@ -678,7 +691,7 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 		const aiTitles = await generateAITitlesBatch(batchInput);
 
 		const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
-		const CACHE_VERSION = 'v13';
+		const CACHE_VERSION = 'v15';
 
 		for (const item of needsAI) {
 			const agent = agents[item.agentIdx]!;

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -172,7 +172,8 @@ function truncateAtWord(str: string, maxLen: number): string {
 		return str;
 	}
 	const lastSpace = str.lastIndexOf(' ', maxLen);
-	return lastSpace > 0 ? str.slice(0, lastSpace) : str.slice(0, maxLen);
+	const truncated = lastSpace > 0 ? str.slice(0, lastSpace) : str.slice(0, maxLen);
+	return `${truncated}…`;
 }
 
 /**
@@ -399,9 +400,9 @@ async function resolveSessionTitle(
 	const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
 	const cachePath = path.join(cacheDir, sessionId);
 
-	// Check cache — versioned format: "v11\n<title>\n<startTime>"
-	// v11: invalidate caches from v10 (fixed trivial message filtering)
-	const CACHE_VERSION = 'v11';
+	// Check cache — versioned format: "v12\n<title>\n<startTime>"
+	// v12: ellipsis truncation on long titles
+	const CACHE_VERSION = 'v12';
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
 		const lines = cached.trim().split('\n');
@@ -641,7 +642,7 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 		const aiTitles = await generateAITitlesBatch(batchInput);
 
 		const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
-		const CACHE_VERSION = 'v11';
+		const CACHE_VERSION = 'v12';
 
 		for (const item of needsAI) {
 			const agent = agents[item.agentIdx]!;

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -164,52 +164,56 @@ function aggregateByRole(agentData: AgentUsage[]): AgentUsage[] {
 }
 
 /**
+ * Truncates a string to maxLen, breaking at the last space before the limit.
+ */
+function truncateAtWord(str: string, maxLen: number): string {
+	if (str.length <= maxLen) {
+		return str;
+	}
+	const lastSpace = str.lastIndexOf(' ', maxLen);
+	return lastSpace > 0 ? str.slice(0, lastSpace) : str.slice(0, maxLen);
+}
+
+/**
  * Extracts a short descriptive title from a compaction summary text.
- * Looks for content between <summary> tags, then extracts the first meaningful
- * line after "Primary Request and Intent:" or the first ~50 chars.
+ * Compaction summaries are plain text starting with "This session is being continued..."
+ * followed by "Summary:\n1. Primary Request and Intent:\n   - <description>".
  */
 function extractCompactionTitle(text: string): string | null {
-	// Extract content between <summary> tags
-	const summaryMatch = text.match(/<summary>([\s\S]*?)<\/summary>/);
-	if (summaryMatch?.[1] == null) {
-		return null;
-	}
-
-	const summaryContent = summaryMatch[1].trim();
-	if (summaryContent.length === 0) {
-		return null;
-	}
-
-	// Look for "Primary Request and Intent:" section and grab the line after it
-	const primaryMatch = summaryContent.match(/Primary Request and Intent[:\s]*\n(.+)/i);
+	// Look for "Primary Request and Intent:" section and grab the first content line after it
+	const primaryMatch = text.match(/Primary Request and Intent[:\s]*\n(.+)/i);
 	if (primaryMatch?.[1] != null) {
 		const line = primaryMatch[1].replace(/^[-\s*]+/, '').trim();
 		if (line.length > 0) {
-			return line.slice(0, 60).trim();
+			return truncateAtWord(line, 60);
 		}
 	}
 
-	// Fallback: first non-header line with meaningful content
-	const lines = summaryContent.split('\n');
-	for (const rawLine of lines) {
-		const line = rawLine.replace(/^[\d.)\-*\s#]+/, '').trim();
-		// Skip headers, numbered section titles, and empty lines
-		if (line.length === 0) {
-			continue;
+	// Fallback: find "Summary:" section and grab first meaningful line
+	const summaryIdx = text.indexOf('Summary:');
+	if (summaryIdx >= 0) {
+		const afterSummary = text.slice(summaryIdx + 'Summary:'.length);
+		const lines = afterSummary.split('\n');
+		for (const rawLine of lines) {
+			const line = rawLine.replace(/^[\d.)\-*\s#]+/, '').trim();
+			if (line.length === 0) {
+				continue;
+			}
+			// Skip section headers
+			if (/^(?:Primary|Key|Current|Important)\s/i.test(line)) {
+				continue;
+			}
+			return truncateAtWord(line, 60);
 		}
-		if (/^(?:Primary|Key|Current|Important)\s/i.test(line)) {
-			continue;
-		}
-		return line.slice(0, 60).trim();
 	}
 
-	return summaryContent.slice(0, 60).trim();
+	return null;
 }
 
 /**
  * Resolves a session title from JSONL file content.
- * Priority: cached title > slug > compaction summary (acompact- assistant entry)
- * > legacy summary > first user message.
+ * Priority: cached title > compaction summary (isCompactSummary user entry)
+ * > legacy summary > slug > first user message.
  */
 async function resolveSessionTitle(
 	sessionId: string,
@@ -219,8 +223,8 @@ async function resolveSessionTitle(
 	const cacheDir = path.join(os.homedir(), '.claude', 'session-titles');
 	const cachePath = path.join(cacheDir, sessionId);
 
-	// Check cache — versioned format: "v3\n<title>\n<startTime>"
-	const CACHE_VERSION = 'v3';
+	// Check cache — versioned format: "v6\n<title>\n<startTime>"
+	const CACHE_VERSION = 'v6';
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
 		const lines = cached.trim().split('\n');
@@ -264,61 +268,42 @@ async function resolveSessionTitle(
 	let userMessageTitle: string | null = null;
 	let startTime: string | null = null;
 
-	const fileStream = createReadStream(jsonlPath, { encoding: 'utf-8' });
-	const rl = createInterface({
-		input: fileStream,
+	// Phase 1: quick scan of first 50 lines for slug, startTime, userMessage, and early compaction
+	const fileStream1 = createReadStream(jsonlPath, { encoding: 'utf-8' });
+	const rl1 = createInterface({
+		input: fileStream1,
 		crlfDelay: Number.POSITIVE_INFINITY,
 	});
 
 	let lineCount = 0;
-	for await (const line of rl) {
+	for await (const line of rl1) {
 		if (line.trim().length === 0) {
 			continue;
 		}
 		lineCount++;
-
-		// Early exit: compaction summary is top priority — if found with startTime, done
-		if (compactionTitle != null && startTime != null) {
-			break;
-		}
-		// Cap scan: stop after 500 lines (compaction summaries can appear deep in the file)
-		if (lineCount > 500) {
+		if (lineCount > 50) {
 			break;
 		}
 
 		try {
 			const parsed = JSON.parse(line) as Record<string, unknown>;
 
-			// Start time from first entry with a timestamp
 			if (startTime == null && typeof parsed.timestamp === 'string') {
 				startTime = parsed.timestamp;
 			}
-
-			// Slug field — Claude Code's session name (highest priority)
 			if (slug == null && typeof parsed.slug === 'string') {
 				slug = parsed.slug;
 			}
-
-			// Compaction summary from assistant entries with acompact- agentId
-			if (compactionTitle == null && parsed.type === 'assistant') {
-				const agentId = parsed.agentId;
-				if (typeof agentId === 'string' && agentId.startsWith('acompact-')) {
-					const msg = parsed.message as Record<string, unknown> | undefined;
-					if (msg?.role === 'assistant' && Array.isArray(msg.content)) {
-						const firstBlock = msg.content[0] as Record<string, unknown> | undefined;
-						if (firstBlock?.type === 'text' && typeof firstBlock.text === 'string') {
-							compactionTitle = extractCompactionTitle(firstBlock.text);
-						}
-					}
+			// Check for compaction summary in early lines too
+			if (compactionTitle == null && parsed.type === 'user' && parsed.isCompactSummary === true) {
+				const msg = parsed.message as Record<string, unknown> | undefined;
+				if (msg?.role === 'user' && typeof msg.content === 'string') {
+					compactionTitle = extractCompactionTitle(msg.content);
 				}
 			}
-
-			// Legacy summary type (third priority)
 			if (summaryTitle == null && parsed.type === 'summary' && typeof parsed.summary === 'string') {
 				summaryTitle = parsed.summary.slice(0, 60).trim();
 			}
-
-			// First real user message (last resort)
 			if (userMessageTitle == null && parsed.type === 'user') {
 				const msg = parsed.message as Record<string, unknown> | undefined;
 				if (msg?.role === 'user') {
@@ -333,8 +318,41 @@ async function resolveSessionTitle(
 		}
 	}
 
-	rl.close();
-	fileStream.destroy();
+	rl1.close();
+	fileStream1.destroy();
+
+	// Phase 2: if no compaction title yet, fast-scan the whole file for isCompactSummary lines
+	if (compactionTitle == null) {
+		const fileStream2 = createReadStream(jsonlPath, { encoding: 'utf-8' });
+		const rl2 = createInterface({
+			input: fileStream2,
+			crlfDelay: Number.POSITIVE_INFINITY,
+		});
+
+		for await (const line of rl2) {
+			// Cheap string check before expensive JSON.parse
+			if (!line.includes('"isCompactSummary"')) {
+				continue;
+			}
+			try {
+				const parsed = JSON.parse(line) as Record<string, unknown>;
+				if (parsed.type === 'user' && parsed.isCompactSummary === true) {
+					const msg = parsed.message as Record<string, unknown> | undefined;
+					if (msg?.role === 'user' && typeof msg.content === 'string') {
+						compactionTitle = extractCompactionTitle(msg.content);
+						if (compactionTitle != null) {
+							break;
+						}
+					}
+				}
+			} catch {
+				// Skip unparseable lines
+			}
+		}
+
+		rl2.close();
+		fileStream2.destroy();
+	}
 
 	// Pick best title: compaction summary > legacy summary > slug > user message
 	const title = compactionTitle ?? summaryTitle ?? slug ?? userMessageTitle;
@@ -475,7 +493,7 @@ export const agentCommand = define({
 			if (useJson) {
 				log(JSON.stringify([]));
 			} else {
-				logger.warn('No agent usage data found.');
+				logger.debug('No agent usage data found.');
 			}
 			process.exit(0);
 		}

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -1468,7 +1468,7 @@ export const agentCommand = define({
 				}
 			}
 
-			addEmptySeparatorRow(table, 9);
+			addEmptySeparatorRow(table, headers.length);
 
 			const grandTotal =
 				totals.inputTokens +

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -172,8 +172,22 @@ function truncateAtWord(str: string, maxLen: number): string {
 		return str;
 	}
 	const lastSpace = str.lastIndexOf(' ', maxLen);
-	const truncated = lastSpace > 0 ? str.slice(0, lastSpace) : str.slice(0, maxLen);
-	return `${truncated}…`;
+	return lastSpace > 0 ? str.slice(0, lastSpace) : str.slice(0, maxLen);
+}
+
+/**
+ * Checks whether a title is valid (non-empty, not a bracketed placeholder like "[No content provided]").
+ */
+function isValidTitle(title: string): boolean {
+	return title.length > 0 && !/^\[.*\]$/.test(title);
+}
+
+/**
+ * Joins non-empty parts with ' · ' separator — prevents trailing/leading separators
+ * when some parts are empty or undefined.
+ */
+function joinParts(parts: (string | undefined)[]): string {
+	return parts.filter((p) => p != null && p !== '').join(' · ');
 }
 
 /**
@@ -373,7 +387,7 @@ async function generateAITitlesBatch(
 			if (match != null) {
 				const idx = Number.parseInt(match[1]!, 10);
 				const title = match[2]!.trim();
-				if (title.length > 0 && title.length <= 80) {
+				if (title.length > 0 && title.length <= 80 && !/^\[.*\]$/.test(title)) {
 					result.set(idx, title);
 				}
 			}
@@ -401,7 +415,7 @@ async function resolveSessionTitle(
 	const cachePath = path.join(cacheDir, sessionId);
 
 	// Check cache — versioned format: "v12\n<title>\n<startTime>"
-	// v12: ellipsis truncation on long titles
+	// v12: invalidate caches from v11 (filter bracketed AI placeholders)
 	const CACHE_VERSION = 'v12';
 	try {
 		const cached = await readFile(cachePath, 'utf-8');
@@ -411,6 +425,7 @@ async function resolveSessionTitle(
 			lines.length >= 3 &&
 			lines[1] != null &&
 			lines[1] !== '' &&
+			isValidTitle(lines[1]) &&
 			lines[2] != null &&
 			lines[2] !== ''
 		) {
@@ -555,7 +570,9 @@ async function resolveSessionTitle(
 	}
 
 	// Only compaction/summary titles are deterministic — use directly
-	const title = compactionTitle ?? summaryTitle;
+	// Filter out bracketed placeholders like "[No content provided]"
+	const rawTitle = compactionTitle ?? summaryTitle;
+	const title = rawTitle != null && isValidTitle(rawTitle) ? rawTitle : null;
 
 	if (title != null && startTime != null) {
 		try {
@@ -625,7 +642,11 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 			agent.agentId = `${prefix}${deriveAgentId({ sessionId: agent.sessionId })}`;
 		} else if (titleInfo.title != null) {
 			// Got a resolved title (cached, compaction, or user message)
-			agent.agentId = `${titleInfo.title} · ${formatStartTime(titleInfo.startTime, timezone)} · ${agent.sessionId}`;
+			agent.agentId = joinParts([
+				titleInfo.title,
+				formatStartTime(titleInfo.startTime, timezone),
+				agent.sessionId,
+			]);
 		} else {
 			// Needs AI title generation — collect for batch
 			needsAI.push({
@@ -649,7 +670,11 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 			const aiTitle = aiTitles.get(needsAI.indexOf(item) + 1);
 
 			if (aiTitle != null) {
-				agent.agentId = `${aiTitle} · ${formatStartTime(item.startTime, timezone)}${agent.sessionId != null ? ` · ${agent.sessionId}` : ''}`;
+				agent.agentId = joinParts([
+					aiTitle,
+					formatStartTime(item.startTime, timezone),
+					agent.sessionId,
+				]);
 
 				// Cache only real AI-generated titles
 				if (agent.sessionId != null) {
@@ -667,7 +692,7 @@ async function resolveLeadDisplayNames(agents: AgentUsage[], timezone?: string):
 			} else {
 				// No AI title (no substantive messages) — show truncated ID + time only
 				const shortId = agent.sessionId?.slice(0, 8) ?? 'Untitled';
-				agent.agentId = `${shortId} · ${formatStartTime(item.startTime, timezone)}`;
+				agent.agentId = joinParts([shortId, formatStartTime(item.startTime, timezone)]);
 			}
 		}
 	}
@@ -989,14 +1014,26 @@ function groupByTeamLead(
 		.sort((a, b) => b.totalCost - a.totalCost);
 
 	const rows: DisplayRow[] = [];
+	// Track sessionIds already emitted to prevent duplicate header rows
+	const emittedSessionIds = new Set<string>();
 
 	for (const group of sortedGroups) {
+		if (emittedSessionIds.has(group.sessionId)) {
+			// Already emitted — just add members under existing lead
+			group.members.sort((a, b) => b.totalCost - a.totalCost);
+			for (const m of group.members) {
+				rows.push({ data: m, isLeadHeader: false, indent: true });
+			}
+			continue;
+		}
+		emittedSessionIds.add(group.sessionId);
+
 		if (group.lead != null) {
 			rows.push({ data: group.lead, isLeadHeader: false, indent: false });
 		} else {
 			// Orphan lead — create header-only row from cached title
 			const cachedTitle = leadTitleCache.get(group.sessionId);
-			const title = cachedTitle != null ? `${cachedTitle} · ${group.sessionId}` : group.sessionId;
+			const title = joinParts([cachedTitle, group.sessionId]);
 			rows.push({
 				data: {
 					agentId: title,
@@ -1066,7 +1103,7 @@ async function loadLeadTitleCache(teamLeadMap: Map<string, string>): Promise<Map
 		try {
 			const raw = await readFile(path.join(cacheDir, sessionId), 'utf-8');
 			const lines = raw.trim().split('\n');
-			if (lines.length >= 2 && lines[1] != null && lines[1] !== '') {
+			if (lines.length >= 2 && lines[1] != null && lines[1] !== '' && isValidTitle(lines[1])) {
 				cache.set(sessionId, lines[1]);
 			}
 		} catch {

--- a/apps/ccusage/src/commands/index.ts
+++ b/apps/ccusage/src/commands/index.ts
@@ -1,6 +1,7 @@
 import process from 'node:process';
 import { cli } from 'gunshi';
 import { description, name, version } from '../../package.json';
+import { agentCommand } from './agent.ts';
 import { blocksCommand } from './blocks.ts';
 import { dailyCommand } from './daily.ts';
 import { monthlyCommand } from './monthly.ts';
@@ -10,6 +11,7 @@ import { weeklyCommand } from './weekly.ts';
 
 // Re-export all commands for easy importing
 export {
+	agentCommand,
 	blocksCommand,
 	dailyCommand,
 	monthlyCommand,
@@ -26,6 +28,7 @@ export const subCommandUnion = [
 	['monthly', monthlyCommand],
 	['weekly', weeklyCommand],
 	['session', sessionCommand],
+	['agent', agentCommand],
 	['blocks', blocksCommand],
 	['statusline', statuslineCommand],
 ] as const;

--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -13,7 +13,7 @@ import type { LoadedUsageEntry, SessionBlock } from './_session-blocks.ts';
 import type { ActivityDate, Bucket, CostMode, ModelName, SortOrder, Version } from './_types.ts';
 import { Buffer } from 'node:buffer';
 import { createReadStream, createWriteStream } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { createInterface } from 'node:readline';
@@ -67,6 +67,7 @@ import {
 	weeklyDateSchema,
 } from './_types.ts';
 import { unreachable } from './_utils.ts';
+import { deriveAgentId } from './agent-id.ts';
 import { logger } from './logger.ts';
 
 /**
@@ -169,6 +170,8 @@ export const usageDataSchema = v.object({
 	sessionId: v.optional(sessionIdSchema), // Session ID for deduplication
 	timestamp: isoTimestampSchema,
 	version: v.optional(versionSchema), // Claude Code version
+	teamName: v.optional(v.string()), // Team name for agent tracking
+	agentName: v.optional(v.string()), // Agent name for agent tracking
 	message: v.object({
 		usage: v.object({
 			input_tokens: v.number(),
@@ -1467,6 +1470,220 @@ export async function loadSessionBlockData(options?: LoadOptions): Promise<Sessi
 
 	// Sort by start time based on order option
 	return sortByDate(dateFiltered, (block) => block.startTime, options?.order);
+}
+
+/**
+ * Agent-level usage aggregation type
+ */
+export type AgentUsage = {
+	agentId: string;
+	agentName: string | undefined;
+	teamName: string | undefined;
+	sessionId: string | undefined;
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationTokens: number;
+	cacheReadTokens: number;
+	totalCost: number;
+	modelsUsed: ModelName[];
+	modelBreakdowns: ModelBreakdown[];
+	project?: string;
+};
+
+/**
+ * Options for filtering agent usage data
+ */
+type AgentLoadOptions = LoadOptions & {
+	teamFilter?: string;
+	sessionFilter?: string;
+	onProgress?: (step: string) => void;
+};
+
+/**
+ * Loads usage data grouped by agent identity
+ * Processes JSONL files and aggregates token usage per unique agent
+ * @param options - Configuration for loading, filtering, and date ranges
+ * @returns Array of agent usage summaries
+ */
+export async function loadAgentUsageData(options?: AgentLoadOptions): Promise<AgentUsage[]> {
+	const onProgress = options?.onProgress;
+
+	const mode = options?.mode ?? 'auto';
+	// Pricing fetch is the slowest step — report it first
+	onProgress?.('Fetching model pricing...');
+	using fetcher = mode === 'display' ? null : new PricingFetcher(options?.offline);
+
+	onProgress?.('Scanning session files...');
+	const claudePaths = toArray(options?.claudePath ?? getClaudePaths());
+	const filesWithBase = await globUsageFiles(claudePaths);
+
+	if (filesWithBase.length === 0) {
+		return [];
+	}
+
+	const projectFilteredWithBase = filterByProject(
+		filesWithBase,
+		(item) => extractProjectFromPath(item.file),
+		options?.project,
+	);
+
+	// Fast pre-filter: skip files not modified on or after `since` date
+	// Uses file mtime (cheap stat) to avoid parsing old sessions
+	let dateFilteredWithBase = projectFilteredWithBase;
+	if (options?.since != null && options.since !== '') {
+		const y = Number.parseInt(options.since.slice(0, 4), 10);
+		const m = Number.parseInt(options.since.slice(4, 6), 10) - 1;
+		const d = Number.parseInt(options.since.slice(6, 8), 10);
+		const cutoff = new Date(y, m, d, 0, 0, 0, 0);
+		const statResults = await Promise.all(
+			projectFilteredWithBase.map(async (item) => {
+				try {
+					const s = await stat(item.file);
+					return s.mtimeMs >= cutoff.getTime() ? item : null;
+				} catch {
+					return item; // keep files we can't stat
+				}
+			}),
+		);
+		dateFilteredWithBase = statResults.filter((item) => item != null);
+	}
+
+	const fileToBaseMap = new Map(dateFilteredWithBase.map((f) => [f.file, f.baseDir]));
+	const sortedFilesWithBase = await sortFilesByTimestamp(
+		dateFilteredWithBase.map((f) => f.file),
+	).then((sortedFiles) =>
+		sortedFiles.map((file) => ({
+			file,
+			baseDir: fileToBaseMap.get(file) ?? '',
+		})),
+	);
+
+	const processedHashes = new Set<string>();
+
+	onProgress?.(`Processing ${sortedFilesWithBase.length} session files...`);
+
+	const allEntries: Array<{
+		data: UsageData;
+		agentId: string;
+		agentName: string | undefined;
+		teamName: string | undefined;
+		sessionId: string | undefined;
+		project: string | undefined;
+		cost: number;
+		timestamp: string;
+		model: string | undefined;
+	}> = [];
+
+	for (const { file } of sortedFilesWithBase) {
+		await processJSONLFileByLine(file, async (line) => {
+			try {
+				const parsed = JSON.parse(line) as unknown;
+				const result = v.safeParse(usageDataSchema, parsed);
+				if (!result.success) {
+					return;
+				}
+				const data = result.output;
+
+				const uniqueHash = createUniqueHash(data);
+				if (isDuplicateEntry(uniqueHash, processedHashes)) {
+					return;
+				}
+				markAsProcessed(uniqueHash, processedHashes);
+
+				// Filter by date range at entry level
+				if (options?.since != null || options?.until != null) {
+					const dateStr = formatDate(data.timestamp, options?.timezone, DEFAULT_LOCALE).replace(
+						/-/g,
+						'',
+					);
+					if (options.since != null && options.since !== '' && dateStr < options.since) {
+						return;
+					}
+					if (options.until != null && options.until !== '' && dateStr > options.until) {
+						return;
+					}
+				}
+
+				const agentId = deriveAgentId({
+					teamName: data.teamName,
+					agentName: data.agentName,
+					sessionId: data.sessionId,
+				});
+
+				// Apply team/session filters
+				if (options?.teamFilter != null && data.teamName !== options.teamFilter) {
+					return;
+				}
+				if (options?.sessionFilter != null && data.sessionId !== options.sessionFilter) {
+					return;
+				}
+
+				const cost =
+					fetcher != null ? await calculateCostForEntry(data, mode, fetcher) : (data.costUSD ?? 0);
+
+				allEntries.push({
+					data,
+					agentId,
+					agentName: data.agentName,
+					teamName: data.teamName,
+					sessionId: data.sessionId,
+					project: extractProjectFromPath(file),
+					cost,
+					timestamp: data.timestamp,
+					model: getDisplayModelName(data),
+				});
+			} catch {
+				// Skip invalid JSON lines
+			}
+		});
+	}
+
+	const groupedByAgent = groupBy(allEntries, (entry) => entry.agentId);
+
+	const results: AgentUsage[] = [];
+
+	for (const [agentId, entries] of Object.entries(groupedByAgent)) {
+		if (entries == null) {
+			continue;
+		}
+
+		const modelAggregates = aggregateByModel(
+			entries,
+			(entry) => entry.model,
+			(entry) => entry.data.message.usage,
+			(entry) => entry.cost,
+		);
+		const modelBreakdowns = createModelBreakdowns(modelAggregates);
+
+		const totalsFull = calculateTotals(
+			entries,
+			(entry) => entry.data.message.usage,
+			(entry) => entry.cost,
+		);
+		const totals = {
+			inputTokens: totalsFull.inputTokens,
+			outputTokens: totalsFull.outputTokens,
+			cacheCreationTokens: totalsFull.cacheCreationTokens,
+			cacheReadTokens: totalsFull.cacheReadTokens,
+			totalCost: totalsFull.totalCost,
+		};
+
+		const modelsUsed = extractUniqueModels(entries, (e) => e.model);
+		const first = entries[0];
+
+		results.push({
+			agentId,
+			agentName: first?.agentName,
+			teamName: first?.teamName,
+			sessionId: first?.sessionId,
+			project: first?.project,
+			...totals,
+			modelsUsed: modelsUsed as ModelName[],
+			modelBreakdowns,
+		});
+	}
+
+	return results;
 }
 
 if (import.meta.vitest != null) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,5 +3,5 @@ import { ryoppippi } from '@ryoppippi/eslint-config';
 export default ryoppippi({
 	type: 'lib',
 	stylistic: false,
-	ignores: ['apps', 'packages', 'docs', '.claude/settings.local.json'],
+	ignores: ['apps', 'packages', 'docs', 'scripts', '.claude/settings.local.json'],
 });

--- a/hooks/cache-team-lead.sh
+++ b/hooks/cache-team-lead.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# PostToolUse hook: cache team→lead session mapping when TeamCreate is called.
+# Writes ~/.claude/team-lead-cache/{team_name} = {session_id}
+# Used by ccusage agent to nest team members under their parent lead,
+# even after JSONL compaction destroys the TeamCreate tool_use entries.
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+if [ "$TOOL" != "TeamCreate" ]; then
+  exit 0
+fi
+
+TEAM_NAME=$(echo "$INPUT" | jq -r '.tool_input.team_name // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+if [ -z "$TEAM_NAME" ] || [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+CACHE_DIR="$HOME/.claude/team-lead-cache"
+mkdir -p "$CACHE_DIR"
+echo -n "$SESSION_ID" > "$CACHE_DIR/$TEAM_NAME"
+exit 0

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -69,6 +69,8 @@ export type TableRow = (string | number | { content: string; hAlign?: TableCellA
 export type TableOptions = {
 	head: string[];
 	colAligns?: TableCellAlign[];
+	/** Per-column max width overrides. Sparse array — only indices with values are applied. */
+	colWidthOverrides?: Record<number, number>;
 	style?: {
 		head?: string[];
 	};
@@ -88,6 +90,7 @@ export class ResponsiveTable {
 	private head: string[];
 	private rows: TableRow[] = [];
 	private colAligns: TableCellAlign[];
+	private colWidthOverrides: Record<number, number>;
 	private style?: { head?: string[] };
 	private dateFormatter?: (dateStr: string) => string;
 	private compactHead?: string[];
@@ -104,6 +107,7 @@ export class ResponsiveTable {
 	constructor(options: TableOptions) {
 		this.head = options.head;
 		this.colAligns = options.colAligns ?? Array.from({ length: this.head.length }, () => 'left');
+		this.colWidthOverrides = options.colWidthOverrides ?? {};
 		this.style = options.style;
 		this.dateFormatter = options.dateFormatter;
 		this.compactHead = options.compactHead;
@@ -224,6 +228,11 @@ export class ResponsiveTable {
 		// Always use content-based widths with generous padding for numeric columns
 		const columnWidths = contentWidths.map((width, index) => {
 			const align = colAligns[index];
+			// Apply explicit max-width overrides — caps content-based width
+			const override = this.colWidthOverrides[index];
+			if (override != null) {
+				return Math.min(Math.max(width + 2, 10), override);
+			}
 			// For numeric columns, ensure generous width to prevent truncation
 			if (align === 'right') {
 				return Math.max(width + 3, 11); // At least 11 chars for numbers, +3 padding
@@ -253,6 +262,12 @@ export class ResponsiveTable {
 					adjustedWidth = Math.max(adjustedWidth, 12);
 				} else {
 					adjustedWidth = Math.max(adjustedWidth, 8);
+				}
+
+				// Apply explicit max-width overrides
+				const override = this.colWidthOverrides[index];
+				if (override != null) {
+					adjustedWidth = Math.min(adjustedWidth, override);
 				}
 
 				return adjustedWidth;

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -248,7 +248,7 @@ export class ResponsiveTable {
 				if (align === 'right') {
 					adjustedWidth = Math.max(adjustedWidth, 10);
 				} else if (index === 0) {
-					adjustedWidth = Math.max(adjustedWidth, 10);
+					adjustedWidth = Math.max(adjustedWidth, 28);
 				} else if (index === 1) {
 					adjustedWidth = Math.max(adjustedWidth, 12);
 				} else {

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -257,7 +257,8 @@ export class ResponsiveTable {
 				if (align === 'right') {
 					adjustedWidth = Math.max(adjustedWidth, 10);
 				} else if (index === 0) {
-					adjustedWidth = Math.max(adjustedWidth, 28);
+					// 38 = UUID (36) + 2 padding; ensures session IDs aren't truncated
+					adjustedWidth = Math.max(adjustedWidth, 38);
 				} else if (index === 1) {
 					adjustedWidth = Math.max(adjustedWidth, 12);
 				} else {

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -307,6 +307,24 @@ export class ResponsiveTable {
 						processedRow = this.filterRowToCompact(processedRow, compactIndices);
 					}
 
+					// Truncate left-aligned text columns that exceed their column width
+					processedRow = processedRow.map((cell, index) => {
+						const colWidth = adjustedWidths[index];
+						if (colWidth == null || typeof cell !== 'string') {
+							return cell;
+						}
+						const align = colAligns[index];
+						if (align === 'right') {
+							return cell;
+						}
+						// Skip truncation for multiline cells — wordWrap handles them
+						if (cell.includes('\n')) {
+							return cell;
+						}
+						// Subtract 2 for cell padding
+						return this.truncateWithEllipsis(cell, colWidth - 2);
+					});
+
 					table.push(processedRow);
 				}
 			}
@@ -339,6 +357,35 @@ export class ResponsiveTable {
 
 			return table.toString();
 		}
+	}
+
+	/**
+	 * Truncates a string to fit within a column width, adding ellipsis if needed
+	 * @param text - Text to truncate
+	 * @param maxWidth - Maximum visual width (excluding cell padding)
+	 * @returns Truncated text with ellipsis if it was cut
+	 */
+	private truncateWithEllipsis(text: string, maxWidth: number): string {
+		if (maxWidth <= 0 || stringWidth(text) <= maxWidth) {
+			return text;
+		}
+		// Find the last space before the max width for word-boundary truncation
+		let truncated = '';
+		let width = 0;
+		for (const char of text) {
+			const charWidth = stringWidth(char);
+			if (width + charWidth > maxWidth - 1) {
+				break;
+			}
+			truncated += char;
+			width += charWidth;
+		}
+		// Try to break at a word boundary
+		const lastSpace = truncated.lastIndexOf(' ');
+		if (lastSpace > truncated.length * 0.5) {
+			truncated = truncated.slice(0, lastSpace);
+		}
+		return `${truncated}…`;
 	}
 
 	/**

--- a/scripts/find-agent-id.mjs
+++ b/scripts/find-agent-id.mjs
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+
+/**
+ * find-agent-id.mjs
+ *
+ * Finds resumable agent IDs from Claude Code JSONL session files.
+ * Supports two ID formats:
+ *   - Team members (TeamCreate): "name@team" from teammate_spawned entries
+ *   - Bare Agent subagents: hex IDs from agent_progress entries
+ *
+ * Usage:
+ *   node scripts/find-agent-id.mjs --team ccusage-fork --agent implementer
+ *   node scripts/find-agent-id.mjs --team ccusage-fork
+ *   node scripts/find-agent-id.mjs --session dff4e7a9-f255-46f2-91f3-fc8f4c367118
+ */
+
+import { createReadStream } from 'node:fs';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+	options: {
+		team: { type: 'string', short: 't' },
+		agent: { type: 'string', short: 'a' },
+		session: { type: 'string', short: 's' },
+		limit: { type: 'string', short: 'n', default: '20' },
+		verbose: { type: 'boolean', short: 'v', default: false },
+	},
+});
+
+if (!values.team && !values.agent && !values.session) {
+	console.error('Usage: node find-agent-id.mjs --team <name> [--agent <name>] [--session <id>]');
+	console.error('  -t, --team     Team name filter');
+	console.error('  -a, --agent    Agent name filter');
+	console.error('  -s, --session  Session ID to scan (instead of all files)');
+	console.error('  -n, --limit    Max results (default: 20)');
+	console.error('  -v, --verbose  Show source file paths');
+	process.exit(1);
+}
+
+const limit = Number.parseInt(values.limit, 10) || 20;
+
+/**
+ * Try to find lead session file(s) from team config
+ */
+async function getTeamLeadFiles(teamName) {
+	const configPath = join(homedir(), '.claude', 'teams', teamName, 'config.json');
+	try {
+		const config = JSON.parse(await readFile(configPath, 'utf-8'));
+		const leadSessionId = config.leadSessionId;
+		if (!leadSessionId) {
+			return null;
+		}
+
+		return await findSessionFiles(leadSessionId);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Find JSONL file(s) for a given session ID across all project dirs
+ */
+async function findSessionFiles(sessionId) {
+	const bases = [
+		join(homedir(), '.claude', 'projects'),
+		join(homedir(), '.config', 'claude', 'projects'),
+	];
+
+	const files = [];
+	for (const base of bases) {
+		try {
+			const projects = await readdir(base);
+			for (const proj of projects) {
+				const candidate = join(base, proj, `${sessionId}.jsonl`);
+				try {
+					await stat(candidate);
+					files.push(candidate);
+				} catch {
+					// not found
+				}
+			}
+		} catch {
+			// base doesn't exist
+		}
+	}
+
+	return files.length > 0 ? files : null;
+}
+
+/**
+ * Collect ALL JSONL files from Claude project directories
+ */
+async function getAllJsonlFiles() {
+	const bases = [
+		join(homedir(), '.claude', 'projects'),
+		join(homedir(), '.config', 'claude', 'projects'),
+	];
+
+	const files = [];
+	for (const base of bases) {
+		try {
+			const projects = await readdir(base);
+			for (const proj of projects) {
+				const dir = join(base, proj);
+				try {
+					const s = await stat(dir);
+					if (!s.isDirectory()) {
+						continue;
+					}
+					const entries = await readdir(dir);
+					for (const e of entries) {
+						if (e.endsWith('.jsonl')) {
+							files.push(join(dir, e));
+						}
+					}
+				} catch {
+					// skip
+				}
+			}
+		} catch {
+			// base doesn't exist
+		}
+	}
+	return files;
+}
+
+/**
+ * Scan a JSONL file for:
+ * 1. teammate_spawned tool results (team members with name@team IDs)
+ * 2. agent_progress entries (bare Agents with hex IDs)
+ */
+async function scanFile(filePath, teamFilter, agentFilter) {
+	const results = [];
+	const stream = createReadStream(filePath, { encoding: 'utf-8' });
+	const rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+	for await (const line of rl) {
+		// Strategy 1: Find teammate_spawned entries (TeamCreate members)
+		if (line.includes('teammate_spawned')) {
+			try {
+				const parsed = JSON.parse(line);
+				const toolResult = parsed.toolUseResult;
+				if (toolResult?.status !== 'teammate_spawned') {
+					continue;
+				}
+
+				const agentId = toolResult.agent_id;
+				const name = toolResult.name;
+				const teamName = toolResult.team_name;
+				if (!agentId) {
+					continue;
+				}
+
+				// Apply filters
+				if (teamFilter && teamName !== teamFilter) {
+					continue;
+				}
+				if (agentFilter && name !== agentFilter) {
+					continue;
+				}
+
+				results.push({
+					timestamp: parsed.timestamp || 'unknown',
+					agentId,
+					label: `${teamName}/${name}`,
+					type: 'team-member',
+					model: toolResult.model,
+					source: filePath,
+				});
+			} catch {
+				// skip
+			}
+			continue;
+		}
+
+		// Strategy 2: Find agent_progress entries (bare Agent subagents)
+		if (line.includes('"agent_progress"')) {
+			// Fast string filter: if team/agent name provided, check line contains it
+			if (teamFilter && !line.includes(teamFilter)) {
+				continue;
+			}
+			if (agentFilter && !line.includes(agentFilter)) {
+				continue;
+			}
+
+			try {
+				const parsed = JSON.parse(line);
+				if (parsed.type !== 'progress') {
+					continue;
+				}
+				if (parsed.data?.type !== 'agent_progress') {
+					continue;
+				}
+
+				const hexId = parsed.data.agentId;
+				if (!hexId || typeof hexId !== 'string') {
+					continue;
+				}
+
+				// Try to extract team/agent info from the nested message
+				let nestedTeam = null;
+				let nestedAgent = null;
+
+				const msg = parsed.data.message;
+				if (msg) {
+					// The nested message may have teamName/agentName directly
+					if (msg.teamName) {
+						nestedTeam = msg.teamName;
+					}
+					if (msg.agentName) {
+						nestedAgent = msg.agentName;
+					}
+				}
+
+				// If we have a prompt, use it for the label
+				const prompt = parsed.data.prompt;
+				let label = 'bare-agent';
+				if (nestedTeam && nestedAgent) {
+					label = `${nestedTeam}/${nestedAgent}`;
+				} else if (prompt) {
+					// Extract first 40 chars of prompt as label
+					label = `agent: ${prompt.slice(0, 40).replace(/\n/g, ' ')}...`;
+				}
+
+				// Strict filter: if team/agent specified, only include if nested data matches
+				if (teamFilter && nestedTeam !== teamFilter) {
+					continue;
+				}
+				if (agentFilter && nestedAgent !== agentFilter) {
+					continue;
+				}
+
+				results.push({
+					timestamp: parsed.timestamp || 'unknown',
+					agentId: hexId,
+					label,
+					type: 'bare-agent',
+					source: filePath,
+				});
+			} catch {
+				// skip
+			}
+		}
+	}
+
+	rl.close();
+	stream.destroy();
+	return results;
+}
+
+async function main() {
+	const { team: teamFilter, agent: agentFilter, session: sessionFilter } = values;
+
+	// Determine which files to scan
+	let files;
+
+	if (sessionFilter) {
+		// Scan specific session
+		files = await findSessionFiles(sessionFilter);
+		if (!files) {
+			console.error(`Session file not found: ${sessionFilter}`);
+			process.exit(1);
+		}
+		console.error(`Scanning session ${sessionFilter}`);
+	} else if (teamFilter) {
+		// Try lead session first (fast path)
+		const leadFiles = await getTeamLeadFiles(teamFilter);
+		if (leadFiles) {
+			console.error(
+				`Found lead session for team "${teamFilter}" — scanning ${leadFiles.length} file(s)`,
+			);
+			files = leadFiles;
+		} else {
+			console.error(`No team config for "${teamFilter}" — scanning all files`);
+			files = await getAllJsonlFiles();
+		}
+	} else {
+		console.error('Scanning all JSONL files...');
+		files = await getAllJsonlFiles();
+	}
+
+	console.error(`Scanning ${files.length} file(s)...`);
+
+	const allResults = [];
+	for (const f of files) {
+		const results = await scanFile(f, teamFilter, agentFilter);
+		allResults.push(...results);
+	}
+
+	// Deduplicate by agentId, keep the EARLIEST timestamp per ID
+	const byId = new Map();
+	for (const r of allResults) {
+		const existing = byId.get(r.agentId);
+		if (!existing || r.timestamp < existing.timestamp) {
+			byId.set(r.agentId, r);
+		}
+	}
+
+	const unique = Array.from(byId.values());
+	// Sort newest first
+	unique.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+	if (unique.length === 0) {
+		console.error('No matching entries found.');
+		process.exit(1);
+	}
+
+	// Output
+	const display = unique.slice(0, limit);
+	for (const r of display) {
+		const parts = [r.timestamp, r.label, r.agentId];
+		if (r.type === 'team-member' && r.model) {
+			parts.push(`(${r.model})`);
+		}
+		if (r.type === 'bare-agent') {
+			parts.push('(bare-agent)');
+		}
+		if (values.verbose) {
+			parts.push(r.source);
+		}
+		console.log(parts.join('  '));
+	}
+
+	console.error(`\n${display.length} result(s) shown (${unique.length} total)`);
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Problem

When using Claude Code's team/agent system heavily, there's no way to see session relationships, costs, or easily resume past sessions. You have to manually inspect JSONL files to understand which sessions are related or find a session UUID for `claude --resume`.

## Solution

This PR adds a new `ccusage agent` command that provides a rich, hierarchical view of Claude Code agent sessions.

### 1. Hierarchical team grouping

Team members are nested under their lead session using indentation, making multi-agent work sessions immediately scannable:

```
Agent                                         │ Model            │ Msgs │  Cost  │  %   │ Cache R │ Cache W
──────────────────────────────────────────────┼──────────────────┼──────┼────────┼──────┼─────────┼────────
Investigating ccusage session file origins    │                  │      │        │      │         │
dff4e7a9-f255-46f2-91f3-fc8f4c367118         │ claude-sonnet-4-6│ 120  │ $1.23  │ 44%  │  1.2M   │  45K
  └─ learner                                  │ claude-opus-4-6  │  65  │ $0.69  │ 25%  │   800K  │  22K
  └─ researcher                               │ claude-opus-4-6  │  43  │ $0.44  │ 16%  │   540K  │  18K
  └─ implementer                              │ claude-opus-4-6  │  88  │ $0.92  │ 33%  │   960K  │  31K
──────────────────────────────────────────────┼──────────────────┼──────┼────────┼──────┼─────────┼────────
Fixing PR iteration loop                      │                  │      │        │      │         │
2748feee-b651-4a4b-b2df-00a0fb6d4801         │ claude-opus-4-6  │  55  │ $0.61  │ 22%  │   620K  │  19K
  └─ pr-reviewer                              │ claude-opus-4-6  │  31  │ $0.38  │ 14%  │   410K  │  12K
```

### 2. Full session UUID on lead rows

Lead rows display the full 36-char UUID, enabling direct session resume:

```bash
# Copy UUID from ccusage agent output, paste directly:
claude --resume dff4e7a9-f255-46f2-91f3-fc8f4c367118
# → Resumes the session immediately, no search dialog
```

### 3. AI-generated session titles

Lead rows show a human-readable title generated via Claude Haiku API. The generator uses compaction summaries from the session JSONL as input to produce concise, descriptive titles (≤60 chars). When no compaction summary is available, the title falls back to a truncated session ID. Slugs were removed entirely as a title source. Titles are cached to `~/.claude/session-titles/<sessionId>` to avoid re-generating on every invocation.

### 4. Orphan team discovery

Sessions spawned as Claude Code team members are linked back to their lead via a 3-phase chain:
1. **Persistent cache** (`~/.claude/team-lead-cache/`): populated by a PostToolUse hook at `TeamCreate` time
2. **Subagent directory scan**: reads `{leadSessionId}/subagents/` directories written by Claude Code
3. **JSONL scan**: finds `TeamCreate` tool_use entries in lead session JSONL files as a final fallback

### 5. Cost % column

A `%` column shows each session's share of total spend — useful for spotting expensive workers at a glance.

## Technical details

New files:
- `agent.ts`: the full `ccusage agent` command implementation including `discoverOrphanTeams()` (3-phase parent discovery) and hierarchical rendering
- `agent-id.ts`: public agent identifier utilities
- `cache-team-lead.sh`: PostToolUse hook that captures team→lead mappings at `TeamCreate` time
- `find-agent-id.mjs`: script for discovering agent IDs from session files

Modified files:
- `data-loader.ts`: new loader to fetch per-agent usage data
- `table.ts`: per-column width overrides to accommodate 36-char UUIDs
- `commands/index.ts`: registers the new `agent` subcommand
- `config-schema.json` / `package.json`: schema and dependency additions

Implementation notes:
- `peekTeamName()` reads only the first 5 lines of a JSONL file to extract `teamName` efficiently  
- Array content handling: Claude Code JSONL `content` field is sometimes a string, sometimes `{type:"text", text:"..."}[]` with optional `isMeta: true` entries — both forms are handled
- Column 0 responsive minimum widened from 28 → 38 chars to accommodate 36-char UUIDs without truncation

## Test plan

- [ ] `ccusage agent` shows team members nested under their lead session
- [ ] Lead rows display full 36-char UUIDs
- [ ] `claude --resume <uuid-from-ccusage>` resumes directly without interactive search
- [ ] Session titles show AI-generated summaries where available
- [ ] Sessions without a parent are still shown (ungrouped, at bottom)
- [ ] `%` column sums to ~100% across all rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-agent usage reporter: grouped by team/lead with AI-assisted session titles, JSON and rich table outputs, agent-level aggregations, filters (time, team, session) and breakdowns.
  * Agent discovery tool and a hook to cache team-lead mappings.
  * Public agent identifier utilities and a loader to fetch per-agent usage.
  * Table display: per-column width overrides.

* **Documentation**
  * Added "Agent Command Notes" and expanded testing guidelines (Vitest globals, model testing, mock data, avoid dynamic imports).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->