### PR TITLE
feat: add cache hit rate column to all usage report commands

### DIFF
--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -2,6 +2,7 @@ import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
 import {
 	addEmptySeparatorRow,
+	calculateCacheHitRate,
 	createUsageReportTable,
 	formatTotalsRow,
 	formatUsageDataRow,
@@ -113,6 +114,7 @@ export const dailyCommand = define({
 								outputTokens: data.outputTokens,
 								cacheCreationTokens: data.cacheCreationTokens,
 								cacheReadTokens: data.cacheReadTokens,
+								cacheHitRate: calculateCacheHitRate(data),
 								totalTokens: getTotalTokens(data),
 								totalCost: data.totalCost,
 								modelsUsed: data.modelsUsed,
@@ -156,12 +158,13 @@ export const dailyCommand = define({
 					// Add project section header
 					if (!isFirstProject) {
 						// Add empty row for visual separation between projects
-						table.push(['', '', '', '', '', '', '', '']);
+						table.push(['', '', '', '', '', '', '', '', '']);
 					}
 
 					// Add project header row
 					table.push([
 						pc.cyan(`Project: ${formatProjectName(projectName, projectAliases)}`),
+						'',
 						'',
 						'',
 						'',
@@ -213,7 +216,7 @@ export const dailyCommand = define({
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, 9);
 
 			// Add totals
 			const totalsRow = formatTotalsRow({

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -2,6 +2,7 @@ import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
 import {
 	addEmptySeparatorRow,
+	calculateCacheHitRate,
 	createUsageReportTable,
 	formatTotalsRow,
 	formatUsageDataRow,
@@ -74,6 +75,7 @@ export const monthlyCommand = define({
 					outputTokens: data.outputTokens,
 					cacheCreationTokens: data.cacheCreationTokens,
 					cacheReadTokens: data.cacheReadTokens,
+					cacheHitRate: calculateCacheHitRate(data),
 					totalTokens: getTotalTokens(data),
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
@@ -130,7 +132,7 @@ export const monthlyCommand = define({
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, 9);
 
 			// Add totals
 			const totalsRow = formatTotalsRow({

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -2,6 +2,7 @@ import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
 import {
 	addEmptySeparatorRow,
+	calculateCacheHitRate,
 	createUsageReportTable,
 	formatTotalsRow,
 	formatUsageDataRow,
@@ -101,6 +102,7 @@ export const sessionCommand = define({
 					outputTokens: data.outputTokens,
 					cacheCreationTokens: data.cacheCreationTokens,
 					cacheReadTokens: data.cacheReadTokens,
+					cacheHitRate: calculateCacheHitRate(data),
 					totalTokens: getTotalTokens(data),
 					totalCost: data.totalCost,
 					lastActivity: data.lastActivity,
@@ -166,7 +168,7 @@ export const sessionCommand = define({
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 9);
+			addEmptySeparatorRow(table, 10);
 
 			// Add totals
 			const totalsRow = formatTotalsRow(

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -2,6 +2,7 @@ import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
 import {
 	addEmptySeparatorRow,
+	calculateCacheHitRate,
 	createUsageReportTable,
 	formatTotalsRow,
 	formatUsageDataRow,
@@ -84,6 +85,7 @@ export const weeklyCommand = define({
 					outputTokens: data.outputTokens,
 					cacheCreationTokens: data.cacheCreationTokens,
 					cacheReadTokens: data.cacheReadTokens,
+					cacheHitRate: calculateCacheHitRate(data),
 					totalTokens: getTotalTokens(data),
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
@@ -136,7 +138,7 @@ export const weeklyCommand = define({
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, 9);
 
 			// Add totals
 			const totalsRow = formatTotalsRow({

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -475,6 +475,7 @@ export function pushBreakdownRows(
 			pc.gray(formatNumber(breakdown.outputTokens)),
 			pc.gray(formatNumber(breakdown.cacheCreationTokens)),
 			pc.gray(formatNumber(breakdown.cacheReadTokens)),
+			pc.gray(formatCacheHitRate(breakdown)),
 			pc.gray(formatNumber(totalTokens)),
 			pc.gray(formatCurrency(breakdown.cost)),
 		);
@@ -515,6 +516,42 @@ export type UsageData = {
 };
 
 /**
+ * Calculates and formats cache hit rate with color coding
+ * @param data - Usage data containing token counts
+ * @returns Color-coded percentage string
+ */
+export function formatCacheHitRate(data: {
+	inputTokens: number;
+	cacheCreationTokens: number;
+	cacheReadTokens: number;
+}): string {
+	const totalInput = data.inputTokens + data.cacheCreationTokens + data.cacheReadTokens;
+	const rate = totalInput > 0 ? data.cacheReadTokens / totalInput : 0;
+	const pct = `${(rate * 100).toFixed(1)}%`;
+	if (rate >= 0.7) {
+		return pc.green(pct);
+	}
+	if (rate >= 0.4) {
+		return pc.yellow(pct);
+	}
+	return pc.red(pct);
+}
+
+/**
+ * Calculates cache hit rate as a number
+ * @param data - Usage data containing token counts
+ * @returns Cache hit rate between 0 and 1
+ */
+export function calculateCacheHitRate(data: {
+	inputTokens: number;
+	cacheCreationTokens: number;
+	cacheReadTokens: number;
+}): number {
+	const totalInput = data.inputTokens + data.cacheCreationTokens + data.cacheReadTokens;
+	return totalInput > 0 ? data.cacheReadTokens / totalInput : 0;
+}
+
+/**
  * Creates a standard usage report table with consistent styling and layout
  * @param config - Configuration options for the table
  * @returns Configured ResponsiveTable instance
@@ -527,6 +564,7 @@ export function createUsageReportTable(config: UsageReportConfig): ResponsiveTab
 		'Output',
 		'Cache Create',
 		'Cache Read',
+		'Hit Rate',
 		'Total Tokens',
 		'Cost (USD)',
 	];
@@ -540,11 +578,19 @@ export function createUsageReportTable(config: UsageReportConfig): ResponsiveTab
 		'right',
 		'right',
 		'right',
+		'right',
 	];
 
-	const compactHeaders = [config.firstColumnName, 'Models', 'Input', 'Output', 'Cost (USD)'];
+	const compactHeaders = [
+		config.firstColumnName,
+		'Models',
+		'Input',
+		'Output',
+		'Hit Rate',
+		'Cost (USD)',
+	];
 
-	const compactAligns: TableCellAlign[] = ['left', 'left', 'right', 'right', 'right'];
+	const compactAligns: TableCellAlign[] = ['left', 'left', 'right', 'right', 'right', 'right'];
 
 	// Add Last Activity column for session reports
 	if (config.includeLastActivity ?? false) {
@@ -588,6 +634,7 @@ export function formatUsageDataRow(
 		formatNumber(data.outputTokens),
 		formatNumber(data.cacheCreationTokens),
 		formatNumber(data.cacheReadTokens),
+		formatCacheHitRate(data),
 		formatNumber(totalTokens),
 		formatCurrency(data.totalCost),
 	];
@@ -619,6 +666,7 @@ export function formatTotalsRow(
 		pc.yellow(formatNumber(totals.outputTokens)),
 		pc.yellow(formatNumber(totals.cacheCreationTokens)),
 		pc.yellow(formatNumber(totals.cacheReadTokens)),
+		pc.yellow(formatCacheHitRate(totals)),
 		pc.yellow(formatNumber(totalTokens)),
 		pc.yellow(formatCurrency(totals.totalCost)),
 	];


### PR DESCRIPTION
## Summary
- Add **Hit Rate** as a first-class metric column in daily, monthly, weekly, and session reports
- Formula: `CacheRead / (Input + CacheCreate + CacheRead)`, color-coded: green (>=70%), yellow (>=40%), red (<40%)
- Hit Rate is shown in both full and compact mode (as a core metric)
- JSON output includes `cacheHitRate` field for programmatic access
- Model breakdown (`-b`) also displays per-model hit rate

## Test plan
- [ ] `ccusage daily` — verify Hit Rate column appears
- [ ] `ccusage session` — verify Hit Rate column with Last Activity
- [ ] `ccusage daily --json` — verify `cacheHitRate` in JSON output
- [ ] `ccusage daily --compact` — verify Hit Rate in compact mode
- [ ] `ccusage daily -b` — verify per-model hit rate in breakdown rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added cache hit rate metrics to all usage reports (daily, weekly, monthly, and session views), displayed as percentages with color-coded indicators: green for optimal performance (≥70%), yellow for adequate (≥40%), and red for lower rates.
* Cache hit rate data is now included in both visual reports and JSON output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->