### PR TITLE
feat(codex): add --instances and --project flags for project-grouped usage reports

### DIFF
--- a/apps/codex/src/_consts.ts
+++ b/apps/codex/src/_consts.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 export const CODEX_HOME_ENV = 'CODEX_HOME';
 export const DEFAULT_CODEX_DIR = path.join(os.homedir(), '.codex');
 export const DEFAULT_SESSION_SUBDIR = 'sessions';
+export const ARCHIVED_SESSION_SUBDIR = 'archived_sessions';
 export const SESSION_GLOB = '**/*.jsonl';
 export const DEFAULT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC';
 export const DEFAULT_LOCALE = 'en-CA';

--- a/apps/codex/src/_shared-args.ts
+++ b/apps/codex/src/_shared-args.ts
@@ -52,4 +52,15 @@ export const sharedArgs = {
 		type: 'boolean',
 		description: 'Disable colored output (default: auto). NO_COLOR=1 has the same effect.',
 	},
+	instances: {
+		type: 'boolean',
+		short: 'i',
+		description: 'Show usage breakdown by project',
+		default: false,
+	},
+	project: {
+		type: 'string',
+		short: 'p',
+		description: 'Filter to a specific project (exact match on normalized path)',
+	},
 } as const satisfies Args;

--- a/apps/codex/src/_types.ts
+++ b/apps/codex/src/_types.ts
@@ -11,6 +11,7 @@ export type TokenUsageEvent = TokenUsageDelta & {
 	sessionId: string;
 	model?: string;
 	isFallbackModel?: boolean;
+	project?: string;
 };
 
 export type ModelUsage = TokenUsageDelta & {
@@ -56,6 +57,7 @@ export type PricingSource = {
 
 export type DailyReportRow = {
 	date: string;
+	project?: string;
 	inputTokens: number;
 	cachedInputTokens: number;
 	outputTokens: number;
@@ -67,6 +69,7 @@ export type DailyReportRow = {
 
 export type MonthlyReportRow = {
 	month: string;
+	project?: string;
 	inputTokens: number;
 	cachedInputTokens: number;
 	outputTokens: number;
@@ -78,6 +81,7 @@ export type MonthlyReportRow = {
 
 export type SessionReportRow = {
 	sessionId: string;
+	project?: string;
 	lastActivity: string;
 	sessionFile: string;
 	directory: string;

--- a/apps/codex/src/command-utils.ts
+++ b/apps/codex/src/command-utils.ts
@@ -1,4 +1,5 @@
 import { sort } from 'fast-sort';
+import { UNKNOWN_PROJECT_LABEL } from './project-utils.ts';
 
 export type UsageGroup = {
 	inputTokens: number;
@@ -33,4 +34,62 @@ export function formatModelsList(
 	return sort(Object.entries(models))
 		.asc(([model]) => model)
 		.map(([model, data]) => (data.isFallback === true ? `${model} (fallback)` : model));
+}
+
+export function groupRowsByProject<T extends { project?: string }>(rows: T[]): Record<string, T[]> {
+	const projects: Record<string, T[]> = {};
+
+	for (const row of rows) {
+		const project = row.project ?? UNKNOWN_PROJECT_LABEL;
+		(projects[project] ??= []).push(row);
+	}
+
+	return projects;
+}
+
+export function createEmptyReportPayload(
+	reportKey: 'daily' | 'monthly' | 'sessions',
+	useInstances: boolean,
+): Record<string, unknown> {
+	if (useInstances) {
+		return { projects: {}, totals: null };
+	}
+
+	return { [reportKey]: [], totals: null };
+}
+
+if (import.meta.vitest != null) {
+	describe('groupRowsByProject', () => {
+		it('groups missing projects under the unknown bucket', () => {
+			const grouped = groupRowsByProject([
+				{ project: '~/repo-a', totalTokens: 1 },
+				{ totalTokens: 2 },
+				{ project: '~/repo-a', totalTokens: 3 },
+			]);
+
+			expect(grouped).toEqual({
+				'~/repo-a': [
+					{ project: '~/repo-a', totalTokens: 1 },
+					{ project: '~/repo-a', totalTokens: 3 },
+				],
+				'(unknown)': [{ totalTokens: 2 }],
+			});
+		});
+	});
+
+	describe('createEmptyReportPayload', () => {
+		it('returns the stable projects shape for empty instances output', () => {
+			expect(createEmptyReportPayload('daily', true)).toEqual({
+				projects: {},
+				totals: null,
+			});
+		});
+
+		it('returns the legacy shape when instances output is disabled', () => {
+			expect(createEmptyReportPayload('sessions', false)).toEqual({
+				sessions: [],
+				totals: null,
+			});
+		});
+	});
 }

--- a/apps/codex/src/command-utils.ts
+++ b/apps/codex/src/command-utils.ts
@@ -37,7 +37,9 @@ export function formatModelsList(
 }
 
 export function groupRowsByProject<T extends { project?: string }>(rows: T[]): Record<string, T[]> {
-	const projects: Record<string, T[]> = {};
+	// Use a null-prototype object so project names like `__proto__` or `constructor`
+	// cannot collide with inherited Object members.
+	const projects = Object.create(null) as Record<string, T[]>;
 
 	for (const row of rows) {
 		const project = row.project ?? UNKNOWN_PROJECT_LABEL;
@@ -67,13 +69,24 @@ if (import.meta.vitest != null) {
 				{ project: '~/repo-a', totalTokens: 3 },
 			]);
 
-			expect(grouped).toEqual({
+			expect({ ...grouped }).toEqual({
 				'~/repo-a': [
 					{ project: '~/repo-a', totalTokens: 1 },
 					{ project: '~/repo-a', totalTokens: 3 },
 				],
 				'(unknown)': [{ totalTokens: 2 }],
 			});
+		});
+
+		it('is immune to prototype-polluting project names', () => {
+			const grouped = groupRowsByProject([
+				{ project: '__proto__', totalTokens: 1 },
+				{ project: 'constructor', totalTokens: 2 },
+			]);
+
+			expect(Object.getPrototypeOf(grouped)).toBeNull();
+			const protoKey = '__proto__';
+			expect(grouped[protoKey]).toEqual([{ project: '__proto__', totalTokens: 1 }]);
 		});
 	});
 

--- a/apps/codex/src/commands/daily.ts
+++ b/apps/codex/src/commands/daily.ts
@@ -11,7 +11,12 @@ import { define } from 'gunshi';
 import pc from 'picocolors';
 import { DEFAULT_TIMEZONE } from '../_consts.ts';
 import { sharedArgs } from '../_shared-args.ts';
-import { formatModelsList, splitUsageTokens } from '../command-utils.ts';
+import {
+	createEmptyReportPayload,
+	formatModelsList,
+	groupRowsByProject,
+	splitUsageTokens,
+} from '../command-utils.ts';
 import { buildDailyReport } from '../daily-report.ts';
 import { loadTokenUsageEvents } from '../data-loader.ts';
 import { normalizeFilterDate } from '../date-utils.ts';
@@ -41,6 +46,8 @@ export const dailyCommand = define({
 			process.exit(1);
 		}
 
+		const useInstances = Boolean(ctx.values.instances);
+		const projectFilter = ctx.values.project;
 		const { events, missingDirectories } = await loadTokenUsageEvents();
 
 		for (const missing of missingDirectories) {
@@ -48,7 +55,11 @@ export const dailyCommand = define({
 		}
 
 		if (events.length === 0) {
-			log(jsonOutput ? JSON.stringify({ daily: [], totals: null }) : 'No Codex usage data found.');
+			log(
+				jsonOutput
+					? JSON.stringify(createEmptyReportPayload('daily', useInstances))
+					: 'No Codex usage data found.',
+			);
 			return;
 		}
 
@@ -62,12 +73,14 @@ export const dailyCommand = define({
 				locale: ctx.values.locale,
 				since,
 				until,
+				project: projectFilter,
+				groupByProject: useInstances,
 			});
 
 			if (rows.length === 0) {
 				log(
 					jsonOutput
-						? JSON.stringify({ daily: [], totals: null })
+						? JSON.stringify(createEmptyReportPayload('daily', useInstances))
 						: 'No Codex usage data found for provided filters.',
 				);
 				return;
@@ -94,16 +107,11 @@ export const dailyCommand = define({
 			);
 
 			if (jsonOutput) {
-				log(
-					JSON.stringify(
-						{
-							daily: rows,
-							totals,
-						},
-						null,
-						2,
-					),
-				);
+				if (useInstances) {
+					log(JSON.stringify({ projects: groupRowsByProject(rows), totals }, null, 2));
+				} else {
+					log(JSON.stringify({ daily: rows, totals }, null, 2));
+				}
 				return;
 			}
 
@@ -140,25 +148,61 @@ export const dailyCommand = define({
 				costUSD: 0,
 			};
 
-			for (const row of rows) {
-				const split = splitUsageTokens(row);
-				totalsForDisplay.inputTokens += split.inputTokens;
-				totalsForDisplay.outputTokens += split.outputTokens;
-				totalsForDisplay.reasoningTokens += split.reasoningTokens;
-				totalsForDisplay.cacheReadTokens += split.cacheReadTokens;
-				totalsForDisplay.totalTokens += row.totalTokens;
-				totalsForDisplay.costUSD += row.costUSD;
+			if (useInstances && rows.some((r) => r.project != null)) {
+				const projectGroups = groupRowsByProject(rows);
+				const sortedProjects = Object.entries(projectGroups).sort(([, a], [, b]) => {
+					const costA = a.reduce((s, r) => s + r.costUSD, 0);
+					const costB = b.reduce((s, r) => s + r.costUSD, 0);
+					return costB - costA;
+				});
+				let isFirst = true;
+				for (const [projectName, projectRows] of sortedProjects) {
+					if (!isFirst) {
+						addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+					}
+					table.push([pc.cyan(`Project: ${projectName}`), '', '', '', '', '', '', '']);
+					for (const row of projectRows) {
+						const split = splitUsageTokens(row);
+						totalsForDisplay.inputTokens += split.inputTokens;
+						totalsForDisplay.outputTokens += split.outputTokens;
+						totalsForDisplay.reasoningTokens += split.reasoningTokens;
+						totalsForDisplay.cacheReadTokens += split.cacheReadTokens;
+						totalsForDisplay.totalTokens += row.totalTokens;
+						totalsForDisplay.costUSD += row.costUSD;
+						table.push([
+							row.date,
+							formatModelsDisplayMultiline(formatModelsList(row.models)),
+							formatNumber(split.inputTokens),
+							formatNumber(split.outputTokens),
+							formatNumber(split.reasoningTokens),
+							formatNumber(split.cacheReadTokens),
+							formatNumber(row.totalTokens),
+							formatCurrency(row.costUSD),
+						]);
+					}
+					isFirst = false;
+				}
+			} else {
+				for (const row of rows) {
+					const split = splitUsageTokens(row);
+					totalsForDisplay.inputTokens += split.inputTokens;
+					totalsForDisplay.outputTokens += split.outputTokens;
+					totalsForDisplay.reasoningTokens += split.reasoningTokens;
+					totalsForDisplay.cacheReadTokens += split.cacheReadTokens;
+					totalsForDisplay.totalTokens += row.totalTokens;
+					totalsForDisplay.costUSD += row.costUSD;
 
-				table.push([
-					row.date,
-					formatModelsDisplayMultiline(formatModelsList(row.models)),
-					formatNumber(split.inputTokens),
-					formatNumber(split.outputTokens),
-					formatNumber(split.reasoningTokens),
-					formatNumber(split.cacheReadTokens),
-					formatNumber(row.totalTokens),
-					formatCurrency(row.costUSD),
-				]);
+					table.push([
+						row.date,
+						formatModelsDisplayMultiline(formatModelsList(row.models)),
+						formatNumber(split.inputTokens),
+						formatNumber(split.outputTokens),
+						formatNumber(split.reasoningTokens),
+						formatNumber(split.cacheReadTokens),
+						formatNumber(row.totalTokens),
+						formatCurrency(row.costUSD),
+					]);
+				}
 			}
 
 			addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);

--- a/apps/codex/src/commands/monthly.ts
+++ b/apps/codex/src/commands/monthly.ts
@@ -11,7 +11,12 @@ import { define } from 'gunshi';
 import pc from 'picocolors';
 import { DEFAULT_TIMEZONE } from '../_consts.ts';
 import { sharedArgs } from '../_shared-args.ts';
-import { formatModelsList, splitUsageTokens } from '../command-utils.ts';
+import {
+	createEmptyReportPayload,
+	formatModelsList,
+	groupRowsByProject,
+	splitUsageTokens,
+} from '../command-utils.ts';
 import { loadTokenUsageEvents } from '../data-loader.ts';
 import { normalizeFilterDate } from '../date-utils.ts';
 import { log, logger } from '../logger.ts';
@@ -41,6 +46,8 @@ export const monthlyCommand = define({
 			process.exit(1);
 		}
 
+		const useInstances = Boolean(ctx.values.instances);
+		const projectFilter = ctx.values.project;
 		const { events, missingDirectories } = await loadTokenUsageEvents();
 
 		for (const missing of missingDirectories) {
@@ -49,7 +56,9 @@ export const monthlyCommand = define({
 
 		if (events.length === 0) {
 			log(
-				jsonOutput ? JSON.stringify({ monthly: [], totals: null }) : 'No Codex usage data found.',
+				jsonOutput
+					? JSON.stringify(createEmptyReportPayload('monthly', useInstances))
+					: 'No Codex usage data found.',
 			);
 			return;
 		}
@@ -64,12 +73,14 @@ export const monthlyCommand = define({
 				locale: ctx.values.locale,
 				since,
 				until,
+				project: projectFilter,
+				groupByProject: useInstances,
 			});
 
 			if (rows.length === 0) {
 				log(
 					jsonOutput
-						? JSON.stringify({ monthly: [], totals: null })
+						? JSON.stringify(createEmptyReportPayload('monthly', useInstances))
 						: 'No Codex usage data found for provided filters.',
 				);
 				return;
@@ -96,16 +107,11 @@ export const monthlyCommand = define({
 			);
 
 			if (jsonOutput) {
-				log(
-					JSON.stringify(
-						{
-							monthly: rows,
-							totals,
-						},
-						null,
-						2,
-					),
-				);
+				if (useInstances) {
+					log(JSON.stringify({ projects: groupRowsByProject(rows), totals }, null, 2));
+				} else {
+					log(JSON.stringify({ monthly: rows, totals }, null, 2));
+				}
 				return;
 			}
 
@@ -142,25 +148,61 @@ export const monthlyCommand = define({
 				costUSD: 0,
 			};
 
-			for (const row of rows) {
-				const split = splitUsageTokens(row);
-				totalsForDisplay.inputTokens += split.inputTokens;
-				totalsForDisplay.outputTokens += split.outputTokens;
-				totalsForDisplay.reasoningTokens += split.reasoningTokens;
-				totalsForDisplay.cacheReadTokens += split.cacheReadTokens;
-				totalsForDisplay.totalTokens += row.totalTokens;
-				totalsForDisplay.costUSD += row.costUSD;
+			if (useInstances && rows.some((r) => r.project != null)) {
+				const projectGroups = groupRowsByProject(rows);
+				const sortedProjects = Object.entries(projectGroups).sort(([, a], [, b]) => {
+					const costA = a.reduce((s, r) => s + r.costUSD, 0);
+					const costB = b.reduce((s, r) => s + r.costUSD, 0);
+					return costB - costA;
+				});
+				let isFirst = true;
+				for (const [projectName, projectRows] of sortedProjects) {
+					if (!isFirst) {
+						addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+					}
+					table.push([pc.cyan(`Project: ${projectName}`), '', '', '', '', '', '', '']);
+					for (const row of projectRows) {
+						const split = splitUsageTokens(row);
+						totalsForDisplay.inputTokens += split.inputTokens;
+						totalsForDisplay.outputTokens += split.outputTokens;
+						totalsForDisplay.reasoningTokens += split.reasoningTokens;
+						totalsForDisplay.cacheReadTokens += split.cacheReadTokens;
+						totalsForDisplay.totalTokens += row.totalTokens;
+						totalsForDisplay.costUSD += row.costUSD;
+						table.push([
+							row.month,
+							formatModelsDisplayMultiline(formatModelsList(row.models)),
+							formatNumber(split.inputTokens),
+							formatNumber(split.outputTokens),
+							formatNumber(split.reasoningTokens),
+							formatNumber(split.cacheReadTokens),
+							formatNumber(row.totalTokens),
+							formatCurrency(row.costUSD),
+						]);
+					}
+					isFirst = false;
+				}
+			} else {
+				for (const row of rows) {
+					const split = splitUsageTokens(row);
+					totalsForDisplay.inputTokens += split.inputTokens;
+					totalsForDisplay.outputTokens += split.outputTokens;
+					totalsForDisplay.reasoningTokens += split.reasoningTokens;
+					totalsForDisplay.cacheReadTokens += split.cacheReadTokens;
+					totalsForDisplay.totalTokens += row.totalTokens;
+					totalsForDisplay.costUSD += row.costUSD;
 
-				table.push([
-					row.month,
-					formatModelsDisplayMultiline(formatModelsList(row.models)),
-					formatNumber(split.inputTokens),
-					formatNumber(split.outputTokens),
-					formatNumber(split.reasoningTokens),
-					formatNumber(split.cacheReadTokens),
-					formatNumber(row.totalTokens),
-					formatCurrency(row.costUSD),
-				]);
+					table.push([
+						row.month,
+						formatModelsDisplayMultiline(formatModelsList(row.models)),
+						formatNumber(split.inputTokens),
+						formatNumber(split.outputTokens),
+						formatNumber(split.reasoningTokens),
+						formatNumber(split.cacheReadTokens),
+						formatNumber(row.totalTokens),
+						formatCurrency(row.costUSD),
+					]);
+				}
 			}
 
 			addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);

--- a/apps/codex/src/commands/session.ts
+++ b/apps/codex/src/commands/session.ts
@@ -11,7 +11,12 @@ import { define } from 'gunshi';
 import pc from 'picocolors';
 import { DEFAULT_TIMEZONE } from '../_consts.ts';
 import { sharedArgs } from '../_shared-args.ts';
-import { formatModelsList, splitUsageTokens } from '../command-utils.ts';
+import {
+	createEmptyReportPayload,
+	formatModelsList,
+	groupRowsByProject,
+	splitUsageTokens,
+} from '../command-utils.ts';
 import { loadTokenUsageEvents } from '../data-loader.ts';
 import {
 	formatDisplayDate,
@@ -23,7 +28,8 @@ import { log, logger } from '../logger.ts';
 import { CodexPricingSource } from '../pricing.ts';
 import { buildSessionReport } from '../session-report.ts';
 
-const TABLE_COLUMN_COUNT = 11;
+const TABLE_COLUMN_COUNT_DEFAULT = 11;
+const TABLE_COLUMN_COUNT_WITH_PROJECT = 12;
 
 export const sessionCommand = define({
 	name: 'session',
@@ -46,6 +52,8 @@ export const sessionCommand = define({
 			process.exit(1);
 		}
 
+		const projectFilter = ctx.values.project;
+		const useInstances = Boolean(ctx.values.instances);
 		const { events, missingDirectories } = await loadTokenUsageEvents();
 
 		for (const missing of missingDirectories) {
@@ -54,7 +62,9 @@ export const sessionCommand = define({
 
 		if (events.length === 0) {
 			log(
-				jsonOutput ? JSON.stringify({ sessions: [], totals: null }) : 'No Codex usage data found.',
+				jsonOutput
+					? JSON.stringify(createEmptyReportPayload('sessions', useInstances))
+					: 'No Codex usage data found.',
 			);
 			return;
 		}
@@ -69,12 +79,14 @@ export const sessionCommand = define({
 				locale: ctx.values.locale,
 				since,
 				until,
+				project: projectFilter,
+				groupByProject: useInstances,
 			});
 
 			if (rows.length === 0) {
 				log(
 					jsonOutput
-						? JSON.stringify({ sessions: [], totals: null })
+						? JSON.stringify(createEmptyReportPayload('sessions', useInstances))
 						: 'No Codex usage data found for provided filters.',
 				);
 				return;
@@ -101,16 +113,11 @@ export const sessionCommand = define({
 			);
 
 			if (jsonOutput) {
-				log(
-					JSON.stringify(
-						{
-							sessions: rows,
-							totals,
-						},
-						null,
-						2,
-					),
-				);
+				if (useInstances) {
+					log(JSON.stringify({ projects: groupRowsByProject(rows), totals }, null, 2));
+				} else {
+					log(JSON.stringify({ sessions: rows, totals }, null, 2));
+				}
 				return;
 			}
 
@@ -118,11 +125,26 @@ export const sessionCommand = define({
 				`Codex Token Usage Report - Sessions (Timezone: ${ctx.values.timezone ?? DEFAULT_TIMEZONE})`,
 			);
 
+			const showProject = useInstances && rows.some((r) => r.project != null);
+			const columnCount = showProject
+				? TABLE_COLUMN_COUNT_WITH_PROJECT
+				: TABLE_COLUMN_COUNT_DEFAULT;
+
+			const baseHead = ['Date', 'Directory', 'Session'];
+			const baseAligns: ('left' | 'right')[] = ['left', 'left', 'left'];
+			const baseCompactHead = ['Date', 'Directory', 'Session'];
+			const baseCompactAligns: ('left' | 'right')[] = ['left', 'left', 'left'];
+
+			if (showProject) {
+				baseHead.splice(1, 0, 'Project');
+				baseAligns.splice(1, 0, 'left');
+				baseCompactHead.splice(1, 0, 'Project');
+				baseCompactAligns.splice(1, 0, 'left');
+			}
+
 			const table: ResponsiveTable = new ResponsiveTable({
 				head: [
-					'Date',
-					'Directory',
-					'Session',
+					...baseHead,
 					'Models',
 					'Input',
 					'Output',
@@ -133,9 +155,7 @@ export const sessionCommand = define({
 					'Last Activity',
 				],
 				colAligns: [
-					'left',
-					'left',
-					'left',
+					...baseAligns,
 					'left',
 					'right',
 					'right',
@@ -145,8 +165,8 @@ export const sessionCommand = define({
 					'right',
 					'left',
 				],
-				compactHead: ['Date', 'Directory', 'Session', 'Input', 'Output', 'Cost (USD)'],
-				compactColAligns: ['left', 'left', 'left', 'right', 'right', 'right'],
+				compactHead: [...baseCompactHead, 'Input', 'Output', 'Cost (USD)'],
+				compactColAligns: [...baseCompactAligns, 'right', 'right', 'right'],
 				compactThreshold: 100,
 				forceCompact: ctx.values.compact,
 				style: { head: ['cyan'] },
@@ -177,10 +197,14 @@ export const sessionCommand = define({
 				const sessionFile = row.sessionFile;
 				const shortSession = sessionFile.length > 8 ? `…${sessionFile.slice(-8)}` : sessionFile;
 
+				const baseColumns = [displayDate];
+				if (showProject) {
+					baseColumns.push(row.project ?? '(unknown)');
+				}
+				baseColumns.push(directoryDisplay, shortSession);
+
 				table.push([
-					displayDate,
-					directoryDisplay,
-					shortSession,
+					...baseColumns,
 					formatModelsDisplayMultiline(formatModelsList(row.models)),
 					formatNumber(split.inputTokens),
 					formatNumber(split.outputTokens),
@@ -192,11 +216,12 @@ export const sessionCommand = define({
 				]);
 			}
 
-			addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+			addEmptySeparatorRow(table, columnCount);
+			const totalPrefix = showProject
+				? ['', '', '', pc.yellow('Total')]
+				: ['', '', pc.yellow('Total')];
 			table.push([
-				'',
-				'',
-				pc.yellow('Total'),
+				...totalPrefix,
 				'',
 				pc.yellow(formatNumber(totalsForDisplay.inputTokens)),
 				pc.yellow(formatNumber(totalsForDisplay.outputTokens)),

--- a/apps/codex/src/daily-report.ts
+++ b/apps/codex/src/daily-report.ts
@@ -6,7 +6,9 @@ import type {
 	PricingSource,
 	TokenUsageEvent,
 } from './_types.ts';
+import os from 'node:os';
 import { formatDisplayDate, isWithinRange, toDateKey } from './date-utils.ts';
+import { normalizeProjectFilter, UNKNOWN_PROJECT_LABEL } from './project-utils.ts';
 import { addUsage, calculateCostUSD, createEmptyUsage } from './token-utils.ts';
 
 export type DailyReportOptions = {
@@ -15,6 +17,8 @@ export type DailyReportOptions = {
 	since?: string;
 	until?: string;
 	pricingSource: PricingSource;
+	project?: string;
+	groupByProject?: boolean;
 };
 
 function createSummary(date: string, initialTimestamp: string): DailyUsageSummary {
@@ -43,9 +47,18 @@ export async function buildDailyReport(
 
 	const summaries = new Map<string, DailyUsageSummary>();
 
+	const projectFilter = normalizeProjectFilter(options.project);
+	const groupByProject = options.groupByProject === true;
+
 	for (const event of events) {
 		const modelName = event.model?.trim();
 		if (modelName == null || modelName === '') {
+			continue;
+		}
+
+		const project = normalizeProjectFilter(event.project);
+
+		if (projectFilter != null && project !== projectFilter) {
 			continue;
 		}
 
@@ -54,9 +67,14 @@ export async function buildDailyReport(
 			continue;
 		}
 
-		const summary = summaries.get(dateKey) ?? createSummary(dateKey, event.timestamp);
-		if (!summaries.has(dateKey)) {
-			summaries.set(dateKey, summary);
+		const groupKey = groupByProject ? `${project ?? UNKNOWN_PROJECT_LABEL}::${dateKey}` : dateKey;
+		const summary = summaries.get(groupKey) ?? createSummary(dateKey, event.timestamp);
+		if (!summaries.has(groupKey)) {
+			summaries.set(groupKey, summary);
+		}
+		if (groupByProject) {
+			(summary as DailyUsageSummary & { project?: string }).project =
+				project ?? UNKNOWN_PROJECT_LABEL;
 		}
 
 		addUsage(summary, event);
@@ -87,9 +105,17 @@ export async function buildDailyReport(
 
 	const rows: DailyReportRow[] = [];
 
-	const sortedSummaries = Array.from(summaries.values()).sort((a, b) =>
-		a.date.localeCompare(b.date),
-	);
+	const sortedSummaries = Array.from(summaries.values()).sort((a, b) => {
+		if (groupByProject) {
+			const projA = (a as DailyUsageSummary & { project?: string }).project ?? '';
+			const projB = (b as DailyUsageSummary & { project?: string }).project ?? '';
+			const projCmp = projA.localeCompare(projB);
+			if (projCmp !== 0) {
+				return projCmp;
+			}
+		}
+		return a.date.localeCompare(b.date);
+	});
 	for (const summary of sortedSummaries) {
 		let cost = 0;
 		for (const [modelName, usage] of summary.models) {
@@ -108,6 +134,7 @@ export async function buildDailyReport(
 
 		rows.push({
 			date: formatDisplayDate(summary.date, locale, timezone),
+			project: (summary as DailyUsageSummary & { project?: string }).project,
 			inputTokens: summary.inputTokens,
 			cachedInputTokens: summary.cachedInputTokens,
 			outputTokens: summary.outputTokens,
@@ -200,6 +227,41 @@ if (import.meta.vitest != null) {
 				(100 / 1_000_000) * 0.06 +
 				(200 / 1_000_000) * 2;
 			expect(first.costUSD).toBeCloseTo(expectedCost, 10);
+		});
+
+		it('normalizes the project filter before exact matching', async () => {
+			const stubPricingSource: PricingSource = {
+				async getPricing(): Promise<ModelPricing> {
+					return {
+						inputCostPerMToken: 1,
+						cachedInputCostPerMToken: 0.1,
+						outputCostPerMToken: 2,
+					};
+				},
+			};
+
+			const home = os.homedir();
+			const report = await buildDailyReport(
+				[
+					{
+						sessionId: 'session-1',
+						timestamp: '2025-09-11T03:00:00.000Z',
+						model: 'gpt-5',
+						project: '~/workspace/repo',
+						inputTokens: 100,
+						cachedInputTokens: 0,
+						outputTokens: 50,
+						reasoningOutputTokens: 0,
+						totalTokens: 150,
+					},
+				],
+				{
+					pricingSource: stubPricingSource,
+					project: `${home}/workspace/repo`,
+				},
+			);
+
+			expect(report).toHaveLength(1);
 		});
 	});
 }

--- a/apps/codex/src/data-loader.ts
+++ b/apps/codex/src/data-loader.ts
@@ -1,5 +1,6 @@
 import type { TokenUsageDelta, TokenUsageEvent } from './_types.ts';
 import { readFile, stat } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { Result } from '@praha/byethrow';
@@ -7,12 +8,14 @@ import { createFixture } from 'fs-fixture';
 import { glob } from 'tinyglobby';
 import * as v from 'valibot';
 import {
+	ARCHIVED_SESSION_SUBDIR,
 	CODEX_HOME_ENV,
 	DEFAULT_CODEX_DIR,
 	DEFAULT_SESSION_SUBDIR,
 	SESSION_GLOB,
 } from './_consts.ts';
 import { logger } from './logger.ts';
+import { normalizeProjectPath } from './project-utils.ts';
 
 type RawUsage = {
 	input_tokens: number;
@@ -175,6 +178,10 @@ function asNonEmptyString(value: unknown): string | undefined {
 	return trimmed === '' ? undefined : trimmed;
 }
 
+function extractCwd(payload: Record<string, unknown>): string | undefined {
+	return asNonEmptyString(payload.cwd);
+}
+
 export type LoadOptions = {
 	sessionDirs?: string[];
 };
@@ -194,7 +201,8 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 	const codexHome =
 		codexHomeEnv != null && codexHomeEnv !== '' ? path.resolve(codexHomeEnv) : DEFAULT_CODEX_DIR;
 	const defaultSessionsDir = path.join(codexHome, DEFAULT_SESSION_SUBDIR);
-	const sessionDirs = providedDirs ?? [defaultSessionsDir];
+	const archivedSessionsDir = path.join(codexHome, ARCHIVED_SESSION_SUBDIR);
+	const sessionDirs = providedDirs ?? [defaultSessionsDir, archivedSessionsDir];
 
 	const events: TokenUsageEvent[] = [];
 	const missingDirectories: string[] = [];
@@ -239,6 +247,7 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 			let currentModel: string | undefined;
 			let currentModelIsFallback = false;
 			let legacyFallbackUsed = false;
+			let sessionCwd: string | undefined;
 			const lines = fileContentResult.value.split(/\r?\n/);
 			for (const line of lines) {
 				const trimmed = line.trim();
@@ -263,6 +272,17 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 
 				const { type: entryType, payload, timestamp } = entryParse.output;
 
+				if (entryType === 'session_meta') {
+					const metaPayload = v.safeParse(recordSchema, payload ?? null);
+					if (metaPayload.success) {
+						const cwd = extractCwd(metaPayload.output);
+						if (cwd != null) {
+							sessionCwd = cwd;
+						}
+					}
+					continue;
+				}
+
 				if (entryType === 'turn_context') {
 					const contextPayload = v.safeParse(recordSchema, payload ?? null);
 					if (contextPayload.success) {
@@ -270,6 +290,10 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 						if (contextModel != null) {
 							currentModel = contextModel;
 							currentModelIsFallback = false;
+						}
+						const cwd = extractCwd(contextPayload.output);
+						if (cwd != null) {
+							sessionCwd = cwd;
 						}
 					}
 					continue;
@@ -346,6 +370,7 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 					outputTokens: delta.outputTokens,
 					reasoningOutputTokens: delta.reasoningOutputTokens,
 					totalTokens: delta.totalTokens,
+					project: sessionCwd != null ? normalizeProjectPath(sessionCwd) : undefined,
 				};
 
 				if (isFallbackModel) {
@@ -451,6 +476,115 @@ if (import.meta.vitest != null) {
 			expect(second.model).toBe('gpt-5');
 			expect(second.inputTokens).toBe(800);
 			expect(second.cachedInputTokens).toBe(100);
+		});
+
+		it('extracts project from session_meta cwd', async () => {
+			const home = os.homedir();
+			await using fixture = await createFixture({
+				sessions: {
+					'with-project.jsonl': [
+						JSON.stringify({
+							timestamp: '2025-09-11T18:25:00.000Z',
+							type: 'session_meta',
+							payload: { cwd: `${home}/workspace/my-project` },
+						}),
+						JSON.stringify({
+							timestamp: '2025-09-11T18:25:30.000Z',
+							type: 'turn_context',
+							payload: { model: 'gpt-5', cwd: `${home}/workspace/my-project` },
+						}),
+						JSON.stringify({
+							timestamp: '2025-09-11T18:25:40.000Z',
+							type: 'event_msg',
+							payload: {
+								type: 'token_count',
+								info: {
+									last_token_usage: {
+										input_tokens: 100,
+										cached_input_tokens: 0,
+										output_tokens: 50,
+										reasoning_output_tokens: 0,
+										total_tokens: 150,
+									},
+									model: 'gpt-5',
+								},
+							},
+						}),
+					].join('\n'),
+				},
+			});
+
+			const { events } = await loadTokenUsageEvents({
+				sessionDirs: [fixture.getPath('sessions')],
+			});
+			expect(events).toHaveLength(1);
+			expect(events[0]!.project).toBe('~/workspace/my-project');
+		});
+
+		it('updates project when turn_context cwd changes mid-session', async () => {
+			const home = os.homedir();
+			await using fixture = await createFixture({
+				sessions: {
+					'cd-mid-session.jsonl': [
+						JSON.stringify({
+							timestamp: '2025-09-11T18:00:00.000Z',
+							type: 'session_meta',
+							payload: { cwd: `${home}/project-a` },
+						}),
+						JSON.stringify({
+							timestamp: '2025-09-11T18:00:10.000Z',
+							type: 'turn_context',
+							payload: { model: 'gpt-5', cwd: `${home}/project-a` },
+						}),
+						JSON.stringify({
+							timestamp: '2025-09-11T18:00:20.000Z',
+							type: 'event_msg',
+							payload: {
+								type: 'token_count',
+								info: {
+									last_token_usage: {
+										input_tokens: 100,
+										cached_input_tokens: 0,
+										output_tokens: 50,
+										reasoning_output_tokens: 0,
+										total_tokens: 150,
+									},
+									model: 'gpt-5',
+								},
+							},
+						}),
+						JSON.stringify({
+							timestamp: '2025-09-11T18:01:00.000Z',
+							type: 'turn_context',
+							payload: { model: 'gpt-5', cwd: `${home}/project-b` },
+						}),
+						JSON.stringify({
+							timestamp: '2025-09-11T18:01:10.000Z',
+							type: 'event_msg',
+							payload: {
+								type: 'token_count',
+								info: {
+									last_token_usage: {
+										input_tokens: 200,
+										cached_input_tokens: 0,
+										output_tokens: 100,
+										reasoning_output_tokens: 0,
+										total_tokens: 300,
+									},
+									model: 'gpt-5',
+								},
+							},
+						}),
+					].join('\n'),
+				},
+			});
+
+			const { events } = await loadTokenUsageEvents({
+				sessionDirs: [fixture.getPath('sessions')],
+			});
+			expect(events).toHaveLength(2);
+			expect(events[0]!.project).toBe('~/project-a');
+			expect(events[1]!.project).toBe('~/project-b');
 		});
 
 		it('falls back to legacy model when metadata is missing entirely', async () => {

--- a/apps/codex/src/data-loader.ts
+++ b/apps/codex/src/data-loader.ts
@@ -219,7 +219,11 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 		});
 
 		if (Result.isFailure(statResult)) {
-			if (!optionalDirs.has(directoryPath)) {
+			// Optional dirs suppress only ENOENT (not found). Permission errors and
+			// other failures still surface so users can diagnose real problems.
+			const errno = (statResult.error as NodeJS.ErrnoException | undefined)?.code;
+			const isNotFound = errno === 'ENOENT' || errno === 'ENOTDIR';
+			if (!(optionalDirs.has(directoryPath) && isNotFound)) {
 				missingDirectories.push(directoryPath);
 			}
 			continue;

--- a/apps/codex/src/data-loader.ts
+++ b/apps/codex/src/data-loader.ts
@@ -203,6 +203,10 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 	const defaultSessionsDir = path.join(codexHome, DEFAULT_SESSION_SUBDIR);
 	const archivedSessionsDir = path.join(codexHome, ARCHIVED_SESSION_SUBDIR);
 	const sessionDirs = providedDirs ?? [defaultSessionsDir, archivedSessionsDir];
+	// When auto-discovering, the archived directory is optional: missing it
+	// is normal (most users have never archived) and should not surface as a warning.
+	const optionalDirs =
+		providedDirs != null ? new Set<string>() : new Set([path.resolve(archivedSessionsDir)]);
 
 	const events: TokenUsageEvent[] = [];
 	const missingDirectories: string[] = [];
@@ -215,12 +219,16 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 		});
 
 		if (Result.isFailure(statResult)) {
-			missingDirectories.push(directoryPath);
+			if (!optionalDirs.has(directoryPath)) {
+				missingDirectories.push(directoryPath);
+			}
 			continue;
 		}
 
 		if (!statResult.value.isDirectory()) {
-			missingDirectories.push(directoryPath);
+			if (!optionalDirs.has(directoryPath)) {
+				missingDirectories.push(directoryPath);
+			}
 			continue;
 		}
 

--- a/apps/codex/src/monthly-report.ts
+++ b/apps/codex/src/monthly-report.ts
@@ -6,7 +6,9 @@ import type {
 	PricingSource,
 	TokenUsageEvent,
 } from './_types.ts';
+import os from 'node:os';
 import { formatDisplayMonth, isWithinRange, toDateKey, toMonthKey } from './date-utils.ts';
+import { normalizeProjectFilter, UNKNOWN_PROJECT_LABEL } from './project-utils.ts';
 import { addUsage, calculateCostUSD, createEmptyUsage } from './token-utils.ts';
 
 export type MonthlyReportOptions = {
@@ -15,6 +17,8 @@ export type MonthlyReportOptions = {
 	since?: string;
 	until?: string;
 	pricingSource: PricingSource;
+	project?: string;
+	groupByProject?: boolean;
 };
 
 function createSummary(month: string, initialTimestamp: string): MonthlyUsageSummary {
@@ -43,9 +47,18 @@ export async function buildMonthlyReport(
 
 	const summaries = new Map<string, MonthlyUsageSummary>();
 
+	const projectFilter = normalizeProjectFilter(options.project);
+	const groupByProject = options.groupByProject === true;
+
 	for (const event of events) {
 		const modelName = event.model?.trim();
 		if (modelName == null || modelName === '') {
+			continue;
+		}
+
+		const project = normalizeProjectFilter(event.project);
+
+		if (projectFilter != null && project !== projectFilter) {
 			continue;
 		}
 
@@ -55,9 +68,14 @@ export async function buildMonthlyReport(
 		}
 
 		const monthKey = toMonthKey(event.timestamp, timezone);
-		const summary = summaries.get(monthKey) ?? createSummary(monthKey, event.timestamp);
-		if (!summaries.has(monthKey)) {
-			summaries.set(monthKey, summary);
+		const groupKey = groupByProject ? `${project ?? UNKNOWN_PROJECT_LABEL}::${monthKey}` : monthKey;
+		const summary = summaries.get(groupKey) ?? createSummary(monthKey, event.timestamp);
+		if (!summaries.has(groupKey)) {
+			summaries.set(groupKey, summary);
+		}
+		if (groupByProject) {
+			(summary as MonthlyUsageSummary & { project?: string }).project =
+				project ?? UNKNOWN_PROJECT_LABEL;
 		}
 
 		addUsage(summary, event);
@@ -88,9 +106,17 @@ export async function buildMonthlyReport(
 
 	const rows: MonthlyReportRow[] = [];
 
-	const sortedSummaries = Array.from(summaries.values()).sort((a, b) =>
-		a.month.localeCompare(b.month),
-	);
+	const sortedSummaries = Array.from(summaries.values()).sort((a, b) => {
+		if (groupByProject) {
+			const projA = (a as MonthlyUsageSummary & { project?: string }).project ?? '';
+			const projB = (b as MonthlyUsageSummary & { project?: string }).project ?? '';
+			const projCmp = projA.localeCompare(projB);
+			if (projCmp !== 0) {
+				return projCmp;
+			}
+		}
+		return a.month.localeCompare(b.month);
+	});
 	for (const summary of sortedSummaries) {
 		let cost = 0;
 		for (const [modelName, usage] of summary.models) {
@@ -109,6 +135,7 @@ export async function buildMonthlyReport(
 
 		rows.push({
 			month: formatDisplayMonth(summary.month, locale, timezone),
+			project: (summary as MonthlyUsageSummary & { project?: string }).project,
 			inputTokens: summary.inputTokens,
 			cachedInputTokens: summary.cachedInputTokens,
 			outputTokens: summary.outputTokens,
@@ -200,6 +227,41 @@ if (import.meta.vitest != null) {
 				(100 / 1_000_000) * 0.06 +
 				(200 / 1_000_000) * 2;
 			expect(first.costUSD).toBeCloseTo(expectedCost, 10);
+		});
+
+		it('normalizes the project filter before exact matching', async () => {
+			const stubPricingSource: PricingSource = {
+				async getPricing(): Promise<ModelPricing> {
+					return {
+						inputCostPerMToken: 1,
+						cachedInputCostPerMToken: 0.1,
+						outputCostPerMToken: 2,
+					};
+				},
+			};
+
+			const home = os.homedir();
+			const report = await buildMonthlyReport(
+				[
+					{
+						sessionId: 'session-1',
+						timestamp: '2025-09-11T03:00:00.000Z',
+						model: 'gpt-5',
+						project: '~/workspace/repo',
+						inputTokens: 100,
+						cachedInputTokens: 0,
+						outputTokens: 50,
+						reasoningOutputTokens: 0,
+						totalTokens: 150,
+					},
+				],
+				{
+					pricingSource: stubPricingSource,
+					project: `${home}/workspace/repo`,
+				},
+			);
+
+			expect(report).toHaveLength(1);
 		});
 	});
 }

--- a/apps/codex/src/project-utils.ts
+++ b/apps/codex/src/project-utils.ts
@@ -1,0 +1,78 @@
+import os from 'node:os';
+import path from 'node:path';
+
+export const UNKNOWN_PROJECT_LABEL = '(unknown)';
+export const MIXED_PROJECT_LABEL = '(mixed)';
+
+function expandHomeDirectory(value: string): string {
+	if (value === '~') {
+		return os.homedir();
+	}
+
+	if (value.startsWith('~/') || value.startsWith('~\\')) {
+		return path.join(os.homedir(), value.slice(2));
+	}
+
+	return value;
+}
+
+export function normalizeProjectPath(value: string): string {
+	let normalized = path.normalize(expandHomeDirectory(value.trim()));
+	const home = path.normalize(os.homedir());
+	const root = path.parse(normalized).root;
+
+	while (normalized.length > root.length && normalized.endsWith(path.sep)) {
+		normalized = normalized.slice(0, -path.sep.length);
+	}
+
+	if (normalized === home) {
+		return '~';
+	}
+
+	if (normalized.startsWith(home + path.sep)) {
+		return `~${normalized.slice(home.length)}`;
+	}
+
+	return normalized;
+}
+
+export function normalizeProjectFilter(value: string | undefined): string | undefined {
+	if (value == null) {
+		return undefined;
+	}
+
+	const trimmed = value.trim();
+	return trimmed === '' ? undefined : normalizeProjectPath(trimmed);
+}
+
+if (import.meta.vitest != null) {
+	describe('normalizeProjectPath', () => {
+		it('replaces home directory with ~', () => {
+			const home = os.homedir();
+			expect(normalizeProjectPath(`${home}/workspace/foo`)).toBe('~/workspace/foo');
+		});
+
+		it('normalizes explicit tilde paths to the same project key', () => {
+			expect(normalizeProjectPath('~/workspace/foo/')).toBe('~/workspace/foo');
+		});
+
+		it('returns exact home as ~', () => {
+			expect(normalizeProjectPath(os.homedir())).toBe('~');
+		});
+
+		it('does not corrupt paths that share the home prefix string', () => {
+			const home = os.homedir();
+			expect(normalizeProjectPath(`${home}-backup/repo`)).toBe(`${home}-backup/repo`);
+		});
+
+		it('leaves non-home paths unchanged', () => {
+			expect(normalizeProjectPath('/opt/projects/foo')).toBe('/opt/projects/foo');
+		});
+	});
+
+	describe('normalizeProjectFilter', () => {
+		it('treats blank filters as absent', () => {
+			expect(normalizeProjectFilter('   ')).toBeUndefined();
+		});
+	});
+}

--- a/apps/codex/src/project-utils.ts
+++ b/apps/codex/src/project-utils.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
 
 export const UNKNOWN_PROJECT_LABEL = '(unknown)';
 export const MIXED_PROJECT_LABEL = '(mixed)';
@@ -16,6 +17,14 @@ function expandHomeDirectory(value: string): string {
 	return value;
 }
 
+// On Windows, the filesystem is case-insensitive, so we compare the home prefix
+// case-insensitively while preserving the original casing in the returned path.
+const IS_CASE_INSENSITIVE_FS = process.platform === 'win32';
+
+function equalsPathSegment(a: string, b: string): boolean {
+	return IS_CASE_INSENSITIVE_FS ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
 export function normalizeProjectPath(value: string): string {
 	let normalized = path.normalize(expandHomeDirectory(value.trim()));
 	const home = path.normalize(os.homedir());
@@ -25,12 +34,16 @@ export function normalizeProjectPath(value: string): string {
 		normalized = normalized.slice(0, -path.sep.length);
 	}
 
-	if (normalized === home) {
+	if (equalsPathSegment(normalized, home)) {
 		return '~';
 	}
 
-	if (normalized.startsWith(home + path.sep)) {
-		return `~${normalized.slice(home.length)}`;
+	const homePrefix = home + path.sep;
+	if (
+		normalized.length > homePrefix.length &&
+		equalsPathSegment(normalized.slice(0, homePrefix.length), homePrefix)
+	) {
+		return `~${path.sep}${normalized.slice(homePrefix.length)}`;
 	}
 
 	return normalized;

--- a/apps/codex/src/session-report.ts
+++ b/apps/codex/src/session-report.ts
@@ -6,7 +6,13 @@ import type {
 	SessionUsageSummary,
 	TokenUsageEvent,
 } from './_types.ts';
+import os from 'node:os';
 import { isWithinRange, toDateKey } from './date-utils.ts';
+import {
+	MIXED_PROJECT_LABEL,
+	normalizeProjectFilter,
+	UNKNOWN_PROJECT_LABEL,
+} from './project-utils.ts';
 import { addUsage, calculateCostUSD, createEmptyUsage } from './token-utils.ts';
 
 export type SessionReportOptions = {
@@ -15,6 +21,8 @@ export type SessionReportOptions = {
 	since?: string;
 	until?: string;
 	pricingSource: PricingSource;
+	project?: string;
+	groupByProject?: boolean;
 };
 
 function createSummary(sessionId: string, initialTimestamp: string): SessionUsageSummary {
@@ -40,8 +48,14 @@ export async function buildSessionReport(
 	const since = options.since;
 	const until = options.until;
 	const pricingSource = options.pricingSource;
+	const projectFilter = normalizeProjectFilter(options.project);
+	const groupByProject = options.groupByProject === true;
 
-	const summaries = new Map<string, SessionUsageSummary>();
+	type SessionSummaryWithProject = SessionUsageSummary & {
+		project?: string;
+		projectKeys: Set<string>;
+	};
+	const summaries = new Map<string, SessionSummaryWithProject>();
 
 	for (const event of events) {
 		const rawSessionId = event.sessionId;
@@ -62,14 +76,29 @@ export async function buildSessionReport(
 			continue;
 		}
 
+		const project = normalizeProjectFilter(event.project);
+
+		if (projectFilter != null && project !== projectFilter) {
+			continue;
+		}
+
 		const dateKey = toDateKey(event.timestamp, timezone);
 		if (!isWithinRange(dateKey, since, until)) {
 			continue;
 		}
 
-		const summary = summaries.get(sessionId) ?? createSummary(sessionId, event.timestamp);
-		if (!summaries.has(sessionId)) {
-			summaries.set(sessionId, summary);
+		const projectKey = project ?? UNKNOWN_PROJECT_LABEL;
+		const groupKey = groupByProject ? `${sessionId}::${projectKey}` : sessionId;
+		const summary: SessionSummaryWithProject = summaries.get(groupKey) ?? {
+			...createSummary(sessionId, event.timestamp),
+			projectKeys: new Set<string>(),
+		};
+		if (!summaries.has(groupKey)) {
+			summaries.set(groupKey, summary);
+		}
+		summary.projectKeys.add(projectKey);
+		if (groupByProject) {
+			summary.project = projectKey;
 		}
 
 		addUsage(summary, event);
@@ -134,6 +163,13 @@ export async function buildSessionReport(
 
 		rows.push({
 			sessionId: summary.sessionId,
+			project: groupByProject
+				? summary.project
+				: summary.projectKeys.size === 1
+					? Array.from(summary.projectKeys)[0] === UNKNOWN_PROJECT_LABEL
+						? undefined
+						: Array.from(summary.projectKeys)[0]
+					: MIXED_PROJECT_LABEL,
 			lastActivity: summary.lastTimestamp,
 			sessionFile,
 			directory,
@@ -232,6 +268,134 @@ if (import.meta.vitest != null) {
 				(100 / 1_000_000) * 0.06 +
 				(200 / 1_000_000) * 2;
 			expect(second.costUSD).toBeCloseTo(expectedCost, 10);
+		});
+
+		it('normalizes the project filter before exact matching', async () => {
+			const stubPricingSource: PricingSource = {
+				async getPricing(): Promise<ModelPricing> {
+					return {
+						inputCostPerMToken: 1,
+						cachedInputCostPerMToken: 0.1,
+						outputCostPerMToken: 2,
+					};
+				},
+			};
+
+			const home = os.homedir();
+			const report = await buildSessionReport(
+				[
+					{
+						sessionId: 'session-a',
+						timestamp: '2025-09-12T01:00:00.000Z',
+						model: 'gpt-5',
+						project: '~/workspace/repo',
+						inputTokens: 100,
+						cachedInputTokens: 0,
+						outputTokens: 50,
+						reasoningOutputTokens: 0,
+						totalTokens: 150,
+					},
+				],
+				{
+					pricingSource: stubPricingSource,
+					project: `${home}/workspace/repo`,
+				},
+			);
+
+			expect(report).toHaveLength(1);
+		});
+
+		it('marks mixed-project sessions explicitly when not grouping by project', async () => {
+			const stubPricingSource: PricingSource = {
+				async getPricing(): Promise<ModelPricing> {
+					return {
+						inputCostPerMToken: 1,
+						cachedInputCostPerMToken: 0.1,
+						outputCostPerMToken: 2,
+					};
+				},
+			};
+
+			const report = await buildSessionReport(
+				[
+					{
+						sessionId: 'session-a',
+						timestamp: '2025-09-12T01:00:00.000Z',
+						model: 'gpt-5',
+						project: '~/repo-a',
+						inputTokens: 100,
+						cachedInputTokens: 0,
+						outputTokens: 50,
+						reasoningOutputTokens: 0,
+						totalTokens: 150,
+					},
+					{
+						sessionId: 'session-a',
+						timestamp: '2025-09-12T02:00:00.000Z',
+						model: 'gpt-5',
+						project: '~/repo-b',
+						inputTokens: 200,
+						cachedInputTokens: 0,
+						outputTokens: 100,
+						reasoningOutputTokens: 0,
+						totalTokens: 300,
+					},
+				],
+				{
+					pricingSource: stubPricingSource,
+				},
+			);
+
+			expect(report).toHaveLength(1);
+			expect(report[0]?.project).toBe('(mixed)');
+			expect(report[0]?.totalTokens).toBe(450);
+		});
+
+		it('splits mixed-project sessions when grouping by project', async () => {
+			const stubPricingSource: PricingSource = {
+				async getPricing(): Promise<ModelPricing> {
+					return {
+						inputCostPerMToken: 1,
+						cachedInputCostPerMToken: 0.1,
+						outputCostPerMToken: 2,
+					};
+				},
+			};
+
+			const report = await buildSessionReport(
+				[
+					{
+						sessionId: 'session-a',
+						timestamp: '2025-09-12T01:00:00.000Z',
+						model: 'gpt-5',
+						project: '~/repo-a',
+						inputTokens: 100,
+						cachedInputTokens: 0,
+						outputTokens: 50,
+						reasoningOutputTokens: 0,
+						totalTokens: 150,
+					},
+					{
+						sessionId: 'session-a',
+						timestamp: '2025-09-12T02:00:00.000Z',
+						model: 'gpt-5',
+						project: '~/repo-b',
+						inputTokens: 200,
+						cachedInputTokens: 0,
+						outputTokens: 100,
+						reasoningOutputTokens: 0,
+						totalTokens: 300,
+					},
+				],
+				{
+					pricingSource: stubPricingSource,
+					groupByProject: true,
+				},
+			);
+
+			expect(report).toHaveLength(2);
+			expect(report.map((row) => row.project)).toEqual(['~/repo-a', '~/repo-b']);
+			expect(report.map((row) => row.totalTokens)).toEqual([150, 300]);
 		});
 	});
 }


### PR DESCRIPTION
## Summary

- Add `--instances` (`-i`) flag to show usage breakdown grouped by project across daily, monthly, and session commands
- Add `--project` (`-p`) flag to filter reports to a specific project (exact match on normalized path)
- Extract project from Codex `session_meta` and `turn_context` cwd with mutable tracking for mid-session directory changes
- Scan `archived_sessions/` alongside live `sessions/` directory
- Handle mixed-project sessions: mark as `(mixed)` in default view, split by project when `--instances` is used
- Safe home-path normalization (`~/...`) with boundary check to prevent corruption of similarly-prefixed paths

## Verification

- `pnpm --filter @ccusage/codex typecheck` passes
- `pnpm --filter @ccusage/codex run test` — 26/26 tests pass (7 files)
- Verified `--instances` table output with real local Codex data
- Verified `--project ~/path` exact-match filtering
- Verified `--instances --json` outputs stable `{ projects: {}, totals }` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --project (-p) and --instances (-i) CLI options to filter and group reports by project.
  * Reports (daily, monthly, sessions) can include a project field and optionally group results by project.

* **Behavior Changes**
  * Command outputs change shape in instances mode ({ projects: ... } vs legacy arrays).
  * Empty-report JSON adapts to instances mode.

* **Other**
  * Optional archived-sessions discovery and automatic project extraction/normalization from session metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->