### PR TITLE
fix(ccusage): `ccusage session id=` issue on Windows with rel paths

### DIFF
--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -1136,7 +1136,8 @@ export async function loadSessionUsageById(
 	const patterns = claudePaths.map((p) =>
 		path.join(p, 'projects', '**', `${sessionId}.jsonl`).replace(/\\/g, '/'),
 	);
-	const jsonlFiles = await glob(patterns);
+	// Absolute paths important on Windows - relative paths will break if session file is on different disk.
+	const jsonlFiles = await glob(patterns, { absolute: true });
 
 	if (jsonlFiles.length === 0) {
 		return null;


### PR DESCRIPTION
Otherwise `glob` resulted in odd relative paths like `"../../../../../../C:/Users/xxxx/.claude/projects/L--test/xxxxxxxxx.json"` leading to the following error on Windows:
```
ccusage session --id=xxxxx
node:internal/modules/run_main:107
    triggerUncaughtException(
    ^

[Error: ENOENT: no such file or directory, open 'L:\C:\Users\xxxxx\.claude\projects\L--test\xxxxx.jsonl'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'L:\\C:\\Users\\xxxxx\\.claude\\projects\\L--test\\xxxxx.jsonl'
}

Node.js v24.14.0
NativeCommandExitException: Program "node.exe" ended with non-zero exit code: 1 (0x00000001).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal file path handling when loading usage data to make discovery and import more reliable across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->