### PR TITLE
feat(ccusage): add --chart flag for terminal bar chart visualization  

### DIFF
--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -97,6 +97,12 @@
 							"description": "Force compact mode for narrow displays (better for screenshots)",
 							"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 							"default": false
+						},
+						"chart": {
+							"type": "boolean",
+							"description": "Display usage as a horizontal bar chart instead of a table",
+							"markdownDescription": "Display usage as a horizontal bar chart instead of a table",
+							"default": false
 						}
 					},
 					"additionalProperties": false,
@@ -193,6 +199,12 @@
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+									"default": false
+								},
+								"chart": {
+									"type": "boolean",
+									"description": "Display usage as a horizontal bar chart instead of a table",
+									"markdownDescription": "Display usage as a horizontal bar chart instead of a table",
 									"default": false
 								},
 								"instances": {
@@ -302,6 +314,12 @@
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
+								},
+								"chart": {
+									"type": "boolean",
+									"description": "Display usage as a horizontal bar chart instead of a table",
+									"markdownDescription": "Display usage as a horizontal bar chart instead of a table",
+									"default": false
 								}
 							},
 							"additionalProperties": false
@@ -393,6 +411,12 @@
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+									"default": false
+								},
+								"chart": {
+									"type": "boolean",
+									"description": "Display usage as a horizontal bar chart instead of a table",
+									"markdownDescription": "Display usage as a horizontal bar chart instead of a table",
 									"default": false
 								},
 								"startOfWeek": {
@@ -495,6 +519,12 @@
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
 								},
+								"chart": {
+									"type": "boolean",
+									"description": "Display usage as a horizontal bar chart instead of a table",
+									"markdownDescription": "Display usage as a horizontal bar chart instead of a table",
+									"default": false
+								},
 								"id": {
 									"type": "string",
 									"description": "Load usage data for a specific session ID",
@@ -590,6 +620,12 @@
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+									"default": false
+								},
+								"chart": {
+									"type": "boolean",
+									"description": "Display usage as a horizontal bar chart instead of a table",
+									"markdownDescription": "Display usage as a horizontal bar chart instead of a table",
 									"default": false
 								},
 								"active": {

--- a/apps/ccusage/src/_shared-args.ts
+++ b/apps/ccusage/src/_shared-args.ts
@@ -110,6 +110,12 @@ export const sharedArgs = {
 		description: 'Force compact mode for narrow displays (better for screenshots)',
 		default: false,
 	},
+	chart: {
+		type: 'boolean',
+		short: 'c',
+		description: 'Display usage as a horizontal bar chart instead of a table',
+		default: false,
+	},
 } as const satisfies Args;
 
 /**

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -299,6 +299,7 @@ export const blocksCommand = define({
 			});
 			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
 				forceCompact: mergedOptions.compact,
+				locale: mergedOptions.locale ?? undefined,
 			});
 			log(output);
 			log(renderChartSeparator());

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -278,17 +278,18 @@ export const blocksCommand = define({
 			} else {
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
-		} else if (ctx.values.chart) {
+		} else if (mergedOptions.chart) {
 			// Chart output
 			logger.box('Claude Code Token Usage Report - Session Blocks');
 
 			const nonGapBlocks = blocks.filter((b: SessionBlock) => !(b.isGap ?? false));
 			const chartData = nonGapBlocks.map((block: SessionBlock) => {
-				const label = block.startTime.toLocaleString(ctx.values.locale, {
+				const label = block.startTime.toLocaleString(mergedOptions.locale, {
 					month: '2-digit',
 					day: '2-digit',
 					hour: '2-digit',
 					minute: '2-digit',
+					...(mergedOptions.timezone != null && { timeZone: mergedOptions.timezone }),
 				});
 				return {
 					label,
@@ -297,7 +298,7 @@ export const blocksCommand = define({
 				};
 			});
 			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
-				forceCompact: ctx.values.compact,
+				forceCompact: mergedOptions.compact,
 			});
 			log(output);
 			log(renderChartSeparator());

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -1,5 +1,6 @@
 import type { SessionBlock } from '../_session-blocks.ts';
 import process from 'node:process';
+import { renderBarChart, renderChartSeparator, renderChartTotals } from '@ccusage/terminal/chart';
 import {
 	formatCurrency,
 	formatModelsDisplayMultiline,
@@ -277,6 +278,30 @@ export const blocksCommand = define({
 			} else {
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
+		} else if (ctx.values.chart) {
+			// Chart output
+			logger.box('Claude Code Token Usage Report - Session Blocks');
+
+			const nonGapBlocks = blocks.filter((b: SessionBlock) => !(b.isGap ?? false));
+			const chartData = nonGapBlocks.map((block: SessionBlock) => {
+				const label = block.startTime.toLocaleString(ctx.values.locale, {
+					month: '2-digit',
+					day: '2-digit',
+					hour: '2-digit',
+					minute: '2-digit',
+				});
+				return {
+					label,
+					value: block.costUSD,
+					formattedValue: formatCurrency(block.costUSD),
+				};
+			});
+			const chart = renderBarChart(chartData, { forceCompact: ctx.values.compact });
+			log(chart);
+			log(renderChartSeparator());
+			const totalCost = nonGapBlocks.reduce((sum: number, b: SessionBlock) => sum + b.costUSD, 0);
+			const maxLabelWidth = Math.max(...chartData.map((d) => d.label.length));
+			log(renderChartTotals('Total', formatCurrency(totalCost), maxLabelWidth + 2));
 		} else {
 			// Table output
 			if (ctx.values.active && blocks.length === 1) {

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -296,13 +296,13 @@ export const blocksCommand = define({
 					formattedValue: formatCurrency(block.costUSD),
 				};
 			});
-			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+			const { output, labelWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
 			const totalCost = nonGapBlocks.reduce((sum: number, b: SessionBlock) => sum + b.costUSD, 0);
-			log(renderChartTotals('Total', formatCurrency(totalCost), labelWidth, barWidth));
+			log(renderChartTotals('Total', formatCurrency(totalCost), labelWidth));
 		} else {
 			// Table output
 			if (ctx.values.active && blocks.length === 1) {

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -296,13 +296,13 @@ export const blocksCommand = define({
 					formattedValue: formatCurrency(block.costUSD),
 				};
 			});
-			const { output, labelWidth } = renderBarChart(chartData, {
+			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
 			const totalCost = nonGapBlocks.reduce((sum: number, b: SessionBlock) => sum + b.costUSD, 0);
-			log(renderChartTotals('Total', formatCurrency(totalCost), labelWidth));
+			log(renderChartTotals('Total', formatCurrency(totalCost), labelWidth, barWidth));
 		} else {
 			// Table output
 			if (ctx.values.active && blocks.length === 1) {

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -296,13 +296,13 @@ export const blocksCommand = define({
 					formattedValue: formatCurrency(block.costUSD),
 				};
 			});
-			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
 			const totalCost = nonGapBlocks.reduce((sum: number, b: SessionBlock) => sum + b.costUSD, 0);
-			log(renderChartTotals('Total', formatCurrency(totalCost), labelWidth, barWidth));
+			log(renderChartTotals('Total', formatCurrency(totalCost), labelWidth, barWidth, valueWidth));
 		} else {
 			// Table output
 			if (ctx.values.active && blocks.length === 1) {

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -296,12 +296,13 @@ export const blocksCommand = define({
 					formattedValue: formatCurrency(block.costUSD),
 				};
 			});
-			const chart = renderBarChart(chartData, { forceCompact: ctx.values.compact });
-			log(chart);
+			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+				forceCompact: ctx.values.compact,
+			});
+			log(output);
 			log(renderChartSeparator());
 			const totalCost = nonGapBlocks.reduce((sum: number, b: SessionBlock) => sum + b.costUSD, 0);
-			const maxLabelWidth = Math.max(...chartData.map((d) => d.label.length));
-			log(renderChartTotals('Total', formatCurrency(totalCost), maxLabelWidth + 2));
+			log(renderChartTotals('Total', formatCurrency(totalCost), labelWidth, barWidth));
 		} else {
 			// Table output
 			if (ctx.values.active && blocks.length === 1) {

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -145,11 +145,12 @@ export const dailyCommand = define({
 			logger.box('Claude Code Token Usage Report - Daily');
 
 			const chartData = createCostChartData(dailyData, 'date');
-			const chart = renderBarChart(chartData, { forceCompact: ctx.values.compact });
-			log(chart);
+			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+				forceCompact: ctx.values.compact,
+			});
+			log(output);
 			log(renderChartSeparator());
-			const maxLabelWidth = Math.max(...dailyData.map((d) => d.date.length));
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), maxLabelWidth + 2));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Daily');

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -145,12 +145,20 @@ export const dailyCommand = define({
 			logger.box('Claude Code Token Usage Report - Daily');
 
 			const chartData = createCostChartData(dailyData, 'date');
-			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
+			log(
+				renderChartTotals(
+					'Total',
+					formatCurrency(totals.totalCost),
+					labelWidth,
+					barWidth,
+					valueWidth,
+				),
+			);
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Daily');

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -145,12 +145,12 @@ export const dailyCommand = define({
 			logger.box('Claude Code Token Usage Report - Daily');
 
 			const chartData = createCostChartData(dailyData, 'date');
-			const { output, labelWidth } = renderBarChart(chartData, {
+			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Daily');

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -145,12 +145,12 @@ export const dailyCommand = define({
 			logger.box('Claude Code Token Usage Report - Daily');
 
 			const chartData = createCostChartData(dailyData, 'date');
-			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+			const { output, labelWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Daily');

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -19,7 +19,7 @@ import { define } from 'gunshi';
 import pc from 'picocolors';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { groupByProject, groupDataByProject } from '../_daily-grouping.ts';
-import { formatDateCompact } from '../_date-utils.ts';
+import { formatDate, formatDateCompact } from '../_date-utils.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { formatProjectName } from '../_project-names.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
@@ -144,7 +144,10 @@ export const dailyCommand = define({
 			// Chart output
 			logger.box('Claude Code Token Usage Report - Daily');
 
-			const chartData = createCostChartData(dailyData, 'date');
+			const chartData = createCostChartData(dailyData, 'date', {
+				labelFormatter: (v) =>
+					formatDate(v, mergedOptions.timezone, mergedOptions.locale ?? undefined),
+			});
 			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -1,8 +1,15 @@
 import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
 import {
+	createCostChartData,
+	renderBarChart,
+	renderChartSeparator,
+	renderChartTotals,
+} from '@ccusage/terminal/chart';
+import {
 	addEmptySeparatorRow,
 	createUsageReportTable,
+	formatCurrency,
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
@@ -133,6 +140,16 @@ export const dailyCommand = define({
 			} else {
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
+		} else if (ctx.values.chart) {
+			// Chart output
+			logger.box('Claude Code Token Usage Report - Daily');
+
+			const chartData = createCostChartData(dailyData, 'date');
+			const chart = renderBarChart(chartData, { forceCompact: ctx.values.compact });
+			log(chart);
+			log(renderChartSeparator());
+			const maxLabelWidth = Math.max(...dailyData.map((d) => d.date.length));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), maxLabelWidth + 2));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Daily');

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -140,8 +140,11 @@ export const dailyCommand = define({
 			} else {
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
-		} else if (ctx.values.chart) {
+		} else if (mergedOptions.chart) {
 			// Chart output
+			if (mergedOptions.instances) {
+				logger.warn('--chart does not support --instances. Ignoring --instances.');
+			}
 			logger.box('Claude Code Token Usage Report - Daily');
 
 			const chartData = createCostChartData(dailyData, 'date', {
@@ -149,7 +152,8 @@ export const dailyCommand = define({
 					formatDate(v, mergedOptions.timezone, mergedOptions.locale ?? undefined),
 			});
 			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
-				forceCompact: ctx.values.compact,
+				forceCompact: mergedOptions.compact,
+				locale: mergedOptions.locale ?? undefined,
 			});
 			log(output);
 			log(renderChartSeparator());

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -105,11 +105,12 @@ export const monthlyCommand = define({
 			logger.box('Claude Code Token Usage Report - Monthly');
 
 			const chartData = createCostChartData(monthlyData, 'month');
-			const chart = renderBarChart(chartData, { forceCompact: ctx.values.compact });
-			log(chart);
+			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+				forceCompact: ctx.values.compact,
+			});
+			log(output);
 			log(renderChartSeparator());
-			const maxLabelWidth = Math.max(...monthlyData.map((d) => d.month.length));
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), maxLabelWidth + 2));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Monthly');

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -18,7 +18,7 @@ import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { DEFAULT_LOCALE } from '../_consts.ts';
-import { formatDateCompact } from '../_date-utils.ts';
+import { formatDate, formatDateCompact } from '../_date-utils.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
 import { calculateTotals, createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
@@ -104,7 +104,10 @@ export const monthlyCommand = define({
 			// Chart output
 			logger.box('Claude Code Token Usage Report - Monthly');
 
-			const chartData = createCostChartData(monthlyData, 'month');
+			const chartData = createCostChartData(monthlyData, 'month', {
+				labelFormatter: (v) =>
+					formatDate(v, mergedOptions.timezone, mergedOptions.locale ?? undefined),
+			});
 			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -105,12 +105,12 @@ export const monthlyCommand = define({
 			logger.box('Claude Code Token Usage Report - Monthly');
 
 			const chartData = createCostChartData(monthlyData, 'month');
-			const { output, labelWidth } = renderBarChart(chartData, {
+			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Monthly');

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -105,12 +105,12 @@ export const monthlyCommand = define({
 			logger.box('Claude Code Token Usage Report - Monthly');
 
 			const chartData = createCostChartData(monthlyData, 'month');
-			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+			const { output, labelWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Monthly');

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -100,7 +100,7 @@ export const monthlyCommand = define({
 			} else {
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
-		} else if (ctx.values.chart) {
+		} else if (mergedOptions.chart) {
 			// Chart output
 			logger.box('Claude Code Token Usage Report - Monthly');
 
@@ -109,7 +109,8 @@ export const monthlyCommand = define({
 					formatDate(v, mergedOptions.timezone, mergedOptions.locale ?? undefined),
 			});
 			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
-				forceCompact: ctx.values.compact,
+				forceCompact: mergedOptions.compact,
+				locale: mergedOptions.locale ?? undefined,
 			});
 			log(output);
 			log(renderChartSeparator());

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -105,12 +105,20 @@ export const monthlyCommand = define({
 			logger.box('Claude Code Token Usage Report - Monthly');
 
 			const chartData = createCostChartData(monthlyData, 'month');
-			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
+			log(
+				renderChartTotals(
+					'Total',
+					formatCurrency(totals.totalCost),
+					labelWidth,
+					barWidth,
+					valueWidth,
+				),
+			);
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Monthly');

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -1,8 +1,15 @@
 import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
 import {
+	createCostChartData,
+	renderBarChart,
+	renderChartSeparator,
+	renderChartTotals,
+} from '@ccusage/terminal/chart';
+import {
 	addEmptySeparatorRow,
 	createUsageReportTable,
+	formatCurrency,
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
@@ -93,6 +100,16 @@ export const monthlyCommand = define({
 			} else {
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
+		} else if (ctx.values.chart) {
+			// Chart output
+			logger.box('Claude Code Token Usage Report - Monthly');
+
+			const chartData = createCostChartData(monthlyData, 'month');
+			const chart = renderBarChart(chartData, { forceCompact: ctx.values.compact });
+			log(chart);
+			log(renderChartSeparator());
+			const maxLabelWidth = Math.max(...monthlyData.map((d) => d.month.length));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), maxLabelWidth + 2));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Monthly');

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -124,7 +124,7 @@ export const sessionCommand = define({
 			} else {
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
-		} else if (ctx.values.chart) {
+		} else if (mergedOptions.chart) {
 			// Chart output
 			logger.box('Claude Code Token Usage Report - By Session');
 
@@ -137,7 +137,7 @@ export const sessionCommand = define({
 				};
 			});
 			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
-				forceCompact: ctx.values.compact,
+				forceCompact: mergedOptions.compact,
 			});
 			log(output);
 			log(renderChartSeparator());

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -136,12 +136,12 @@ export const sessionCommand = define({
 					formattedValue: formatCurrency(data.totalCost),
 				};
 			});
-			const { output, labelWidth } = renderBarChart(chartData, {
+			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - By Session');

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -138,6 +138,7 @@ export const sessionCommand = define({
 			});
 			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
 				forceCompact: mergedOptions.compact,
+				locale: mergedOptions.locale ?? undefined,
 			});
 			log(output);
 			log(renderChartSeparator());

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -1,8 +1,10 @@
 import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
+import { renderBarChart, renderChartSeparator, renderChartTotals } from '@ccusage/terminal/chart';
 import {
 	addEmptySeparatorRow,
 	createUsageReportTable,
+	formatCurrency,
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
@@ -122,6 +124,25 @@ export const sessionCommand = define({
 			} else {
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
+		} else if (ctx.values.chart) {
+			// Chart output
+			logger.box('Claude Code Token Usage Report - By Session');
+
+			const chartData = sessionData.map((data) => {
+				const sessionDisplay = data.sessionId.split('-').slice(-2).join('-');
+				return {
+					label: sessionDisplay,
+					value: data.totalCost,
+					formattedValue: formatCurrency(data.totalCost),
+				};
+			});
+			const chart = renderBarChart(chartData, { forceCompact: ctx.values.compact });
+			log(chart);
+			log(renderChartSeparator());
+			const maxLabelWidth = Math.max(
+				...sessionData.map((d) => d.sessionId.split('-').slice(-2).join('-').length),
+			);
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), maxLabelWidth + 2));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - By Session');

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -136,12 +136,20 @@ export const sessionCommand = define({
 					formattedValue: formatCurrency(data.totalCost),
 				};
 			});
-			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
+			log(
+				renderChartTotals(
+					'Total',
+					formatCurrency(totals.totalCost),
+					labelWidth,
+					barWidth,
+					valueWidth,
+				),
+			);
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - By Session');

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -136,13 +136,12 @@ export const sessionCommand = define({
 					formattedValue: formatCurrency(data.totalCost),
 				};
 			});
-			const chart = renderBarChart(chartData, { forceCompact: ctx.values.compact });
-			log(chart);
+			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+				forceCompact: ctx.values.compact,
+			});
+			log(output);
 			log(renderChartSeparator());
-			const maxLabelWidth = Math.max(
-				...sessionData.map((d) => d.sessionId.split('-').slice(-2).join('-').length),
-			);
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), maxLabelWidth + 2));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - By Session');

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -136,12 +136,12 @@ export const sessionCommand = define({
 					formattedValue: formatCurrency(data.totalCost),
 				};
 			});
-			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+			const { output, labelWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - By Session');

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -115,12 +115,12 @@ export const weeklyCommand = define({
 			logger.box('Claude Code Token Usage Report - Weekly');
 
 			const chartData = createCostChartData(weeklyData, 'week');
-			const { output, labelWidth } = renderBarChart(chartData, {
+			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Weekly');

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -115,12 +115,12 @@ export const weeklyCommand = define({
 			logger.box('Claude Code Token Usage Report - Weekly');
 
 			const chartData = createCostChartData(weeklyData, 'week');
-			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+			const { output, labelWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Weekly');

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -18,7 +18,7 @@ import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { WEEK_DAYS } from '../_consts.ts';
-import { formatDateCompact } from '../_date-utils.ts';
+import { formatDate, formatDateCompact } from '../_date-utils.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { sharedArgs } from '../_shared-args.ts';
 import { calculateTotals, createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
@@ -114,7 +114,10 @@ export const weeklyCommand = define({
 			// Chart output
 			logger.box('Claude Code Token Usage Report - Weekly');
 
-			const chartData = createCostChartData(weeklyData, 'week');
+			const chartData = createCostChartData(weeklyData, 'week', {
+				labelFormatter: (v) =>
+					formatDate(v, mergedOptions.timezone, mergedOptions.locale ?? undefined),
+			});
 			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -110,7 +110,7 @@ export const weeklyCommand = define({
 			} else {
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
-		} else if (ctx.values.chart) {
+		} else if (mergedOptions.chart) {
 			// Chart output
 			logger.box('Claude Code Token Usage Report - Weekly');
 
@@ -119,7 +119,8 @@ export const weeklyCommand = define({
 					formatDate(v, mergedOptions.timezone, mergedOptions.locale ?? undefined),
 			});
 			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
-				forceCompact: ctx.values.compact,
+				forceCompact: mergedOptions.compact,
+				locale: mergedOptions.locale ?? undefined,
 			});
 			log(output);
 			log(renderChartSeparator());

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -115,12 +115,20 @@ export const weeklyCommand = define({
 			logger.box('Claude Code Token Usage Report - Weekly');
 
 			const chartData = createCostChartData(weeklyData, 'week');
-			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+			const { output, labelWidth, barWidth, valueWidth } = renderBarChart(chartData, {
 				forceCompact: ctx.values.compact,
 			});
 			log(output);
 			log(renderChartSeparator());
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
+			log(
+				renderChartTotals(
+					'Total',
+					formatCurrency(totals.totalCost),
+					labelWidth,
+					barWidth,
+					valueWidth,
+				),
+			);
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Weekly');

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -115,11 +115,12 @@ export const weeklyCommand = define({
 			logger.box('Claude Code Token Usage Report - Weekly');
 
 			const chartData = createCostChartData(weeklyData, 'week');
-			const chart = renderBarChart(chartData, { forceCompact: ctx.values.compact });
-			log(chart);
+			const { output, labelWidth, barWidth } = renderBarChart(chartData, {
+				forceCompact: ctx.values.compact,
+			});
+			log(output);
 			log(renderChartSeparator());
-			const maxLabelWidth = Math.max(...weeklyData.map((d) => d.week.length));
-			log(renderChartTotals('Total', formatCurrency(totals.totalCost), maxLabelWidth + 2));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), labelWidth, barWidth));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Weekly');

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -1,8 +1,15 @@
 import type { UsageReportConfig } from '@ccusage/terminal/table';
 import process from 'node:process';
 import {
+	createCostChartData,
+	renderBarChart,
+	renderChartSeparator,
+	renderChartTotals,
+} from '@ccusage/terminal/chart';
+import {
 	addEmptySeparatorRow,
 	createUsageReportTable,
+	formatCurrency,
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
@@ -103,6 +110,16 @@ export const weeklyCommand = define({
 			} else {
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
+		} else if (ctx.values.chart) {
+			// Chart output
+			logger.box('Claude Code Token Usage Report - Weekly');
+
+			const chartData = createCostChartData(weeklyData, 'week');
+			const chart = renderBarChart(chartData, { forceCompact: ctx.values.compact });
+			log(chart);
+			log(renderChartSeparator());
+			const maxLabelWidth = Math.max(...weeklyData.map((d) => d.week.length));
+			log(renderChartTotals('Total', formatCurrency(totals.totalCost), maxLabelWidth + 2));
 		} else {
 			// Print header
 			logger.box('Claude Code Token Usage Report - Weekly');

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -6,6 +6,7 @@
 	"description": "Terminal utilities for ccusage",
 	"exports": {
 		"./table": "./src/table.ts",
+		"./chart": "./src/chart.ts",
 		"./utils": "./src/utils.ts"
 	},
 	"scripts": {

--- a/packages/terminal/src/chart.ts
+++ b/packages/terminal/src/chart.ts
@@ -29,6 +29,8 @@ export type ChartOptions = {
 	valueSuffix?: string;
 	/** Force compact layout for narrow terminals */
 	forceCompact?: boolean;
+	/** Locale for formatting group headers (e.g., "en-US", "ja-JP") */
+	locale?: string;
 };
 
 /**
@@ -91,7 +93,7 @@ export function renderBarChart(
 		return { output: '', labelWidth: 0, barWidth: 0, valueWidth: 0 };
 	}
 
-	const { fillChar = '█', showValues = true, forceCompact = false } = options;
+	const { fillChar = '█', showValues = true, forceCompact = false, locale } = options;
 
 	// Determine terminal width
 	const terminalWidth =
@@ -114,37 +116,18 @@ export function renderBarChart(
 	// Find max value for scaling
 	const maxValue = Math.max(...data.map((d) => d.value), 0);
 
-	// Month name lookup for group headers
-	const monthNames = [
-		'January',
-		'February',
-		'March',
-		'April',
-		'May',
-		'June',
-		'July',
-		'August',
-		'September',
-		'October',
-		'November',
-		'December',
-	];
-
 	/**
-	 * Converts a YYYY-MM group key to a readable month label (e.g., "March 2026")
+	 * Converts a YYYY-MM group key to a localized month label (e.g., "March 2026")
 	 */
 	function formatGroupLabel(group: string): string | undefined {
 		const match = group.match(/^(\d{4})-(\d{2})$/);
 		if (match == null) {
 			return undefined;
 		}
-		const year = match[1];
+		const year = Number.parseInt(match[1]!, 10);
 		const monthIndex = Number.parseInt(match[2]!, 10) - 1;
-		const name = monthNames[monthIndex];
-		if (name == null) {
-			return undefined;
-		}
-		return `${name} ${year}`;
+		const date = new Date(year, monthIndex);
+		return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(date);
 	}
 
 	const lines: string[] = [];
@@ -270,9 +253,10 @@ export function createCostChartData<T extends Record<string, unknown>>(
 	const costKey = options?.costKey ?? ('totalCost' as keyof T & string);
 	const labelFormatter = options?.labelFormatter;
 
-	// Auto-detect date labels for month grouping
+	// Auto-detect full date labels (YYYY-MM-DD) for month grouping
+	// Intentionally excludes YYYY-MM (monthly keys) to avoid redundant per-row headers
 	const autoGroupByMonth = (val: string): string | undefined => {
-		const match = val.match(/^(\d{4}-\d{2})/);
+		const match = val.match(/^(\d{4}-\d{2})-\d{2}/);
 		return match?.[1];
 	};
 
@@ -508,6 +492,18 @@ if (import.meta.vitest != null) {
 
 			expect(data[0]?.group).toBe('2026-01');
 			expect(data[1]?.group).toBe('2026-02');
+		});
+
+		it('should not auto-group monthly keys (YYYY-MM)', () => {
+			const items = [
+				{ month: '2026-01', totalCost: 5 },
+				{ month: '2026-02', totalCost: 10 },
+			];
+
+			const data = createCostChartData(items, 'month');
+
+			expect(data[0]?.group).toBeUndefined();
+			expect(data[1]?.group).toBeUndefined();
 		});
 
 		it('should apply label formatter', () => {

--- a/packages/terminal/src/chart.ts
+++ b/packages/terminal/src/chart.ts
@@ -21,12 +21,10 @@ export type ChartOptions = {
 	maxBarWidth?: number;
 	/** Character used for filled portion of bars */
 	fillChar?: string;
+	/** Character used for the bar tip (partial block) */
+	tipChar?: string;
 	/** Whether to show value labels to the right of bars */
 	showValues?: boolean;
-	/** Color function applied to bars (from picocolors) */
-	barColor?: (text: string) => string;
-	/** Color function applied to the max-value bar */
-	maxBarColor?: (text: string) => string;
 	/** Suffix appended to formatted values (e.g., " tokens") */
 	valueSuffix?: string;
 	/** Force compact layout for narrow terminals */
@@ -41,12 +39,37 @@ function formatCurrencyValue(amount: number): string {
 }
 
 /**
+ * Picks a color based on where a value falls within the range [0, max].
+ * Low values get dim blue, mid gets cyan, high gets yellow, top gets bold green.
+ */
+function colorForValue(value: number, maxValue: number): (text: string) => string {
+	if (maxValue <= 0) {
+		return pc.gray;
+	}
+	const ratio = value / maxValue;
+	if (ratio >= 0.95) {
+		return (t: string) => pc.bold(pc.green(t));
+	}
+	if (ratio >= 0.65) {
+		return pc.yellow;
+	}
+	if (ratio >= 0.35) {
+		return pc.cyan;
+	}
+	if (ratio > 0) {
+		return pc.blue;
+	}
+	return pc.gray;
+}
+
+/**
  * Renders a horizontal bar chart as a string for terminal output
  *
- * Example output:
- *   2026-03-28  ████████████████████████████████████  $12.45
- *   2026-03-29  ██████████████████████               $8.20
- *   Total                                             $35.10
+ * Features:
+ * - Color gradient: bars transition from blue (low) -> cyan -> yellow -> bold green (peak)
+ * - Non-zero values always show at least a thin bar (▏) so nothing is invisible
+ * - Cost values are placed right next to bars for easy reading
+ * - Fractional block characters (▏▎▍▌▋▊▉█) for sub-character precision
  *
  * @param data - Array of data points to render
  * @param options - Chart display options
@@ -57,13 +80,10 @@ export function renderBarChart(data: ChartDataPoint[], options: ChartOptions = {
 		return '';
 	}
 
-	const {
-		fillChar = '█',
-		showValues = true,
-		barColor = pc.cyan,
-		maxBarColor = pc.green,
-		forceCompact = false,
-	} = options;
+	const { fillChar = '█', tipChar = '▏', showValues = true, forceCompact = false } = options;
+
+	// Sub-character block elements for fractional widths (⅛ increments)
+	const fractionalBlocks = ['', '▏', '▎', '▍', '▌', '▋', '▊', '▉'];
 
 	// Determine terminal width
 	const terminalWidth =
@@ -95,22 +115,40 @@ export function renderBarChart(data: ChartDataPoint[], options: ChartOptions = {
 
 		// Pad label to consistent width (right-align)
 		const labelPad = labelWidth - stringWidth(point.label);
-		const paddedLabel = ' '.repeat(labelPad) + point.label;
+		const paddedLabel = ' '.repeat(labelPad) + pc.white(point.label);
 
-		// Calculate bar length
-		const barLength = maxValue > 0 ? Math.round((point.value / maxValue) * maxBarWidth) : 0;
-		const bar = fillChar.repeat(barLength);
-		const barPadding = ' '.repeat(maxBarWidth - barLength);
+		// Calculate bar length with fractional precision
+		const exactBarWidth = maxValue > 0 ? (point.value / maxValue) * maxBarWidth : 0;
+		const fullBlocks = Math.floor(exactBarWidth);
+		const fractionalIndex = Math.round((exactBarWidth - fullBlocks) * 8);
+		const fractional = fractionalBlocks[fractionalIndex] ?? '';
 
-		// Apply color - highlight the max value bar
-		const colorFn = point.value === maxValue && maxValue > 0 ? maxBarColor : barColor;
+		// Ensure non-zero values always show at least a minimal bar
+		let bar: string;
+		if (point.value === 0) {
+			bar = '';
+		} else if (fullBlocks === 0 && fractional === '') {
+			bar = tipChar; // minimum visible bar for tiny values
+		} else {
+			bar = fillChar.repeat(fullBlocks) + fractional;
+		}
+
+		const barVisualWidth = stringWidth(bar);
+		const barPadding = ' '.repeat(Math.max(0, maxBarWidth - barVisualWidth));
+
+		// Apply gradient color based on value
+		const colorFn = colorForValue(point.value, maxValue);
 		const coloredBar = bar.length > 0 ? colorFn(bar) : '';
+
+		// Color the value based on magnitude too
+		const valueColorFn = point.value === 0 ? pc.gray : colorFn;
+		const coloredValue = valueColorFn(formattedValue);
 
 		// Build line
 		let line = `${paddedLabel}  ${coloredBar}${barPadding}`;
 		if (showValues) {
 			const valuePad = maxValueWidth - stringWidth(formattedValue);
-			line += `  ${' '.repeat(valuePad)}${formattedValue}`;
+			line += `  ${' '.repeat(valuePad)}${coloredValue}`;
 		}
 
 		lines.push(line);
@@ -144,8 +182,8 @@ export function renderChartTotals(
 	labelWidth?: number,
 ): string {
 	const padWidth = (labelWidth ?? 12) - stringWidth(label);
-	const paddedLabel = ' '.repeat(Math.max(0, padWidth)) + pc.yellow(label);
-	return `${paddedLabel}  ${pc.yellow(formattedValue)}`;
+	const paddedLabel = ' '.repeat(Math.max(0, padWidth)) + pc.bold(pc.yellow(label));
+	return `${paddedLabel}  ${pc.bold(pc.yellow(formattedValue))}`;
 }
 
 /**
@@ -193,7 +231,8 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '80';
 
-			const output = renderBarChart(data, { barColor: (t) => t, maxBarColor: (t) => t });
+			// Strip ANSI codes for content assertions
+			const output = renderBarChart(data);
 
 			expect(output).toContain('2026-03-28');
 			expect(output).toContain('2026-03-29');
@@ -201,15 +240,6 @@ if (import.meta.vitest != null) {
 			expect(output).toContain('$12.45');
 			expect(output).toContain('$8.20');
 			expect(output).toContain('$4.00');
-
-			// The first row should have the longest bar (highest value)
-			const lines = output.split('\n');
-			const bar1Length = (lines[0]?.match(/█/g) ?? []).length;
-			const bar2Length = (lines[1]?.match(/█/g) ?? []).length;
-			const bar3Length = (lines[2]?.match(/█/g) ?? []).length;
-
-			expect(bar1Length).toBeGreaterThan(bar2Length);
-			expect(bar2Length).toBeGreaterThan(bar3Length);
 
 			process.env.COLUMNS = originalColumns;
 		});
@@ -225,7 +255,7 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '80';
 
-			const output = renderBarChart(data, { barColor: (t) => t, maxBarColor: (t) => t });
+			const output = renderBarChart(data);
 			expect(output).toContain('Jan');
 			expect(output).toContain('$10.00');
 			// Single data point should get full bar width
@@ -234,7 +264,24 @@ if (import.meta.vitest != null) {
 			process.env.COLUMNS = originalColumns;
 		});
 
-		it('should handle zero values', () => {
+		it('should show minimal bar for tiny non-zero values', () => {
+			const data: ChartDataPoint[] = [
+				{ label: 'A', value: 0.01, formattedValue: '$0.01' },
+				{ label: 'B', value: 100, formattedValue: '$100.00' },
+			];
+
+			const originalColumns = process.env.COLUMNS;
+			process.env.COLUMNS = '80';
+
+			const output = renderBarChart(data);
+			const lines = output.split('\n');
+			// First line (tiny value) should still have a visible bar character
+			expect(lines[0]).toMatch(/[▏▎▍▌▋▊▉█]/);
+
+			process.env.COLUMNS = originalColumns;
+		});
+
+		it('should handle zero values with no bar', () => {
 			const data: ChartDataPoint[] = [
 				{ label: 'A', value: 0, formattedValue: '$0.00' },
 				{ label: 'B', value: 5, formattedValue: '$5.00' },
@@ -243,12 +290,12 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '80';
 
-			const output = renderBarChart(data, { barColor: (t) => t, maxBarColor: (t) => t });
+			const output = renderBarChart(data);
 			const lines = output.split('\n');
 			// First line (value=0) should have no bar characters
-			expect(lines[0]?.match(/█/g) ?? []).toHaveLength(0);
+			expect(lines[0]).not.toMatch(/[▏▎▍▌▋▊▉█]/);
 			// Second line should have bars
-			expect((lines[1]?.match(/█/g) ?? []).length).toBeGreaterThan(0);
+			expect(lines[1]).toMatch(/█/);
 
 			process.env.COLUMNS = originalColumns;
 		});
@@ -259,25 +306,55 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '120';
 
-			const normalOutput = renderBarChart(data, { barColor: (t) => t, maxBarColor: (t) => t });
-			const compactOutput = renderBarChart(data, {
-				forceCompact: true,
-				barColor: (t) => t,
-				maxBarColor: (t) => t,
-			});
+			const normalOutput = renderBarChart(data);
+			const compactOutput = renderBarChart(data, { forceCompact: true });
 
 			// Compact output should be shorter or equal
-			expect(normalOutput.length).toBeGreaterThanOrEqual(compactOutput.length);
+			expect(stringWidth(normalOutput)).toBeGreaterThanOrEqual(stringWidth(compactOutput));
 
 			process.env.COLUMNS = originalColumns;
+		});
+	});
+
+	describe('colorForValue', () => {
+		it('should return gray for zero value', () => {
+			const color = colorForValue(0, 100);
+			expect(color('test')).toBe(pc.gray('test'));
+		});
+
+		it('should return bold green for peak value', () => {
+			const color = colorForValue(100, 100);
+			expect(color('test')).toBe(pc.bold(pc.green('test')));
+		});
+
+		it('should return blue for low values', () => {
+			const color = colorForValue(10, 100);
+			expect(color('test')).toBe(pc.blue('test'));
+		});
+
+		it('should return cyan for mid values', () => {
+			const color = colorForValue(50, 100);
+			expect(color('test')).toBe(pc.cyan('test'));
+		});
+
+		it('should return yellow for high values', () => {
+			const color = colorForValue(75, 100);
+			expect(color('test')).toBe(pc.yellow('test'));
 		});
 	});
 
 	describe('renderChartSeparator', () => {
 		it('should render a separator line', () => {
 			const separator = renderChartSeparator(80);
-			// Should contain dash characters (may be wrapped in ANSI codes)
 			expect(separator).toContain('─');
+		});
+	});
+
+	describe('renderChartTotals', () => {
+		it('should render bold yellow totals', () => {
+			const totals = renderChartTotals('Total', '$100.00', 12);
+			expect(totals).toContain('Total');
+			expect(totals).toContain('$100.00');
 		});
 	});
 

--- a/packages/terminal/src/chart.ts
+++ b/packages/terminal/src/chart.ts
@@ -80,9 +80,9 @@ function colorForValue(value: number, maxValue: number): (text: string) => strin
 export function renderBarChart(
 	data: ChartDataPoint[],
 	options: ChartOptions = {},
-): { output: string; labelWidth: number; barWidth: number } {
+): { output: string; labelWidth: number; barWidth: number; valueWidth: number } {
 	if (data.length === 0) {
-		return { output: '', labelWidth: 0, barWidth: 0 };
+		return { output: '', labelWidth: 0, barWidth: 0, valueWidth: 0 };
 	}
 
 	const { fillChar = '█', showValues = true, forceCompact = false } = options;
@@ -192,7 +192,7 @@ export function renderBarChart(
 		lines.push(line);
 	}
 
-	return { output: lines.join('\n'), labelWidth, barWidth: maxBarWidth };
+	return { output: lines.join('\n'), labelWidth, barWidth: maxBarWidth, valueWidth: maxValueWidth };
 }
 
 /**
@@ -215,11 +215,12 @@ export function renderChartSeparator(width?: number): string {
  * @returns Formatted totals string
  */
 /**
- * Renders a totals line right-aligned with the chart cost column
+ * Renders a totals line right-aligned so the value ends at the same column as chart cost values
  * @param label - Label for the totals line (e.g., "Total")
  * @param formattedValue - Pre-formatted value string (e.g., "$35.10")
  * @param labelWidth - Width used for labels in the chart (from renderBarChart result)
  * @param barWidth - Width used for bars in the chart (from renderBarChart result)
+ * @param valueWidth - Width of the widest value in the chart (from renderBarChart result)
  * @returns Formatted totals string
  */
 export function renderChartTotals(
@@ -227,14 +228,16 @@ export function renderChartTotals(
 	formattedValue: string,
 	labelWidth: number,
 	barWidth: number,
+	valueWidth: number,
 ): string {
-	// Right-align: fill label area + bar area with spaces, then label + value at the end
-	const totalText = `${pc.bold(pc.yellow(label))}  ${pc.bold(pc.yellow(formattedValue))}`;
-	const totalTextWidth = stringWidth(label) + 2 + stringWidth(formattedValue);
-	// Total line width = labelWidth + 1 (space) + barWidth + 1 (space) + value
-	const fullWidth = labelWidth + 1 + barWidth + 1;
-	const leftPad = Math.max(0, fullWidth - totalTextWidth);
-	return `${' '.repeat(leftPad)}${totalText}`;
+	// Chart row end position: labelWidth(pad+label) + " " + barWidth(bar+track) + " " + valueWidth
+	const rowEndCol = labelWidth + 1 + barWidth + 1 + valueWidth;
+	// Right-pad value to match valueWidth so the last char aligns
+	const valuePad = Math.max(0, valueWidth - stringWidth(formattedValue));
+	const paddedValue = ' '.repeat(valuePad) + formattedValue;
+	const paddedTotalWidth = stringWidth(label) + 2 + valueWidth;
+	const leftPad = Math.max(0, rowEndCol - paddedTotalWidth);
+	return `${' '.repeat(leftPad)}${pc.bold(pc.yellow(label))}  ${pc.bold(pc.yellow(paddedValue))}`;
 }
 
 /**
@@ -453,7 +456,7 @@ if (import.meta.vitest != null) {
 
 	describe('renderChartTotals', () => {
 		it('should right-align totals with the cost column', () => {
-			const totals = renderChartTotals('Total', '$100.00', 12, 40);
+			const totals = renderChartTotals('Total', '$100.00', 12, 40, 7);
 			expect(totals).toContain('Total');
 			expect(totals).toContain('$100.00');
 			// Should have left padding to push it right

--- a/packages/terminal/src/chart.ts
+++ b/packages/terminal/src/chart.ts
@@ -1,0 +1,320 @@
+import process from 'node:process';
+import pc from 'picocolors';
+import stringWidth from 'string-width';
+
+/**
+ * Data point for chart rendering
+ */
+export type ChartDataPoint = {
+	label: string;
+	value: number;
+	formattedValue?: string;
+};
+
+/**
+ * Configuration options for chart rendering
+ */
+export type ChartOptions = {
+	/** Title displayed above the chart */
+	title?: string;
+	/** Maximum bar width in characters (auto-calculated from terminal width if omitted) */
+	maxBarWidth?: number;
+	/** Character used for filled portion of bars */
+	fillChar?: string;
+	/** Whether to show value labels to the right of bars */
+	showValues?: boolean;
+	/** Color function applied to bars (from picocolors) */
+	barColor?: (text: string) => string;
+	/** Color function applied to the max-value bar */
+	maxBarColor?: (text: string) => string;
+	/** Suffix appended to formatted values (e.g., " tokens") */
+	valueSuffix?: string;
+	/** Force compact layout for narrow terminals */
+	forceCompact?: boolean;
+};
+
+/**
+ * Formats a number as USD currency
+ */
+function formatCurrencyValue(amount: number): string {
+	return `$${amount.toFixed(2)}`;
+}
+
+/**
+ * Renders a horizontal bar chart as a string for terminal output
+ *
+ * Example output:
+ *   2026-03-28  ████████████████████████████████████  $12.45
+ *   2026-03-29  ██████████████████████               $8.20
+ *   Total                                             $35.10
+ *
+ * @param data - Array of data points to render
+ * @param options - Chart display options
+ * @returns Formatted chart string ready for terminal output
+ */
+export function renderBarChart(data: ChartDataPoint[], options: ChartOptions = {}): string {
+	if (data.length === 0) {
+		return '';
+	}
+
+	const {
+		fillChar = '█',
+		showValues = true,
+		barColor = pc.cyan,
+		maxBarColor = pc.green,
+		forceCompact = false,
+	} = options;
+
+	// Determine terminal width
+	const terminalWidth =
+		Number.parseInt(process.env.COLUMNS ?? '', 10) || process.stdout.columns || 120;
+
+	// Calculate label width (max label length + padding)
+	const maxLabelWidth = Math.max(...data.map((d) => stringWidth(d.label)));
+	const labelWidth = maxLabelWidth + 2; // 2 chars padding
+
+	// Calculate value width
+	const formattedValues = data.map((d) => d.formattedValue ?? formatCurrencyValue(d.value));
+	const maxValueWidth = Math.max(...formattedValues.map((v) => stringWidth(v)));
+	const valueWidth = showValues ? maxValueWidth + 2 : 0; // 2 chars padding
+
+	// Calculate available bar width
+	const overhead = labelWidth + valueWidth + 4; // spacing between sections
+	const maxBarWidth =
+		options.maxBarWidth ??
+		Math.max(10, (forceCompact ? Math.min(terminalWidth, 60) : terminalWidth) - overhead);
+
+	// Find max value for scaling
+	const maxValue = Math.max(...data.map((d) => d.value), 0);
+
+	const lines: string[] = [];
+
+	for (let i = 0; i < data.length; i++) {
+		const point = data[i]!;
+		const formattedValue = formattedValues[i]!;
+
+		// Pad label to consistent width (right-align)
+		const labelPad = labelWidth - stringWidth(point.label);
+		const paddedLabel = ' '.repeat(labelPad) + point.label;
+
+		// Calculate bar length
+		const barLength = maxValue > 0 ? Math.round((point.value / maxValue) * maxBarWidth) : 0;
+		const bar = fillChar.repeat(barLength);
+		const barPadding = ' '.repeat(maxBarWidth - barLength);
+
+		// Apply color - highlight the max value bar
+		const colorFn = point.value === maxValue && maxValue > 0 ? maxBarColor : barColor;
+		const coloredBar = bar.length > 0 ? colorFn(bar) : '';
+
+		// Build line
+		let line = `${paddedLabel}  ${coloredBar}${barPadding}`;
+		if (showValues) {
+			const valuePad = maxValueWidth - stringWidth(formattedValue);
+			line += `  ${' '.repeat(valuePad)}${formattedValue}`;
+		}
+
+		lines.push(line);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Renders a separator line for visual separation in charts
+ * @param width - Width of the separator line
+ * @returns Formatted separator string
+ */
+export function renderChartSeparator(width?: number): string {
+	const terminalWidth =
+		width ?? (Number.parseInt(process.env.COLUMNS ?? '', 10) || process.stdout.columns || 120);
+	const separatorWidth = Math.min(terminalWidth - 4, 60);
+	return `  ${pc.gray('─'.repeat(separatorWidth))}`;
+}
+
+/**
+ * Renders a totals line aligned with chart output
+ * @param label - Label for the totals line (e.g., "Total")
+ * @param formattedValue - Pre-formatted value string (e.g., "$35.10")
+ * @param labelWidth - Width to use for label alignment
+ * @returns Formatted totals string
+ */
+export function renderChartTotals(
+	label: string,
+	formattedValue: string,
+	labelWidth?: number,
+): string {
+	const padWidth = (labelWidth ?? 12) - stringWidth(label);
+	const paddedLabel = ' '.repeat(Math.max(0, padWidth)) + pc.yellow(label);
+	return `${paddedLabel}  ${pc.yellow(formattedValue)}`;
+}
+
+/**
+ * Creates chart data from usage data with cost as the displayed metric
+ *
+ * @param items - Array of usage items with a label key and cost
+ * @param labelKey - Key to use for the chart label
+ * @param options - Additional options
+ * @param options.costKey - Key to use for the cost value (default: 'totalCost')
+ * @param options.labelFormatter - Function to format label values
+ * @returns Array of ChartDataPoint for rendering
+ */
+export function createCostChartData<T extends Record<string, unknown>>(
+	items: T[],
+	labelKey: keyof T & string,
+	options?: {
+		costKey?: keyof T & string;
+		labelFormatter?: (value: string) => string;
+	},
+): ChartDataPoint[] {
+	const costKey = options?.costKey ?? ('totalCost' as keyof T & string);
+	const labelFormatter = options?.labelFormatter;
+
+	return items.map((item) => {
+		const rawLabel = String(item[labelKey]);
+		const label = labelFormatter != null ? labelFormatter(rawLabel) : rawLabel;
+		const value = Number(item[costKey]);
+		return {
+			label,
+			value,
+			formattedValue: formatCurrencyValue(value),
+		};
+	});
+}
+
+if (import.meta.vitest != null) {
+	describe('renderBarChart', () => {
+		it('should render a basic bar chart', () => {
+			const data: ChartDataPoint[] = [
+				{ label: '2026-03-28', value: 12.45, formattedValue: '$12.45' },
+				{ label: '2026-03-29', value: 8.2, formattedValue: '$8.20' },
+				{ label: '2026-03-30', value: 4.0, formattedValue: '$4.00' },
+			];
+
+			const originalColumns = process.env.COLUMNS;
+			process.env.COLUMNS = '80';
+
+			const output = renderBarChart(data, { barColor: (t) => t, maxBarColor: (t) => t });
+
+			expect(output).toContain('2026-03-28');
+			expect(output).toContain('2026-03-29');
+			expect(output).toContain('2026-03-30');
+			expect(output).toContain('$12.45');
+			expect(output).toContain('$8.20');
+			expect(output).toContain('$4.00');
+
+			// The first row should have the longest bar (highest value)
+			const lines = output.split('\n');
+			const bar1Length = (lines[0]?.match(/█/g) ?? []).length;
+			const bar2Length = (lines[1]?.match(/█/g) ?? []).length;
+			const bar3Length = (lines[2]?.match(/█/g) ?? []).length;
+
+			expect(bar1Length).toBeGreaterThan(bar2Length);
+			expect(bar2Length).toBeGreaterThan(bar3Length);
+
+			process.env.COLUMNS = originalColumns;
+		});
+
+		it('should handle empty data', () => {
+			const output = renderBarChart([]);
+			expect(output).toBe('');
+		});
+
+		it('should handle single data point', () => {
+			const data: ChartDataPoint[] = [{ label: 'Jan', value: 10.0, formattedValue: '$10.00' }];
+
+			const originalColumns = process.env.COLUMNS;
+			process.env.COLUMNS = '80';
+
+			const output = renderBarChart(data, { barColor: (t) => t, maxBarColor: (t) => t });
+			expect(output).toContain('Jan');
+			expect(output).toContain('$10.00');
+			// Single data point should get full bar width
+			expect((output.match(/█/g) ?? []).length).toBeGreaterThan(0);
+
+			process.env.COLUMNS = originalColumns;
+		});
+
+		it('should handle zero values', () => {
+			const data: ChartDataPoint[] = [
+				{ label: 'A', value: 0, formattedValue: '$0.00' },
+				{ label: 'B', value: 5, formattedValue: '$5.00' },
+			];
+
+			const originalColumns = process.env.COLUMNS;
+			process.env.COLUMNS = '80';
+
+			const output = renderBarChart(data, { barColor: (t) => t, maxBarColor: (t) => t });
+			const lines = output.split('\n');
+			// First line (value=0) should have no bar characters
+			expect(lines[0]?.match(/█/g) ?? []).toHaveLength(0);
+			// Second line should have bars
+			expect((lines[1]?.match(/█/g) ?? []).length).toBeGreaterThan(0);
+
+			process.env.COLUMNS = originalColumns;
+		});
+
+		it('should respect forceCompact option', () => {
+			const data: ChartDataPoint[] = [{ label: 'Day 1', value: 10, formattedValue: '$10.00' }];
+
+			const originalColumns = process.env.COLUMNS;
+			process.env.COLUMNS = '120';
+
+			const normalOutput = renderBarChart(data, { barColor: (t) => t, maxBarColor: (t) => t });
+			const compactOutput = renderBarChart(data, {
+				forceCompact: true,
+				barColor: (t) => t,
+				maxBarColor: (t) => t,
+			});
+
+			// Compact output should be shorter or equal
+			expect(normalOutput.length).toBeGreaterThanOrEqual(compactOutput.length);
+
+			process.env.COLUMNS = originalColumns;
+		});
+	});
+
+	describe('renderChartSeparator', () => {
+		it('should render a separator line', () => {
+			const separator = renderChartSeparator(80);
+			// Should contain dash characters (may be wrapped in ANSI codes)
+			expect(separator).toContain('─');
+		});
+	});
+
+	describe('createCostChartData', () => {
+		it('should create chart data from usage items', () => {
+			const items = [
+				{ date: '2026-03-28', totalCost: 12.45 },
+				{ date: '2026-03-29', totalCost: 8.2 },
+			];
+
+			const data = createCostChartData(items, 'date');
+
+			expect(data).toHaveLength(2);
+			expect(data[0]?.label).toBe('2026-03-28');
+			expect(data[0]?.value).toBe(12.45);
+			expect(data[0]?.formattedValue).toBe('$12.45');
+			expect(data[1]?.label).toBe('2026-03-29');
+			expect(data[1]?.value).toBe(8.2);
+			expect(data[1]?.formattedValue).toBe('$8.20');
+		});
+
+		it('should apply label formatter', () => {
+			const items = [{ month: '2026-03', totalCost: 50.0 }];
+
+			const data = createCostChartData(items, 'month', {
+				labelFormatter: (v) => `Month: ${v}`,
+			});
+
+			expect(data[0]?.label).toBe('Month: 2026-03');
+		});
+
+		it('should use custom cost key', () => {
+			const items = [{ label: 'test', costUSD: 25.0 }];
+
+			const data = createCostChartData(items, 'label', { costKey: 'costUSD' });
+
+			expect(data[0]?.value).toBe(25.0);
+		});
+	});
+}

--- a/packages/terminal/src/chart.ts
+++ b/packages/terminal/src/chart.ts
@@ -105,6 +105,39 @@ export function renderBarChart(data: ChartDataPoint[], options: ChartOptions = {
 	// Find max value for scaling
 	const maxValue = Math.max(...data.map((d) => d.value), 0);
 
+	// Month name lookup for group headers
+	const monthNames = [
+		'January',
+		'February',
+		'March',
+		'April',
+		'May',
+		'June',
+		'July',
+		'August',
+		'September',
+		'October',
+		'November',
+		'December',
+	];
+
+	/**
+	 * Converts a YYYY-MM group key to a readable month label (e.g., "March 2026")
+	 */
+	function formatGroupLabel(group: string): string | undefined {
+		const match = group.match(/^(\d{4})-(\d{2})$/);
+		if (match == null) {
+			return undefined;
+		}
+		const year = match[1];
+		const monthIndex = Number.parseInt(match[2]!, 10) - 1;
+		const name = monthNames[monthIndex];
+		if (name == null) {
+			return undefined;
+		}
+		return `${name} ${year}`;
+	}
+
 	const lines: string[] = [];
 	let lastGroup: string | undefined;
 
@@ -112,11 +145,15 @@ export function renderBarChart(data: ChartDataPoint[], options: ChartOptions = {
 		const point = data[i]!;
 		const formattedValue = formattedValues[i]!;
 
-		// Insert group separator when group changes
+		// Insert group separator with month label when group changes
 		if (point.group != null && point.group !== lastGroup) {
 			if (lastGroup != null) {
-				// Blank line between groups
-				lines.push('');
+				lines.push(''); // blank line
+			}
+			const groupLabel = formatGroupLabel(point.group);
+			if (groupLabel != null) {
+				const pad = ' '.repeat(Math.max(0, labelWidth - stringWidth(groupLabel)));
+				lines.push(`${pad}${pc.bold(pc.white(groupLabel))}`);
 			}
 			lastGroup = point.group;
 		}

--- a/packages/terminal/src/chart.ts
+++ b/packages/terminal/src/chart.ts
@@ -75,11 +75,14 @@ function colorForValue(value: number, maxValue: number): (text: string) => strin
  *
  * @param data - Array of data points to render
  * @param options - Chart display options
- * @returns Formatted chart string ready for terminal output
+ * @returns Object with the chart string and layout metrics for aligning totals
  */
-export function renderBarChart(data: ChartDataPoint[], options: ChartOptions = {}): string {
+export function renderBarChart(
+	data: ChartDataPoint[],
+	options: ChartOptions = {},
+): { output: string; labelWidth: number; barWidth: number } {
 	if (data.length === 0) {
-		return '';
+		return { output: '', labelWidth: 0, barWidth: 0 };
 	}
 
 	const { fillChar = '█', showValues = true, forceCompact = false } = options;
@@ -189,7 +192,7 @@ export function renderBarChart(data: ChartDataPoint[], options: ChartOptions = {
 		lines.push(line);
 	}
 
-	return lines.join('\n');
+	return { output: lines.join('\n'), labelWidth, barWidth: maxBarWidth };
 }
 
 /**
@@ -205,20 +208,24 @@ export function renderChartSeparator(width?: number): string {
 }
 
 /**
- * Renders a totals line aligned with chart output
+ * Renders a totals line aligned with chart bar output
  * @param label - Label for the totals line (e.g., "Total")
  * @param formattedValue - Pre-formatted value string (e.g., "$35.10")
- * @param labelWidth - Width to use for label alignment
+ * @param labelWidth - Width used for labels in the chart (from renderBarChart result)
+ * @param barWidth - Width used for bars in the chart (from renderBarChart result)
  * @returns Formatted totals string
  */
 export function renderChartTotals(
 	label: string,
 	formattedValue: string,
-	labelWidth?: number,
+	labelWidth: number,
+	barWidth: number,
 ): string {
-	const padWidth = (labelWidth ?? 12) - stringWidth(label);
+	const padWidth = labelWidth - stringWidth(label);
 	const paddedLabel = ' '.repeat(Math.max(0, padWidth)) + pc.bold(pc.yellow(label));
-	return `${paddedLabel}  ${pc.bold(pc.yellow(formattedValue))}`;
+	// Align value at the same position as chart values: after label + space + bar + space
+	const barPadding = ' '.repeat(barWidth);
+	return `${paddedLabel} ${barPadding} ${pc.bold(pc.yellow(formattedValue))}`;
 }
 
 /**
@@ -285,7 +292,7 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '80';
 
-			const output = renderBarChart(data);
+			const { output } = renderBarChart(data);
 
 			expect(output).toContain('2026-03-28');
 			expect(output).toContain('2026-03-29');
@@ -298,7 +305,7 @@ if (import.meta.vitest != null) {
 		});
 
 		it('should handle empty data', () => {
-			const output = renderBarChart([]);
+			const { output } = renderBarChart([]);
 			expect(output).toBe('');
 		});
 
@@ -308,7 +315,7 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '80';
 
-			const output = renderBarChart(data);
+			const { output } = renderBarChart(data);
 			expect(output).toContain('Jan');
 			expect(output).toContain('$10.00');
 			expect((output.match(/█/g) ?? []).length).toBeGreaterThan(0);
@@ -325,7 +332,7 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '80';
 
-			const output = renderBarChart(data);
+			const { output } = renderBarChart(data);
 			const lines = output.split('\n');
 			// First line (tiny value) should still have at least one filled block
 			expect(lines[0]).toMatch(/█/);
@@ -342,7 +349,7 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '80';
 
-			const output = renderBarChart(data);
+			const { output } = renderBarChart(data);
 			const lines = output.split('\n');
 			// First line (value=0) should have no filled bar characters
 			expect(lines[0]).not.toMatch(/█/);
@@ -361,7 +368,7 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '80';
 
-			const output = renderBarChart(data);
+			const { output } = renderBarChart(data);
 			// Should contain track characters
 			expect(output).toContain('░');
 
@@ -378,7 +385,7 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '80';
 
-			const output = renderBarChart(data);
+			const { output } = renderBarChart(data);
 			const lines = output.split('\n');
 			// Should have a blank line between groups
 			expect(lines.includes('')).toBe(true);
@@ -392,10 +399,10 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '120';
 
-			const normalOutput = renderBarChart(data);
-			const compactOutput = renderBarChart(data, { forceCompact: true });
+			const normal = renderBarChart(data);
+			const compact = renderBarChart(data, { forceCompact: true });
 
-			expect(stringWidth(normalOutput)).toBeGreaterThanOrEqual(stringWidth(compactOutput));
+			expect(stringWidth(normal.output)).toBeGreaterThanOrEqual(stringWidth(compact.output));
 
 			process.env.COLUMNS = originalColumns;
 		});
@@ -436,10 +443,12 @@ if (import.meta.vitest != null) {
 	});
 
 	describe('renderChartTotals', () => {
-		it('should render bold yellow totals', () => {
-			const totals = renderChartTotals('Total', '$100.00', 12);
+		it('should render bold yellow totals aligned with bar width', () => {
+			const totals = renderChartTotals('Total', '$100.00', 12, 40);
 			expect(totals).toContain('Total');
 			expect(totals).toContain('$100.00');
+			// Should have spacing for the bar area
+			expect(stringWidth(totals)).toBeGreaterThan(50);
 		});
 	});
 

--- a/packages/terminal/src/chart.ts
+++ b/packages/terminal/src/chart.ts
@@ -208,24 +208,20 @@ export function renderChartSeparator(width?: number): string {
 }
 
 /**
- * Renders a totals line aligned with chart bar output
+ * Renders a totals line with label and value together on the left
  * @param label - Label for the totals line (e.g., "Total")
  * @param formattedValue - Pre-formatted value string (e.g., "$35.10")
  * @param labelWidth - Width used for labels in the chart (from renderBarChart result)
- * @param barWidth - Width used for bars in the chart (from renderBarChart result)
  * @returns Formatted totals string
  */
 export function renderChartTotals(
 	label: string,
 	formattedValue: string,
 	labelWidth: number,
-	barWidth: number,
 ): string {
 	const padWidth = labelWidth - stringWidth(label);
 	const paddedLabel = ' '.repeat(Math.max(0, padWidth)) + pc.bold(pc.yellow(label));
-	// Align value at the same position as chart values: after label + space + bar + space
-	const barPadding = ' '.repeat(barWidth);
-	return `${paddedLabel} ${barPadding} ${pc.bold(pc.yellow(formattedValue))}`;
+	return `${paddedLabel} ${pc.bold(pc.yellow(formattedValue))}`;
 }
 
 /**
@@ -443,12 +439,10 @@ if (import.meta.vitest != null) {
 	});
 
 	describe('renderChartTotals', () => {
-		it('should render bold yellow totals aligned with bar width', () => {
-			const totals = renderChartTotals('Total', '$100.00', 12, 40);
+		it('should render bold yellow label and value together', () => {
+			const totals = renderChartTotals('Total', '$100.00', 12);
 			expect(totals).toContain('Total');
 			expect(totals).toContain('$100.00');
-			// Should have spacing for the bar area
-			expect(stringWidth(totals)).toBeGreaterThan(50);
 		});
 	});
 

--- a/packages/terminal/src/chart.ts
+++ b/packages/terminal/src/chart.ts
@@ -214,14 +214,27 @@ export function renderChartSeparator(width?: number): string {
  * @param labelWidth - Width used for labels in the chart (from renderBarChart result)
  * @returns Formatted totals string
  */
+/**
+ * Renders a totals line right-aligned with the chart cost column
+ * @param label - Label for the totals line (e.g., "Total")
+ * @param formattedValue - Pre-formatted value string (e.g., "$35.10")
+ * @param labelWidth - Width used for labels in the chart (from renderBarChart result)
+ * @param barWidth - Width used for bars in the chart (from renderBarChart result)
+ * @returns Formatted totals string
+ */
 export function renderChartTotals(
 	label: string,
 	formattedValue: string,
 	labelWidth: number,
+	barWidth: number,
 ): string {
-	const padWidth = labelWidth - stringWidth(label);
-	const paddedLabel = ' '.repeat(Math.max(0, padWidth)) + pc.bold(pc.yellow(label));
-	return `${paddedLabel} ${pc.bold(pc.yellow(formattedValue))}`;
+	// Right-align: fill label area + bar area with spaces, then label + value at the end
+	const totalText = `${pc.bold(pc.yellow(label))}  ${pc.bold(pc.yellow(formattedValue))}`;
+	const totalTextWidth = stringWidth(label) + 2 + stringWidth(formattedValue);
+	// Total line width = labelWidth + 1 (space) + barWidth + 1 (space) + value
+	const fullWidth = labelWidth + 1 + barWidth + 1;
+	const leftPad = Math.max(0, fullWidth - totalTextWidth);
+	return `${' '.repeat(leftPad)}${totalText}`;
 }
 
 /**
@@ -439,10 +452,12 @@ if (import.meta.vitest != null) {
 	});
 
 	describe('renderChartTotals', () => {
-		it('should render bold yellow label and value together', () => {
-			const totals = renderChartTotals('Total', '$100.00', 12);
+		it('should right-align totals with the cost column', () => {
+			const totals = renderChartTotals('Total', '$100.00', 12, 40);
 			expect(totals).toContain('Total');
 			expect(totals).toContain('$100.00');
+			// Should have left padding to push it right
+			expect(totals.startsWith(' ')).toBe(true);
 		});
 	});
 

--- a/packages/terminal/src/chart.ts
+++ b/packages/terminal/src/chart.ts
@@ -40,8 +40,8 @@ function formatCurrencyValue(amount: number): string {
 
 /**
  * Picks a color based on where a value falls within the range [0, max].
- * Uses bright colors that read well on dark terminal backgrounds.
- * Low = magenta, mid = cyan, high = yellow, peak = bold green.
+ * Uses a cold-to-hot thermal gradient that reads well on dark terminals:
+ * dim cyan (cold/low) → cyan → green → yellow → red → bold red (hot/peak).
  */
 function colorForValue(value: number, maxValue: number): (text: string) => string {
 	if (maxValue <= 0) {
@@ -49,16 +49,22 @@ function colorForValue(value: number, maxValue: number): (text: string) => strin
 	}
 	const ratio = value / maxValue;
 	if (ratio >= 0.95) {
-		return (t: string) => pc.bold(pc.green(t));
+		return (t: string) => pc.bold(pc.red(t));
 	}
-	if (ratio >= 0.65) {
+	if (ratio >= 0.75) {
+		return pc.red;
+	}
+	if (ratio >= 0.55) {
 		return pc.yellow;
 	}
 	if (ratio >= 0.35) {
+		return pc.green;
+	}
+	if (ratio >= 0.15) {
 		return pc.cyan;
 	}
 	if (ratio > 0) {
-		return pc.magenta;
+		return (t: string) => pc.dim(pc.cyan(t));
 	}
 	return pc.gray;
 }
@@ -67,7 +73,7 @@ function colorForValue(value: number, maxValue: number): (text: string) => strin
  * Renders a horizontal bar chart as a string for terminal output
  *
  * Features:
- * - Color gradient: magenta (low) -> cyan (mid) -> yellow (high) -> bold green (peak)
+ * - Color gradient: dim cyan (cold) -> cyan -> green -> yellow -> red -> bold red (hot)
  * - Non-zero values always show at least a thin bar (▏) so nothing is invisible
  * - Cost values placed immediately after the bar for easy scanning
  * - Automatic month/group separators when data spans multiple groups
@@ -426,24 +432,34 @@ if (import.meta.vitest != null) {
 			expect(color('test')).toBe(pc.gray('test'));
 		});
 
-		it('should return bold green for peak value', () => {
+		it('should return bold red for peak value', () => {
 			const color = colorForValue(100, 100);
-			expect(color('test')).toBe(pc.bold(pc.green('test')));
+			expect(color('test')).toBe(pc.bold(pc.red('test')));
 		});
 
-		it('should return magenta for low values', () => {
+		it('should return dim cyan for low values', () => {
 			const color = colorForValue(10, 100);
-			expect(color('test')).toBe(pc.magenta('test'));
+			expect(color('test')).toBe(pc.dim(pc.cyan('test')));
 		});
 
-		it('should return cyan for mid values', () => {
-			const color = colorForValue(50, 100);
+		it('should return cyan for low-mid values', () => {
+			const color = colorForValue(25, 100);
 			expect(color('test')).toBe(pc.cyan('test'));
 		});
 
+		it('should return green for mid values', () => {
+			const color = colorForValue(45, 100);
+			expect(color('test')).toBe(pc.green('test'));
+		});
+
 		it('should return yellow for high values', () => {
-			const color = colorForValue(75, 100);
+			const color = colorForValue(65, 100);
 			expect(color('test')).toBe(pc.yellow('test'));
+		});
+
+		it('should return red for very high values', () => {
+			const color = colorForValue(85, 100);
+			expect(color('test')).toBe(pc.red('test'));
 		});
 	});
 

--- a/packages/terminal/src/chart.ts
+++ b/packages/terminal/src/chart.ts
@@ -9,6 +9,8 @@ export type ChartDataPoint = {
 	label: string;
 	value: number;
 	formattedValue?: string;
+	/** Optional group key for visual separators (e.g., "2026-03" for month grouping) */
+	group?: string;
 };
 
 /**
@@ -21,8 +23,6 @@ export type ChartOptions = {
 	maxBarWidth?: number;
 	/** Character used for filled portion of bars */
 	fillChar?: string;
-	/** Character used for the bar tip (partial block) */
-	tipChar?: string;
 	/** Whether to show value labels to the right of bars */
 	showValues?: boolean;
 	/** Suffix appended to formatted values (e.g., " tokens") */
@@ -40,7 +40,8 @@ function formatCurrencyValue(amount: number): string {
 
 /**
  * Picks a color based on where a value falls within the range [0, max].
- * Low values get dim blue, mid gets cyan, high gets yellow, top gets bold green.
+ * Uses bright colors that read well on dark terminal backgrounds.
+ * Low = magenta, mid = cyan, high = yellow, peak = bold green.
  */
 function colorForValue(value: number, maxValue: number): (text: string) => string {
 	if (maxValue <= 0) {
@@ -57,7 +58,7 @@ function colorForValue(value: number, maxValue: number): (text: string) => strin
 		return pc.cyan;
 	}
 	if (ratio > 0) {
-		return pc.blue;
+		return pc.magenta;
 	}
 	return pc.gray;
 }
@@ -66,10 +67,11 @@ function colorForValue(value: number, maxValue: number): (text: string) => strin
  * Renders a horizontal bar chart as a string for terminal output
  *
  * Features:
- * - Color gradient: bars transition from blue (low) -> cyan -> yellow -> bold green (peak)
+ * - Color gradient: magenta (low) -> cyan (mid) -> yellow (high) -> bold green (peak)
  * - Non-zero values always show at least a thin bar (▏) so nothing is invisible
- * - Cost values are placed right next to bars for easy reading
- * - Fractional block characters (▏▎▍▌▋▊▉█) for sub-character precision
+ * - Cost values placed immediately after the bar for easy scanning
+ * - Automatic month/group separators when data spans multiple groups
+ * - Background track (░) for visual reference of the scale
  *
  * @param data - Array of data points to render
  * @param options - Chart display options
@@ -80,10 +82,7 @@ export function renderBarChart(data: ChartDataPoint[], options: ChartOptions = {
 		return '';
 	}
 
-	const { fillChar = '█', tipChar = '▏', showValues = true, forceCompact = false } = options;
-
-	// Sub-character block elements for fractional widths (⅛ increments)
-	const fractionalBlocks = ['', '▏', '▎', '▍', '▌', '▋', '▊', '▉'];
+	const { fillChar = '█', showValues = true, forceCompact = false } = options;
 
 	// Determine terminal width
 	const terminalWidth =
@@ -96,10 +95,9 @@ export function renderBarChart(data: ChartDataPoint[], options: ChartOptions = {
 	// Calculate value width
 	const formattedValues = data.map((d) => d.formattedValue ?? formatCurrencyValue(d.value));
 	const maxValueWidth = Math.max(...formattedValues.map((v) => stringWidth(v)));
-	const valueWidth = showValues ? maxValueWidth + 2 : 0; // 2 chars padding
 
-	// Calculate available bar width
-	const overhead = labelWidth + valueWidth + 4; // spacing between sections
+	// Calculate available bar width — leave room for label + gap + bar + gap + value
+	const overhead = labelWidth + 3 + maxValueWidth + 1; // "label  bar value"
 	const maxBarWidth =
 		options.maxBarWidth ??
 		Math.max(10, (forceCompact ? Math.min(terminalWidth, 60) : terminalWidth) - overhead);
@@ -108,47 +106,47 @@ export function renderBarChart(data: ChartDataPoint[], options: ChartOptions = {
 	const maxValue = Math.max(...data.map((d) => d.value), 0);
 
 	const lines: string[] = [];
+	let lastGroup: string | undefined;
 
 	for (let i = 0; i < data.length; i++) {
 		const point = data[i]!;
 		const formattedValue = formattedValues[i]!;
 
-		// Pad label to consistent width (right-align)
-		const labelPad = labelWidth - stringWidth(point.label);
-		const paddedLabel = ' '.repeat(labelPad) + pc.white(point.label);
-
-		// Calculate bar length with fractional precision
-		const exactBarWidth = maxValue > 0 ? (point.value / maxValue) * maxBarWidth : 0;
-		const fullBlocks = Math.floor(exactBarWidth);
-		const fractionalIndex = Math.round((exactBarWidth - fullBlocks) * 8);
-		const fractional = fractionalBlocks[fractionalIndex] ?? '';
-
-		// Ensure non-zero values always show at least a minimal bar
-		let bar: string;
-		if (point.value === 0) {
-			bar = '';
-		} else if (fullBlocks === 0 && fractional === '') {
-			bar = tipChar; // minimum visible bar for tiny values
-		} else {
-			bar = fillChar.repeat(fullBlocks) + fractional;
+		// Insert group separator when group changes
+		if (point.group != null && point.group !== lastGroup) {
+			if (lastGroup != null) {
+				// Blank line between groups
+				lines.push('');
+			}
+			lastGroup = point.group;
 		}
 
-		const barVisualWidth = stringWidth(bar);
-		const barPadding = ' '.repeat(Math.max(0, maxBarWidth - barVisualWidth));
+		// Pad label to consistent width (right-align), dim the label
+		const labelPad = labelWidth - stringWidth(point.label);
+		const paddedLabel = ' '.repeat(labelPad) + pc.dim(pc.white(point.label));
+
+		// Calculate bar length (integer only — no fractional blocks to avoid stripy look)
+		const barLength = maxValue > 0 ? Math.round((point.value / maxValue) * maxBarWidth) : 0;
+
+		// Ensure non-zero values always show at least 1 block
+		const effectiveBarLength = point.value > 0 ? Math.max(1, barLength) : 0;
+
+		// Build bar with background track
+		const bar = fillChar.repeat(effectiveBarLength);
+		const track = pc.gray('░'.repeat(Math.max(0, maxBarWidth - effectiveBarLength)));
 
 		// Apply gradient color based on value
 		const colorFn = colorForValue(point.value, maxValue);
 		const coloredBar = bar.length > 0 ? colorFn(bar) : '';
 
-		// Color the value based on magnitude too
+		// Color the value to match the bar
 		const valueColorFn = point.value === 0 ? pc.gray : colorFn;
 		const coloredValue = valueColorFn(formattedValue);
 
-		// Build line
-		let line = `${paddedLabel}  ${coloredBar}${barPadding}`;
+		// Build line — value immediately after bar (no right-align to edge)
+		let line = `${paddedLabel} ${coloredBar}${track}`;
 		if (showValues) {
-			const valuePad = maxValueWidth - stringWidth(formattedValue);
-			line += `  ${' '.repeat(valuePad)}${coloredValue}`;
+			line += ` ${coloredValue}`;
 		}
 
 		lines.push(line);
@@ -187,13 +185,15 @@ export function renderChartTotals(
 }
 
 /**
- * Creates chart data from usage data with cost as the displayed metric
+ * Creates chart data from usage data with cost as the displayed metric.
+ * Automatically groups by month when the label looks like a date (YYYY-MM-DD).
  *
  * @param items - Array of usage items with a label key and cost
  * @param labelKey - Key to use for the chart label
  * @param options - Additional options
  * @param options.costKey - Key to use for the cost value (default: 'totalCost')
  * @param options.labelFormatter - Function to format label values
+ * @param options.groupBy - Function to extract group key for visual separators
  * @returns Array of ChartDataPoint for rendering
  */
 export function createCostChartData<T extends Record<string, unknown>>(
@@ -202,19 +202,36 @@ export function createCostChartData<T extends Record<string, unknown>>(
 	options?: {
 		costKey?: keyof T & string;
 		labelFormatter?: (value: string) => string;
+		groupBy?: (value: string) => string;
 	},
 ): ChartDataPoint[] {
 	const costKey = options?.costKey ?? ('totalCost' as keyof T & string);
 	const labelFormatter = options?.labelFormatter;
 
+	// Auto-detect date labels for month grouping
+	const autoGroupByMonth = (val: string): string | undefined => {
+		const match = val.match(/^(\d{4}-\d{2})/);
+		return match?.[1];
+	};
+
 	return items.map((item) => {
 		const rawLabel = String(item[labelKey]);
 		const label = labelFormatter != null ? labelFormatter(rawLabel) : rawLabel;
 		const value = Number(item[costKey]);
+
+		// Determine group
+		let group: string | undefined;
+		if (options?.groupBy != null) {
+			group = options.groupBy(rawLabel);
+		} else {
+			group = autoGroupByMonth(rawLabel);
+		}
+
 		return {
 			label,
 			value,
 			formattedValue: formatCurrencyValue(value),
+			group,
 		};
 	});
 }
@@ -231,7 +248,6 @@ if (import.meta.vitest != null) {
 			const originalColumns = process.env.COLUMNS;
 			process.env.COLUMNS = '80';
 
-			// Strip ANSI codes for content assertions
 			const output = renderBarChart(data);
 
 			expect(output).toContain('2026-03-28');
@@ -258,7 +274,6 @@ if (import.meta.vitest != null) {
 			const output = renderBarChart(data);
 			expect(output).toContain('Jan');
 			expect(output).toContain('$10.00');
-			// Single data point should get full bar width
 			expect((output.match(/█/g) ?? []).length).toBeGreaterThan(0);
 
 			process.env.COLUMNS = originalColumns;
@@ -275,8 +290,8 @@ if (import.meta.vitest != null) {
 
 			const output = renderBarChart(data);
 			const lines = output.split('\n');
-			// First line (tiny value) should still have a visible bar character
-			expect(lines[0]).toMatch(/[▏▎▍▌▋▊▉█]/);
+			// First line (tiny value) should still have at least one filled block
+			expect(lines[0]).toMatch(/█/);
 
 			process.env.COLUMNS = originalColumns;
 		});
@@ -292,10 +307,44 @@ if (import.meta.vitest != null) {
 
 			const output = renderBarChart(data);
 			const lines = output.split('\n');
-			// First line (value=0) should have no bar characters
-			expect(lines[0]).not.toMatch(/[▏▎▍▌▋▊▉█]/);
+			// First line (value=0) should have no filled bar characters
+			expect(lines[0]).not.toMatch(/█/);
 			// Second line should have bars
 			expect(lines[1]).toMatch(/█/);
+
+			process.env.COLUMNS = originalColumns;
+		});
+
+		it('should render background track', () => {
+			const data: ChartDataPoint[] = [
+				{ label: 'A', value: 5, formattedValue: '$5.00' },
+				{ label: 'B', value: 10, formattedValue: '$10.00' },
+			];
+
+			const originalColumns = process.env.COLUMNS;
+			process.env.COLUMNS = '80';
+
+			const output = renderBarChart(data);
+			// Should contain track characters
+			expect(output).toContain('░');
+
+			process.env.COLUMNS = originalColumns;
+		});
+
+		it('should insert group separators', () => {
+			const data: ChartDataPoint[] = [
+				{ label: '2026-01-15', value: 5, group: '2026-01' },
+				{ label: '2026-02-01', value: 10, group: '2026-02' },
+				{ label: '2026-02-02', value: 8, group: '2026-02' },
+			];
+
+			const originalColumns = process.env.COLUMNS;
+			process.env.COLUMNS = '80';
+
+			const output = renderBarChart(data);
+			const lines = output.split('\n');
+			// Should have a blank line between groups
+			expect(lines.includes('')).toBe(true);
 
 			process.env.COLUMNS = originalColumns;
 		});
@@ -309,7 +358,6 @@ if (import.meta.vitest != null) {
 			const normalOutput = renderBarChart(data);
 			const compactOutput = renderBarChart(data, { forceCompact: true });
 
-			// Compact output should be shorter or equal
 			expect(stringWidth(normalOutput)).toBeGreaterThanOrEqual(stringWidth(compactOutput));
 
 			process.env.COLUMNS = originalColumns;
@@ -327,9 +375,9 @@ if (import.meta.vitest != null) {
 			expect(color('test')).toBe(pc.bold(pc.green('test')));
 		});
 
-		it('should return blue for low values', () => {
+		it('should return magenta for low values', () => {
 			const color = colorForValue(10, 100);
-			expect(color('test')).toBe(pc.blue('test'));
+			expect(color('test')).toBe(pc.magenta('test'));
 		});
 
 		it('should return cyan for mid values', () => {
@@ -376,6 +424,18 @@ if (import.meta.vitest != null) {
 			expect(data[1]?.formattedValue).toBe('$8.20');
 		});
 
+		it('should auto-detect month groups from date labels', () => {
+			const items = [
+				{ date: '2026-01-15', totalCost: 5 },
+				{ date: '2026-02-01', totalCost: 10 },
+			];
+
+			const data = createCostChartData(items, 'date');
+
+			expect(data[0]?.group).toBe('2026-01');
+			expect(data[1]?.group).toBe('2026-02');
+		});
+
 		it('should apply label formatter', () => {
 			const items = [{ month: '2026-03', totalCost: 50.0 }];
 
@@ -392,6 +452,20 @@ if (import.meta.vitest != null) {
 			const data = createCostChartData(items, 'label', { costKey: 'costUSD' });
 
 			expect(data[0]?.value).toBe(25.0);
+		});
+
+		it('should use custom groupBy function', () => {
+			const items = [
+				{ week: '2026-W01', totalCost: 5 },
+				{ week: '2026-W05', totalCost: 10 },
+			];
+
+			const data = createCostChartData(items, 'week', {
+				groupBy: (v) => v.slice(0, 4),
+			});
+
+			expect(data[0]?.group).toBe('2026');
+			expect(data[1]?.group).toBe('2026');
 		});
 	});
 }


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                    
  - Add --chart / -c flag to all report commands (daily, monthly, weekly, session, blocks) that renders a horizontal bar chart as an alternative to the default table view                                                                          
  - Cold-to-hot thermal color gradient (dim cyan → cyan → green → yellow → red → bold red) communicates spending intensity at a glance                                                                                                              
  - Month name headers between groups, background tracks (░) for scale reference, and right-aligned totals                                                                                                                                          
  - Chart labels respect --locale and --timezone flags, consistent with table output                                                                                                                                                                
  - New @ccusage/terminal/chart module with full test coverage            
  
  Example screenshot:                                                      
<img width="1695" height="950" alt="ccusage-chart" src="https://github.com/user-attachments/assets/4c5e09db-9ac6-4eb6-bd32-65d3cc6e686f" />                                                                                                                     

  Test plan

  - All 376 existing tests pass
  - ccusage daily -c renders chart with color gradient
  - ccusage daily -c --locale en-US formats date labels as MM/DD/YYYY
  - ccusage monthly -c and ccusage weekly -c work correctly
  - ccusage session -c and ccusage blocks -c work for non-date commands
  - --compact flag works with chart mode
  - Zero-value rows show no bar, tiny values show at least 1 block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --chart (-c) option to render usage as horizontal bar charts instead of tables.
  * Chart view available for daily, weekly, monthly, session and blocks reports; includes per-row values, group headers, colored bars, separators, and a formatted Total footer.
  * Chart respects compact layout, timezone/locale for labels, and warns when --instances is ignored with chart output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->