### PR TITLE
feat(ccusage): add --human/-H flag for human-readable token display

### DIFF
--- a/apps/ccusage/src/_shared-args.ts
+++ b/apps/ccusage/src/_shared-args.ts
@@ -110,6 +110,12 @@ export const sharedArgs = {
 		description: 'Force compact mode for narrow displays (better for screenshots)',
 		default: false,
 	},
+	human: {
+		type: 'boolean',
+		short: 'H',
+		description: 'Display token counts in human-readable format (K/M/B suffixes)',
+		default: false,
+	},
 } as const satisfies Args;
 
 /**

--- a/apps/ccusage/src/commands/_session_id.ts
+++ b/apps/ccusage/src/commands/_session_id.ts
@@ -25,6 +25,7 @@ export type SessionIdContext = {
 export async function handleSessionIdLookup(
 	ctx: SessionIdContext,
 	useJson: boolean,
+	humanReadable = false,
 ): Promise<void> {
 	const sessionUsage = await loadSessionUsageById(ctx.values.id, {
 		mode: ctx.values.mode,
@@ -72,7 +73,7 @@ export async function handleSessionIdLookup(
 		const totalTokens = calculateSessionTotalTokens(sessionUsage.entries);
 
 		log(`Total Cost: ${formatCurrency(sessionUsage.totalCost)}`);
-		log(`Total Tokens: ${formatNumber(totalTokens)}`);
+		log(`Total Tokens: ${formatNumber(totalTokens, humanReadable)}`);
 		log(`Total Entries: ${sessionUsage.entries.length}`);
 		log('');
 
@@ -87,10 +88,10 @@ export async function handleSessionIdLookup(
 				table.push([
 					formatDateCompact(entry.timestamp, ctx.values.timezone, ctx.values.locale),
 					entry.message.model ?? 'unknown',
-					formatNumber(entry.message.usage.input_tokens),
-					formatNumber(entry.message.usage.output_tokens),
-					formatNumber(entry.message.usage.cache_creation_input_tokens ?? 0),
-					formatNumber(entry.message.usage.cache_read_input_tokens ?? 0),
+					formatNumber(entry.message.usage.input_tokens, humanReadable),
+					formatNumber(entry.message.usage.output_tokens, humanReadable),
+					formatNumber(entry.message.usage.cache_creation_input_tokens ?? 0, humanReadable),
+					formatNumber(entry.message.usage.cache_read_input_tokens ?? 0, humanReadable),
 					formatCurrency(entry.costUSD ?? 0),
 				]);
 			}

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -5,6 +5,7 @@ import {
 	formatModelsDisplayMultiline,
 	formatNumber,
 	ResponsiveTable,
+	setHumanReadableNumbers,
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -278,6 +279,11 @@ export const blocksCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
+			// Enable human-readable numbers if requested
+			if (mergedOptions.human) {
+				setHumanReadableNumbers(true);
+			}
+
 			// Table output
 			if (ctx.values.active && blocks.length === 1) {
 				// Detailed active block view

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -5,7 +5,6 @@ import {
 	formatModelsDisplayMultiline,
 	formatNumber,
 	ResponsiveTable,
-	setHumanReadableNumbers,
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -155,6 +154,7 @@ export const blocksCommand = define({
 
 		// --jq implies --json
 		const useJson = mergedOptions.json || mergedOptions.jq != null;
+		const humanReadable = Boolean(mergedOptions.human);
 		if (useJson) {
 			logger.level = 0;
 		}
@@ -201,7 +201,9 @@ export const blocksCommand = define({
 				}
 			}
 			if (!useJson && maxTokensFromAll > 0) {
-				logger.info(`Using max tokens from previous sessions: ${formatNumber(maxTokensFromAll)}`);
+				logger.info(
+					`Using max tokens from previous sessions: ${formatNumber(maxTokensFromAll, humanReadable)}`,
+				);
 			}
 		}
 
@@ -279,11 +281,6 @@ export const blocksCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
-			// Enable human-readable numbers if requested
-			if (mergedOptions.human) {
-				setHumanReadableNumbers(true);
-			}
-
 			// Table output
 			if (ctx.values.active && blocks.length === 1) {
 				// Detailed active block view
@@ -307,19 +304,19 @@ export const blocksCommand = define({
 				log(`Time Remaining: ${pc.green(`${Math.floor(remaining / 60)}h ${remaining % 60}m`)}\n`);
 
 				log(pc.bold('Current Usage:'));
-				log(`  Input Tokens:     ${formatNumber(block.tokenCounts.inputTokens)}`);
-				log(`  Output Tokens:    ${formatNumber(block.tokenCounts.outputTokens)}`);
+				log(`  Input Tokens:     ${formatNumber(block.tokenCounts.inputTokens, humanReadable)}`);
+				log(`  Output Tokens:    ${formatNumber(block.tokenCounts.outputTokens, humanReadable)}`);
 				log(`  Total Cost:       ${formatCurrency(block.costUSD)}\n`);
 
 				if (burnRate != null) {
 					log(pc.bold('Burn Rate:'));
-					log(`  Tokens/minute:    ${formatNumber(burnRate.tokensPerMinute)}`);
+					log(`  Tokens/minute:    ${formatNumber(burnRate.tokensPerMinute, humanReadable)}`);
 					log(`  Cost/hour:        ${formatCurrency(burnRate.costPerHour)}\n`);
 				}
 
 				if (projection != null) {
 					log(pc.bold('Projected Usage (if current rate continues):'));
-					log(`  Total Tokens:     ${formatNumber(projection.totalTokens)}`);
+					log(`  Total Tokens:     ${formatNumber(projection.totalTokens, humanReadable)}`);
 					log(`  Total Cost:       ${formatCurrency(projection.totalCost)}\n`);
 
 					if (ctx.values.tokenLimit != null) {
@@ -337,11 +334,11 @@ export const blocksCommand = define({
 										: pc.green('OK');
 
 							log(pc.bold('Token Limit Status:'));
-							log(`  Limit:            ${formatNumber(limit)} tokens`);
+							log(`  Limit:            ${formatNumber(limit, humanReadable)} tokens`);
 							log(
-								`  Current Usage:    ${formatNumber(currentTokens)} (${((currentTokens / limit) * 100).toFixed(1)}%)`,
+								`  Current Usage:    ${formatNumber(currentTokens, humanReadable)} (${((currentTokens / limit) * 100).toFixed(1)}%)`,
 							);
-							log(`  Remaining:        ${formatNumber(remainingTokens)} tokens`);
+							log(`  Remaining:        ${formatNumber(remainingTokens, humanReadable)} tokens`);
 							log(`  Projected Usage:  ${percentUsed.toFixed(1)}% ${status}`);
 						}
 					}
@@ -401,7 +398,7 @@ export const blocksCommand = define({
 							formatBlockTime(block, useCompactFormat, ctx.values.locale),
 							status,
 							formatModels(block.models),
-							formatNumber(totalTokens),
+							formatNumber(totalTokens, humanReadable),
 						];
 
 						// Add percentage if token limit is set
@@ -421,7 +418,7 @@ export const blocksCommand = define({
 								const currentTokens = getTotalTokens(block.tokenCounts);
 								const remainingTokens = Math.max(0, actualTokenLimit - currentTokens);
 								const remainingText =
-									remainingTokens > 0 ? formatNumber(remainingTokens) : pc.red('0');
+									remainingTokens > 0 ? formatNumber(remainingTokens, humanReadable) : pc.red('0');
 
 								// Calculate remaining percentage (how much of limit is left)
 								const remainingPercent =
@@ -431,7 +428,9 @@ export const blocksCommand = define({
 
 								const remainingRow = [
 									{
-										content: pc.gray(`(assuming ${formatNumber(actualTokenLimit)} token limit)`),
+										content: pc.gray(
+											`(assuming ${formatNumber(actualTokenLimit, humanReadable)} token limit)`,
+										),
 										hAlign: 'right' as const,
 									},
 									pc.blue('REMAINING'),
@@ -446,7 +445,7 @@ export const blocksCommand = define({
 							// PROJECTED row
 							const projection = projectBlockUsage(block);
 							if (projection != null) {
-								const projectedTokens = formatNumber(projection.totalTokens);
+								const projectedTokens = formatNumber(projection.totalTokens, humanReadable);
 								const projectedText =
 									actualTokenLimit != null &&
 									actualTokenLimit > 0 &&

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -6,7 +6,6 @@ import {
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
-	setHumanReadableNumbers,
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -135,10 +134,7 @@ export const dailyCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
-			// Enable human-readable numbers if requested
-			if (mergedOptions.human) {
-				setHumanReadableNumbers(true);
-			}
+			const humanReadable = Boolean(mergedOptions.human);
 
 			// Print header
 			logger.box('Claude Code Token Usage Report - Daily');
@@ -179,19 +175,24 @@ export const dailyCommand = define({
 
 					// Add data rows for this project
 					for (const data of projectData) {
-						const row = formatUsageDataRow(data.date, {
-							inputTokens: data.inputTokens,
-							outputTokens: data.outputTokens,
-							cacheCreationTokens: data.cacheCreationTokens,
-							cacheReadTokens: data.cacheReadTokens,
-							totalCost: data.totalCost,
-							modelsUsed: data.modelsUsed,
-						});
+						const row = formatUsageDataRow(
+							data.date,
+							{
+								inputTokens: data.inputTokens,
+								outputTokens: data.outputTokens,
+								cacheCreationTokens: data.cacheCreationTokens,
+								cacheReadTokens: data.cacheReadTokens,
+								totalCost: data.totalCost,
+								modelsUsed: data.modelsUsed,
+							},
+							undefined,
+							humanReadable,
+						);
 						table.push(row);
 
 						// Add model breakdown rows if flag is set
 						if (mergedOptions.breakdown) {
-							pushBreakdownRows(table, data.modelBreakdowns);
+							pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 						}
 					}
 
@@ -201,19 +202,24 @@ export const dailyCommand = define({
 				// Standard display without project grouping
 				for (const data of dailyData) {
 					// Main row
-					const row = formatUsageDataRow(data.date, {
-						inputTokens: data.inputTokens,
-						outputTokens: data.outputTokens,
-						cacheCreationTokens: data.cacheCreationTokens,
-						cacheReadTokens: data.cacheReadTokens,
-						totalCost: data.totalCost,
-						modelsUsed: data.modelsUsed,
-					});
+					const row = formatUsageDataRow(
+						data.date,
+						{
+							inputTokens: data.inputTokens,
+							outputTokens: data.outputTokens,
+							cacheCreationTokens: data.cacheCreationTokens,
+							cacheReadTokens: data.cacheReadTokens,
+							totalCost: data.totalCost,
+							modelsUsed: data.modelsUsed,
+						},
+						undefined,
+						humanReadable,
+					);
 					table.push(row);
 
 					// Add model breakdown rows if flag is set
 					if (mergedOptions.breakdown) {
-						pushBreakdownRows(table, data.modelBreakdowns);
+						pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 					}
 				}
 			}
@@ -222,13 +228,17 @@ export const dailyCommand = define({
 			addEmptySeparatorRow(table, 8);
 
 			// Add totals
-			const totalsRow = formatTotalsRow({
-				inputTokens: totals.inputTokens,
-				outputTokens: totals.outputTokens,
-				cacheCreationTokens: totals.cacheCreationTokens,
-				cacheReadTokens: totals.cacheReadTokens,
-				totalCost: totals.totalCost,
-			});
+			const totalsRow = formatTotalsRow(
+				{
+					inputTokens: totals.inputTokens,
+					outputTokens: totals.outputTokens,
+					cacheCreationTokens: totals.cacheCreationTokens,
+					cacheReadTokens: totals.cacheReadTokens,
+					totalCost: totals.totalCost,
+				},
+				false,
+				humanReadable,
+			);
 			table.push(totalsRow);
 
 			log(table.toString());

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -6,6 +6,7 @@ import {
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
+	setHumanReadableNumbers,
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -134,6 +135,11 @@ export const dailyCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
+			// Enable human-readable numbers if requested
+			if (mergedOptions.human) {
+				setHumanReadableNumbers(true);
+			}
+
 			// Print header
 			logger.box('Claude Code Token Usage Report - Daily');
 

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -6,7 +6,6 @@ import {
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
-	setHumanReadableNumbers,
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -95,10 +94,7 @@ export const monthlyCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
-			// Enable human-readable numbers if requested
-			if (mergedOptions.human) {
-				setHumanReadableNumbers(true);
-			}
+			const humanReadable = Boolean(mergedOptions.human);
 
 			// Print header
 			logger.box('Claude Code Token Usage Report - Monthly');
@@ -119,19 +115,24 @@ export const monthlyCommand = define({
 			// Add monthly data
 			for (const data of monthlyData) {
 				// Main row
-				const row = formatUsageDataRow(data.month, {
-					inputTokens: data.inputTokens,
-					outputTokens: data.outputTokens,
-					cacheCreationTokens: data.cacheCreationTokens,
-					cacheReadTokens: data.cacheReadTokens,
-					totalCost: data.totalCost,
-					modelsUsed: data.modelsUsed,
-				});
+				const row = formatUsageDataRow(
+					data.month,
+					{
+						inputTokens: data.inputTokens,
+						outputTokens: data.outputTokens,
+						cacheCreationTokens: data.cacheCreationTokens,
+						cacheReadTokens: data.cacheReadTokens,
+						totalCost: data.totalCost,
+						modelsUsed: data.modelsUsed,
+					},
+					undefined,
+					humanReadable,
+				);
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 				}
 			}
 
@@ -139,13 +140,17 @@ export const monthlyCommand = define({
 			addEmptySeparatorRow(table, 8);
 
 			// Add totals
-			const totalsRow = formatTotalsRow({
-				inputTokens: totals.inputTokens,
-				outputTokens: totals.outputTokens,
-				cacheCreationTokens: totals.cacheCreationTokens,
-				cacheReadTokens: totals.cacheReadTokens,
-				totalCost: totals.totalCost,
-			});
+			const totalsRow = formatTotalsRow(
+				{
+					inputTokens: totals.inputTokens,
+					outputTokens: totals.outputTokens,
+					cacheCreationTokens: totals.cacheCreationTokens,
+					cacheReadTokens: totals.cacheReadTokens,
+					totalCost: totals.totalCost,
+				},
+				false,
+				humanReadable,
+			);
 			table.push(totalsRow);
 
 			log(table.toString());

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -6,6 +6,7 @@ import {
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
+	setHumanReadableNumbers,
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -94,6 +95,11 @@ export const monthlyCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
+			// Enable human-readable numbers if requested
+			if (mergedOptions.human) {
+				setHumanReadableNumbers(true);
+			}
+
 			// Print header
 			logger.box('Claude Code Token Usage Report - Monthly');
 

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -6,6 +6,7 @@ import {
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
+	setHumanReadableNumbers,
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -45,6 +46,11 @@ export const sessionCommand = define({
 		const useJson = mergedOptions.json || mergedOptions.jq != null;
 		if (useJson) {
 			logger.level = 0;
+		}
+
+		// Enable human-readable numbers if requested (before any output)
+		if (mergedOptions.human) {
+			setHumanReadableNumbers(true);
 		}
 
 		// Handle specific session ID lookup

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -6,7 +6,6 @@ import {
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
-	setHumanReadableNumbers,
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -48,10 +47,7 @@ export const sessionCommand = define({
 			logger.level = 0;
 		}
 
-		// Enable human-readable numbers if requested (before any output)
-		if (mergedOptions.human) {
-			setHumanReadableNumbers(true);
-		}
+		const humanReadable = Boolean(mergedOptions.human);
 
 		// Handle specific session ID lookup
 		if (mergedOptions.id != null) {
@@ -67,6 +63,7 @@ export const sessionCommand = define({
 					},
 				},
 				useJson,
+				humanReadable,
 			);
 		}
 
@@ -161,13 +158,14 @@ export const sessionCommand = define({
 						modelsUsed: data.modelsUsed,
 					},
 					data.lastActivity,
+					humanReadable,
 				);
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (ctx.values.breakdown) {
 					// Session has 1 extra column before data and 1 trailing column
-					pushBreakdownRows(table, data.modelBreakdowns, 1, 1);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 1, humanReadable);
 				}
 			}
 
@@ -184,6 +182,7 @@ export const sessionCommand = define({
 					totalCost: totals.totalCost,
 				},
 				true,
+				humanReadable,
 			); // Include Last Activity column
 			table.push(totalsRow);
 

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -6,7 +6,6 @@ import {
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
-	setHumanReadableNumbers,
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -105,10 +104,7 @@ export const weeklyCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
-			// Enable human-readable numbers if requested
-			if (mergedOptions.human) {
-				setHumanReadableNumbers(true);
-			}
+			const humanReadable = Boolean(mergedOptions.human);
 
 			// Print header
 			logger.box('Claude Code Token Usage Report - Weekly');
@@ -125,19 +121,24 @@ export const weeklyCommand = define({
 			// Add weekly data
 			for (const data of weeklyData) {
 				// Main row
-				const row = formatUsageDataRow(data.week, {
-					inputTokens: data.inputTokens,
-					outputTokens: data.outputTokens,
-					cacheCreationTokens: data.cacheCreationTokens,
-					cacheReadTokens: data.cacheReadTokens,
-					totalCost: data.totalCost,
-					modelsUsed: data.modelsUsed,
-				});
+				const row = formatUsageDataRow(
+					data.week,
+					{
+						inputTokens: data.inputTokens,
+						outputTokens: data.outputTokens,
+						cacheCreationTokens: data.cacheCreationTokens,
+						cacheReadTokens: data.cacheReadTokens,
+						totalCost: data.totalCost,
+						modelsUsed: data.modelsUsed,
+					},
+					undefined,
+					humanReadable,
+				);
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 				}
 			}
 
@@ -145,13 +146,17 @@ export const weeklyCommand = define({
 			addEmptySeparatorRow(table, 8);
 
 			// Add totals
-			const totalsRow = formatTotalsRow({
-				inputTokens: totals.inputTokens,
-				outputTokens: totals.outputTokens,
-				cacheCreationTokens: totals.cacheCreationTokens,
-				cacheReadTokens: totals.cacheReadTokens,
-				totalCost: totals.totalCost,
-			});
+			const totalsRow = formatTotalsRow(
+				{
+					inputTokens: totals.inputTokens,
+					outputTokens: totals.outputTokens,
+					cacheCreationTokens: totals.cacheCreationTokens,
+					cacheReadTokens: totals.cacheReadTokens,
+					totalCost: totals.totalCost,
+				},
+				false,
+				humanReadable,
+			);
 			table.push(totalsRow);
 
 			log(table.toString());

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -6,6 +6,7 @@ import {
 	formatTotalsRow,
 	formatUsageDataRow,
 	pushBreakdownRows,
+	setHumanReadableNumbers,
 } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
@@ -104,6 +105,11 @@ export const weeklyCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
+			// Enable human-readable numbers if requested
+			if (mergedOptions.human) {
+				setHumanReadableNumbers(true);
+			}
+
 			// Print header
 			logger.box('Claude Code Token Usage Report - Weekly');
 

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -351,16 +351,6 @@ export class ResponsiveTable {
 	}
 }
 
-let _humanReadable = false;
-
-/**
- * Enables or disables human-readable number formatting (K/M/B suffixes)
- * @param human - Whether to use human-readable format
- */
-export function setHumanReadableNumbers(human: boolean): void {
-	_humanReadable = human;
-}
-
 /**
  * Formats a number with human-readable suffixes (K, M, B)
  * Numbers below 1000 are displayed as-is with locale formatting
@@ -389,8 +379,8 @@ export function formatNumberHuman(num: number): string {
  * @param num - The number to format
  * @returns Formatted number string
  */
-export function formatNumber(num: number): string {
-	if (_humanReadable) {
+export function formatNumber(num: number, humanReadable = false): string {
+	if (humanReadable) {
 		return formatNumberHuman(num);
 	}
 	return num.toLocaleString('en-US');
@@ -490,6 +480,7 @@ export function pushBreakdownRows(
 	}>,
 	extraColumns = 1,
 	trailingColumns = 0,
+	humanReadable = false,
 ): void {
 	for (const breakdown of breakdowns) {
 		const row: (string | number)[] = [`  └─ ${formatModelName(breakdown.modelName)}`];
@@ -507,11 +498,11 @@ export function pushBreakdownRows(
 			breakdown.cacheReadTokens;
 
 		row.push(
-			pc.gray(formatNumber(breakdown.inputTokens)),
-			pc.gray(formatNumber(breakdown.outputTokens)),
-			pc.gray(formatNumber(breakdown.cacheCreationTokens)),
-			pc.gray(formatNumber(breakdown.cacheReadTokens)),
-			pc.gray(formatNumber(totalTokens)),
+			pc.gray(formatNumber(breakdown.inputTokens, humanReadable)),
+			pc.gray(formatNumber(breakdown.outputTokens, humanReadable)),
+			pc.gray(formatNumber(breakdown.cacheCreationTokens, humanReadable)),
+			pc.gray(formatNumber(breakdown.cacheReadTokens, humanReadable)),
+			pc.gray(formatNumber(totalTokens, humanReadable)),
 			pc.gray(formatCurrency(breakdown.cost)),
 		);
 
@@ -613,6 +604,7 @@ export function formatUsageDataRow(
 	firstColumnValue: string,
 	data: UsageData,
 	lastActivity?: string,
+	humanReadable = false,
 ): (string | number)[] {
 	const totalTokens =
 		data.inputTokens + data.outputTokens + data.cacheCreationTokens + data.cacheReadTokens;
@@ -620,11 +612,11 @@ export function formatUsageDataRow(
 	const row: (string | number)[] = [
 		firstColumnValue,
 		data.modelsUsed != null ? formatModelsDisplayMultiline(data.modelsUsed) : '',
-		formatNumber(data.inputTokens),
-		formatNumber(data.outputTokens),
-		formatNumber(data.cacheCreationTokens),
-		formatNumber(data.cacheReadTokens),
-		formatNumber(totalTokens),
+		formatNumber(data.inputTokens, humanReadable),
+		formatNumber(data.outputTokens, humanReadable),
+		formatNumber(data.cacheCreationTokens, humanReadable),
+		formatNumber(data.cacheReadTokens, humanReadable),
+		formatNumber(totalTokens, humanReadable),
 		formatCurrency(data.totalCost),
 	];
 
@@ -644,6 +636,7 @@ export function formatUsageDataRow(
 export function formatTotalsRow(
 	totals: UsageData,
 	includeLastActivity = false,
+	humanReadable = false,
 ): (string | number)[] {
 	const totalTokens =
 		totals.inputTokens + totals.outputTokens + totals.cacheCreationTokens + totals.cacheReadTokens;
@@ -651,11 +644,11 @@ export function formatTotalsRow(
 	const row: (string | number)[] = [
 		pc.yellow('Total'),
 		'', // Empty for Models column in totals
-		pc.yellow(formatNumber(totals.inputTokens)),
-		pc.yellow(formatNumber(totals.outputTokens)),
-		pc.yellow(formatNumber(totals.cacheCreationTokens)),
-		pc.yellow(formatNumber(totals.cacheReadTokens)),
-		pc.yellow(formatNumber(totalTokens)),
+		pc.yellow(formatNumber(totals.inputTokens, humanReadable)),
+		pc.yellow(formatNumber(totals.outputTokens, humanReadable)),
+		pc.yellow(formatNumber(totals.cacheCreationTokens, humanReadable)),
+		pc.yellow(formatNumber(totals.cacheReadTokens, humanReadable)),
+		pc.yellow(formatNumber(totalTokens, humanReadable)),
 		pc.yellow(formatCurrency(totals.totalCost)),
 	];
 
@@ -1053,20 +1046,19 @@ if (import.meta.vitest != null) {
 		});
 	});
 
-	describe('setHumanReadableNumbers', () => {
-		afterEach(() => {
-			setHumanReadableNumbers(false);
-		});
-
+	describe('formatNumber with humanReadable parameter', () => {
 		it('formatNumber uses human-readable format when enabled', () => {
-			setHumanReadableNumbers(true);
-			expect(formatNumber(1_500_000)).toBe('1.50M');
-			expect(formatNumber(2_500)).toBe('2.50K');
-			expect(formatNumber(500)).toBe('500');
+			expect(formatNumber(1_500_000, true)).toBe('1.50M');
+			expect(formatNumber(2_500, true)).toBe('2.50K');
+			expect(formatNumber(500, true)).toBe('500');
 		});
 
 		it('formatNumber uses default format when disabled', () => {
-			setHumanReadableNumbers(false);
+			expect(formatNumber(1_500_000, false)).toBe('1,500,000');
+			expect(formatNumber(2_500, false)).toBe('2,500');
+		});
+
+		it('formatNumber defaults to non-human-readable', () => {
 			expect(formatNumber(1_500_000)).toBe('1,500,000');
 			expect(formatNumber(2_500)).toBe('2,500');
 		});

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -351,12 +351,48 @@ export class ResponsiveTable {
 	}
 }
 
+let _humanReadable = false;
+
+/**
+ * Enables or disables human-readable number formatting (K/M/B suffixes)
+ * @param human - Whether to use human-readable format
+ */
+export function setHumanReadableNumbers(human: boolean): void {
+	_humanReadable = human;
+}
+
+/**
+ * Formats a number with human-readable suffixes (K, M, B)
+ * Numbers below 1000 are displayed as-is with locale formatting
+ * @param num - The number to format
+ * @returns Formatted string with suffix (e.g., "1.23M", "456K")
+ */
+export function formatNumberHuman(num: number): string {
+	const absNum = Math.abs(num);
+	const sign = num < 0 ? '-' : '';
+
+	if (absNum >= 1_000_000_000) {
+		return `${sign}${(absNum / 1_000_000_000).toFixed(2)}B`;
+	}
+	if (absNum >= 1_000_000) {
+		return `${sign}${(absNum / 1_000_000).toFixed(2)}M`;
+	}
+	if (absNum >= 1_000) {
+		return `${sign}${(absNum / 1_000).toFixed(2)}K`;
+	}
+	return num.toLocaleString('en-US');
+}
+
 /**
  * Formats a number with locale-specific thousand separators
+ * When human-readable mode is enabled, uses K/M/B suffixes instead
  * @param num - The number to format
- * @returns Formatted number string with commas as thousand separators
+ * @returns Formatted number string
  */
 export function formatNumber(num: number): string {
+	if (_humanReadable) {
+		return formatNumberHuman(num);
+	}
 	return num.toLocaleString('en-US');
 }
 
@@ -981,6 +1017,58 @@ if (import.meta.vitest != null) {
 		it('handles edge cases', () => {
 			expect(formatNumber(Number.MAX_SAFE_INTEGER)).toBe('9,007,199,254,740,991');
 			expect(formatNumber(Number.MIN_SAFE_INTEGER)).toBe('-9,007,199,254,740,991');
+		});
+	});
+
+	describe('formatNumberHuman', () => {
+		it('formats billions', () => {
+			expect(formatNumberHuman(1_000_000_000)).toBe('1.00B');
+			expect(formatNumberHuman(2_500_000_000)).toBe('2.50B');
+			expect(formatNumberHuman(1_234_567_890)).toBe('1.23B');
+		});
+
+		it('formats millions', () => {
+			expect(formatNumberHuman(1_000_000)).toBe('1.00M');
+			expect(formatNumberHuman(1_500_000)).toBe('1.50M');
+			expect(formatNumberHuman(12_345_678)).toBe('12.35M');
+		});
+
+		it('formats thousands', () => {
+			expect(formatNumberHuman(1_000)).toBe('1.00K');
+			expect(formatNumberHuman(1_500)).toBe('1.50K');
+			expect(formatNumberHuman(999_999)).toBe('1000.00K');
+		});
+
+		it('keeps numbers below 1000 as-is', () => {
+			expect(formatNumberHuman(0)).toBe('0');
+			expect(formatNumberHuman(1)).toBe('1');
+			expect(formatNumberHuman(999)).toBe('999');
+			expect(formatNumberHuman(500)).toBe('500');
+		});
+
+		it('handles negative numbers', () => {
+			expect(formatNumberHuman(-1_500_000)).toBe('-1.50M');
+			expect(formatNumberHuman(-2_500)).toBe('-2.50K');
+			expect(formatNumberHuman(-500)).toBe('-500');
+		});
+	});
+
+	describe('setHumanReadableNumbers', () => {
+		afterEach(() => {
+			setHumanReadableNumbers(false);
+		});
+
+		it('formatNumber uses human-readable format when enabled', () => {
+			setHumanReadableNumbers(true);
+			expect(formatNumber(1_500_000)).toBe('1.50M');
+			expect(formatNumber(2_500)).toBe('2.50K');
+			expect(formatNumber(500)).toBe('500');
+		});
+
+		it('formatNumber uses default format when disabled', () => {
+			setHumanReadableNumbers(false);
+			expect(formatNumber(1_500_000)).toBe('1,500,000');
+			expect(formatNumber(2_500)).toBe('2,500');
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Add `--human` / `-H` flag to all commands (daily, weekly, monthly, session, blocks)
- When enabled, token counts are displayed with K/M/B suffixes (e.g., `1.50M` instead of `1,500,000`)
- Includes unit tests for `formatNumberHuman` and `setHumanReadableNumbers`

## Details

Large token counts (millions+) are hard to scan visually. The `--human` flag provides a compact format:

| Raw | Human |
|---|---|
| 1,500,000 | 1.50M |
| 2,500 | 2.50K |
| 999 | 999 |

Implementation:
- New `formatNumberHuman()` function in `packages/terminal/src/table.ts`
- Global toggle via `setHumanReadableNumbers()` — called before any table output when `--human` is passed
- `formatNumber()` automatically delegates to `formatNumberHuman()` when the flag is active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-H` / `--human` CLI flag to show token counts in human-readable format (K/M/B suffixes, rounded) in non-JSON tables and reports across blocks, daily, weekly, monthly, and session commands. JSON output remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->