### PR TITLE
feat(codex): Added last subcommand:  npx @ccusage/codex@latest last --day <n>

### DIFF
--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -60,6 +60,9 @@ npx @ccusage/codex@latest daily
 # Date range filtering
 npx @ccusage/codex@latest daily --since 20250911 --until 20250917
 
+# Last N days (excluding today)
+npx @ccusage/codex@latest last --day 10
+
 # JSON output for scripting
 npx @ccusage/codex@latest daily --json
 

--- a/apps/codex/src/commands/last.ts
+++ b/apps/codex/src/commands/last.ts
@@ -1,0 +1,224 @@
+import process from 'node:process';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatDateCompact,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { DEFAULT_TIMEZONE } from '../_consts.ts';
+import { sharedArgs } from '../_shared-args.ts';
+import { formatModelsList, splitUsageTokens } from '../command-utils.ts';
+import { buildDailyReport } from '../daily-report.ts';
+import { loadTokenUsageEvents } from '../data-loader.ts';
+import { formatDisplayDate, getLastNDaysRange } from '../date-utils.ts';
+import { log, logger } from '../logger.ts';
+import { CodexPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 8;
+
+export const lastCommand = define({
+	name: 'last',
+	description: 'Show Codex token usage for the last N days (excluding today)',
+	args: {
+		...sharedArgs,
+		day: {
+			type: 'string',
+			description: 'Number of days to include (must be a positive integer)',
+			required: true,
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+		if (jsonOutput) {
+			logger.level = 0;
+		}
+
+		const rawDay = String(ctx.values.day ?? '').trim();
+		if (!/^\d+$/.test(rawDay)) {
+			logger.error(`Invalid --day value: ${rawDay}. Expected a positive integer.`);
+			process.exit(1);
+		}
+
+		const dayCount = Number.parseInt(rawDay, 10);
+		if (!Number.isSafeInteger(dayCount) || dayCount <= 0) {
+			logger.error(`Invalid --day value: ${rawDay}. Expected a positive integer greater than 0.`);
+			process.exit(1);
+		}
+
+		const range = getLastNDaysRange(dayCount, ctx.values.timezone);
+		const displaySince = formatDisplayDate(range.since, ctx.values.locale, ctx.values.timezone);
+		const displayUntil = formatDisplayDate(range.until, ctx.values.locale, ctx.values.timezone);
+
+		const { events, missingDirectories } = await loadTokenUsageEvents();
+
+		for (const missing of missingDirectories) {
+			logger.warn(`Codex session directory not found: ${missing}`);
+		}
+
+		if (events.length === 0) {
+			if (jsonOutput) {
+				log(
+					JSON.stringify({
+						range,
+						daily: [],
+						totals: null,
+					}),
+				);
+				return;
+			}
+			logger.info(
+				`Date range: ${displaySince} ~ ${displayUntil} (${range.since} to ${range.until})`,
+			);
+			log('No Codex usage data found.');
+			return;
+		}
+
+		const pricingSource = new CodexPricingSource({
+			offline: ctx.values.offline,
+		});
+		try {
+			const rows = await buildDailyReport(events, {
+				pricingSource,
+				timezone: ctx.values.timezone,
+				locale: ctx.values.locale,
+				since: range.since,
+				until: range.until,
+			});
+
+			if (rows.length === 0) {
+				if (jsonOutput) {
+					log(
+						JSON.stringify({
+							range,
+							daily: [],
+							totals: null,
+						}),
+					);
+					return;
+				}
+				logger.info(
+					`Date range: ${displaySince} ~ ${displayUntil} (${range.since} to ${range.until})`,
+				);
+				log('No Codex usage data found for provided filters.');
+				return;
+			}
+
+			const totals = rows.reduce(
+				(acc, row) => {
+					acc.inputTokens += row.inputTokens;
+					acc.cachedInputTokens += row.cachedInputTokens;
+					acc.outputTokens += row.outputTokens;
+					acc.reasoningOutputTokens += row.reasoningOutputTokens;
+					acc.totalTokens += row.totalTokens;
+					acc.costUSD += row.costUSD;
+					return acc;
+				},
+				{
+					inputTokens: 0,
+					cachedInputTokens: 0,
+					outputTokens: 0,
+					reasoningOutputTokens: 0,
+					totalTokens: 0,
+					costUSD: 0,
+				},
+			);
+
+			if (jsonOutput) {
+				log(
+					JSON.stringify(
+						{
+							range,
+							daily: rows,
+							totals,
+						},
+						null,
+						2,
+					),
+				);
+				return;
+			}
+
+			logger.box(
+				`Codex Token Usage Report - Last ${dayCount} Days (Timezone: ${ctx.values.timezone ?? DEFAULT_TIMEZONE})`,
+			);
+			logger.info(
+				`Date range: ${displaySince} ~ ${displayUntil} (${range.since} to ${range.until})`,
+			);
+
+			const table: ResponsiveTable = new ResponsiveTable({
+				head: [
+					'Date',
+					'Models',
+					'Input',
+					'Output',
+					'Reasoning',
+					'Cache Read',
+					'Total Tokens',
+					'Cost (USD)',
+				],
+				colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
+				compactHead: ['Date', 'Models', 'Input', 'Output', 'Cost (USD)'],
+				compactColAligns: ['left', 'left', 'right', 'right', 'right'],
+				compactThreshold: 100,
+				forceCompact: ctx.values.compact,
+				style: { head: ['cyan'] },
+				dateFormatter: (dateStr: string) => formatDateCompact(dateStr),
+			});
+
+			const totalsForDisplay = {
+				inputTokens: 0,
+				outputTokens: 0,
+				reasoningTokens: 0,
+				cacheReadTokens: 0,
+				totalTokens: 0,
+				costUSD: 0,
+			};
+
+			for (const row of rows) {
+				const split = splitUsageTokens(row);
+				totalsForDisplay.inputTokens += split.inputTokens;
+				totalsForDisplay.outputTokens += split.outputTokens;
+				totalsForDisplay.reasoningTokens += split.reasoningTokens;
+				totalsForDisplay.cacheReadTokens += split.cacheReadTokens;
+				totalsForDisplay.totalTokens += row.totalTokens;
+				totalsForDisplay.costUSD += row.costUSD;
+
+				table.push([
+					row.date,
+					formatModelsDisplayMultiline(formatModelsList(row.models)),
+					formatNumber(split.inputTokens),
+					formatNumber(split.outputTokens),
+					formatNumber(split.reasoningTokens),
+					formatNumber(split.cacheReadTokens),
+					formatNumber(row.totalTokens),
+					formatCurrency(row.costUSD),
+				]);
+			}
+
+			addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+			table.push([
+				pc.yellow('Total'),
+				'',
+				pc.yellow(formatNumber(totalsForDisplay.inputTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.outputTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.reasoningTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.cacheReadTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.totalTokens)),
+				pc.yellow(formatCurrency(totalsForDisplay.costUSD)),
+			]);
+
+			log(table.toString());
+
+			if (table.isCompactMode()) {
+				logger.info('\nRunning in Compact Mode');
+				logger.info('Expand terminal width to see cache metrics and total tokens');
+			}
+		} finally {
+			pricingSource[Symbol.dispose]();
+		}
+	},
+});

--- a/apps/codex/src/commands/last.ts
+++ b/apps/codex/src/commands/last.ts
@@ -20,6 +20,30 @@ import { CodexPricingSource } from '../pricing.ts';
 
 const TABLE_COLUMN_COUNT = 8;
 
+function parseDayCount(rawDay: unknown): number {
+	const value = String(rawDay ?? '').trim();
+	if (!/^\d+$/.test(value)) {
+		logger.error(`Invalid --day value: ${value}. Expected a positive integer.`);
+		process.exit(1);
+	}
+
+	const dayCount = Number.parseInt(value, 10);
+	if (!Number.isSafeInteger(dayCount) || dayCount <= 0) {
+		logger.error(`Invalid --day value: ${value}. Expected a positive integer greater than 0.`);
+		process.exit(1);
+	}
+
+	return dayCount;
+}
+
+function createEmptyJsonResult(range: { since: string; until: string }) {
+	return {
+		range,
+		daily: [],
+		totals: null,
+	};
+}
+
 export const lastCommand = define({
 	name: 'last',
 	description: 'Show Codex token usage for the last N days (excluding today)',
@@ -37,17 +61,7 @@ export const lastCommand = define({
 			logger.level = 0;
 		}
 
-		const rawDay = String(ctx.values.day ?? '').trim();
-		if (!/^\d+$/.test(rawDay)) {
-			logger.error(`Invalid --day value: ${rawDay}. Expected a positive integer.`);
-			process.exit(1);
-		}
-
-		const dayCount = Number.parseInt(rawDay, 10);
-		if (!Number.isSafeInteger(dayCount) || dayCount <= 0) {
-			logger.error(`Invalid --day value: ${rawDay}. Expected a positive integer greater than 0.`);
-			process.exit(1);
-		}
+		const dayCount = parseDayCount(ctx.values.day);
 
 		const range = getLastNDaysRange(dayCount, ctx.values.timezone);
 		const displaySince = formatDisplayDate(range.since, ctx.values.locale, ctx.values.timezone);
@@ -61,13 +75,7 @@ export const lastCommand = define({
 
 		if (events.length === 0) {
 			if (jsonOutput) {
-				log(
-					JSON.stringify({
-						range,
-						daily: [],
-						totals: null,
-					}),
-				);
+				log(JSON.stringify(createEmptyJsonResult(range)));
 				return;
 			}
 			logger.info(
@@ -91,13 +99,7 @@ export const lastCommand = define({
 
 			if (rows.length === 0) {
 				if (jsonOutput) {
-					log(
-						JSON.stringify({
-							range,
-							daily: [],
-							totals: null,
-						}),
-					);
+					log(JSON.stringify(createEmptyJsonResult(range)));
 					return;
 				}
 				logger.info(

--- a/apps/codex/src/commands/last.ts
+++ b/apps/codex/src/commands/last.ts
@@ -44,6 +44,14 @@ function createEmptyJsonResult(range: { since: string; until: string }) {
 	};
 }
 
+function formatDateRangeLine(
+	range: { since: string; until: string },
+	displaySince: string,
+	displayUntil: string,
+): string {
+	return `Date range: ${displaySince} ~ ${displayUntil} (${range.since} to ${range.until})`;
+}
+
 export const lastCommand = define({
 	name: 'last',
 	description: 'Show Codex token usage for the last N days (excluding today)',
@@ -66,6 +74,7 @@ export const lastCommand = define({
 		const range = getLastNDaysRange(dayCount, ctx.values.timezone);
 		const displaySince = formatDisplayDate(range.since, ctx.values.locale, ctx.values.timezone);
 		const displayUntil = formatDisplayDate(range.until, ctx.values.locale, ctx.values.timezone);
+		const dateRangeLine = formatDateRangeLine(range, displaySince, displayUntil);
 
 		const { events, missingDirectories } = await loadTokenUsageEvents();
 
@@ -78,9 +87,7 @@ export const lastCommand = define({
 				log(JSON.stringify(createEmptyJsonResult(range)));
 				return;
 			}
-			logger.info(
-				`Date range: ${displaySince} ~ ${displayUntil} (${range.since} to ${range.until})`,
-			);
+			logger.info(dateRangeLine);
 			log('No Codex usage data found.');
 			return;
 		}
@@ -102,9 +109,7 @@ export const lastCommand = define({
 					log(JSON.stringify(createEmptyJsonResult(range)));
 					return;
 				}
-				logger.info(
-					`Date range: ${displaySince} ~ ${displayUntil} (${range.since} to ${range.until})`,
-				);
+				logger.info(dateRangeLine);
 				log('No Codex usage data found for provided filters.');
 				return;
 			}
@@ -147,9 +152,7 @@ export const lastCommand = define({
 			logger.box(
 				`Codex Token Usage Report - Last ${dayCount} Days (Timezone: ${ctx.values.timezone ?? DEFAULT_TIMEZONE})`,
 			);
-			logger.info(
-				`Date range: ${displaySince} ~ ${displayUntil} (${range.since} to ${range.until})`,
-			);
+			logger.info(dateRangeLine);
 
 			const table: ResponsiveTable = new ResponsiveTable({
 				head: [

--- a/apps/codex/src/date-utils.ts
+++ b/apps/codex/src/date-utils.ts
@@ -111,3 +111,44 @@ export function formatDisplayDateTime(
 	});
 	return formatter.format(date);
 }
+
+function shiftDateKey(dateKey: string, offsetDays: number): string {
+	const [yearStr = '0', monthStr = '1', dayStr = '1'] = dateKey.split('-');
+	const year = Number.parseInt(yearStr, 10);
+	const month = Number.parseInt(monthStr, 10);
+	const day = Number.parseInt(dayStr, 10);
+	const date = new Date(Date.UTC(year, month - 1, day));
+	date.setUTCDate(date.getUTCDate() + offsetDays);
+	return date.toISOString().slice(0, 10);
+}
+
+export function getLastNDaysRange(
+	dayCount: number,
+	timezone?: string,
+): { since: string; until: string } {
+	const todayDateKey = toDateKey(new Date().toISOString(), timezone);
+	const until = shiftDateKey(todayDateKey, -1);
+	const since = shiftDateKey(until, -(dayCount - 1));
+
+	return {
+		since,
+		until,
+	};
+}
+
+if (import.meta.vitest != null) {
+	describe('getLastNDaysRange', () => {
+		it('returns yesterday as end date and excludes today', () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-03-29T12:00:00.000Z'));
+
+			const range = getLastNDaysRange(10, 'UTC');
+			expect(range).toEqual({
+				since: '2026-03-19',
+				until: '2026-03-28',
+			});
+
+			vi.useRealTimers();
+		});
+	});
+}

--- a/apps/codex/src/run.ts
+++ b/apps/codex/src/run.ts
@@ -2,11 +2,13 @@ import process from 'node:process';
 import { cli } from 'gunshi';
 import { description, name, version } from '../package.json';
 import { dailyCommand } from './commands/daily.ts';
+import { lastCommand } from './commands/last.ts';
 import { monthlyCommand } from './commands/monthly.ts';
 import { sessionCommand } from './commands/session.ts';
 
 const subCommands = new Map([
 	['daily', dailyCommand],
+	['last', lastCommand],
 	['monthly', monthlyCommand],
 	['session', sessionCommand],
 ]);

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
 					items: [
 						{ text: 'Overview', link: '/guide/codex/' },
 						{ text: 'Daily Report', link: '/guide/codex/daily' },
+						{ text: 'Last N Days Report', link: '/guide/codex/last-n-days' },
 						{ text: 'Monthly Report', link: '/guide/codex/monthly' },
 						{ text: 'Session Report', link: '/guide/codex/session' },
 					],

--- a/docs/guide/codex/daily.md
+++ b/docs/guide/codex/daily.md
@@ -8,6 +8,10 @@ bunx @ccusage/codex@latest daily
 
 # Using npx
 npx @ccusage/codex@latest daily
+
+
+# Last 10 days (excluding today)
+npx @ccusage/codex@latest last --day 10
 ```
 
 ## Options
@@ -20,6 +24,7 @@ npx @ccusage/codex@latest daily
 | `--json`                     | Emit structured JSON instead of a table                        |
 | `--offline` / `--no-offline` | Force cached LiteLLM pricing or enable live fetching           |
 | `--compact`                  | Force compact table layout (same columns as a narrow terminal) |
+| `last --day <n>`             | Last n days (excluding today), and prints start/end date range |
 
 The output uses the same responsive table component as ccusage, including compact mode support and per-model token summaries.
 

--- a/docs/guide/codex/daily.md
+++ b/docs/guide/codex/daily.md
@@ -8,10 +8,6 @@ bunx @ccusage/codex@latest daily
 
 # Using npx
 npx @ccusage/codex@latest daily
-
-
-# Last 10 days (excluding today)
-npx @ccusage/codex@latest last --day 10
 ```
 
 ## Options
@@ -24,8 +20,9 @@ npx @ccusage/codex@latest last --day 10
 | `--json`                     | Emit structured JSON instead of a table                        |
 | `--offline` / `--no-offline` | Force cached LiteLLM pricing or enable live fetching           |
 | `--compact`                  | Force compact table layout (same columns as a narrow terminal) |
-| `last --day <n>`             | Last n days (excluding today), and prints start/end date range |
 
 The output uses the same responsive table component as ccusage, including compact mode support and per-model token summaries.
 
 Need higher-level trends? Switch to the [monthly report](./monthly.md) for month-by-month rollups with the same flag set.
+
+Need a fixed rolling window? See the [last N days report](./last-n-days.md).

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -67,8 +67,8 @@ When Codex emits a model alias (for example `gpt-5-codex`), the CLI automaticall
 ## Next Steps
 
 - [Daily report command](./daily.md)
+- [Last N days report command](./last-n-days.md)
 - [Monthly report command](./monthly.md)
-- Last N days example: `npx @ccusage/codex@latest last --day 10` (excluding today)
 - [Session report command](./session.md)
 - Additional reports will mirror the ccusage CLI as the Codex tooling stabilizes.
 

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -53,7 +53,7 @@ The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to 
 - **Pricing** – Rates come from LiteLLM's pricing dataset via the shared `LiteLLMPricingFetcher`. Aliases such as `gpt-5-codex` map to canonical entries (`gpt-5`) so cost calculations remain accurate.
 - **Legacy fallback** – Early September 2025 logs that never recorded `turn_context` metadata are still included; the CLI assumes `gpt-5` for pricing so you can review the tokens even though the model tag is missing (the JSON output also marks these rows with `"isFallback": true`).
 - **Cost formula** – Non-cached input uses the standard input price; cached input uses the cache-read price (falling back to the input price when missing); and output tokens are billed at the output price. All prices are per million tokens. Reasoning tokens may be shown for reference, but they are part of the output charge and are not billed separately.
-- **Totals and reports** – Daily, monthly, and session commands display per-model breakdowns, overall totals, and optional JSON for automation.
+- **Totals and reports** – Daily, last-N-days (`last --day <n>`), monthly, and session commands display per-model breakdowns, overall totals, and optional JSON for automation.
 
 ## Environment Variables
 
@@ -68,6 +68,7 @@ When Codex emits a model alias (for example `gpt-5-codex`), the CLI automaticall
 
 - [Daily report command](./daily.md)
 - [Monthly report command](./monthly.md)
+- Last N days example: `npx @ccusage/codex@latest last --day 10` (excluding today)
 - [Session report command](./session.md)
 - Additional reports will mirror the ccusage CLI as the Codex tooling stabilizes.
 

--- a/docs/guide/codex/last-n-days.md
+++ b/docs/guide/codex/last-n-days.md
@@ -33,15 +33,6 @@ The CLI prints the computed start/end dates in terminal output, and `--json` out
 }
 ```
 
-## Validation rules for `--day`
-
-`--day` must be a positive integer:
-
-- ✅ valid: `1`, `7`, `30`
-- ❌ invalid: `abc`, `0`, `-3`
-
-Invalid input exits with an explicit error message.
-
 ## Related commands
 
 - [Daily report command](./daily.md)

--- a/docs/guide/codex/last-n-days.md
+++ b/docs/guide/codex/last-n-days.md
@@ -1,0 +1,49 @@
+# Codex Last N Days Report (Beta)
+
+Use the `last` command to view usage for the most recent **N days**, automatically **excluding today**.
+
+```bash
+# Last 10 days, excluding today
+npx @ccusage/codex@latest last --day 10
+
+# JSON output (includes computed range)
+npx @ccusage/codex@latest last --day 10 --json
+```
+
+## How the date range works
+
+`--day <n>` is converted to a closed date range:
+
+- **End date (`until`)**: yesterday
+- **Start date (`since`)**: `n - 1` days before yesterday
+
+For example, if today is `2026-03-29` and `--day 10`:
+
+- since = `2026-03-19`
+- until = `2026-03-28`
+
+The CLI prints the computed start/end dates in terminal output, and `--json` output includes:
+
+```json
+{
+	"range": {
+		"since": "2026-03-19",
+		"until": "2026-03-28"
+	}
+}
+```
+
+## Validation rules for `--day`
+
+`--day` must be a positive integer:
+
+- ✅ valid: `1`, `7`, `30`
+- ❌ invalid: `abc`, `0`, `-3`
+
+Invalid input exits with an explicit error message.
+
+## Related commands
+
+- [Daily report command](./daily.md)
+- [Monthly report command](./monthly.md)
+- [Session report command](./session.md)


### PR DESCRIPTION
## Motivation

- Provide a simple CLI command to view Codex token usage for the most recent N days as a fixed rolling window that explicitly excludes today.

## Description

- Add a new `last` subcommand implemented in `apps/codex/src/commands/last.ts` that validates `--day`, computes the date range, builds the daily report, and emits table or JSON output.
- Introduce `getLastNDaysRange` and helper `shiftDateKey` in `apps/codex/src/date-utils.ts` to compute the closed `since`/`until` range (until = yesterday, since = `n-1` days before yesterday).
- Register the new command in `apps/codex/src/run.ts` and add user-facing documentation and navigation changes including `docs/guide/codex/last-n-days.md`, updates to `README.md`, and sidebar changes in `docs/.vitepress/config.ts` and related guide pages.
- Include an inline Vitest unit test for `getLastNDaysRange` to ensure the date math excludes today and yields the expected range.

## Files Changed

- apps/codex/src/commands/last.ts
- apps/codex/src/date-utils.ts
- apps/codex/src/run.ts
- apps/codex/README.md
- docs/guide/codex/last-n-days.md
- docs/.vitepress/config.ts
- docs/guide/codex/daily.md
- docs/guide/codex/index.md

## Example Usage

```bash
# Last 10 days, excluding today
npx @ccusage/codex@latest last --day 10

# JSON output
npx @ccusage/codex@latest last --day 10 --json
```

## Testing
- [x] pnpm --filter @ccusage/codex run start -- last --day 10 --json
- [x] pnpm --filter @ccusage/codex run start -- last --day 0
- [x] pnpm --filter @ccusage/codex run start -- last --day abc
- [x] pnpm --filter @ccusage/codex run start -- last --day=-3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Last N Days Report" command to retrieve token usage for the most recent N days, excluding today, via `last --day <n>`.
  * Supports JSON output format with the `--json` flag.

* **Documentation**
  * Added new guide page for the Last N Days Report command.
  * Updated existing documentation with the new reporting option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->