### PR TITLE
fix(statusline): use current_usage instead of total_input_tokens for context display

### DIFF
--- a/apps/ccusage/src/_types.ts
+++ b/apps/ccusage/src/_types.ts
@@ -184,6 +184,16 @@ export const statuslineHookJsonSchema = v.object({
 			total_input_tokens: v.number(),
 			total_output_tokens: v.optional(v.number()),
 			context_window_size: v.number(),
+			current_usage: v.optional(
+				v.object({
+					input_tokens: v.number(),
+					output_tokens: v.number(),
+					cache_creation_input_tokens: v.number(),
+					cache_read_input_tokens: v.number(),
+				}),
+			),
+			used_percentage: v.optional(v.number()),
+			remaining_percentage: v.optional(v.number()),
 		}),
 	),
 });

--- a/apps/ccusage/src/_types.ts
+++ b/apps/ccusage/src/_types.ts
@@ -184,7 +184,7 @@ export const statuslineHookJsonSchema = v.object({
 			total_input_tokens: v.number(),
 			total_output_tokens: v.optional(v.number()),
 			context_window_size: v.number(),
-			current_usage: v.optional(
+			current_usage: v.nullable(
 				v.object({
 					input_tokens: v.number(),
 					output_tokens: v.number(),
@@ -192,8 +192,8 @@ export const statuslineHookJsonSchema = v.object({
 					cache_read_input_tokens: v.number(),
 				}),
 			),
-			used_percentage: v.optional(v.number()),
-			remaining_percentage: v.optional(v.number()),
+			used_percentage: v.nullable(v.number()),
+			remaining_percentage: v.nullable(v.number()),
 		}),
 	),
 });

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -472,10 +472,10 @@ export const statuslineCommand = define({
 
 					// Get context tokens from Claude Code hook data, or fall back to calculating from transcript
 					const contextDataResult =
-						hookData.context_window != null
+						hookData.context_window?.current_usage != null
 							? // Prefer context_window data from Claude Code hook if available
 								Result.succeed({
-									inputTokens: hookData.context_window.total_input_tokens,
+									inputTokens: hookData.context_window.current_usage.input_tokens + hookData.context_window.current_usage.cache_creation_input_tokens + hookData.context_window.current_usage.cache_read_input_tokens,
 									contextLimit: hookData.context_window.context_window_size,
 								})
 							: // Fall back to calculating context tokens from transcript

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -501,6 +501,10 @@ export const statuslineCommand = define({
 						),
 						Result.map((contextResult) => {
 							if (contextResult == null) {
+								// If transcript calculation failed but we have context_window_size, show 0 tokens
+								if (hookData.context_window?.context_window_size != null) {
+									return formatContextInfo(0, hookData.context_window.context_window_size);
+								}
 								return undefined;
 							}
 							return formatContextInfo(contextResult.inputTokens, contextResult.contextLimit);

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -476,9 +476,9 @@ export const statuslineCommand = define({
 							? // Prefer context_window data from Claude Code hook if available
 								Result.succeed({
 									inputTokens:
-										hookData.context_window.current_usage.input_tokens +
-										hookData.context_window.current_usage.cache_creation_input_tokens +
-										hookData.context_window.current_usage.cache_read_input_tokens,
+										(hookData.context_window.current_usage.input_tokens ?? 0) +
+										(hookData.context_window.current_usage.cache_creation_input_tokens ?? 0) +
+										(hookData.context_window.current_usage.cache_read_input_tokens ?? 0),
 									contextLimit: hookData.context_window.context_window_size,
 								})
 							: // Fall back to calculating context tokens from transcript

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -475,7 +475,10 @@ export const statuslineCommand = define({
 						hookData.context_window?.current_usage != null
 							? // Prefer context_window data from Claude Code hook if available
 								Result.succeed({
-									inputTokens: hookData.context_window.current_usage.input_tokens + hookData.context_window.current_usage.cache_creation_input_tokens + hookData.context_window.current_usage.cache_read_input_tokens,
+									inputTokens:
+										hookData.context_window.current_usage.input_tokens +
+										hookData.context_window.current_usage.cache_creation_input_tokens +
+										hookData.context_window.current_usage.cache_read_input_tokens,
 									contextLimit: hookData.context_window.context_window_size,
 								})
 							: // Fall back to calculating context tokens from transcript


### PR DESCRIPTION
I'm sorry to open this pull request without an attached issue to it. My organization recently switched to Claude Code and I installed your project to track my token usage. The regular `ccusage` works as expected, but then I installed it to the Claude Code status line (via `ccusage statusline`) and saw the incorrect token calculations near the 🧠 emoji. 

So here is the PR with the fix for this issue. After the fix, the tokens in statusline match the tokens with `/config -> Verbose output (set to true)`.

## Summary

This fix resolves an issue where the statusline command (`ccusage statusline`) was displaying incorrect context window token counts and percentages.

See the testing section for before/after.

## The Problem

The statusline was reading `hookData.context_window.total_input_tokens`, which represents the **cumulative session input tokens** rather than the actual tokens currently in the context window. This led to wildly inaccurate displays.

## The Solution

Now calculates actual context window usage by summing three components from `current_usage`:
- `input_tokens` - current input in context
- `cache_creation_input_tokens` - tokens written to cache
- `cache_read_input_tokens` - tokens read from cache

This matches how Claude Code itself calculates and displays context usage, providing users with accurate real-time visibility.

## Additional Changes

- Updated `statuslineHookJsonSchema` to properly validate the `current_usage`, `used_percentage`, and `remaining_percentage` fields from Claude Code's statusline hook
- Made these fields nullable to handle fresh sessions where no API calls have been made yet (`current_usage` is `null`)
- When `current_usage` is unavailable but context window size is known, displays `0 (0%)` instead of falling back to transcript calculation or showing "N/A"

## Testing

Verified that statusline output now matches Claude Code's context display:
- Before:
<img width="1725" height="200" alt="Screenshot 2026-03-31 at 23 08 32" src="https://github.com/user-attachments/assets/03e893ae-6a9e-48b4-a859-bd4b1bb8a9c8" />

- After:
<img width="1728" height="195" alt="Screenshot 2026-03-31 at 23 07 44" src="https://github.com/user-attachments/assets/ba967ff6-5218-4354-8c73-c4b6c02434f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status display now prefers explicit current-usage metrics when available, summing input and cached tokens for more accurate context counts. If transcript-based estimation fails but a context window size is present, context tokens are shown as 0 instead of undefined.
* **New Features**
  * Added optional current-usage, used-percentage, and remaining-percentage fields to improve status reporting fidelity and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->