### PR TITLE
feat(ccusage): add weekly cost and flash-then-hide expiry time in statusline

### DIFF
--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -22,6 +22,7 @@ import {
 	loadDailyUsageData,
 	loadSessionBlockData,
 	loadSessionUsageById,
+	loadWeeklyUsageData,
 } from '../data-loader.ts';
 import { log, logger } from '../logger.ts';
 
@@ -76,6 +77,8 @@ type SemaphoreType = {
 	isUpdating?: boolean;
 	/** Process ID of updating process for deadlock detection */
 	pid?: number;
+	/** Timestamp (milliseconds) of the last observed transcript file change, used for expiry time visibility */
+	lastFileChangeTime?: number;
 };
 
 const visualBurnRateChoices = ['off', 'emoji', 'text', 'emoji-text'] as const;
@@ -207,6 +210,15 @@ export const statuslineCommand = define({
 		// Get current file modification time for cache validation and semaphore update
 		const currentMtime = await getFileModifiedTime(hookData.transcript_path);
 
+		// Determine file modification status unconditionally so it can be used in rendering logic
+		const isFileModified =
+			initialSemaphoreState != null ? initialSemaphoreState.transcriptMtime !== currentMtime : true; // First run: treat as change to show expiry immediately
+
+		// Track when the transcript was last modified; carry forward from semaphore if unchanged
+		const lastFileChangeTime = isFileModified
+			? Date.now()
+			: (initialSemaphoreState?.lastFileChangeTime ?? Date.now());
+
 		if (mergedOptions.cache && initialSemaphoreState != null) {
 			/**
 			 * Hybrid cache validation:
@@ -217,7 +229,6 @@ export const statuslineCommand = define({
 			const now = Date.now();
 			const timeElapsed = now - (initialSemaphoreState.lastUpdateTime ?? 0);
 			const isExpired = timeElapsed >= refreshInterval * 1000;
-			const isFileModified = initialSemaphoreState.transcriptMtime !== currentMtime;
 
 			if (!isExpired && !isFileModified) {
 				// Cache is still valid, return cached output
@@ -358,6 +369,27 @@ export const statuslineCommand = define({
 						Result.unwrap(0),
 					);
 
+					// Load this week's usage data (Sunday-based week)
+					const weekStart = new Date(today);
+					weekStart.setDate(today.getDate() - today.getDay());
+					const weekStartStr = weekStart.toISOString().split('T')[0]?.replace(/-/g, '') ?? '';
+
+					const weeklyCost = await Result.pipe(
+						Result.try({
+							try: async () =>
+								loadWeeklyUsageData({
+									since: weekStartStr,
+									until: todayStr,
+									mode: 'auto',
+									offline: mergedOptions.offline,
+								}),
+							catch: (error) => error,
+						})(),
+						Result.map((weeklyData) => weeklyData.reduce((sum, w) => sum + w.totalCost, 0)),
+						Result.inspectError((error) => logger.error('Failed to load weekly data:', error)),
+						Result.unwrap(0),
+					);
+
 					// Load session block data to find active block
 					const { blockInfo, burnRateInfo } = await Result.pipe(
 						Result.try({
@@ -393,7 +425,20 @@ export const statuslineCommand = define({
 								);
 								const blockCost = activeBlock.costUSD;
 
-								const blockInfo = `${formatCurrency(blockCost)} block (${formatRemainingTime(remaining)})`;
+								// Show expiry time for 30s after last file change; flash briefly on update
+								const EXPIRY_SHOW_MS = 30_000;
+								const EXPIRY_FLASH_MS = 3_000;
+								const timeSinceChange = Date.now() - lastFileChangeTime;
+								const showExpiry = remaining > 0 && timeSinceChange < EXPIRY_SHOW_MS;
+								const flashExpiry = showExpiry && timeSinceChange < EXPIRY_FLASH_MS;
+
+								const blockInfo = showExpiry
+									? (() => {
+											const timeStr = formatRemainingTime(remaining);
+											const formattedTime = flashExpiry ? pc.bold(`⚡ ${timeStr}`) : timeStr;
+											return `${formatCurrency(blockCost)} block (${formattedTime})`;
+										})()
+									: `${formatCurrency(blockCost)} block`;
 
 								// Calculate burn rate
 								const burnRate = calculateBurnRate(activeBlock);
@@ -520,7 +565,7 @@ export const statuslineCommand = define({
 						// Single cost display
 						return sessionCost != null ? formatCurrency(sessionCost) : 'N/A';
 					})();
-					const statusLine = `🤖 ${modelName} | 💰 ${sessionDisplay} session / ${formatCurrency(todayCost)} today / ${blockInfo}${burnRateInfo} | 🧠 ${contextInfo ?? 'N/A'}`;
+					const statusLine = `🤖 ${modelName} | 💰 ${sessionDisplay} session / ${formatCurrency(todayCost)} today / ${formatCurrency(weeklyCost)} week / ${blockInfo}${burnRateInfo} | 🧠 ${contextInfo ?? 'N/A'}`;
 					return statusLine;
 				},
 				catch: (error) => error,
@@ -543,6 +588,7 @@ export const statuslineCommand = define({
 				transcriptMtime: currentMtime, // Use mtime from when we started processing
 				isUpdating: false,
 				pid: undefined,
+				lastFileChangeTime,
 			};
 			return;
 		}


### PR DESCRIPTION
## Motivation

Inspired by [the custom statusline script in #902](https://github.com/ryoppippi/ccusage/discussions/902), this PR adds two UX improvements to the built-in statusline:

1. **Weekly cost** — useful for tracking spend across a work-week at a glance, not just today
2. **Flash-then-hide expiry time** — draws attention when a 5-hour block is active, but stays out of the way during idle periods

## Changes

### Weekly cost in the status line

Loads this week's (Sunday–Saturday) total cost using the existing `loadWeeklyUsageData` API and displays it between *today* and *block*:

```
Before: 🤖 Sonnet 4 | 💰 $0.06 session / $2.30 today / $0.45 block (2h30m left) | 🧠 42,500 (21%)
After:  🤖 Sonnet 4 | 💰 $0.06 session / $2.30 today / $15.40 week / $0.45 block (2h30m left) | 🧠 42,500 (21%)
```

### Flash-then-hide expiry time

The block expiry time is now context-aware using a new `lastFileChangeTime` field in the semaphore:

| Time since last activity | Expiry display |
|---|---|
| 0–3 s | `⚡ **2h30m left**` (bold flash) |
| 3–30 s | `2h30m left` (normal) |
| > 30 s | hidden (clean idle state) |

This keeps the status line informative right after each interaction and quiet during long idle periods, matching the spirit of the script in #902.

## Implementation details

- `lastFileChangeTime` is persisted in the semaphore so the 30 s window survives across caching cycles (default 1 s refresh interval)
- On first run or if the semaphore is missing, the time is initialised to `Date.now()` so the expiry shows immediately
- All existing cache/concurrency logic is unchanged; the only new semaphore field is optional and backward-compatible

## Testing

- TypeScript passes clean (`pnpm typecheck`)
- ESLint/formatter passes clean (`pnpm run format`)
- Existing test failures are pre-existing ENOSPC (disk space) issues in the CI environment, unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly cost breakdown now displays in the status line alongside today's cost.
  * Block display shows remaining time for 30 seconds after transcript changes.
  * Added ⚡ indicator during the first 3 seconds following updates for visual emphasis.
  * Enhanced status line formatting with improved cost information presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->