### PR TITLE
fix(ccusage): sort session reports by cost instead of last activity

### DIFF
--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -20,6 +20,7 @@ import { createInterface } from 'node:readline';
 import { toArray } from '@antfu/utils';
 import { Result } from '@praha/byethrow';
 import { groupBy, uniq } from 'es-toolkit'; // TODO: after node20 is deprecated, switch to native Object.groupBy
+import { sort } from 'fast-sort';
 import { createFixture } from 'fs-fixture';
 import { isDirectorySync } from 'path-type';
 import { glob } from 'tinyglobby';
@@ -904,7 +905,7 @@ export async function loadDailyUsageData(options?: LoadOptions): Promise<DailyUs
  * Loads and aggregates Claude usage data by session
  * Groups usage data by project path and session ID based on file structure
  * @param options - Optional configuration for loading and filtering data
- * @returns Array of session usage summaries sorted by last activity
+ * @returns Array of session usage summaries sorted by cost (highest first)
  */
 export async function loadSessionData(options?: LoadOptions): Promise<SessionUsage[]> {
 	// Get all Claude paths or use the specific one from options
@@ -1080,7 +1081,17 @@ export async function loadSessionData(options?: LoadOptions): Promise<SessionUsa
 		options?.project,
 	);
 
-	return sortByDate(sessionFiltered, (item) => item.lastActivity, options?.order);
+	// Sort sessions by cost (highest first by default), as documented
+	const sorted = sort(sessionFiltered);
+	const order = options?.order ?? 'desc';
+	switch (order) {
+		case 'asc':
+			return sorted.asc((item) => item.totalCost);
+		case 'desc':
+			return sorted.desc((item) => item.totalCost);
+		default:
+			unreachable(order);
+	}
 }
 
 /**
@@ -2820,14 +2831,14 @@ invalid json line
 			expect(session?.versions).toEqual(['1.0.0', '1.1.0']); // Sorted and unique
 		});
 
-		it('sorts by last activity descending', async () => {
+		it('sorts by cost descending by default', async () => {
 			const sessions = [
 				{
 					sessionId: 'session1',
 					data: {
 						timestamp: createISOTimestamp('2024-01-15T12:00:00Z'),
 						message: { usage: { input_tokens: 100, output_tokens: 50 } },
-						costUSD: 0.01,
+						costUSD: 0.05,
 					},
 				},
 				{
@@ -2843,7 +2854,7 @@ invalid json line
 					data: {
 						timestamp: createISOTimestamp('2024-01-31T12:00:00Z'),
 						message: { usage: { input_tokens: 100, output_tokens: 50 } },
-						costUSD: 0.01,
+						costUSD: 0.1,
 					},
 				},
 			];
@@ -2856,21 +2867,21 @@ invalid json line
 				},
 			});
 
-			const result = await loadSessionData({ claudePath: fixture.path });
+			const result = await loadSessionData({ claudePath: fixture.path, mode: 'display' });
 
-			expect(result[0]?.sessionId).toBe('session3');
+			expect(result[0]?.sessionId).toBe('session3'); // highest cost
 			expect(result[1]?.sessionId).toBe('session1');
-			expect(result[2]?.sessionId).toBe('session2');
+			expect(result[2]?.sessionId).toBe('session2'); // lowest cost
 		});
 
-		it("sorts by last activity ascending when order is 'asc'", async () => {
+		it("sorts by cost ascending when order is 'asc'", async () => {
 			const sessions = [
 				{
 					sessionId: 'session1',
 					data: {
 						timestamp: createISOTimestamp('2024-01-15T12:00:00Z'),
 						message: { usage: { input_tokens: 100, output_tokens: 50 } },
-						costUSD: 0.01,
+						costUSD: 0.05,
 					},
 				},
 				{
@@ -2886,7 +2897,7 @@ invalid json line
 					data: {
 						timestamp: createISOTimestamp('2024-01-31T12:00:00Z'),
 						message: { usage: { input_tokens: 100, output_tokens: 50 } },
-						costUSD: 0.01,
+						costUSD: 0.1,
 					},
 				},
 			];
@@ -2902,21 +2913,22 @@ invalid json line
 			const result = await loadSessionData({
 				claudePath: fixture.path,
 				order: 'asc',
+				mode: 'display',
 			});
 
-			expect(result[0]?.sessionId).toBe('session2'); // oldest first
+			expect(result[0]?.sessionId).toBe('session2'); // lowest cost first
 			expect(result[1]?.sessionId).toBe('session1');
-			expect(result[2]?.sessionId).toBe('session3'); // newest last
+			expect(result[2]?.sessionId).toBe('session3'); // highest cost last
 		});
 
-		it("sorts by last activity descending when order is 'desc'", async () => {
+		it("sorts by cost descending when order is 'desc'", async () => {
 			const sessions = [
 				{
 					sessionId: 'session1',
 					data: {
 						timestamp: createISOTimestamp('2024-01-15T12:00:00Z'),
 						message: { usage: { input_tokens: 100, output_tokens: 50 } },
-						costUSD: 0.01,
+						costUSD: 0.05,
 					},
 				},
 				{
@@ -2932,7 +2944,7 @@ invalid json line
 					data: {
 						timestamp: createISOTimestamp('2024-01-31T12:00:00Z'),
 						message: { usage: { input_tokens: 100, output_tokens: 50 } },
-						costUSD: 0.01,
+						costUSD: 0.1,
 					},
 				},
 			];
@@ -2948,11 +2960,12 @@ invalid json line
 			const result = await loadSessionData({
 				claudePath: fixture.path,
 				order: 'desc',
+				mode: 'display',
 			});
 
-			expect(result[0]?.sessionId).toBe('session3'); // newest first (same as default)
+			expect(result[0]?.sessionId).toBe('session3'); // highest cost (same as default)
 			expect(result[1]?.sessionId).toBe('session1');
-			expect(result[2]?.sessionId).toBe('session2'); // oldest last
+			expect(result[2]?.sessionId).toBe('session2'); // lowest cost
 		});
 
 		it('filters by date range based on last activity', async () => {


### PR DESCRIPTION
## Problem

The [Session Reports documentation](https://ccusage.com/guide/session-reports#sorting) says:

> Sessions are sorted by cost (highest first) by default

But actually running `pnpx ccusage session` shows entries sorted by Last Activity timestamp instead of by Cost. This was confusing because the expensive sessions were not at the top like I was expecting.

## What I changed

In `apps/ccusage/src/data-loader.ts`, the `loadSessionData` function was using `sortByDate` on `lastActivity` field:

```ts
// before
return sortByDate(sessionFiltered, (item) => item.lastActivity, options?.order);
```

Changed to sort by `totalCost` using `fast-sort` directly:

```ts
// after
const sorted = sort(sessionFiltered);
const order = options?.order ?? 'desc';
switch (order) {
  case 'asc':
    return sorted.asc((item) => item.totalCost);
  case 'desc':
    return sorted.desc((item) => item.totalCost);
  default:
    unreachable(order);
}
```

Also updated:
- The JSDoc comment that said "sorted by last activity" to say "sorted by cost"
- The 3 related tests to use different `costUSD` values per session so they actually verify sorting by cost and not just any order

## Testing

- All 252 tests pass (127 in data-loader.ts)
- `pnpm run format` passes
- Tests now use `costUSD: 0.01`, `0.05`, `0.10` to verify cost ordering works correct

Closes #903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sessions are now sorted by total cost (highest to lowest) by default, making it easier to spot expensive sessions.
  * Sorting can be reversed to show lowest-cost sessions first.
  * Display-mode session lists now align ordering with the displayed cost values for consistent viewing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/907)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->