### PR TITLE
feat(ccusage): add --custom-dirs flag for additional Claude data directories

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -102,7 +102,13 @@ npx ccusage daily --instances --project myproject --json  # Combined usage
 # Compact mode for screenshots/sharing
 npx ccusage --compact  # Force compact table mode
 npx ccusage monthly --compact  # Compact monthly report
+
+# Include extra Claude data directories
+npx ccusage daily --custom-dirs ~/.claude-work
+npx ccusage daily --custom-dirs ~/.claude-work,~/.claude-personal
 ```
+
+> `--custom-dirs` takes a comma-separated list of extra directories to merge in alongside the defaults (`~/.config/claude`, `~/.claude`) and anything set via `CLAUDE_CONFIG_DIR`. Each entry must contain a `projects/` subdirectory. Paths starting with `~/` are expanded to your home directory; shell globs like `~/.claude*` are **not** expanded — pass each path explicitly.
 
 ## Features
 
@@ -114,7 +120,7 @@ npx ccusage monthly --compact  # Compact monthly report
 - 🤖 **Model Tracking**: See which Claude models you're using (Opus, Sonnet, etc.)
 - 📊 **Model Breakdown**: View per-model cost breakdown with `--breakdown` flag
 - 📅 **Date Filtering**: Filter reports by date range using `--since` and `--until`
-- 📁 **Custom Path**: Support for custom Claude data directory locations
+- 📁 **Custom Path**: Support for custom Claude data directory locations, including merging multiple directories with `--custom-dirs`
 - 🎨 **Beautiful Output**: Colorful table-formatted display with automatic responsive layout
 - 📱 **Smart Tables**: Automatic compact mode for narrow terminals (< 100 characters) with essential columns
 - 📸 **Compact Mode**: Use `--compact` flag to force compact table layout, perfect for screenshots and sharing

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -92,6 +92,11 @@
 							"description": "Process JSON output with jq command (requires jq binary, implies --json)",
 							"markdownDescription": "Process JSON output with jq command (requires jq binary, implies --json)"
 						},
+						"customDirs": {
+							"type": "string",
+							"description": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory.",
+							"markdownDescription": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory."
+						},
 						"compact": {
 							"type": "boolean",
 							"description": "Force compact mode for narrow displays (better for screenshots)",
@@ -188,6 +193,11 @@
 									"type": "string",
 									"description": "Process JSON output with jq command (requires jq binary, implies --json)",
 									"markdownDescription": "Process JSON output with jq command (requires jq binary, implies --json)"
+								},
+								"customDirs": {
+									"type": "string",
+									"description": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory.",
+									"markdownDescription": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory."
 								},
 								"compact": {
 									"type": "boolean",
@@ -297,6 +307,11 @@
 									"description": "Process JSON output with jq command (requires jq binary, implies --json)",
 									"markdownDescription": "Process JSON output with jq command (requires jq binary, implies --json)"
 								},
+								"customDirs": {
+									"type": "string",
+									"description": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory.",
+									"markdownDescription": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory."
+								},
 								"compact": {
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
@@ -388,6 +403,11 @@
 									"type": "string",
 									"description": "Process JSON output with jq command (requires jq binary, implies --json)",
 									"markdownDescription": "Process JSON output with jq command (requires jq binary, implies --json)"
+								},
+								"customDirs": {
+									"type": "string",
+									"description": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory.",
+									"markdownDescription": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory."
 								},
 								"compact": {
 									"type": "boolean",
@@ -489,6 +509,11 @@
 									"description": "Process JSON output with jq command (requires jq binary, implies --json)",
 									"markdownDescription": "Process JSON output with jq command (requires jq binary, implies --json)"
 								},
+								"customDirs": {
+									"type": "string",
+									"description": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory.",
+									"markdownDescription": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory."
+								},
 								"compact": {
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
@@ -585,6 +610,11 @@
 									"type": "string",
 									"description": "Process JSON output with jq command (requires jq binary, implies --json)",
 									"markdownDescription": "Process JSON output with jq command (requires jq binary, implies --json)"
+								},
+								"customDirs": {
+									"type": "string",
+									"description": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory.",
+									"markdownDescription": "Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory."
 								},
 								"compact": {
 									"type": "boolean",

--- a/apps/ccusage/src/_config-loader-tokens.ts
+++ b/apps/ccusage/src/_config-loader-tokens.ts
@@ -55,7 +55,13 @@ export type ConfigData = {
  * 2. User config directories from getClaudePaths() + ccusage.json
  */
 function getConfigSearchPaths(): string[] {
-	const claudeConfigDirs = [join(process.cwd(), '.ccusage'), ...toArray(getClaudePaths())];
+	let claudePathDirs: string[] = [];
+	try {
+		claudePathDirs = toArray(getClaudePaths());
+	} catch {
+		// No Claude data dirs found — still allow local config discovery
+	}
+	const claudeConfigDirs = [join(process.cwd(), '.ccusage'), ...claudePathDirs];
 	return claudeConfigDirs.map((dir) => join(dir, CONFIG_FILE_NAME));
 }
 

--- a/apps/ccusage/src/_shared-args.ts
+++ b/apps/ccusage/src/_shared-args.ts
@@ -105,6 +105,11 @@ export const sharedArgs = {
 		type: 'string',
 		description: 'Path to configuration file (default: auto-discovery)',
 	},
+	customDirs: {
+		type: 'string',
+		description:
+			'Additional Claude data directories to include (comma-separated paths). Each must contain a projects/ subdirectory.',
+	},
 	compact: {
 		type: 'boolean',
 		description: 'Force compact mode for narrow displays (better for screenshots)',

--- a/apps/ccusage/src/commands/_session_id.ts
+++ b/apps/ccusage/src/commands/_session_id.ts
@@ -16,6 +16,7 @@ export type SessionIdContext = {
 		jq?: string;
 		timezone?: string;
 		locale: string; // normalized to non-optional to avoid touching data-loader
+		customDirs?: string;
 	};
 };
 
@@ -29,6 +30,7 @@ export async function handleSessionIdLookup(
 	const sessionUsage = await loadSessionUsageById(ctx.values.id, {
 		mode: ctx.values.mode,
 		offline: ctx.values.offline,
+		customDirs: ctx.values.customDirs,
 	});
 
 	if (sessionUsage == null) {

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -173,6 +173,7 @@ export const blocksCommand = define({
 			sessionDurationHours: ctx.values.sessionLength,
 			timezone: ctx.values.timezone,
 			locale: ctx.values.locale,
+			customDirs: mergedOptions.customDirs,
 		});
 
 		if (blocks.length === 0) {

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -58,6 +58,7 @@ export const sessionCommand = define({
 						jq: mergedOptions.jq,
 						timezone: mergedOptions.timezone,
 						locale: mergedOptions.locale ?? DEFAULT_LOCALE,
+						customDirs: mergedOptions.customDirs,
 					},
 				},
 				useJson,
@@ -72,6 +73,7 @@ export const sessionCommand = define({
 			offline: ctx.values.offline,
 			timezone: ctx.values.timezone,
 			locale: ctx.values.locale,
+			customDirs: mergedOptions.customDirs,
 		});
 
 		if (sessionData.length === 0) {

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -155,6 +155,7 @@ export const statuslineCommand = define({
 			default: DEFAULT_CONTEXT_USAGE_THRESHOLDS.MEDIUM,
 		},
 		config: sharedArgs.config,
+		customDirs: sharedArgs.customDirs,
 		debug: sharedArgs.debug,
 	},
 	async run(ctx) {
@@ -292,6 +293,7 @@ export const statuslineCommand = define({
 										loadSessionUsageById(sessionId, {
 											mode: 'auto',
 											offline: mergedOptions.offline,
+											customDirs: ctx.values.customDirs,
 										}),
 									catch: (error) => error,
 								})(),
@@ -344,6 +346,7 @@ export const statuslineCommand = define({
 									until: todayStr,
 									mode: 'auto',
 									offline: mergedOptions.offline,
+									customDirs: ctx.values.customDirs,
 								}),
 							catch: (error) => error,
 						})(),
@@ -365,6 +368,7 @@ export const statuslineCommand = define({
 								loadSessionBlockData({
 									mode: 'auto',
 									offline: mergedOptions.offline,
+									customDirs: ctx.values.customDirs,
 								}),
 							catch: (error) => error,
 						})(),

--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -75,9 +75,25 @@ import { logger } from './logger.ts';
  * When not set: uses default paths (~/.config/claude and ~/.claude)
  * @returns Array of valid Claude data directory paths
  */
-export function getClaudePaths(): string[] {
-	const paths = [];
+export function getClaudePaths(customDirs?: string): string[] {
+	const paths: string[] = [];
 	const normalizedPaths = new Set<string>();
+
+	/**
+	 * Try to add a directory path if it's valid (exists and has projects/ subdir)
+	 */
+	function addIfValid(dirPath: string): void {
+		const normalizedPath = path.resolve(dirPath);
+		if (isDirectorySync(normalizedPath)) {
+			const projectsPath = path.join(normalizedPath, CLAUDE_PROJECTS_DIR_NAME);
+			if (isDirectorySync(projectsPath)) {
+				if (!normalizedPaths.has(normalizedPath)) {
+					normalizedPaths.add(normalizedPath);
+					paths.push(normalizedPath);
+				}
+			}
+		}
+	}
 
 	// Check environment variable first (supports comma-separated paths)
 	const envPaths = (process.env[CLAUDE_CONFIG_DIR_ENV] ?? '').trim();
@@ -87,46 +103,39 @@ export function getClaudePaths(): string[] {
 			.map((p) => p.trim())
 			.filter((p) => p !== '');
 		for (const envPath of envPathList) {
-			const normalizedPath = path.resolve(envPath);
-			if (isDirectorySync(normalizedPath)) {
-				const projectsPath = path.join(normalizedPath, CLAUDE_PROJECTS_DIR_NAME);
-				if (isDirectorySync(projectsPath)) {
-					// Avoid duplicates using normalized paths
-					if (!normalizedPaths.has(normalizedPath)) {
-						normalizedPaths.add(normalizedPath);
-						paths.push(normalizedPath);
-					}
-				}
-			}
+			addIfValid(envPath);
 		}
-		// If environment variable is set, return only those paths (or error if none valid)
-		if (paths.length > 0) {
-			return paths;
-		}
-		// If environment variable is set but no valid paths found, throw error
-		throw new Error(
-			`No valid Claude data directories found in CLAUDE_CONFIG_DIR. Please ensure the following exists:
+		// If environment variable is set but no valid paths found (before custom dirs), throw error
+		if (paths.length === 0 && (customDirs == null || customDirs.trim() === '')) {
+			throw new Error(
+				`No valid Claude data directories found in CLAUDE_CONFIG_DIR. Please ensure the following exists:
 - ${envPaths}/${CLAUDE_PROJECTS_DIR_NAME}`.trim(),
-		);
+			);
+		}
+	} else {
+		// Only check default paths if no environment variable is set
+		const defaultPaths = [
+			DEFAULT_CLAUDE_CONFIG_PATH, // New default: XDG config directory
+			path.join(USER_HOME_DIR, DEFAULT_CLAUDE_CODE_PATH), // Old default: ~/.claude
+		];
+
+		for (const defaultPath of defaultPaths) {
+			addIfValid(defaultPath);
+		}
 	}
 
-	// Only check default paths if no environment variable is set
-	const defaultPaths = [
-		DEFAULT_CLAUDE_CONFIG_PATH, // New default: XDG config directory
-		path.join(USER_HOME_DIR, DEFAULT_CLAUDE_CODE_PATH), // Old default: ~/.claude
-	];
-
-	for (const defaultPath of defaultPaths) {
-		const normalizedPath = path.resolve(defaultPath);
-		if (isDirectorySync(normalizedPath)) {
-			const projectsPath = path.join(normalizedPath, CLAUDE_PROJECTS_DIR_NAME);
-			if (isDirectorySync(projectsPath)) {
-				// Avoid duplicates using normalized paths
-				if (!normalizedPaths.has(normalizedPath)) {
-					normalizedPaths.add(normalizedPath);
-					paths.push(normalizedPath);
-				}
-			}
+	// Add custom directories (always, regardless of env var)
+	if (customDirs != null && customDirs.trim() !== '') {
+		const customDirList = customDirs
+			.split(',')
+			.map((p) => p.trim())
+			.filter((p) => p !== '');
+		for (const customDir of customDirList) {
+			// Expand ~ to home directory
+			const expandedPath = customDir.startsWith('~/')
+				? path.join(USER_HOME_DIR, customDir.slice(2))
+				: customDir;
+			addIfValid(expandedPath);
 		}
 	}
 
@@ -740,6 +749,7 @@ export type DateFilter = {
  */
 export type LoadOptions = {
 	claudePath?: string; // Custom path to Claude data directory
+	customDirs?: string; // Additional comma-separated Claude data directories
 	mode?: CostMode; // Cost calculation mode
 	order?: SortOrder; // Sort order for dates
 	offline?: boolean; // Use offline mode for pricing
@@ -759,7 +769,7 @@ export type LoadOptions = {
  */
 export async function loadDailyUsageData(options?: LoadOptions): Promise<DailyUsage[]> {
 	// Get all Claude paths or use the specific one from options
-	const claudePaths = toArray(options?.claudePath ?? getClaudePaths());
+	const claudePaths = toArray(options?.claudePath ?? getClaudePaths(options?.customDirs));
 
 	// Collect files from all paths in parallel
 	const allFiles = await globUsageFiles(claudePaths);
@@ -908,7 +918,7 @@ export async function loadDailyUsageData(options?: LoadOptions): Promise<DailyUs
  */
 export async function loadSessionData(options?: LoadOptions): Promise<SessionUsage[]> {
 	// Get all Claude paths or use the specific one from options
-	const claudePaths = toArray(options?.claudePath ?? getClaudePaths());
+	const claudePaths = toArray(options?.claudePath ?? getClaudePaths(options?.customDirs));
 
 	// Collect files from all paths with their base directories in parallel
 	const filesWithBase = await globUsageFiles(claudePaths);
@@ -1123,13 +1133,14 @@ export async function loadWeeklyUsageData(options?: LoadOptions): Promise<Weekly
  * @param options - Options for loading data
  * @param options.mode - Cost calculation mode (auto, calculate, display)
  * @param options.offline - Whether to use offline pricing data
+ * @param options.customDirs - Additional comma-separated Claude data directories
  * @returns Usage data for the specific session or null if not found
  */
 export async function loadSessionUsageById(
 	sessionId: string,
-	options?: { mode?: CostMode; offline?: boolean },
+	options?: { mode?: CostMode; offline?: boolean; customDirs?: string },
 ): Promise<{ totalCost: number; entries: UsageData[] } | null> {
-	const claudePaths = getClaudePaths();
+	const claudePaths = getClaudePaths(options?.customDirs);
 
 	// Find the JSONL file for this session ID
 	// On Windows, replace backslashes from path.join with forward slashes for tinyglobby compatibility
@@ -1354,7 +1365,7 @@ export async function calculateContextTokens(
  */
 export async function loadSessionBlockData(options?: LoadOptions): Promise<SessionBlock[]> {
 	// Get all Claude paths or use the specific one from options
-	const claudePaths = toArray(options?.claudePath ?? getClaudePaths());
+	const claudePaths = toArray(options?.claudePath ?? getClaudePaths(options?.customDirs));
 
 	// Collect files from all paths
 	const allFiles: string[] = [];
@@ -4771,6 +4782,80 @@ if (import.meta.vitest != null) {
 			expect(Array.isArray(paths)).toBe(true);
 			// At least one path should exist in our test environment (CI creates both)
 			expect(paths.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('includes customDirs paths alongside env-var paths', async () => {
+			await using envFixture = await createFixture({ projects: {} });
+			await using customFixture = await createFixture({ projects: {} });
+
+			vi.stubEnv('CLAUDE_CONFIG_DIR', envFixture.path);
+
+			const paths = getClaudePaths(customFixture.path);
+			const normalizedEnv = path.resolve(envFixture.path);
+			const normalizedCustom = path.resolve(customFixture.path);
+
+			expect(paths).toEqual(expect.arrayContaining([normalizedEnv, normalizedCustom]));
+		});
+
+		it('parses comma-separated customDirs into multiple paths', async () => {
+			await using fixture1 = await createFixture({ projects: {} });
+			await using fixture2 = await createFixture({ projects: {} });
+
+			vi.stubEnv('CLAUDE_CONFIG_DIR', '/nonexistent/should/trigger/empty');
+
+			const paths = getClaudePaths(`${fixture1.path},${fixture2.path}`);
+			expect(paths).toEqual(
+				expect.arrayContaining([path.resolve(fixture1.path), path.resolve(fixture2.path)]),
+			);
+		});
+
+		it('deduplicates customDirs against env-var paths', async () => {
+			await using fixture = await createFixture({ projects: {} });
+
+			vi.stubEnv('CLAUDE_CONFIG_DIR', fixture.path);
+
+			const paths = getClaudePaths(fixture.path);
+			const normalized = path.resolve(fixture.path);
+			const count = paths.filter((p) => p === normalized).length;
+			expect(count).toBe(1);
+		});
+
+		it('treats empty customDirs as no-op', async () => {
+			await using fixture = await createFixture({ projects: {} });
+			vi.stubEnv('CLAUDE_CONFIG_DIR', fixture.path);
+
+			expect(getClaudePaths('')).toEqual(getClaudePaths());
+			expect(getClaudePaths('   ')).toEqual(getClaudePaths());
+		});
+
+		it('ignores trailing commas and whitespace in customDirs', async () => {
+			await using fixture = await createFixture({ projects: {} });
+			vi.stubEnv('CLAUDE_CONFIG_DIR', '/nonexistent/dummy');
+
+			const paths = getClaudePaths(` ${fixture.path} , , `);
+			expect(paths).toContain(path.resolve(fixture.path));
+		});
+
+		it('silently drops customDirs entries missing a projects/ subdirectory', async () => {
+			await using noProjects = await createFixture({}); // no projects/ subdir
+			await using valid = await createFixture({ projects: {} });
+
+			vi.stubEnv('CLAUDE_CONFIG_DIR', '/nonexistent/dummy');
+
+			const paths = getClaudePaths(`${noProjects.path},${valid.path},/also-nonexistent`);
+			expect(paths).toContain(path.resolve(valid.path));
+			expect(paths).not.toContain(path.resolve(noProjects.path));
+			expect(paths).not.toContain(path.resolve('/also-nonexistent'));
+		});
+
+		it('customDirs rescues an empty CLAUDE_CONFIG_DIR without throwing', async () => {
+			await using fixture = await createFixture({ projects: {} });
+			vi.stubEnv('CLAUDE_CONFIG_DIR', '/nonexistent/path');
+
+			// Without customDirs, this would throw; with customDirs it must not.
+			expect(() => getClaudePaths()).toThrow();
+			expect(() => getClaudePaths(fixture.path)).not.toThrow();
+			expect(getClaudePaths(fixture.path)).toContain(path.resolve(fixture.path));
 		});
 	});
 

--- a/ccusage.example.json
+++ b/ccusage.example.json
@@ -6,7 +6,8 @@
 		"timezone": "Asia/Tokyo",
 		"locale": "ja-JP",
 		"offline": false,
-		"breakdown": false
+		"breakdown": false,
+		"customDirs": "~/.claude-work,~/.claude-personal"
 	},
 	"commands": {
 		"daily": {

--- a/docs/guide/cli-options.md
+++ b/docs/guide/cli-options.md
@@ -155,6 +155,24 @@ ccusage daily --config ./my-config.json
 ccusage monthly --config /path/to/team-config.json
 ```
 
+### Custom Data Directories
+
+Add extra Claude data directories inline, alongside the defaults (`~/.config/claude`, `~/.claude`) and anything from `CLAUDE_CONFIG_DIR`:
+
+```bash
+# Single extra directory
+ccusage daily --custom-dirs ~/.claude-work
+
+# Multiple directories (comma-separated)
+ccusage daily --custom-dirs ~/.claude-work,~/.claude-personal
+
+# Works with every data command
+ccusage monthly --custom-dirs ~/.claude-archive
+ccusage blocks --active --custom-dirs ~/.claude-work
+```
+
+Paths starting with `~/` are expanded to the user's home directory. Entries without a `projects/` subdirectory are silently skipped. See [Custom Paths](/guide/custom-paths#custom-dirs-cli-flag) for details on how this composes with `CLAUDE_CONFIG_DIR`.
+
 ## Command-Specific Options
 
 ### Daily Command

--- a/docs/guide/config-files.md
+++ b/docs/guide/config-files.md
@@ -149,10 +149,13 @@ The `defaults` section sets default values for all commands:
 		"offline": false,
 		"timezone": "UTC",
 		"locale": "en-CA",
-		"jq": ".data[]"
+		"jq": ".data[]",
+		"customDirs": "~/.claude-work,~/.claude-personal"
 	}
 }
 ```
+
+`customDirs` accepts a comma-separated string of additional Claude data directories (paths starting with `~/` are expanded). It behaves the same as the `--custom-dirs` CLI flag and composes with `CLAUDE_CONFIG_DIR`. See [Custom Paths](/guide/custom-paths#custom-dirs-cli-flag) for details.
 
 ### Command-Specific Configuration
 

--- a/docs/guide/custom-paths.md
+++ b/docs/guide/custom-paths.md
@@ -63,6 +63,31 @@ When multiple paths are specified:
 - ✅ **Automatic filtering** - Invalid or empty directories are silently skipped
 - ✅ **Consistent reporting** - All reports show unified data across paths
 
+## `--custom-dirs` CLI Flag
+
+The `--custom-dirs` flag is a per-invocation alternative to the `CLAUDE_CONFIG_DIR` environment variable. It accepts a comma-separated list of additional directories and merges them with whatever is already being loaded.
+
+```bash
+# Use alongside defaults (no env var set)
+ccusage daily --custom-dirs ~/.claude-work
+
+# Merge several dirs in one call
+ccusage daily --custom-dirs ~/.claude-work,~/.claude-personal
+
+# Combine with CLAUDE_CONFIG_DIR — both sources are merged and deduplicated
+CLAUDE_CONFIG_DIR=/backup/claude-archive ccusage monthly --custom-dirs ~/.claude-work
+```
+
+Behavior:
+
+- Paths starting with `~/` are expanded to the user's home directory.
+- Entries without a `projects/` subdirectory are silently dropped.
+- Duplicate paths (from env var ∪ `--custom-dirs`) are deduplicated.
+- When `CLAUDE_CONFIG_DIR` points at a non-existent dir, `--custom-dirs` alone is enough to keep ccusage working (no error).
+- Shell globs like `~/.claude*` are **not** expanded — pass each directory explicitly.
+
+Use the env var for defaults that should apply to every invocation; use `--custom-dirs` for one-off analysis without modifying your shell configuration. Both work in every data command (`daily`, `monthly`, `weekly`, `session`, `blocks`, `statusline`) and can be set as a default in `ccusage.json`.
+
 ## Default Path Detection
 
 ### Standard Locations


### PR DESCRIPTION
## Summary

Adds a `--custom-dirs` CLI flag that accepts a comma-separated list of additional Claude data directories. These are merged with the defaults (`~/.config/claude`, `~/.claude`) and anything set via `CLAUDE_CONFIG_DIR`, deduplicated, and validated (each entry must contain a `projects/` subdirectory).

```bash
# Per-invocation (no shell config needed)
ccusage daily --custom-dirs ~/.claude-work,~/.claude-personal

# Composes with the env var
CLAUDE_CONFIG_DIR=/archive/claude ccusage monthly --custom-dirs ~/.claude-work
```

## What Changed

- **`_shared-args.ts`** — new `customDirs` shared arg.
- **`data-loader.ts`** — `getClaudePaths(customDirs?)` refactored with an `addIfValid` helper, `~/` home-dir expansion, and dedup across env-var + custom-dirs. `LoadOptions.customDirs` threaded through `loadDailyUsageData`, `loadSessionData`, `loadSessionBlockData`, and `loadSessionUsageById`.
- **Commands** — `session`, `blocks`, `statusline` and the shared `_session_id` helper now pass `customDirs` to their loaders. `daily`, `monthly`, and `weekly` already spread `mergedOptions` and pick it up for free.
- **`config-schema.json`** — regenerated from `_shared-args.ts` via `pnpm run generate:schema`.
- **Docs** — `docs/guide/custom-paths.md`, `docs/guide/cli-options.md`, `docs/guide/config-files.md`, `ccusage.example.json`, `apps/ccusage/README.md`.
- **`_config-loader-tokens.ts`** (separate commit) — fix a latent bug where `getConfigSearchPaths` threw during config discovery on systems where no default Claude dir exists (e.g. fresh installs, containerized dev envs, systems relying entirely on `--custom-dirs`). Wrapped in try/catch so the correct error surfaces later in the data-loading layer.

## Why

Users with multiple Claude Code installs (work, personal, worktrees, archives) have to concatenate everything into a single `CLAUDE_CONFIG_DIR` env var — awkward for one-off analysis and impossible to express cleanly in `ccusage.json`. `--custom-dirs` lets them add dirs inline per-invocation or set a default via config file, and composes with the env var.

## Test Plan

- 7 new in-source vitest cases in `data-loader.ts` covering: CSV parsing, env-var ∪ custom-dirs dedup, empty/whitespace no-op, trailing comma tolerance, invalid-dir silent drop, and the empty-`CLAUDE_CONFIG_DIR`-rescue scenario.
- `pnpm run test` — all tests pass (1 pre-existing test that depends on `~/.claude/projects` existing on the dev machine continues to pass on CI).
- `pnpm run format` / `pnpm typecheck` — clean.
- Manual: `pnpm --filter ccusage run start daily --custom-dirs ~/.claude-work,~/.claude-personal` aggregates data from both dirs.

## Known limitations / follow-ups

- **MCP package** (`apps/mcp`) still only reads `claudePath` from `LoadOptions` — it will silently ignore `customDirs` from MCP clients. Happy to wire this up in a follow-up PR if you'd prefer to keep this one scoped to the CLI.
- **Array form in config JSON** — the generated schema declares `customDirs` as a string only. Users may naturally write `"customDirs": ["/a", "/b"]`. Can extend the schema + merger to accept both forms if preferred.
- **Shell globs** — `--custom-dirs ~/.claude*` is not expanded by ccusage (users must list paths explicitly or rely on shell expansion into comma-separated form). Documented as a known behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--custom-dirs` CLI flag to specify comma-separated paths for extra Claude data directories, merging with defaults and `CLAUDE_CONFIG_DIR`.
  * Added `customDirs` configuration option in `ccusage.json` for default custom directory paths.
  * Custom directories require a `projects/` subdirectory; home directory expansion (`~/`) is supported.

* **Documentation**
  * Updated CLI options, configuration, and custom paths guides with examples and behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->