### PR TITLE
feat(ccusage): add --compare-model flag for cross-model cost comparison

### DIFF
--- a/apps/ccusage/src/_compare-model.ts
+++ b/apps/ccusage/src/_compare-model.ts
@@ -1,0 +1,43 @@
+import { Result } from '@praha/byethrow';
+import { PricingFetcher } from './_pricing-fetcher.ts';
+
+type TokenData = {
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationTokens: number;
+	cacheReadTokens: number;
+};
+
+/**
+ * Augments usage data rows with comparison costs using a different model's pricing.
+ * When compareModel is undefined, returns data unchanged.
+ * When compareModel is provided, calculates what the same tokens would cost with that model.
+ */
+export async function withComparisonCosts<T extends TokenData>(
+	data: T[],
+	compareModel: string | undefined,
+	offline?: boolean,
+): Promise<(T & { comparisonCost?: number; comparisonModelName?: string })[]> {
+	if (compareModel == null) {
+		return data;
+	}
+
+	using fetcher = new PricingFetcher(offline);
+	return await Promise.all(
+		data.map(async (item) => {
+			const comparisonCost = await Result.unwrap(
+				fetcher.calculateCostFromTokens(
+					{
+						input_tokens: item.inputTokens,
+						output_tokens: item.outputTokens,
+						cache_creation_input_tokens: item.cacheCreationTokens,
+						cache_read_input_tokens: item.cacheReadTokens,
+					},
+					compareModel,
+				),
+				0,
+			);
+			return { ...item, comparisonCost, comparisonModelName: compareModel };
+		}),
+	);
+}

--- a/apps/ccusage/src/_daily-grouping.ts
+++ b/apps/ccusage/src/_daily-grouping.ts
@@ -11,7 +11,9 @@ type DailyData = Awaited<ReturnType<typeof loadDailyUsageData>>;
 /**
  * Group daily usage data by project for JSON output
  */
-export function groupByProject(dailyData: DailyData): Record<string, DailyProjectOutput[]> {
+export function groupByProject<T extends DailyData[number]>(
+	dailyData: T[],
+): Record<string, DailyProjectOutput[]> {
 	const projects: Record<string, DailyProjectOutput[]> = {};
 
 	for (const data of dailyData) {
@@ -21,7 +23,7 @@ export function groupByProject(dailyData: DailyData): Record<string, DailyProjec
 			projects[projectName] = [];
 		}
 
-		projects[projectName].push({
+		const entry: DailyProjectOutput = {
 			date: data.date,
 			inputTokens: data.inputTokens,
 			outputTokens: data.outputTokens,
@@ -31,7 +33,21 @@ export function groupByProject(dailyData: DailyData): Record<string, DailyProjec
 			totalCost: data.totalCost,
 			modelsUsed: data.modelsUsed,
 			modelBreakdowns: data.modelBreakdowns,
-		});
+		};
+
+		// Copy comparison fields if present
+		const dataWithComparison = data as T & {
+			comparisonCost?: number;
+			comparisonModelName?: string;
+		};
+		if (dataWithComparison.comparisonCost != null) {
+			entry.comparisonCost = dataWithComparison.comparisonCost;
+		}
+		if (dataWithComparison.comparisonModelName != null) {
+			entry.comparisonModelName = dataWithComparison.comparisonModelName;
+		}
+
+		projects[projectName].push(entry);
 	}
 
 	return projects;
@@ -40,8 +56,10 @@ export function groupByProject(dailyData: DailyData): Record<string, DailyProjec
 /**
  * Group daily usage data by project for table display
  */
-export function groupDataByProject(dailyData: DailyData): Record<string, DailyData> {
-	const projects: Record<string, DailyData> = {};
+export function groupDataByProject<T extends DailyData[number]>(
+	dailyData: T[],
+): Record<string, T[]> {
+	const projects: Record<string, T[]> = {};
 
 	for (const data of dailyData) {
 		const projectName = data.project ?? 'unknown';

--- a/apps/ccusage/src/_json-output-types.ts
+++ b/apps/ccusage/src/_json-output-types.ts
@@ -25,4 +25,6 @@ export type DailyProjectOutput = {
 	totalCost: number;
 	modelsUsed: ModelName[];
 	modelBreakdowns: ModelBreakdown[];
+	comparisonCost?: number;
+	comparisonModelName?: string;
 };

--- a/apps/ccusage/src/_macro.ts
+++ b/apps/ccusage/src/_macro.ts
@@ -9,7 +9,11 @@ function isClaudeModel(modelName: string, _pricing: LiteLLMModelPricing): boolea
 	return (
 		modelName.startsWith('claude-') ||
 		modelName.startsWith('anthropic.claude-') ||
-		modelName.startsWith('anthropic/claude-')
+		modelName.startsWith('anthropic/claude-') ||
+		modelName.startsWith('gpt-') ||
+		modelName.startsWith('openai/gpt-') ||
+		modelName.startsWith('gemini-') ||
+		modelName.startsWith('google/gemini-')
 	);
 }
 

--- a/apps/ccusage/src/_shared-args.ts
+++ b/apps/ccusage/src/_shared-args.ts
@@ -110,6 +110,12 @@ export const sharedArgs = {
 		description: 'Force compact mode for narrow displays (better for screenshots)',
 		default: false,
 	},
+	compareModel: {
+		type: 'string',
+		short: 'C',
+		description:
+			'Compare costs with another model from LiteLLM (e.g., "gpt-4o", "anthropic/claude-3-5-sonnet-20240620", "gemini-1.5-pro")',
+	},
 } as const satisfies Args;
 
 /**

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -10,6 +10,7 @@ import {
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
+import { withComparisonCosts } from '../_compare-model.ts';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { groupByProject, groupDataByProject } from '../_daily-grouping.ts';
 import { formatDateCompact } from '../_date-utils.ts';
@@ -75,10 +76,15 @@ export const dailyCommand = define({
 			logger.level = 0;
 		}
 
-		const dailyData = await loadDailyUsageData({
+		const rawDailyData = await loadDailyUsageData({
 			...mergedOptions,
 			groupByProject: mergedOptions.instances,
 		});
+		const dailyData = await withComparisonCosts(
+			rawDailyData,
+			mergedOptions.compareModel,
+			mergedOptions.offline,
+		);
 
 		if (dailyData.length === 0) {
 			if (useJson) {
@@ -104,7 +110,13 @@ export const dailyCommand = define({
 				Boolean(mergedOptions.instances) && dailyData.some((d) => d.project != null)
 					? {
 							projects: groupByProject(dailyData),
-							totals: createTotalsObject(totals),
+							totals: {
+								...createTotalsObject(totals),
+								...(mergedOptions.compareModel != null && {
+									comparisonCost: dailyData.reduce((sum, d) => sum + (d.comparisonCost ?? 0), 0),
+									comparisonModelName: mergedOptions.compareModel,
+								}),
+							},
 						}
 					: {
 							daily: dailyData.map((data) => ({
@@ -118,8 +130,18 @@ export const dailyCommand = define({
 								modelsUsed: data.modelsUsed,
 								modelBreakdowns: data.modelBreakdowns,
 								...(data.project != null && { project: data.project }),
+								...(data.comparisonCost != null && { comparisonCost: data.comparisonCost }),
+								...(data.comparisonModelName != null && {
+									comparisonModelName: data.comparisonModelName,
+								}),
 							})),
-							totals: createTotalsObject(totals),
+							totals: {
+								...createTotalsObject(totals),
+								...(mergedOptions.compareModel != null && {
+									comparisonCost: dailyData.reduce((sum, d) => sum + (d.comparisonCost ?? 0), 0),
+									comparisonModelName: mergedOptions.compareModel,
+								}),
+							},
 						};
 
 			// Process with jq if specified
@@ -143,6 +165,7 @@ export const dailyCommand = define({
 				dateFormatter: (dateStr: string) =>
 					formatDateCompact(dateStr, mergedOptions.timezone, mergedOptions.locale ?? undefined),
 				forceCompact: ctx.values.compact,
+				comparisonModelName: mergedOptions.compareModel,
 			};
 			const table = createUsageReportTable(tableConfig);
 
@@ -156,7 +179,7 @@ export const dailyCommand = define({
 					// Add project section header
 					if (!isFirstProject) {
 						// Add empty row for visual separation between projects
-						table.push(['', '', '', '', '', '', '', '']);
+						addEmptySeparatorRow(table, tableConfig.comparisonModelName != null ? 10 : 8);
 					}
 
 					// Add project header row
@@ -169,6 +192,7 @@ export const dailyCommand = define({
 						'',
 						'',
 						'',
+						...(tableConfig.comparisonModelName != null ? ['', ''] : []),
 					]);
 
 					// Add data rows for this project
@@ -180,12 +204,18 @@ export const dailyCommand = define({
 							cacheReadTokens: data.cacheReadTokens,
 							totalCost: data.totalCost,
 							modelsUsed: data.modelsUsed,
+							comparisonCost: data.comparisonCost,
 						});
 						table.push(row);
 
 						// Add model breakdown rows if flag is set
 						if (mergedOptions.breakdown) {
-							pushBreakdownRows(table, data.modelBreakdowns);
+							pushBreakdownRows(
+								table,
+								data.modelBreakdowns,
+								1,
+								tableConfig.comparisonModelName != null ? 2 : 0,
+							);
 						}
 					}
 
@@ -202,18 +232,24 @@ export const dailyCommand = define({
 						cacheReadTokens: data.cacheReadTokens,
 						totalCost: data.totalCost,
 						modelsUsed: data.modelsUsed,
+						comparisonCost: data.comparisonCost,
 					});
 					table.push(row);
 
 					// Add model breakdown rows if flag is set
 					if (mergedOptions.breakdown) {
-						pushBreakdownRows(table, data.modelBreakdowns);
+						pushBreakdownRows(
+							table,
+							data.modelBreakdowns,
+							1,
+							tableConfig.comparisonModelName != null ? 2 : 0,
+						);
 					}
 				}
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, tableConfig.comparisonModelName != null ? 10 : 8);
 
 			// Add totals
 			const totalsRow = formatTotalsRow({
@@ -222,6 +258,9 @@ export const dailyCommand = define({
 				cacheCreationTokens: totals.cacheCreationTokens,
 				cacheReadTokens: totals.cacheReadTokens,
 				totalCost: totals.totalCost,
+				...(mergedOptions.compareModel != null && {
+					comparisonCost: dailyData.reduce((sum, d) => sum + (d.comparisonCost ?? 0), 0),
+				}),
 			});
 			table.push(totalsRow);
 

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -9,6 +9,7 @@ import {
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
+import { withComparisonCosts } from '../_compare-model.ts';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { DEFAULT_LOCALE } from '../_consts.ts';
 import { formatDateCompact } from '../_date-utils.ts';
@@ -34,7 +35,12 @@ export const monthlyCommand = define({
 			logger.level = 0;
 		}
 
-		const monthlyData = await loadMonthlyUsageData(mergedOptions);
+		const rawMonthlyData = await loadMonthlyUsageData(mergedOptions);
+		const monthlyData = await withComparisonCosts(
+			rawMonthlyData,
+			mergedOptions.compareModel,
+			mergedOptions.offline,
+		);
 
 		if (monthlyData.length === 0) {
 			if (useJson) {
@@ -47,6 +53,10 @@ export const monthlyCommand = define({
 						cacheReadTokens: 0,
 						totalTokens: 0,
 						totalCost: 0,
+						...(mergedOptions.compareModel != null && {
+							comparisonCost: 0,
+							comparisonModelName: mergedOptions.compareModel,
+						}),
 					},
 				};
 				log(JSON.stringify(emptyOutput, null, 2));
@@ -78,8 +88,18 @@ export const monthlyCommand = define({
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
+					...(data.comparisonCost != null && { comparisonCost: data.comparisonCost }),
+					...(data.comparisonModelName != null && {
+						comparisonModelName: data.comparisonModelName,
+					}),
 				})),
-				totals: createTotalsObject(totals),
+				totals: {
+					...createTotalsObject(totals),
+					...(mergedOptions.compareModel != null && {
+						comparisonCost: monthlyData.reduce((sum, d) => sum + (d.comparisonCost ?? 0), 0),
+						comparisonModelName: mergedOptions.compareModel,
+					}),
+				},
 			};
 
 			// Process with jq if specified
@@ -107,6 +127,7 @@ export const monthlyCommand = define({
 						mergedOptions.locale ?? DEFAULT_LOCALE,
 					),
 				forceCompact: ctx.values.compact,
+				comparisonModelName: mergedOptions.compareModel,
 			};
 			const table = createUsageReportTable(tableConfig);
 
@@ -120,17 +141,23 @@ export const monthlyCommand = define({
 					cacheReadTokens: data.cacheReadTokens,
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
+					comparisonCost: data.comparisonCost,
 				});
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(
+						table,
+						data.modelBreakdowns,
+						1,
+						tableConfig.comparisonModelName != null ? 2 : 0,
+					);
 				}
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, tableConfig.comparisonModelName != null ? 10 : 8);
 
 			// Add totals
 			const totalsRow = formatTotalsRow({
@@ -139,6 +166,9 @@ export const monthlyCommand = define({
 				cacheCreationTokens: totals.cacheCreationTokens,
 				cacheReadTokens: totals.cacheReadTokens,
 				totalCost: totals.totalCost,
+				...(mergedOptions.compareModel != null && {
+					comparisonCost: monthlyData.reduce((sum, d) => sum + (d.comparisonCost ?? 0), 0),
+				}),
 			});
 			table.push(totalsRow);
 

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -9,6 +9,7 @@ import {
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
+import { withComparisonCosts } from '../_compare-model.ts';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { DEFAULT_LOCALE } from '../_consts.ts';
 import { formatDateCompact } from '../_date-utils.ts';
@@ -65,14 +66,12 @@ export const sessionCommand = define({
 		}
 
 		// Original session listing logic
-		const sessionData = await loadSessionData({
-			since: ctx.values.since,
-			until: ctx.values.until,
-			mode: ctx.values.mode,
-			offline: ctx.values.offline,
-			timezone: ctx.values.timezone,
-			locale: ctx.values.locale,
-		});
+		const rawSessionData = await loadSessionData(mergedOptions);
+		const sessionData = await withComparisonCosts(
+			rawSessionData,
+			mergedOptions.compareModel,
+			mergedOptions.offline,
+		);
 
 		if (sessionData.length === 0) {
 			if (useJson) {
@@ -87,9 +86,9 @@ export const sessionCommand = define({
 		const totals = calculateTotals(sessionData);
 
 		// Show debug information if requested
-		if (ctx.values.debug && !useJson) {
+		if (mergedOptions.debug && !useJson) {
 			const mismatchStats = await detectMismatches(undefined);
-			printMismatchReport(mismatchStats, ctx.values.debugSamples);
+			printMismatchReport(mismatchStats, mergedOptions.debugSamples as number | undefined);
 		}
 
 		if (useJson) {
@@ -107,13 +106,23 @@ export const sessionCommand = define({
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
 					projectPath: data.projectPath,
+					...(data.comparisonCost != null && { comparisonCost: data.comparisonCost }),
+					...(data.comparisonModelName != null && {
+						comparisonModelName: data.comparisonModelName,
+					}),
 				})),
-				totals: createTotalsObject(totals),
+				totals: {
+					...createTotalsObject(totals),
+					...(mergedOptions.compareModel != null && {
+						comparisonCost: sessionData.reduce((sum, d) => sum + (d.comparisonCost ?? 0), 0),
+						comparisonModelName: mergedOptions.compareModel,
+					}),
+				},
 			};
 
 			// Process with jq if specified
-			if (ctx.values.jq != null) {
-				const jqResult = await processWithJq(jsonOutput, ctx.values.jq);
+			if (mergedOptions.jq != null) {
+				const jqResult = await processWithJq(jsonOutput, mergedOptions.jq);
 				if (Result.isFailure(jqResult)) {
 					logger.error(jqResult.error.message);
 					process.exit(1);
@@ -131,8 +140,9 @@ export const sessionCommand = define({
 				firstColumnName: 'Session',
 				includeLastActivity: true,
 				dateFormatter: (dateStr: string) =>
-					formatDateCompact(dateStr, ctx.values.timezone, ctx.values.locale),
+					formatDateCompact(dateStr, mergedOptions.timezone, mergedOptions.locale ?? undefined),
 				forceCompact: ctx.values.compact,
+				comparisonModelName: mergedOptions.compareModel,
 			};
 			const table = createUsageReportTable(tableConfig);
 
@@ -153,20 +163,26 @@ export const sessionCommand = define({
 						cacheReadTokens: data.cacheReadTokens,
 						totalCost: data.totalCost,
 						modelsUsed: data.modelsUsed,
+						comparisonCost: data.comparisonCost,
 					},
 					data.lastActivity,
 				);
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
-				if (ctx.values.breakdown) {
+				if (mergedOptions.breakdown) {
 					// Session has 1 extra column before data and 1 trailing column
-					pushBreakdownRows(table, data.modelBreakdowns, 1, 1);
+					pushBreakdownRows(
+						table,
+						data.modelBreakdowns,
+						1,
+						tableConfig.comparisonModelName != null ? 3 : 1, // Last Activity column + 2 comparison columns
+					);
 				}
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 9);
+			addEmptySeparatorRow(table, tableConfig.comparisonModelName != null ? 11 : 9);
 
 			// Add totals
 			const totalsRow = formatTotalsRow(
@@ -176,6 +192,9 @@ export const sessionCommand = define({
 					cacheCreationTokens: totals.cacheCreationTokens,
 					cacheReadTokens: totals.cacheReadTokens,
 					totalCost: totals.totalCost,
+					...(mergedOptions.compareModel != null && {
+						comparisonCost: sessionData.reduce((sum, d) => sum + (d.comparisonCost ?? 0), 0),
+					}),
 				},
 				true,
 			); // Include Last Activity column

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -9,6 +9,7 @@ import {
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
+import { withComparisonCosts } from '../_compare-model.ts';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
 import { WEEK_DAYS } from '../_consts.ts';
 import { formatDateCompact } from '../_date-utils.ts';
@@ -44,7 +45,12 @@ export const weeklyCommand = define({
 			logger.level = 0;
 		}
 
-		const weeklyData = await loadWeeklyUsageData(mergedOptions);
+		const rawWeeklyData = await loadWeeklyUsageData(mergedOptions);
+		const weeklyData = await withComparisonCosts(
+			rawWeeklyData,
+			mergedOptions.compareModel,
+			mergedOptions.offline,
+		);
 
 		if (weeklyData.length === 0) {
 			if (useJson) {
@@ -57,6 +63,10 @@ export const weeklyCommand = define({
 						cacheReadTokens: 0,
 						totalTokens: 0,
 						totalCost: 0,
+						...(mergedOptions.compareModel != null && {
+							comparisonCost: 0,
+							comparisonModelName: mergedOptions.compareModel,
+						}),
 					},
 				};
 				log(JSON.stringify(emptyOutput, null, 2));
@@ -88,8 +98,18 @@ export const weeklyCommand = define({
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
+					...(data.comparisonCost != null && { comparisonCost: data.comparisonCost }),
+					...(data.comparisonModelName != null && {
+						comparisonModelName: data.comparisonModelName,
+					}),
 				})),
-				totals: createTotalsObject(totals),
+				totals: {
+					...createTotalsObject(totals),
+					...(mergedOptions.compareModel != null && {
+						comparisonCost: weeklyData.reduce((sum, d) => sum + (d.comparisonCost ?? 0), 0),
+						comparisonModelName: mergedOptions.compareModel,
+					}),
+				},
 			};
 
 			// Process with jq if specified
@@ -113,6 +133,7 @@ export const weeklyCommand = define({
 				dateFormatter: (dateStr: string) =>
 					formatDateCompact(dateStr, mergedOptions.timezone, mergedOptions.locale ?? undefined),
 				forceCompact: ctx.values.compact,
+				comparisonModelName: mergedOptions.compareModel,
 			};
 			const table = createUsageReportTable(tableConfig);
 
@@ -126,17 +147,23 @@ export const weeklyCommand = define({
 					cacheReadTokens: data.cacheReadTokens,
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
+					comparisonCost: data.comparisonCost,
 				});
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(
+						table,
+						data.modelBreakdowns,
+						1,
+						tableConfig.comparisonModelName != null ? 2 : 0,
+					);
 				}
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, tableConfig.comparisonModelName != null ? 10 : 8);
 
 			// Add totals
 			const totalsRow = formatTotalsRow({
@@ -145,6 +172,9 @@ export const weeklyCommand = define({
 				cacheCreationTokens: totals.cacheCreationTokens,
 				cacheReadTokens: totals.cacheReadTokens,
 				totalCost: totals.totalCost,
+				...(mergedOptions.compareModel != null && {
+					comparisonCost: weeklyData.reduce((sum, d) => sum + (d.comparisonCost ?? 0), 0),
+				}),
 			});
 			table.push(totalsRow);
 

--- a/apps/ccusage/vitest.config.ts
+++ b/apps/ccusage/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 	},
 	plugins: [
 		Macros({
-			include: ['src/index.ts', 'src/pricing-fetcher.ts'],
+			include: ['src/index.ts', 'src/_pricing-fetcher.ts'],
 		}) as any, // vitest bundles its own vite types, so relax plugin typing here
 	],
 });

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -211,8 +211,15 @@ export class LiteLLMPricingFetcher implements Disposable {
 		const candidates = new Set<string>();
 		candidates.add(modelName);
 
-		for (const prefix of this.providerPrefixes) {
-			candidates.add(`${prefix}${modelName}`);
+		if (modelName.includes('/')) {
+			// Also try without the provider prefix (e.g., "google/gemini-..." → "gemini-...")
+			const withoutPrefix = modelName.slice(modelName.indexOf('/') + 1);
+			candidates.add(withoutPrefix);
+		} else {
+			// Try adding known provider prefixes
+			for (const prefix of this.providerPrefixes) {
+				candidates.add(`${prefix}${modelName}`);
+			}
 		}
 
 		return Array.from(candidates);
@@ -226,14 +233,6 @@ export class LiteLLMPricingFetcher implements Disposable {
 					const direct = pricing.get(candidate);
 					if (direct != null) {
 						return direct;
-					}
-				}
-
-				const lower = modelName.toLowerCase();
-				for (const [key, value] of pricing) {
-					const comparison = key.toLowerCase();
-					if (comparison.includes(lower) || lower.includes(comparison)) {
-						return value;
 					}
 				}
 

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -500,6 +500,8 @@ export type UsageReportConfig = {
 	dateFormatter?: (dateStr: string) => string;
 	/** Force compact mode regardless of terminal width */
 	forceCompact?: boolean;
+	/** Optional comparison model name */
+	comparisonModelName?: string;
 };
 
 /**
@@ -512,7 +514,24 @@ export type UsageData = {
 	cacheReadTokens: number;
 	totalCost: number;
 	modelsUsed?: string[];
+	comparisonCost?: number;
 };
+
+/**
+ * Formats a percentage difference between two costs
+ * @param original - Original cost
+ * @param comparison - Comparison cost
+ * @returns Formatted percentage string (e.g., "+10.5%" or "-5.2%")
+ */
+function formatCostDiff(original: number, comparison: number): string {
+	if (original === 0) {
+		return comparison === 0 ? '0.0%' : '+100.0%';
+	}
+	const diff = ((comparison - original) / original) * 100;
+	const sign = diff >= 0 ? '+' : '';
+	const color = diff > 0 ? pc.red : diff < 0 ? pc.green : pc.gray;
+	return color(`${sign}${diff.toFixed(1)}%`);
+}
 
 /**
  * Creates a standard usage report table with consistent styling and layout
@@ -545,6 +564,15 @@ export function createUsageReportTable(config: UsageReportConfig): ResponsiveTab
 	const compactHeaders = [config.firstColumnName, 'Models', 'Input', 'Output', 'Cost (USD)'];
 
 	const compactAligns: TableCellAlign[] = ['left', 'left', 'right', 'right', 'right'];
+
+	// Add comparison columns if model name provided
+	if (config.comparisonModelName != null) {
+		const shortenedModel = formatModelName(config.comparisonModelName);
+		baseHeaders.push(`${shortenedModel} Cost`, 'Diff (%)');
+		baseAligns.push('right', 'right');
+		compactHeaders.push(`${shortenedModel} Cost`);
+		compactAligns.push('right');
+	}
 
 	// Add Last Activity column for session reports
 	if (config.includeLastActivity ?? false) {
@@ -592,6 +620,13 @@ export function formatUsageDataRow(
 		formatCurrency(data.totalCost),
 	];
 
+	if (data.comparisonCost !== undefined) {
+		row.push(
+			formatCurrency(data.comparisonCost),
+			formatCostDiff(data.totalCost, data.comparisonCost),
+		);
+	}
+
 	if (lastActivity !== undefined) {
 		row.push(lastActivity);
 	}
@@ -622,6 +657,13 @@ export function formatTotalsRow(
 		pc.yellow(formatNumber(totalTokens)),
 		pc.yellow(formatCurrency(totals.totalCost)),
 	];
+
+	if (totals.comparisonCost !== undefined) {
+		row.push(
+			pc.yellow(formatCurrency(totals.comparisonCost)),
+			pc.yellow(formatCostDiff(totals.totalCost, totals.comparisonCost)),
+		);
+	}
 
 	if (includeLastActivity) {
 		row.push(''); // Empty for Last Activity column in totals


### PR DESCRIPTION
## Summary

Adds a `--compare-model` (`-C`) flag to the `daily`, `weekly`, `monthly`, and `session` commands. This lets users see what the same token usage would cost with a different model from LiteLLM's pricing database — useful for evaluating model switches or comparing cost efficiency.

**Example:** `ccusage daily --compare-model gpt-4o`

### Changes

- **New `_compare-model.ts` module** — `withComparisonCosts()` helper that augments usage data rows with comparison costs using any LiteLLM-supported model
- **Table output** — Two new columns (`<model> Cost` and `Diff (%)`) with green/red color coding for savings vs. increased cost
- **JSON output** — `comparisonCost` and `comparisonModelName` fields in both row-level and totals objects
- **Compact mode** — Comparison columns included in responsive compact layout
- **All four time-based commands** — `daily`, `weekly`, `monthly`, and `session` all support the new flag consistently
- **Pricing lookup fix** — Handle provider-prefixed model names (e.g., `google/gemini-...` → `gemini-...`) and remove overly-broad fuzzy matching that could return wrong models
- **Vitest config fix** — Updated include path for renamed `_pricing-fetcher.ts`

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm run test` — 354 tests pass
- [x] `pnpm run format` clean
- [ ] Manual: `ccusage daily --compare-model gpt-4o` shows comparison columns
- [ ] Manual: `ccusage daily --compare-model gpt-4o --json` includes comparison fields
- [ ] Manual: `ccusage monthly -C gemini-2.0-flash` works with provider-prefixed models
- [ ] Manual: `ccusage session -C claude-sonnet-4-20250514` compares against another Claude model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--compareModel` (short: `-C`) flag to compare token costs against another LLM model across all reports
  * Comparison costs and model names now displayed in daily, weekly, monthly, and session outputs
  * Table output includes cost difference percentages relative to the original model
  * Extended pricing support for OpenAI GPT and Google Gemini models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->