### PR TITLE
fix(codex): correct session command in README

### DIFF
--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -70,7 +70,7 @@ npx @ccusage/codex@latest monthly
 npx @ccusage/codex@latest monthly --json
 
 # Session-level detailed report
-npx @ccusage/codex@latest sessions
+npx @ccusage/codex@latest session
 ```
 
 Useful environment variables:


### PR DESCRIPTION
### Motivation
- Fix an incorrect example in the Codex README where the CLI subcommand was documented as `npx @ccusage/codex@latest sessions` instead of the actual `npx @ccusage/codex@latest session`.

### Description
- Replace the incorrect command in `apps/codex/README.md`, changing `npx @ccusage/codex@latest sessions` to `npx @ccusage/codex@latest session`.

### Testing
- Ran `pnpm run format`, which completed successfully.
- Ran `pnpm typecheck`, which failed due to existing TypeScript typing issues in the baseline unrelated to this README change.
- Ran `pnpm run test`, which showed baseline test failures in `apps/ccusage` caused by environment-dependent pricing and Claude data-dir issues and are unrelated to this documentation fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Codex CLI command documentation for session-level detailed reports to reflect the accurate command syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->