### PR TITLE
feat(codebuff): add @ccusage/codebuff companion package

### DIFF
--- a/apps/codebuff/CLAUDE.md
+++ b/apps/codebuff/CLAUDE.md
@@ -60,7 +60,7 @@ Credits live directly on `message.credits` and are surfaced alongside the USD co
 		"timestamp": "2025-12-14T10:00:00.000Z",
 		"credits": 1.25,
 		"metadata": {
-			"model": "claude-haiku-4-5-20251001",
+			"model": "claude-sonnet-4-20250514",
 			"usage": {
 				"inputTokens": 500,
 				"outputTokens": 200,

--- a/apps/codebuff/CLAUDE.md
+++ b/apps/codebuff/CLAUDE.md
@@ -1,0 +1,73 @@
+# Codebuff CLI Notes
+
+## Log Sources
+
+- Codebuff persists chat history under `${CODEBUFF_DATA_DIR:-~/.config/manicode}`.
+- The product was previously called **Manicode**, so on disk the directory is still `manicode`. Dev and staging channels live under `manicode-dev` and `manicode-staging`; the loader walks all three when present.
+- Layout per channel:
+  - `projects/<projectBasename>/chats/<chatId>/chat-messages.json` – serialized `ChatMessage[]`.
+  - `projects/<projectBasename>/chats/<chatId>/run-state.json` – SDK `RunState` snapshot (used to recover the real `cwd`).
+- `chatId` is the chat's ISO timestamp with `:` substituted by `-` so it's filesystem-safe (e.g. `2025-12-14T10-00-00.000Z`).
+
+## Token / Credit Extraction
+
+Codebuff routes calls through several upstream providers, so usage can live in any of these spots on an assistant `ChatMessage`:
+
+1. `metadata.usage` – direct assistant-side usage numbers.
+2. `metadata.codebuff.usage` – Codebuff-specific usage payload.
+3. `metadata.runState.sessionState.mainAgentState.messageHistory[*].providerOptions` – when the SDK stashed the RunState after completion, the most recent `role === 'assistant'` entry carries OpenRouter-shaped usage under `providerOptions.usage` (snake_case keys) or `providerOptions.codebuff.usage`.
+
+Both camelCase and snake_case shapes are accepted (`inputTokens`/`input_tokens`/`promptTokens`, etc.).
+
+Credits live directly on `message.credits` and are surfaced alongside the USD cost estimate.
+
+## Cost Calculation
+
+- Pricing is pulled from LiteLLM's public JSON (`model_prices_and_context_window.json`) via `@ccusage/internal/pricing`.
+- Codebuff supports multiple providers; the pre-fetched dataset retains models that start with: `claude-`, `anthropic/`, `gpt-`, `o1`/`o3`/`o4`, `openai/`, `azure/`, `gemini-`, `google/`, `grok-`, `xai/`, `mistral*/`, `deepseek/`, `qwen/`, `openrouter/`.
+- Unknown models fall back to zero-cost pricing and surface a warning.
+
+## CLI Usage
+
+- Entry point uses Gunshi with subcommands: `daily`, `monthly`, `session`.
+- Default command when no subcommand is given: `daily`.
+- Add `--json` for structured JSON output; `--compact` forces compact table mode.
+
+## Environment Variables
+
+- `CODEBUFF_DATA_DIR` – override for the Codebuff base directory. Point it at a single channel root such as `~/.config/manicode-dev`.
+- `LOG_LEVEL` – control logging verbosity (0=silent … 5=trace).
+
+## Testing Notes
+
+- Tests rely on `fs-fixture` with `using` to ensure cleanup.
+- Vitest blocks live alongside implementation files via `if (import.meta.vitest != null)`.
+- Vitest globals are enabled – use `describe`, `it`, `expect` directly without imports.
+- **CRITICAL**: NEVER use `await import()` dynamic imports anywhere, especially in test blocks.
+
+## Data Structure (example)
+
+```json
+[
+	{
+		"variant": "user",
+		"content": "Add a readme for Codebuff support",
+		"timestamp": "2025-12-14T09:59:58.000Z"
+	},
+	{
+		"variant": "ai",
+		"content": "Sure, here is the readme",
+		"timestamp": "2025-12-14T10:00:00.000Z",
+		"credits": 1.25,
+		"metadata": {
+			"model": "claude-haiku-4-5-20251001",
+			"usage": {
+				"inputTokens": 500,
+				"outputTokens": 200,
+				"cacheCreationInputTokens": 300,
+				"cacheReadInputTokens": 100
+			}
+		}
+	}
+]
+```

--- a/apps/codebuff/eslint.config.js
+++ b/apps/codebuff/eslint.config.js
@@ -1,0 +1,16 @@
+import { ryoppippi } from '@ryoppippi/eslint-config';
+
+/** @type {import('eslint').Linter.FlatConfig[]} */
+const config = ryoppippi(
+	{
+		type: 'app',
+		stylistic: false,
+	},
+	{
+		rules: {
+			'test/no-importing-vitest-globals': 'error',
+		},
+	},
+);
+
+export default config;

--- a/apps/codebuff/package.json
+++ b/apps/codebuff/package.json
@@ -1,0 +1,64 @@
+{
+	"name": "@ccusage/codebuff",
+	"type": "module",
+	"version": "18.0.11",
+	"description": "Usage analysis tool for Codebuff CLI sessions",
+	"author": "ryoppippi",
+	"license": "MIT",
+	"funding": "https://github.com/ryoppippi/ccusage?sponsor=1",
+	"homepage": "https://github.com/ryoppippi/ccusage#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ryoppippi/ccusage.git",
+		"directory": "apps/codebuff"
+	},
+	"bugs": {
+		"url": "https://github.com/ryoppippi/ccusage/issues"
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"bin": {
+		"ccusage-codebuff": "./src/index.ts"
+	},
+	"files": [
+		"dist"
+	],
+	"publishConfig": {
+		"bin": {
+			"ccusage-codebuff": "./dist/index.js"
+		}
+	},
+	"engines": {
+		"node": ">=20.19.4"
+	},
+	"scripts": {
+		"build": "tsdown",
+		"format": "pnpm run lint --fix",
+		"lint": "eslint --cache .",
+		"prepack": "pnpm run build && clean-pkg-json",
+		"prerelease": "pnpm run lint && pnpm run typecheck && pnpm run build",
+		"start": "bun ./src/index.ts",
+		"test": "TZ=UTC vitest",
+		"typecheck": "tsgo --noEmit"
+	},
+	"devDependencies": {
+		"@ccusage/internal": "workspace:*",
+		"@ccusage/terminal": "workspace:*",
+		"@praha/byethrow": "catalog:runtime",
+		"@ryoppippi/eslint-config": "catalog:lint",
+		"@typescript/native-preview": "catalog:types",
+		"clean-pkg-json": "catalog:release",
+		"eslint": "catalog:lint",
+		"fast-sort": "catalog:runtime",
+		"fs-fixture": "catalog:testing",
+		"gunshi": "catalog:runtime",
+		"path-type": "catalog:runtime",
+		"picocolors": "catalog:runtime",
+		"tinyglobby": "catalog:runtime",
+		"tsdown": "catalog:build",
+		"unplugin-macros": "catalog:build",
+		"unplugin-unused": "catalog:build",
+		"valibot": "catalog:runtime",
+		"vitest": "catalog:testing"
+	}
+}

--- a/apps/codebuff/package.json
+++ b/apps/codebuff/package.json
@@ -18,16 +18,11 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"bin": {
-		"ccusage-codebuff": "./src/index.ts"
+		"ccusage-codebuff": "./dist/index.js"
 	},
 	"files": [
 		"dist"
 	],
-	"publishConfig": {
-		"bin": {
-			"ccusage-codebuff": "./dist/index.js"
-		}
-	},
 	"engines": {
 		"node": ">=20.19.4"
 	},

--- a/apps/codebuff/src/_consts.ts
+++ b/apps/codebuff/src/_consts.ts
@@ -1,0 +1,50 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+/**
+ * Environment variable name for custom Codebuff data directory (points at the
+ * equivalent of `~/.config/manicode`).
+ */
+export const CODEBUFF_DATA_DIR_ENV = 'CODEBUFF_DATA_DIR';
+
+/**
+ * User home directory
+ */
+const USER_HOME_DIR = homedir();
+
+/**
+ * Default base path for Codebuff installations (production channel). Codebuff
+ * ships under the legacy `manicode` folder name because the product was
+ * originally called Manicode.
+ */
+export const DEFAULT_CODEBUFF_DIR = path.join(USER_HOME_DIR, '.config', 'manicode');
+
+/**
+ * Codebuff release channels. Each one is laid out under `~/.config/<channel>`.
+ */
+export const CODEBUFF_CHANNELS = ['manicode', 'manicode-dev', 'manicode-staging'] as const;
+
+/**
+ * Sub-directory under a Codebuff channel root where per-project chat history is stored.
+ */
+export const CODEBUFF_PROJECTS_DIR_NAME = 'projects';
+
+/**
+ * Sub-directory under `projects/<projectBasename>/` that holds chat sessions.
+ */
+export const CODEBUFF_CHATS_DIR_NAME = 'chats';
+
+/**
+ * File name within each chat directory containing serialized ChatMessage[].
+ */
+export const CODEBUFF_CHAT_MESSAGES_FILE = 'chat-messages.json';
+
+/**
+ * File name within each chat directory containing the SDK RunState snapshot.
+ */
+export const CODEBUFF_RUN_STATE_FILE = 'run-state.json';
+
+/**
+ * Million constant for pricing calculations.
+ */
+export const MILLION = 1_000_000;

--- a/apps/codebuff/src/_macro.ts
+++ b/apps/codebuff/src/_macro.ts
@@ -1,0 +1,44 @@
+import type { LiteLLMModelPricing } from '@ccusage/internal/pricing';
+import {
+	createPricingDataset,
+	fetchLiteLLMPricingDataset,
+	filterPricingDataset,
+} from '@ccusage/internal/pricing-fetch-utils';
+
+/**
+ * Codebuff routes to several upstream providers via OpenRouter, so we retain a
+ * generous set of model-name prefixes when prefetching pricing.
+ */
+const CODEBUFF_MODEL_PREFIXES = [
+	'claude-',
+	'anthropic/',
+	'gpt-',
+	'o1',
+	'o3',
+	'o4',
+	'openai/',
+	'azure/',
+	'gemini-',
+	'google/',
+	'grok-',
+	'xai/',
+	'mistral/',
+	'mistralai/',
+	'deepseek/',
+	'qwen/',
+	'openrouter/',
+];
+
+function isCodebuffModel(modelName: string, _pricing: LiteLLMModelPricing): boolean {
+	return CODEBUFF_MODEL_PREFIXES.some((prefix) => modelName.startsWith(prefix));
+}
+
+export async function prefetchCodebuffPricing(): Promise<Record<string, LiteLLMModelPricing>> {
+	try {
+		const dataset = await fetchLiteLLMPricingDataset();
+		return filterPricingDataset(dataset, isCodebuffModel);
+	} catch (error) {
+		console.warn('Failed to prefetch Codebuff pricing data, proceeding with empty cache.', error);
+		return createPricingDataset();
+	}
+}

--- a/apps/codebuff/src/_macro.ts
+++ b/apps/codebuff/src/_macro.ts
@@ -4,6 +4,7 @@ import {
 	fetchLiteLLMPricingDataset,
 	filterPricingDataset,
 } from '@ccusage/internal/pricing-fetch-utils';
+import { logger } from './logger.ts';
 
 /**
  * Codebuff routes to several upstream providers via OpenRouter, so we retain a
@@ -38,7 +39,9 @@ export async function prefetchCodebuffPricing(): Promise<Record<string, LiteLLMM
 		const dataset = await fetchLiteLLMPricingDataset();
 		return filterPricingDataset(dataset, isCodebuffModel);
 	} catch (error) {
-		console.warn('Failed to prefetch Codebuff pricing data, proceeding with empty cache.', error);
+		logger.warn('Failed to prefetch Codebuff pricing data, proceeding with empty cache.', {
+			error,
+		});
 		return createPricingDataset();
 	}
 }

--- a/apps/codebuff/src/_types.ts
+++ b/apps/codebuff/src/_types.ts
@@ -1,0 +1,59 @@
+/**
+ * Token usage delta for a single event.
+ */
+export type TokenUsageDelta = {
+	inputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+};
+
+/**
+ * Token usage event loaded from Codebuff chat-messages files.
+ */
+export type TokenUsageEvent = TokenUsageDelta & {
+	timestamp: string;
+	chatId: string;
+	projectBasename: string;
+	channel: string;
+	model: string;
+	credits: number;
+};
+
+/**
+ * Metadata about a Codebuff chat session.
+ */
+export type ChatMetadata = {
+	chatId: string;
+	title: string;
+	projectBasename: string;
+	channel: string;
+	cwd: string | null;
+	firstTimestamp: string;
+	lastTimestamp: string;
+};
+
+/**
+ * Model usage summary with token counts and credits.
+ */
+export type ModelUsage = TokenUsageDelta & {
+	credits: number;
+};
+
+/**
+ * Model pricing (per-million token rates).
+ */
+export type ModelPricing = {
+	inputCostPerMToken: number;
+	cachedInputCostPerMToken: number;
+	cacheCreationCostPerMToken: number;
+	outputCostPerMToken: number;
+};
+
+/**
+ * Pricing source interface used by commands.
+ */
+export type PricingSource = {
+	getPricing: (model: string) => Promise<ModelPricing>;
+};

--- a/apps/codebuff/src/commands/daily.ts
+++ b/apps/codebuff/src/commands/daily.ts
@@ -77,6 +77,7 @@ export const dailyCommand = define({
 			let outputTokens = 0;
 			let cacheCreationTokens = 0;
 			let cacheReadTokens = 0;
+			let totalTokens = 0;
 			let credits = 0;
 			let totalCost = 0;
 			const modelsSet = new Set<string>();
@@ -86,6 +87,7 @@ export const dailyCommand = define({
 				outputTokens += event.outputTokens;
 				cacheCreationTokens += event.cacheCreationInputTokens;
 				cacheReadTokens += event.cacheReadInputTokens;
+				totalTokens += event.totalTokens;
 				credits += event.credits;
 
 				const cost = await pricingSource.calculateCost(event.model, {
@@ -97,8 +99,6 @@ export const dailyCommand = define({
 				totalCost += cost;
 				modelsSet.add(event.model);
 			}
-
-			const totalTokens = inputTokens + outputTokens;
 
 			dailyData.push({
 				date,

--- a/apps/codebuff/src/commands/daily.ts
+++ b/apps/codebuff/src/commands/daily.ts
@@ -1,0 +1,204 @@
+import type { TokenUsageEvent } from '../_types.ts';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatDateCompact,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { loadCodebuffUsageEvents } from '../data-loader.ts';
+import { CodebuffPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 9;
+
+function groupByDate(events: TokenUsageEvent[]): Map<string, TokenUsageEvent[]> {
+	const grouped = new Map<string, TokenUsageEvent[]>();
+	for (const event of events) {
+		const date = event.timestamp.split('T')[0]!;
+		const existing = grouped.get(date);
+		if (existing != null) {
+			existing.push(event);
+		} else {
+			grouped.set(date, [event]);
+		}
+	}
+	return grouped;
+}
+
+export const dailyCommand = define({
+	name: 'daily',
+	description: 'Show Codebuff token usage grouped by day',
+	args: {
+		json: {
+			type: 'boolean',
+			short: 'j',
+			description: 'Output in JSON format',
+		},
+		compact: {
+			type: 'boolean',
+			description: 'Force compact table mode',
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+
+		const { events } = await loadCodebuffUsageEvents();
+
+		if (events.length === 0) {
+			const output = jsonOutput
+				? JSON.stringify({ daily: [], totals: null })
+				: 'No Codebuff usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using pricingSource = new CodebuffPricingSource({ offline: false });
+
+		const eventsByDate = groupByDate(events);
+
+		const dailyData: Array<{
+			date: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationTokens: number;
+			cacheReadTokens: number;
+			totalTokens: number;
+			credits: number;
+			totalCost: number;
+			modelsUsed: string[];
+		}> = [];
+
+		for (const [date, dayEvents] of eventsByDate) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheCreationTokens = 0;
+			let cacheReadTokens = 0;
+			let credits = 0;
+			let totalCost = 0;
+			const modelsSet = new Set<string>();
+
+			for (const event of dayEvents) {
+				inputTokens += event.inputTokens;
+				outputTokens += event.outputTokens;
+				cacheCreationTokens += event.cacheCreationInputTokens;
+				cacheReadTokens += event.cacheReadInputTokens;
+				credits += event.credits;
+
+				const cost = await pricingSource.calculateCost(event.model, {
+					inputTokens: event.inputTokens,
+					outputTokens: event.outputTokens,
+					cacheCreationInputTokens: event.cacheCreationInputTokens,
+					cacheReadInputTokens: event.cacheReadInputTokens,
+				});
+				totalCost += cost;
+				modelsSet.add(event.model);
+			}
+
+			const totalTokens = inputTokens + outputTokens;
+
+			dailyData.push({
+				date,
+				inputTokens,
+				outputTokens,
+				cacheCreationTokens,
+				cacheReadTokens,
+				totalTokens,
+				credits,
+				totalCost,
+				modelsUsed: Array.from(modelsSet),
+			});
+		}
+
+		dailyData.sort((a, b) => a.date.localeCompare(b.date));
+
+		const totals = {
+			inputTokens: dailyData.reduce((sum, d) => sum + d.inputTokens, 0),
+			outputTokens: dailyData.reduce((sum, d) => sum + d.outputTokens, 0),
+			cacheCreationTokens: dailyData.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
+			cacheReadTokens: dailyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
+			totalTokens: dailyData.reduce((sum, d) => sum + d.totalTokens, 0),
+			credits: dailyData.reduce((sum, d) => sum + d.credits, 0),
+			totalCost: dailyData.reduce((sum, d) => sum + d.totalCost, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify(
+					{
+						daily: dailyData,
+						totals,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log('\nCodebuff Token Usage Report - Daily\n');
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: [
+				'Date',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Create',
+				'Cache Read',
+				'Total Tokens',
+				'Credits',
+				'Cost (USD)',
+			],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Date', 'Models', 'Input', 'Output', 'Credits', 'Cost (USD)'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+			dateFormatter: (dateStr: string) => formatDateCompact(dateStr),
+		});
+
+		for (const data of dailyData) {
+			table.push([
+				data.date,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheCreationTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				data.credits.toFixed(2),
+				formatCurrency(data.totalCost),
+			]);
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(totals.credits.toFixed(2)),
+			pc.yellow(formatCurrency(totals.totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/codebuff/src/commands/index.ts
+++ b/apps/codebuff/src/commands/index.ts
@@ -1,0 +1,3 @@
+export { dailyCommand } from './daily.ts';
+export { monthlyCommand } from './monthly.ts';
+export { sessionCommand } from './session.ts';

--- a/apps/codebuff/src/commands/monthly.ts
+++ b/apps/codebuff/src/commands/monthly.ts
@@ -77,6 +77,7 @@ export const monthlyCommand = define({
 			let outputTokens = 0;
 			let cacheCreationTokens = 0;
 			let cacheReadTokens = 0;
+			let totalTokens = 0;
 			let credits = 0;
 			let totalCost = 0;
 			const modelsSet = new Set<string>();
@@ -86,6 +87,7 @@ export const monthlyCommand = define({
 				outputTokens += event.outputTokens;
 				cacheCreationTokens += event.cacheCreationInputTokens;
 				cacheReadTokens += event.cacheReadInputTokens;
+				totalTokens += event.totalTokens;
 				credits += event.credits;
 
 				const cost = await pricingSource.calculateCost(event.model, {
@@ -97,8 +99,6 @@ export const monthlyCommand = define({
 				totalCost += cost;
 				modelsSet.add(event.model);
 			}
-
-			const totalTokens = inputTokens + outputTokens;
 
 			monthlyData.push({
 				month,

--- a/apps/codebuff/src/commands/monthly.ts
+++ b/apps/codebuff/src/commands/monthly.ts
@@ -1,0 +1,204 @@
+import type { TokenUsageEvent } from '../_types.ts';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatDateCompact,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { loadCodebuffUsageEvents } from '../data-loader.ts';
+import { CodebuffPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 9;
+
+function groupByMonth(events: TokenUsageEvent[]): Map<string, TokenUsageEvent[]> {
+	const grouped = new Map<string, TokenUsageEvent[]>();
+	for (const event of events) {
+		const month = event.timestamp.slice(0, 7);
+		const existing = grouped.get(month);
+		if (existing != null) {
+			existing.push(event);
+		} else {
+			grouped.set(month, [event]);
+		}
+	}
+	return grouped;
+}
+
+export const monthlyCommand = define({
+	name: 'monthly',
+	description: 'Show Codebuff token usage grouped by month',
+	args: {
+		json: {
+			type: 'boolean',
+			short: 'j',
+			description: 'Output in JSON format',
+		},
+		compact: {
+			type: 'boolean',
+			description: 'Force compact table mode',
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+
+		const { events } = await loadCodebuffUsageEvents();
+
+		if (events.length === 0) {
+			const output = jsonOutput
+				? JSON.stringify({ monthly: [], totals: null })
+				: 'No Codebuff usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using pricingSource = new CodebuffPricingSource({ offline: false });
+
+		const eventsByMonth = groupByMonth(events);
+
+		const monthlyData: Array<{
+			month: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationTokens: number;
+			cacheReadTokens: number;
+			totalTokens: number;
+			credits: number;
+			totalCost: number;
+			modelsUsed: string[];
+		}> = [];
+
+		for (const [month, monthEvents] of eventsByMonth) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheCreationTokens = 0;
+			let cacheReadTokens = 0;
+			let credits = 0;
+			let totalCost = 0;
+			const modelsSet = new Set<string>();
+
+			for (const event of monthEvents) {
+				inputTokens += event.inputTokens;
+				outputTokens += event.outputTokens;
+				cacheCreationTokens += event.cacheCreationInputTokens;
+				cacheReadTokens += event.cacheReadInputTokens;
+				credits += event.credits;
+
+				const cost = await pricingSource.calculateCost(event.model, {
+					inputTokens: event.inputTokens,
+					outputTokens: event.outputTokens,
+					cacheCreationInputTokens: event.cacheCreationInputTokens,
+					cacheReadInputTokens: event.cacheReadInputTokens,
+				});
+				totalCost += cost;
+				modelsSet.add(event.model);
+			}
+
+			const totalTokens = inputTokens + outputTokens;
+
+			monthlyData.push({
+				month,
+				inputTokens,
+				outputTokens,
+				cacheCreationTokens,
+				cacheReadTokens,
+				totalTokens,
+				credits,
+				totalCost,
+				modelsUsed: Array.from(modelsSet),
+			});
+		}
+
+		monthlyData.sort((a, b) => a.month.localeCompare(b.month));
+
+		const totals = {
+			inputTokens: monthlyData.reduce((sum, d) => sum + d.inputTokens, 0),
+			outputTokens: monthlyData.reduce((sum, d) => sum + d.outputTokens, 0),
+			cacheCreationTokens: monthlyData.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
+			cacheReadTokens: monthlyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
+			totalTokens: monthlyData.reduce((sum, d) => sum + d.totalTokens, 0),
+			credits: monthlyData.reduce((sum, d) => sum + d.credits, 0),
+			totalCost: monthlyData.reduce((sum, d) => sum + d.totalCost, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify(
+					{
+						monthly: monthlyData,
+						totals,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log('\nCodebuff Token Usage Report - Monthly\n');
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: [
+				'Month',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Create',
+				'Cache Read',
+				'Total Tokens',
+				'Credits',
+				'Cost (USD)',
+			],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Month', 'Models', 'Input', 'Output', 'Credits', 'Cost (USD)'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+			dateFormatter: (dateStr: string) => formatDateCompact(dateStr),
+		});
+
+		for (const data of monthlyData) {
+			table.push([
+				data.month,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheCreationTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				data.credits.toFixed(2),
+				formatCurrency(data.totalCost),
+			]);
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(totals.credits.toFixed(2)),
+			pc.yellow(formatCurrency(totals.totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/codebuff/src/commands/session.ts
+++ b/apps/codebuff/src/commands/session.ts
@@ -1,0 +1,220 @@
+import type { TokenUsageEvent } from '../_types.ts';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatDateCompact,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { loadCodebuffUsageEvents } from '../data-loader.ts';
+import { CodebuffPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 9;
+
+function groupByChat(events: TokenUsageEvent[]): Map<string, TokenUsageEvent[]> {
+	const grouped = new Map<string, TokenUsageEvent[]>();
+	for (const event of events) {
+		const existing = grouped.get(event.chatId);
+		if (existing != null) {
+			existing.push(event);
+		} else {
+			grouped.set(event.chatId, [event]);
+		}
+	}
+	return grouped;
+}
+
+export const sessionCommand = define({
+	name: 'session',
+	description: 'Show Codebuff token usage grouped by chat (session)',
+	args: {
+		json: {
+			type: 'boolean',
+			short: 'j',
+			description: 'Output in JSON format',
+		},
+		compact: {
+			type: 'boolean',
+			description: 'Force compact table mode',
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+
+		const { events, chats } = await loadCodebuffUsageEvents();
+
+		if (events.length === 0) {
+			const output = jsonOutput
+				? JSON.stringify({ sessions: [], totals: null })
+				: 'No Codebuff usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using pricingSource = new CodebuffPricingSource({ offline: false });
+
+		const eventsByChat = groupByChat(events);
+
+		const sessionData: Array<{
+			chatId: string;
+			title: string;
+			projectBasename: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationTokens: number;
+			cacheReadTokens: number;
+			totalTokens: number;
+			credits: number;
+			totalCost: number;
+			modelsUsed: string[];
+			lastActivity: string;
+		}> = [];
+
+		for (const [chatId, chatEvents] of eventsByChat) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheCreationTokens = 0;
+			let cacheReadTokens = 0;
+			let credits = 0;
+			let totalCost = 0;
+			const modelsSet = new Set<string>();
+			let lastActivity = chatEvents[0]!.timestamp;
+
+			for (const event of chatEvents) {
+				inputTokens += event.inputTokens;
+				outputTokens += event.outputTokens;
+				cacheCreationTokens += event.cacheCreationInputTokens;
+				cacheReadTokens += event.cacheReadInputTokens;
+				credits += event.credits;
+
+				const cost = await pricingSource.calculateCost(event.model, {
+					inputTokens: event.inputTokens,
+					outputTokens: event.outputTokens,
+					cacheCreationInputTokens: event.cacheCreationInputTokens,
+					cacheReadInputTokens: event.cacheReadInputTokens,
+				});
+				totalCost += cost;
+				modelsSet.add(event.model);
+
+				if (event.timestamp > lastActivity) {
+					lastActivity = event.timestamp;
+				}
+			}
+
+			const totalTokens = inputTokens + outputTokens;
+			const chatInfo = chats.get(chatId);
+
+			sessionData.push({
+				chatId,
+				title: chatInfo?.title ?? 'Untitled',
+				projectBasename: chatInfo?.projectBasename ?? '',
+				inputTokens,
+				outputTokens,
+				cacheCreationTokens,
+				cacheReadTokens,
+				totalTokens,
+				credits,
+				totalCost,
+				modelsUsed: Array.from(modelsSet),
+				lastActivity,
+			});
+		}
+
+		sessionData.sort((a, b) => a.lastActivity.localeCompare(b.lastActivity));
+
+		const totals = {
+			inputTokens: sessionData.reduce((sum, s) => sum + s.inputTokens, 0),
+			outputTokens: sessionData.reduce((sum, s) => sum + s.outputTokens, 0),
+			cacheCreationTokens: sessionData.reduce((sum, s) => sum + s.cacheCreationTokens, 0),
+			cacheReadTokens: sessionData.reduce((sum, s) => sum + s.cacheReadTokens, 0),
+			totalTokens: sessionData.reduce((sum, s) => sum + s.totalTokens, 0),
+			credits: sessionData.reduce((sum, s) => sum + s.credits, 0),
+			totalCost: sessionData.reduce((sum, s) => sum + s.totalCost, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify(
+					{
+						sessions: sessionData,
+						totals,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log('\nCodebuff Token Usage Report - Sessions (Chats)\n');
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: [
+				'Session',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Create',
+				'Cache Read',
+				'Total Tokens',
+				'Credits',
+				'Cost (USD)',
+			],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Session', 'Models', 'Input', 'Output', 'Credits', 'Cost (USD)'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+			dateFormatter: (dateStr: string) => formatDateCompact(dateStr),
+		});
+
+		for (const data of sessionData) {
+			// Compose "project :: title" for the row label and truncate for readability.
+			const label =
+				data.projectBasename !== '' ? `${data.projectBasename} :: ${data.title}` : data.title;
+			const displayLabel = label.length > 40 ? `${label.slice(0, 37)}...` : label;
+
+			table.push([
+				displayLabel,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheCreationTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				data.credits.toFixed(2),
+				formatCurrency(data.totalCost),
+			]);
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(totals.credits.toFixed(2)),
+			pc.yellow(formatCurrency(totals.totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/codebuff/src/commands/session.ts
+++ b/apps/codebuff/src/commands/session.ts
@@ -79,6 +79,7 @@ export const sessionCommand = define({
 			let outputTokens = 0;
 			let cacheCreationTokens = 0;
 			let cacheReadTokens = 0;
+			let totalTokens = 0;
 			let credits = 0;
 			let totalCost = 0;
 			const modelsSet = new Set<string>();
@@ -89,6 +90,7 @@ export const sessionCommand = define({
 				outputTokens += event.outputTokens;
 				cacheCreationTokens += event.cacheCreationInputTokens;
 				cacheReadTokens += event.cacheReadInputTokens;
+				totalTokens += event.totalTokens;
 				credits += event.credits;
 
 				const cost = await pricingSource.calculateCost(event.model, {
@@ -105,7 +107,6 @@ export const sessionCommand = define({
 				}
 			}
 
-			const totalTokens = inputTokens + outputTokens;
 			const chatInfo = chats.get(chatId);
 
 			sessionData.push({

--- a/apps/codebuff/src/data-loader.ts
+++ b/apps/codebuff/src/data-loader.ts
@@ -55,6 +55,7 @@ const usageSchema = v.object({
 	cacheCreationInputTokens: v.optional(v.number()),
 	cache_creation_input_tokens: v.optional(v.number()),
 	cachedTokensCreated: v.optional(v.number()),
+	cached_tokens_created: v.optional(v.number()),
 	cacheReadInputTokens: v.optional(v.number()),
 	cache_read_input_tokens: v.optional(v.number()),
 	promptTokensDetails: v.optional(
@@ -185,6 +186,7 @@ function extractUsage(usage: ParsedUsage | undefined): {
 				usage.cacheCreationInputTokens,
 				usage.cache_creation_input_tokens,
 				usage.cachedTokensCreated,
+				usage.cached_tokens_created,
 			) ?? 0,
 	};
 }
@@ -223,7 +225,10 @@ function extractAssistantUsage(msg: ParsedChatMessage): {
 	let model: string | undefined = meta?.model ?? meta?.modelId ?? meta?.codebuff?.model;
 	const credits = msg.credits ?? 0;
 
-	const directUsage = extractUsage(meta?.usage ?? meta?.codebuff?.usage);
+	const directUsage = mergeUsageFallback(
+		extractUsage(meta?.usage),
+		extractUsage(meta?.codebuff?.usage),
+	);
 
 	let providerUsage = {
 		inputTokens: 0,
@@ -242,7 +247,10 @@ function extractAssistantUsage(msg: ParsedChatMessage): {
 			if (providerOptions == null) {
 				continue;
 			}
-			const found = extractUsage(providerOptions.usage ?? providerOptions.codebuff?.usage);
+			const found = mergeUsageFallback(
+				extractUsage(providerOptions.usage),
+				extractUsage(providerOptions.codebuff?.usage),
+			);
 			if (
 				found.inputTokens > 0 ||
 				found.outputTokens > 0 ||
@@ -440,7 +448,8 @@ export async function loadCodebuffUsageEvents(options: LoadOptions = {}): Promis
 			const cwd = extractCwdFromRunState(runState);
 
 			const firstUser = messages.find(
-				(m) => m.variant === 'user' && typeof m.content === 'string' && m.content.length > 0,
+				(m) =>
+					(m.variant ?? m.role) === 'user' && typeof m.content === 'string' && m.content.length > 0,
 			);
 			const rawTitle = (firstUser?.content ?? '').replace(/\s+/g, ' ').trim().slice(0, 80);
 			const title = rawTitle !== '' ? rawTitle : 'Untitled';
@@ -495,7 +504,7 @@ export async function loadCodebuffUsageEvents(options: LoadOptions = {}): Promis
 					outputTokens,
 					cacheCreationInputTokens,
 					cacheReadInputTokens,
-					totalTokens: inputTokens + outputTokens,
+					totalTokens: inputTokens + outputTokens + cacheCreationInputTokens + cacheReadInputTokens,
 				});
 				ingested += 1;
 			}
@@ -536,7 +545,7 @@ if (import.meta.vitest != null) {
 					timestamp: '2025-12-14T10:00:00.000Z',
 					credits: 1.25,
 					metadata: {
-						model: 'claude-haiku-4-5-20251001',
+						model: 'claude-sonnet-4-20250514',
 						usage: {
 							inputTokens: 500,
 							outputTokens: 200,
@@ -575,13 +584,13 @@ if (import.meta.vitest != null) {
 			expect(events).toHaveLength(1);
 
 			const event = events[0]!;
-			expect(event.model).toBe('claude-haiku-4-5-20251001');
+			expect(event.model).toBe('claude-sonnet-4-20250514');
 			expect(event.inputTokens).toBe(500);
 			expect(event.outputTokens).toBe(200);
 			expect(event.cacheCreationInputTokens).toBe(300);
 			expect(event.cacheReadInputTokens).toBe(100);
 			expect(event.credits).toBe(1.25);
-			expect(event.totalTokens).toBe(700);
+			expect(event.totalTokens).toBe(1100);
 			expect(event.projectBasename).toBe('agentlytics');
 
 			const chatMeta = chats.get(event.chatId);

--- a/apps/codebuff/src/data-loader.ts
+++ b/apps/codebuff/src/data-loader.ts
@@ -19,6 +19,7 @@
 
 import type { ChatMetadata, TokenUsageEvent } from './_types.ts';
 import { readFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { Result } from '@praha/byethrow';
@@ -319,6 +320,24 @@ function extractCwdFromRunState(runState: ParsedRunState | null): string | null 
 	);
 }
 
+/**
+ * Resolve a user-supplied path, expanding a leading `~` or `~/` to the current
+ * user's home directory before falling through to `path.resolve`. Node's
+ * `path.resolve` does not expand `~` on its own, so docs examples like
+ * `CODEBUFF_DATA_DIR=~/.config/manicode-dev` would otherwise resolve to
+ * `<cwd>/~/.config/manicode-dev`.
+ */
+function resolveCodebuffPath(input: string): string {
+	const trimmed = input.trim();
+	if (trimmed === '~') {
+		return os.homedir();
+	}
+	if (trimmed.startsWith('~/')) {
+		return path.join(os.homedir(), trimmed.slice(2));
+	}
+	return path.resolve(trimmed);
+}
+
 export type CodebuffChannelRoot = { channel: string; root: string };
 
 export type CodebuffChannelRootsResult = {
@@ -342,7 +361,7 @@ export type CodebuffChannelRootsResult = {
  */
 export function getCodebuffChannelRoots(customBaseDir?: string): CodebuffChannelRootsResult {
 	if (customBaseDir != null && customBaseDir.trim() !== '') {
-		const normalized = path.resolve(customBaseDir);
+		const normalized = resolveCodebuffPath(customBaseDir);
 		if (isDirectorySync(normalized)) {
 			const basename = path.basename(normalized);
 			const channel = basename !== '' ? basename : 'manicode';
@@ -359,7 +378,7 @@ export function getCodebuffChannelRoots(customBaseDir?: string): CodebuffChannel
 
 	const envPath = process.env[CODEBUFF_DATA_DIR_ENV];
 	if (envPath != null && envPath.trim() !== '') {
-		const normalized = path.resolve(envPath);
+		const normalized = resolveCodebuffPath(envPath);
 		if (isDirectorySync(normalized)) {
 			const basename = path.basename(normalized);
 			const channel = basename !== '' ? basename : 'manicode';
@@ -505,11 +524,9 @@ export async function loadCodebuffUsageEvents(options: LoadOptions = {}): Promis
 			let ingested = 0;
 
 			for (const msg of messages) {
-				const variant = msg.variant ?? msg.role;
-				if (variant !== 'ai' && variant !== 'agent' && variant !== 'assistant') {
-					continue;
-				}
-
+				// Track session bounds across *all* messages (user + assistant) so
+				// chats that start or end with a user message still report accurate
+				// firstTimestamp/lastTimestamp in their ChatMetadata.
 				const messageTs =
 					coerceTimestamp(msg.timestamp ?? msg.createdAt ?? msg.metadata?.timestamp) ?? fallbackTs;
 				if (messageTs < firstTs) {
@@ -517,6 +534,11 @@ export async function loadCodebuffUsageEvents(options: LoadOptions = {}): Promis
 				}
 				if (messageTs > lastTs) {
 					lastTs = messageTs;
+				}
+
+				const variant = msg.variant ?? msg.role;
+				if (variant !== 'ai' && variant !== 'agent' && variant !== 'assistant') {
+					continue;
 				}
 
 				const {
@@ -721,6 +743,26 @@ if (import.meta.vitest != null) {
 					source: 'env',
 					path: path.resolve('/nonexistent/codebuff-env-override'),
 				});
+			} finally {
+				if (previous == null) {
+					delete process.env[CODEBUFF_DATA_DIR_ENV];
+				} else {
+					process.env[CODEBUFF_DATA_DIR_ENV] = previous;
+				}
+			}
+		});
+
+		it('expands a leading ~ in CODEBUFF_DATA_DIR before resolving', async () => {
+			const previous = process.env[CODEBUFF_DATA_DIR_ENV];
+			process.env[CODEBUFF_DATA_DIR_ENV] = '~/__codebuff_does_not_exist__';
+			try {
+				const { invalidOverride } = getCodebuffChannelRoots();
+				const home = os.homedir();
+				expect(invalidOverride).toEqual({
+					source: 'env',
+					path: path.join(home, '__codebuff_does_not_exist__'),
+				});
+				expect(invalidOverride?.path.startsWith(home)).toBe(true);
 			} finally {
 				if (previous == null) {
 					delete process.env[CODEBUFF_DATA_DIR_ENV];

--- a/apps/codebuff/src/data-loader.ts
+++ b/apps/codebuff/src/data-loader.ts
@@ -140,9 +140,9 @@ const chatMessageSchema = v.object({
 type ParsedChatMessage = v.InferOutput<typeof chatMessageSchema>;
 
 function pickNumber(...vals: Array<number | undefined>): number | undefined {
-	for (const v of vals) {
-		if (typeof v === 'number' && Number.isFinite(v)) {
-			return v;
+	for (const candidate of vals) {
+		if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+			return candidate;
 		}
 	}
 	return undefined;
@@ -192,20 +192,30 @@ function extractUsage(usage: ParsedUsage | undefined): {
 }
 
 /**
- * Merge two usage extractions, preferring non-zero values from the second if
- * the first is empty. Used when a per-message `metadata.usage` is absent but
- * the RunState history has equivalent numbers in `providerOptions`.
+ * Merge two usage extractions with per-field fallback: for each token class we
+ * prefer the primary value when non-zero and fall through to the fallback
+ * otherwise. This matters when the two sources are complementary — e.g.,
+ * `metadata.usage` carries only input/output while `metadata.codebuff.usage`
+ * is the only place cache tokens are recorded (or vice versa for the
+ * RunState providerOptions fallback). An all-or-nothing merge would silently
+ * drop the cache tokens in that case.
  */
 function mergeUsageFallback(
 	primary: ReturnType<typeof extractUsage>,
 	fallback: ReturnType<typeof extractUsage>,
 ): ReturnType<typeof extractUsage> {
-	const hasPrimary =
-		primary.inputTokens > 0 ||
-		primary.outputTokens > 0 ||
-		primary.cacheReadInputTokens > 0 ||
-		primary.cacheCreationInputTokens > 0;
-	return hasPrimary ? primary : fallback;
+	return {
+		inputTokens: primary.inputTokens > 0 ? primary.inputTokens : fallback.inputTokens,
+		outputTokens: primary.outputTokens > 0 ? primary.outputTokens : fallback.outputTokens,
+		cacheReadInputTokens:
+			primary.cacheReadInputTokens > 0
+				? primary.cacheReadInputTokens
+				: fallback.cacheReadInputTokens,
+		cacheCreationInputTokens:
+			primary.cacheCreationInputTokens > 0
+				? primary.cacheCreationInputTokens
+				: fallback.cacheCreationInputTokens,
+	};
 }
 
 /**
@@ -338,6 +348,9 @@ export function getCodebuffChannelRoots(customBaseDir?: string): CodebuffChannel
 			const channel = basename !== '' ? basename : 'manicode';
 			return { roots: [{ channel, root: normalized }], invalidOverride: null };
 		}
+		logger.warn(
+			`Codebuff baseDir "${customBaseDir}" is not a directory; no channel roots will be scanned.`,
+		);
 		return {
 			roots: [],
 			invalidOverride: { source: 'baseDir', path: normalized },

--- a/apps/codebuff/src/data-loader.ts
+++ b/apps/codebuff/src/data-loader.ts
@@ -1,0 +1,682 @@
+/**
+ * @fileoverview Data loading utilities for Codebuff CLI usage analysis.
+ *
+ * Codebuff (formerly Manicode) persists chat history under
+ * `~/.config/manicode/projects/<projectBasename>/chats/<chatId>/`:
+ *
+ *   - `chat-messages.json`  – serialized ChatMessage[]; token/credit data lives
+ *                             on `message.metadata` and (for provider-routed
+ *                             calls) on the stashed RunState's message history.
+ *   - `run-state.json`      – SDK RunState snapshot; we read `cwd` from it so
+ *                             sessions can be grouped by the originating
+ *                             project directory.
+ *
+ * Dev / staging channels use the same layout under `manicode-dev` /
+ * `manicode-staging` roots, and the loader walks all three when present.
+ *
+ * @module data-loader
+ */
+
+import type { ChatMetadata, TokenUsageEvent } from './_types.ts';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { Result } from '@praha/byethrow';
+import { createFixture } from 'fs-fixture';
+import { isDirectorySync } from 'path-type';
+import { glob } from 'tinyglobby';
+import * as v from 'valibot';
+import {
+	CODEBUFF_CHANNELS,
+	CODEBUFF_CHAT_MESSAGES_FILE,
+	CODEBUFF_CHATS_DIR_NAME,
+	CODEBUFF_DATA_DIR_ENV,
+	CODEBUFF_PROJECTS_DIR_NAME,
+	CODEBUFF_RUN_STATE_FILE,
+	DEFAULT_CODEBUFF_DIR,
+} from './_consts.ts';
+import { logger } from './logger.ts';
+
+/**
+ * Codebuff stores per-assistant usage in several places depending on which
+ * path the message took. We lean on valibot's permissive schemas because the
+ * same key can show up in snake_case (OpenAI/OpenRouter) or camelCase
+ * (Anthropic SDK, Codebuff's own builds).
+ */
+const usageSchema = v.object({
+	inputTokens: v.optional(v.number()),
+	input_tokens: v.optional(v.number()),
+	promptTokens: v.optional(v.number()),
+	prompt_tokens: v.optional(v.number()),
+	outputTokens: v.optional(v.number()),
+	output_tokens: v.optional(v.number()),
+	completionTokens: v.optional(v.number()),
+	completion_tokens: v.optional(v.number()),
+	cacheCreationInputTokens: v.optional(v.number()),
+	cache_creation_input_tokens: v.optional(v.number()),
+	cachedTokensCreated: v.optional(v.number()),
+	cacheReadInputTokens: v.optional(v.number()),
+	cache_read_input_tokens: v.optional(v.number()),
+	promptTokensDetails: v.optional(
+		v.object({
+			cachedTokens: v.optional(v.number()),
+		}),
+	),
+	prompt_tokens_details: v.optional(
+		v.object({
+			cached_tokens: v.optional(v.number()),
+		}),
+	),
+});
+
+type ParsedUsage = v.InferOutput<typeof usageSchema>;
+
+const providerOptionsSchema = v.object({
+	codebuff: v.optional(
+		v.object({
+			model: v.optional(v.string()),
+			usage: v.optional(usageSchema),
+		}),
+	),
+	usage: v.optional(usageSchema),
+});
+
+const historyMessageSchema = v.object({
+	role: v.optional(v.string()),
+	providerOptions: v.optional(providerOptionsSchema),
+});
+
+const runStateSchema = v.object({
+	cwd: v.optional(v.string()),
+	sessionState: v.optional(
+		v.object({
+			cwd: v.optional(v.string()),
+			projectContext: v.optional(
+				v.object({
+					cwd: v.optional(v.string()),
+				}),
+			),
+			fileContext: v.optional(
+				v.object({
+					cwd: v.optional(v.string()),
+				}),
+			),
+			mainAgentState: v.optional(
+				v.object({
+					messageHistory: v.optional(v.array(historyMessageSchema)),
+				}),
+			),
+		}),
+	),
+});
+
+type ParsedRunState = v.InferOutput<typeof runStateSchema>;
+
+const messageMetadataSchema = v.object({
+	model: v.optional(v.string()),
+	modelId: v.optional(v.string()),
+	timestamp: v.optional(v.union([v.string(), v.number()])),
+	codebuff: v.optional(
+		v.object({
+			model: v.optional(v.string()),
+			usage: v.optional(usageSchema),
+		}),
+	),
+	usage: v.optional(usageSchema),
+	runState: v.optional(runStateSchema),
+});
+
+const chatMessageSchema = v.object({
+	variant: v.optional(v.string()),
+	role: v.optional(v.string()),
+	content: v.optional(v.string()),
+	credits: v.optional(v.number()),
+	timestamp: v.optional(v.union([v.string(), v.number()])),
+	createdAt: v.optional(v.union([v.string(), v.number()])),
+	metadata: v.optional(messageMetadataSchema),
+});
+
+type ParsedChatMessage = v.InferOutput<typeof chatMessageSchema>;
+
+function pickNumber(...vals: Array<number | undefined>): number | undefined {
+	for (const v of vals) {
+		if (typeof v === 'number' && Number.isFinite(v)) {
+			return v;
+		}
+	}
+	return undefined;
+}
+
+function extractUsage(usage: ParsedUsage | undefined): {
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+} {
+	if (usage == null) {
+		return {
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheReadInputTokens: 0,
+			cacheCreationInputTokens: 0,
+		};
+	}
+
+	return {
+		inputTokens:
+			pickNumber(usage.inputTokens, usage.input_tokens, usage.promptTokens, usage.prompt_tokens) ??
+			0,
+		outputTokens:
+			pickNumber(
+				usage.outputTokens,
+				usage.output_tokens,
+				usage.completionTokens,
+				usage.completion_tokens,
+			) ?? 0,
+		cacheReadInputTokens:
+			pickNumber(
+				usage.cacheReadInputTokens,
+				usage.cache_read_input_tokens,
+				usage.promptTokensDetails?.cachedTokens,
+				usage.prompt_tokens_details?.cached_tokens,
+			) ?? 0,
+		cacheCreationInputTokens:
+			pickNumber(
+				usage.cacheCreationInputTokens,
+				usage.cache_creation_input_tokens,
+				usage.cachedTokensCreated,
+			) ?? 0,
+	};
+}
+
+/**
+ * Merge two usage extractions, preferring non-zero values from the second if
+ * the first is empty. Used when a per-message `metadata.usage` is absent but
+ * the RunState history has equivalent numbers in `providerOptions`.
+ */
+function mergeUsageFallback(
+	primary: ReturnType<typeof extractUsage>,
+	fallback: ReturnType<typeof extractUsage>,
+): ReturnType<typeof extractUsage> {
+	const hasPrimary =
+		primary.inputTokens > 0 ||
+		primary.outputTokens > 0 ||
+		primary.cacheReadInputTokens > 0 ||
+		primary.cacheCreationInputTokens > 0;
+	return hasPrimary ? primary : fallback;
+}
+
+/**
+ * Extract model name + usage for a single assistant ChatMessage. Checks direct
+ * metadata first then walks the stashed RunState history (where multi-provider
+ * calls tend to record their OpenRouter-style totals).
+ */
+function extractAssistantUsage(msg: ParsedChatMessage): {
+	model: string;
+	credits: number;
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+} {
+	const meta = msg.metadata;
+	let model: string | undefined = meta?.model ?? meta?.modelId ?? meta?.codebuff?.model;
+	const credits = msg.credits ?? 0;
+
+	const directUsage = extractUsage(meta?.usage ?? meta?.codebuff?.usage);
+
+	let providerUsage = {
+		inputTokens: 0,
+		outputTokens: 0,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+	};
+	const history = meta?.runState?.sessionState?.mainAgentState?.messageHistory;
+	if (Array.isArray(history)) {
+		for (let i = history.length - 1; i >= 0; i--) {
+			const entry = history[i];
+			if (entry == null || entry.role !== 'assistant') {
+				continue;
+			}
+			const providerOptions = entry.providerOptions;
+			if (providerOptions == null) {
+				continue;
+			}
+			const found = extractUsage(providerOptions.usage ?? providerOptions.codebuff?.usage);
+			if (
+				found.inputTokens > 0 ||
+				found.outputTokens > 0 ||
+				found.cacheReadInputTokens > 0 ||
+				found.cacheCreationInputTokens > 0
+			) {
+				providerUsage = found;
+				if (model == null && providerOptions.codebuff?.model != null) {
+					model = providerOptions.codebuff.model;
+				}
+				break;
+			}
+		}
+	}
+
+	const usage = mergeUsageFallback(directUsage, providerUsage);
+
+	return {
+		model: model ?? 'unknown',
+		credits,
+		...usage,
+	};
+}
+
+/**
+ * Reverse Codebuff's chatId → timestamp substitution (`:` replaced by `-` in
+ * the time portion so the folder is filesystem-safe).
+ */
+function parseChatIdToIso(chatId: string): string | null {
+	const iso = chatId.replace(/(\d{4}-\d{2}-\d{2}T\d{2})-(\d{2})-(\d{2})/, '$1:$2:$3');
+	const parsed = Date.parse(iso);
+	return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function coerceTimestamp(value: string | number | undefined): string | null {
+	if (value == null) {
+		return null;
+	}
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? new Date(value).toISOString() : null;
+	}
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function extractCwdFromRunState(runState: ParsedRunState | null): string | null {
+	if (runState == null) {
+		return null;
+	}
+	return (
+		runState.sessionState?.projectContext?.cwd ??
+		runState.sessionState?.fileContext?.cwd ??
+		runState.sessionState?.cwd ??
+		runState.cwd ??
+		null
+	);
+}
+
+/**
+ * Discover all Codebuff channel roots on disk (`~/.config/manicode`,
+ * `-dev`, `-staging`). Honors `CODEBUFF_DATA_DIR` for a single custom root.
+ */
+export function getCodebuffChannelRoots(customBaseDir?: string): Array<{
+	channel: string;
+	root: string;
+}> {
+	if (customBaseDir != null && customBaseDir.trim() !== '') {
+		const normalized = path.resolve(customBaseDir);
+		if (isDirectorySync(normalized)) {
+			const basename = path.basename(normalized);
+			const channel = basename !== '' ? basename : 'manicode';
+			return [{ channel, root: normalized }];
+		}
+		return [];
+	}
+
+	const envPath = process.env[CODEBUFF_DATA_DIR_ENV];
+	if (envPath != null && envPath.trim() !== '') {
+		const normalized = path.resolve(envPath);
+		if (isDirectorySync(normalized)) {
+			const basename = path.basename(normalized);
+			const channel = basename !== '' ? basename : 'manicode';
+			return [{ channel, root: normalized }];
+		}
+	}
+
+	const roots: Array<{ channel: string; root: string }> = [];
+	const configDir = path.dirname(DEFAULT_CODEBUFF_DIR);
+	for (const channel of CODEBUFF_CHANNELS) {
+		const root = path.join(configDir, channel);
+		if (isDirectorySync(root)) {
+			roots.push({ channel, root });
+		}
+	}
+	return roots;
+}
+
+async function loadJsonFile<T>(
+	filePath: string,
+	schema: v.BaseSchema<unknown, T, v.BaseIssue<unknown>>,
+): Promise<T | null> {
+	const readResult = await Result.try({
+		try: readFile(filePath, 'utf-8'),
+		catch: (error) => error,
+	});
+
+	if (Result.isFailure(readResult)) {
+		logger.debug('Failed to read Codebuff JSON file', { filePath, error: readResult.error });
+		return null;
+	}
+
+	const parseResult = Result.try({
+		try: () => JSON.parse(readResult.value) as unknown,
+		catch: (error) => error,
+	})();
+
+	if (Result.isFailure(parseResult)) {
+		logger.debug('Failed to parse Codebuff JSON', { filePath, error: parseResult.error });
+		return null;
+	}
+
+	const validation = v.safeParse(schema, parseResult.value);
+	if (!validation.success) {
+		logger.debug('Failed to validate Codebuff schema', {
+			filePath,
+			issues: validation.issues,
+		});
+		return null;
+	}
+
+	return validation.output;
+}
+
+export type LoadOptions = {
+	/** Optional override for the Codebuff base directory. */
+	baseDir?: string;
+};
+
+export type LoadResult = {
+	events: TokenUsageEvent[];
+	chats: Map<string, ChatMetadata>;
+	missingDirectories: string[];
+};
+
+/**
+ * Load all Codebuff usage events from local chat-messages files.
+ */
+export async function loadCodebuffUsageEvents(options: LoadOptions = {}): Promise<LoadResult> {
+	const roots = getCodebuffChannelRoots(options.baseDir);
+
+	const events: TokenUsageEvent[] = [];
+	const chats = new Map<string, ChatMetadata>();
+	const missingDirectories: string[] = [];
+
+	if (roots.length === 0) {
+		// Only surface a missing-directory error when the user explicitly
+		// pointed at a non-existent path; leaving it implicit for the default
+		// case matches how @ccusage/amp behaves.
+		if (options.baseDir != null && options.baseDir.trim() !== '') {
+			missingDirectories.push(path.resolve(options.baseDir));
+		}
+		return { events, chats, missingDirectories };
+	}
+
+	for (const { channel, root } of roots) {
+		const projectsDir = path.join(root, CODEBUFF_PROJECTS_DIR_NAME);
+		if (!isDirectorySync(projectsDir)) {
+			continue;
+		}
+
+		const chatDirs = await glob([`*/${CODEBUFF_CHATS_DIR_NAME}/*/`], {
+			cwd: projectsDir,
+			absolute: true,
+			onlyDirectories: true,
+		});
+
+		for (const chatDir of chatDirs) {
+			const chatId = path.basename(chatDir);
+			const projectBasename = path.basename(path.dirname(path.dirname(chatDir)));
+			const composedId = `${channel}::${projectBasename}::${chatId}`;
+
+			const messages = await loadJsonFile(
+				path.join(chatDir, CODEBUFF_CHAT_MESSAGES_FILE),
+				v.array(chatMessageSchema),
+			);
+			if (messages == null || messages.length === 0) {
+				continue;
+			}
+
+			const runState = await loadJsonFile(
+				path.join(chatDir, CODEBUFF_RUN_STATE_FILE),
+				runStateSchema,
+			);
+
+			const cwd = extractCwdFromRunState(runState);
+
+			const firstUser = messages.find(
+				(m) => m.variant === 'user' && typeof m.content === 'string' && m.content.length > 0,
+			);
+			const rawTitle = (firstUser?.content ?? '').replace(/\s+/g, ' ').trim().slice(0, 80);
+			const title = rawTitle !== '' ? rawTitle : 'Untitled';
+
+			const fallbackTs = parseChatIdToIso(chatId) ?? new Date(0).toISOString();
+			let firstTs = fallbackTs;
+			let lastTs = fallbackTs;
+			let ingested = 0;
+
+			for (const msg of messages) {
+				const variant = msg.variant ?? msg.role;
+				if (variant !== 'ai' && variant !== 'agent' && variant !== 'assistant') {
+					continue;
+				}
+
+				const messageTs =
+					coerceTimestamp(msg.timestamp ?? msg.createdAt ?? msg.metadata?.timestamp) ?? fallbackTs;
+				if (messageTs < firstTs) {
+					firstTs = messageTs;
+				}
+				if (messageTs > lastTs) {
+					lastTs = messageTs;
+				}
+
+				const {
+					model,
+					credits,
+					inputTokens,
+					outputTokens,
+					cacheReadInputTokens,
+					cacheCreationInputTokens,
+				} = extractAssistantUsage(msg);
+
+				const hasAnySignal =
+					inputTokens > 0 ||
+					outputTokens > 0 ||
+					cacheReadInputTokens > 0 ||
+					cacheCreationInputTokens > 0 ||
+					credits > 0;
+				if (!hasAnySignal) {
+					continue;
+				}
+
+				events.push({
+					timestamp: messageTs,
+					chatId: composedId,
+					projectBasename,
+					channel,
+					model,
+					credits,
+					inputTokens,
+					outputTokens,
+					cacheCreationInputTokens,
+					cacheReadInputTokens,
+					totalTokens: inputTokens + outputTokens,
+				});
+				ingested += 1;
+			}
+
+			if (ingested === 0) {
+				continue;
+			}
+
+			chats.set(composedId, {
+				chatId: composedId,
+				title,
+				projectBasename,
+				channel,
+				cwd,
+				firstTimestamp: firstTs,
+				lastTimestamp: lastTs,
+			});
+		}
+	}
+
+	events.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+	return { events, chats, missingDirectories };
+}
+
+if (import.meta.vitest != null) {
+	describe('loadCodebuffUsageEvents', () => {
+		it('parses Codebuff chat-messages files and extracts usage events', async () => {
+			const chatMessages = [
+				{
+					variant: 'user',
+					content: 'Add a readme for Codebuff support',
+					timestamp: '2025-12-14T09:59:58.000Z',
+				},
+				{
+					variant: 'ai',
+					content: 'Sure, here is the readme',
+					timestamp: '2025-12-14T10:00:00.000Z',
+					credits: 1.25,
+					metadata: {
+						model: 'claude-haiku-4-5-20251001',
+						usage: {
+							inputTokens: 500,
+							outputTokens: 200,
+							cacheCreationInputTokens: 300,
+							cacheReadInputTokens: 100,
+						},
+					},
+				},
+			];
+			const runState = {
+				sessionState: {
+					projectContext: { cwd: '/Users/demo/repos/agentlytics' },
+				},
+			};
+
+			await using fixture = await createFixture({
+				manicode: {
+					projects: {
+						agentlytics: {
+							chats: {
+								'2025-12-14T10-00-00.000Z': {
+									'chat-messages.json': JSON.stringify(chatMessages),
+									'run-state.json': JSON.stringify(runState),
+								},
+							},
+						},
+					},
+				},
+			});
+
+			const { events, chats, missingDirectories } = await loadCodebuffUsageEvents({
+				baseDir: fixture.getPath('manicode'),
+			});
+
+			expect(missingDirectories).toEqual([]);
+			expect(events).toHaveLength(1);
+
+			const event = events[0]!;
+			expect(event.model).toBe('claude-haiku-4-5-20251001');
+			expect(event.inputTokens).toBe(500);
+			expect(event.outputTokens).toBe(200);
+			expect(event.cacheCreationInputTokens).toBe(300);
+			expect(event.cacheReadInputTokens).toBe(100);
+			expect(event.credits).toBe(1.25);
+			expect(event.totalTokens).toBe(700);
+			expect(event.projectBasename).toBe('agentlytics');
+
+			const chatMeta = chats.get(event.chatId);
+			expect(chatMeta?.title).toBe('Add a readme for Codebuff support');
+			expect(chatMeta?.cwd).toBe('/Users/demo/repos/agentlytics');
+		});
+
+		it('falls back to provider-options usage in the stashed RunState history', async () => {
+			const chatMessages = [
+				{ variant: 'user', content: 'Hi' },
+				{
+					variant: 'ai',
+					content: 'Hello',
+					metadata: {
+						runState: {
+							sessionState: {
+								mainAgentState: {
+									messageHistory: [
+										{ role: 'user' },
+										{
+											role: 'assistant',
+											providerOptions: {
+												codebuff: {
+													model: 'openai/gpt-4o',
+													usage: {
+														prompt_tokens: 2000,
+														completion_tokens: 800,
+														prompt_tokens_details: { cached_tokens: 400 },
+													},
+												},
+											},
+										},
+									],
+								},
+							},
+						},
+					},
+				},
+			];
+
+			await using fixture = await createFixture({
+				manicode: {
+					projects: {
+						sandbox: {
+							chats: {
+								'2025-12-20T12-00-00.000Z': {
+									'chat-messages.json': JSON.stringify(chatMessages),
+								},
+							},
+						},
+					},
+				},
+			});
+
+			const { events } = await loadCodebuffUsageEvents({
+				baseDir: fixture.getPath('manicode'),
+			});
+
+			expect(events).toHaveLength(1);
+			const event = events[0]!;
+			expect(event.model).toBe('openai/gpt-4o');
+			expect(event.inputTokens).toBe(2000);
+			expect(event.outputTokens).toBe(800);
+			expect(event.cacheReadInputTokens).toBe(400);
+		});
+
+		it('returns empty result and records missing directory for an invalid baseDir', async () => {
+			const { events, chats, missingDirectories } = await loadCodebuffUsageEvents({
+				baseDir: '/nonexistent/codebuff-path',
+			});
+
+			expect(events).toEqual([]);
+			expect(chats.size).toBe(0);
+			expect(missingDirectories).toContain(path.resolve('/nonexistent/codebuff-path'));
+		});
+
+		it('skips malformed chat-messages files gracefully', async () => {
+			await using fixture = await createFixture({
+				manicode: {
+					projects: {
+						broken: {
+							chats: {
+								'2025-12-20T13-00-00.000Z': {
+									'chat-messages.json': 'not-valid-json',
+								},
+							},
+						},
+					},
+				},
+			});
+
+			const { events } = await loadCodebuffUsageEvents({
+				baseDir: fixture.getPath('manicode'),
+			});
+			expect(events).toEqual([]);
+		});
+	});
+}

--- a/apps/codebuff/src/data-loader.ts
+++ b/apps/codebuff/src/data-loader.ts
@@ -309,22 +309,39 @@ function extractCwdFromRunState(runState: ParsedRunState | null): string | null 
 	);
 }
 
+export type CodebuffChannelRoot = { channel: string; root: string };
+
+export type CodebuffChannelRootsResult = {
+	roots: CodebuffChannelRoot[];
+	/**
+	 * An explicitly-set but invalid override (either the `baseDir` option or
+	 * the `CODEBUFF_DATA_DIR` env var). Callers should surface this to the
+	 * user so a typo'd path doesn't silently fall through to the default
+	 * channels.
+	 */
+	invalidOverride: { source: 'baseDir' | 'env'; path: string } | null;
+};
+
 /**
  * Discover all Codebuff channel roots on disk (`~/.config/manicode`,
  * `-dev`, `-staging`). Honors `CODEBUFF_DATA_DIR` for a single custom root.
+ *
+ * When the explicit `customBaseDir` or `CODEBUFF_DATA_DIR` env var is set but
+ * does not resolve to an existing directory, the invalid path is returned in
+ * `invalidOverride` and a warning is logged so the mismatch is discoverable.
  */
-export function getCodebuffChannelRoots(customBaseDir?: string): Array<{
-	channel: string;
-	root: string;
-}> {
+export function getCodebuffChannelRoots(customBaseDir?: string): CodebuffChannelRootsResult {
 	if (customBaseDir != null && customBaseDir.trim() !== '') {
 		const normalized = path.resolve(customBaseDir);
 		if (isDirectorySync(normalized)) {
 			const basename = path.basename(normalized);
 			const channel = basename !== '' ? basename : 'manicode';
-			return [{ channel, root: normalized }];
+			return { roots: [{ channel, root: normalized }], invalidOverride: null };
 		}
-		return [];
+		return {
+			roots: [],
+			invalidOverride: { source: 'baseDir', path: normalized },
+		};
 	}
 
 	const envPath = process.env[CODEBUFF_DATA_DIR_ENV];
@@ -333,11 +350,26 @@ export function getCodebuffChannelRoots(customBaseDir?: string): Array<{
 		if (isDirectorySync(normalized)) {
 			const basename = path.basename(normalized);
 			const channel = basename !== '' ? basename : 'manicode';
-			return [{ channel, root: normalized }];
+			return { roots: [{ channel, root: normalized }], invalidOverride: null };
 		}
+		logger.warn(
+			`${CODEBUFF_DATA_DIR_ENV} is set to "${envPath}" but it is not a directory; falling back to default channels.`,
+		);
+		const roots: CodebuffChannelRoot[] = [];
+		const configDir = path.dirname(DEFAULT_CODEBUFF_DIR);
+		for (const channel of CODEBUFF_CHANNELS) {
+			const root = path.join(configDir, channel);
+			if (isDirectorySync(root)) {
+				roots.push({ channel, root });
+			}
+		}
+		return {
+			roots,
+			invalidOverride: { source: 'env', path: normalized },
+		};
 	}
 
-	const roots: Array<{ channel: string; root: string }> = [];
+	const roots: CodebuffChannelRoot[] = [];
 	const configDir = path.dirname(DEFAULT_CODEBUFF_DIR);
 	for (const channel of CODEBUFF_CHANNELS) {
 		const root = path.join(configDir, channel);
@@ -345,7 +377,7 @@ export function getCodebuffChannelRoots(customBaseDir?: string): Array<{
 			roots.push({ channel, root });
 		}
 	}
-	return roots;
+	return { roots, invalidOverride: null };
 }
 
 async function loadJsonFile<T>(
@@ -399,19 +431,19 @@ export type LoadResult = {
  * Load all Codebuff usage events from local chat-messages files.
  */
 export async function loadCodebuffUsageEvents(options: LoadOptions = {}): Promise<LoadResult> {
-	const roots = getCodebuffChannelRoots(options.baseDir);
+	const { roots, invalidOverride } = getCodebuffChannelRoots(options.baseDir);
 
 	const events: TokenUsageEvent[] = [];
 	const chats = new Map<string, ChatMetadata>();
 	const missingDirectories: string[] = [];
 
+	// Surface an explicit-but-invalid override so callers see the typo'd path
+	// rather than silently falling back to (or missing) the defaults.
+	if (invalidOverride != null) {
+		missingDirectories.push(invalidOverride.path);
+	}
+
 	if (roots.length === 0) {
-		// Only surface a missing-directory error when the user explicitly
-		// pointed at a non-existent path; leaving it implicit for the default
-		// case matches how @ccusage/amp behaves.
-		if (options.baseDir != null && options.baseDir.trim() !== '') {
-			missingDirectories.push(path.resolve(options.baseDir));
-		}
 		return { events, chats, missingDirectories };
 	}
 
@@ -665,6 +697,24 @@ if (import.meta.vitest != null) {
 			expect(events).toEqual([]);
 			expect(chats.size).toBe(0);
 			expect(missingDirectories).toContain(path.resolve('/nonexistent/codebuff-path'));
+		});
+
+		it('records CODEBUFF_DATA_DIR in missingDirectories when it points at a non-directory', async () => {
+			const previous = process.env[CODEBUFF_DATA_DIR_ENV];
+			process.env[CODEBUFF_DATA_DIR_ENV] = '/nonexistent/codebuff-env-override';
+			try {
+				const { invalidOverride } = getCodebuffChannelRoots();
+				expect(invalidOverride).toEqual({
+					source: 'env',
+					path: path.resolve('/nonexistent/codebuff-env-override'),
+				});
+			} finally {
+				if (previous == null) {
+					delete process.env[CODEBUFF_DATA_DIR_ENV];
+				} else {
+					process.env[CODEBUFF_DATA_DIR_ENV] = previous;
+				}
+			}
 		});
 
 		it('skips malformed chat-messages files gracefully', async () => {

--- a/apps/codebuff/src/index.ts
+++ b/apps/codebuff/src/index.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { run } from './run.ts';
+
+// eslint-disable-next-line antfu/no-top-level-await
+await run();

--- a/apps/codebuff/src/logger.ts
+++ b/apps/codebuff/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@ccusage/internal/logger';
+
+export const logger = createLogger('@ccusage/codebuff');

--- a/apps/codebuff/src/pricing.ts
+++ b/apps/codebuff/src/pricing.ts
@@ -7,11 +7,19 @@ import { prefetchCodebuffPricing } from './_macro.ts' with { type: 'macro' };
 import { logger } from './logger.ts';
 
 const CODEBUFF_PROVIDER_PREFIXES = [
+	'claude-',
 	'anthropic/',
+	'gpt-',
+	'o1',
+	'o3',
+	'o4',
 	'openai/',
 	'azure/',
+	'gemini-',
 	'google/',
+	'grok-',
 	'xai/',
+	'mistral',
 	'mistralai/',
 	'deepseek/',
 	'qwen/',
@@ -113,7 +121,7 @@ if (import.meta.vitest != null) {
 			using source = new CodebuffPricingSource({
 				offline: true,
 				offlineLoader: async () => ({
-					'claude-haiku-4-5-20251001': {
+					'claude-sonnet-4-20250514': {
 						input_cost_per_token: 1e-6,
 						output_cost_per_token: 5e-6,
 						cache_read_input_token_cost: 1e-7,
@@ -122,7 +130,7 @@ if (import.meta.vitest != null) {
 				}),
 			});
 
-			const pricing = await source.getPricing('claude-haiku-4-5-20251001');
+			const pricing = await source.getPricing('claude-sonnet-4-20250514');
 			expect(pricing.inputCostPerMToken).toBeCloseTo(1);
 			expect(pricing.outputCostPerMToken).toBeCloseTo(5);
 			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.1);

--- a/apps/codebuff/src/pricing.ts
+++ b/apps/codebuff/src/pricing.ts
@@ -1,0 +1,164 @@
+import type { LiteLLMModelPricing } from '@ccusage/internal/pricing';
+import type { ModelPricing, PricingSource } from './_types.ts';
+import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
+import { Result } from '@praha/byethrow';
+import { MILLION } from './_consts.ts';
+import { prefetchCodebuffPricing } from './_macro.ts' with { type: 'macro' };
+import { logger } from './logger.ts';
+
+const CODEBUFF_PROVIDER_PREFIXES = [
+	'anthropic/',
+	'openai/',
+	'azure/',
+	'google/',
+	'xai/',
+	'mistralai/',
+	'deepseek/',
+	'qwen/',
+	'openrouter/',
+];
+
+const ZERO_MODEL_PRICING = {
+	inputCostPerMToken: 0,
+	cachedInputCostPerMToken: 0,
+	cacheCreationCostPerMToken: 0,
+	outputCostPerMToken: 0,
+} as const satisfies ModelPricing;
+
+function toPerMillion(value: number | undefined, fallback?: number): number {
+	const perToken = value ?? fallback ?? 0;
+	return perToken * MILLION;
+}
+
+export type CodebuffPricingSourceOptions = {
+	offline?: boolean;
+	offlineLoader?: () => Promise<Record<string, LiteLLMModelPricing>>;
+};
+
+const PREFETCHED_CODEBUFF_PRICING = prefetchCodebuffPricing();
+
+export class CodebuffPricingSource implements PricingSource, Disposable {
+	private readonly fetcher: LiteLLMPricingFetcher;
+
+	constructor(options: CodebuffPricingSourceOptions = {}) {
+		this.fetcher = new LiteLLMPricingFetcher({
+			offline: options.offline ?? false,
+			offlineLoader: options.offlineLoader ?? (async () => PREFETCHED_CODEBUFF_PRICING),
+			logger,
+			providerPrefixes: CODEBUFF_PROVIDER_PREFIXES,
+		});
+	}
+
+	[Symbol.dispose](): void {
+		this.fetcher[Symbol.dispose]();
+	}
+
+	async getPricing(model: string): Promise<ModelPricing> {
+		const directLookup = await this.fetcher.getModelPricing(model);
+		if (Result.isFailure(directLookup)) {
+			throw directLookup.error;
+		}
+
+		const pricing = directLookup.value;
+		if (pricing == null) {
+			logger.warn(`Pricing not found for model ${model}; defaulting to zero-cost pricing.`);
+			return ZERO_MODEL_PRICING;
+		}
+
+		return {
+			inputCostPerMToken: toPerMillion(pricing.input_cost_per_token),
+			cachedInputCostPerMToken: toPerMillion(
+				pricing.cache_read_input_token_cost,
+				pricing.input_cost_per_token,
+			),
+			cacheCreationCostPerMToken: toPerMillion(
+				pricing.cache_creation_input_token_cost,
+				pricing.input_cost_per_token,
+			),
+			outputCostPerMToken: toPerMillion(pricing.output_cost_per_token),
+		};
+	}
+
+	async calculateCost(
+		model: string,
+		tokens: {
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationInputTokens?: number;
+			cacheReadInputTokens?: number;
+		},
+	): Promise<number> {
+		const result = await this.fetcher.calculateCostFromTokens(
+			{
+				input_tokens: tokens.inputTokens,
+				output_tokens: tokens.outputTokens,
+				cache_creation_input_tokens: tokens.cacheCreationInputTokens,
+				cache_read_input_tokens: tokens.cacheReadInputTokens,
+			},
+			model,
+		);
+
+		if (Result.isFailure(result)) {
+			logger.warn(`Failed to calculate cost for model ${model}:`, result.error);
+			return 0;
+		}
+
+		return result.value;
+	}
+}
+
+if (import.meta.vitest != null) {
+	describe('CodebuffPricingSource', () => {
+		it('converts LiteLLM pricing to per-million costs', async () => {
+			using source = new CodebuffPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'claude-haiku-4-5-20251001': {
+						input_cost_per_token: 1e-6,
+						output_cost_per_token: 5e-6,
+						cache_read_input_token_cost: 1e-7,
+						cache_creation_input_token_cost: 1.25e-6,
+					},
+				}),
+			});
+
+			const pricing = await source.getPricing('claude-haiku-4-5-20251001');
+			expect(pricing.inputCostPerMToken).toBeCloseTo(1);
+			expect(pricing.outputCostPerMToken).toBeCloseTo(5);
+			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.1);
+			expect(pricing.cacheCreationCostPerMToken).toBeCloseTo(1.25);
+		});
+
+		it('calculates cost from tokens for Codebuff-style multi-provider models', async () => {
+			using source = new CodebuffPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'openai/gpt-4o': {
+						input_cost_per_token: 2.5e-6,
+						output_cost_per_token: 1e-5,
+						cache_read_input_token_cost: 1.25e-6,
+					},
+				}),
+			});
+
+			const cost = await source.calculateCost('openai/gpt-4o', {
+				inputTokens: 1000,
+				outputTokens: 500,
+				cacheReadInputTokens: 200,
+			});
+
+			const expected = 1000 * 2.5e-6 + 500 * 1e-5 + 200 * 1.25e-6;
+			expect(cost).toBeCloseTo(expected);
+		});
+
+		it('falls back to zero pricing for unknown models', async () => {
+			using source = new CodebuffPricingSource({
+				offline: true,
+				offlineLoader: async () => ({}),
+			});
+
+			const pricing = await source.getPricing('openrouter/does-not-exist');
+			expect(pricing).toEqual(ZERO_MODEL_PRICING);
+		});
+	});
+}

--- a/apps/codebuff/src/run.ts
+++ b/apps/codebuff/src/run.ts
@@ -1,0 +1,29 @@
+import process from 'node:process';
+import { cli } from 'gunshi';
+import { description, name, version } from '../package.json';
+import { dailyCommand, monthlyCommand, sessionCommand } from './commands/index.ts';
+
+const subCommands = new Map([
+	['daily', dailyCommand],
+	['monthly', monthlyCommand],
+	['session', sessionCommand],
+]);
+
+const mainCommand = dailyCommand;
+
+export async function run(): Promise<void> {
+	// When invoked through npx, the binary name might be passed as the first argument
+	// Filter it out if it matches the expected binary name.
+	let args = process.argv.slice(2);
+	if (args[0] === 'ccusage-codebuff') {
+		args = args.slice(1);
+	}
+
+	await cli(args, mainCommand, {
+		name,
+		version,
+		description,
+		subCommands,
+		renderHeader: null,
+	});
+}

--- a/apps/codebuff/tsconfig.json
+++ b/apps/codebuff/tsconfig.json
@@ -1,0 +1,25 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"lib": ["ESNext"],
+		"moduleDetection": "force",
+		"module": "Preserve",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"types": ["vitest/globals", "vitest/importMeta"],
+		"allowImportingTsExtensions": true,
+		"allowJs": false,
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": false,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noEmit": true,
+		"verbatimModuleSyntax": true,
+		"erasableSyntaxOnly": true,
+		"skipLibCheck": true
+	},
+	"exclude": ["dist"]
+}

--- a/apps/codebuff/tsdown.config.ts
+++ b/apps/codebuff/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	format: ['esm'],
+	clean: true,
+	dts: false,
+	shims: true,
+	platform: 'node',
+	target: 'node20',
+	fixedExtension: false,
+});

--- a/apps/codebuff/vitest.config.ts
+++ b/apps/codebuff/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		includeSource: ['src/**/*.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+		},
+	},
+	define: {
+		'import.meta.vitest': 'undefined',
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,63 @@ importers:
         specifier: catalog:runtime
         version: 5.1.0
 
+  apps/codebuff:
+    devDependencies:
+      '@ccusage/internal':
+        specifier: workspace:*
+        version: link:../../packages/internal
+      '@ccusage/terminal':
+        specifier: workspace:*
+        version: link:../../packages/terminal
+      '@praha/byethrow':
+        specifier: catalog:runtime
+        version: 0.6.3
+      '@ryoppippi/eslint-config':
+        specifier: catalog:lint
+        version: 0.4.0(@vue/compiler-sfc@3.5.30)(eslint-plugin-format@2.0.1(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.1.2(@types/node@24.5.1)(happy-dom@16.8.1)(vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)))
+      '@typescript/native-preview':
+        specifier: catalog:types
+        version: 7.0.0-dev.20260107.1
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.3.0
+      eslint:
+        specifier: catalog:lint
+        version: 9.35.0(jiti@2.6.1)
+      fast-sort:
+        specifier: catalog:runtime
+        version: 3.4.1
+      fs-fixture:
+        specifier: catalog:testing
+        version: 2.8.1
+      gunshi:
+        specifier: catalog:runtime
+        version: 0.26.3
+      path-type:
+        specifier: catalog:runtime
+        version: 6.0.0
+      picocolors:
+        specifier: catalog:runtime
+        version: 1.1.1
+      tinyglobby:
+        specifier: catalog:runtime
+        version: 0.2.15
+      tsdown:
+        specifier: catalog:build
+        version: 0.16.6(@typescript/native-preview@7.0.0-dev.20260107.1)(publint@0.3.12)(synckit@0.11.12)(typescript@5.9.2)(unplugin-unused@0.5.3)
+      unplugin-macros:
+        specifier: catalog:build
+        version: 0.18.2(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
+      unplugin-unused:
+        specifier: catalog:build
+        version: 0.5.3
+      valibot:
+        specifier: catalog:runtime
+        version: 1.1.0(typescript@5.9.2)
+      vitest:
+        specifier: catalog:testing
+        version: 4.1.2(@types/node@24.5.1)(happy-dom@16.8.1)(vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3))
+
   apps/codex:
     devDependencies:
       '@ccusage/internal':
@@ -809,19 +866,10 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -925,12 +973,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.25.9':
-    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
     engines: {node: '>=18'}
@@ -939,12 +981,6 @@ packages:
 
   '@esbuild/android-arm64@0.25.4':
     resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.25.9':
-    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -961,12 +997,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.25.9':
-    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.27.4':
     resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
     engines: {node: '>=18'}
@@ -975,12 +1005,6 @@ packages:
 
   '@esbuild/android-x64@0.25.4':
     resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.9':
-    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -997,12 +1021,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.25.9':
-    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.4':
     resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
@@ -1011,12 +1029,6 @@ packages:
 
   '@esbuild/darwin-x64@0.25.4':
     resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.9':
-    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1033,12 +1045,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.25.9':
-    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.4':
     resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
@@ -1047,12 +1053,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.4':
     resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.9':
-    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1069,12 +1069,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.25.9':
-    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.4':
     resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
@@ -1083,12 +1077,6 @@ packages:
 
   '@esbuild/linux-arm@0.25.4':
     resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.9':
-    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1105,12 +1093,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.9':
-    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.4':
     resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
@@ -1119,12 +1101,6 @@ packages:
 
   '@esbuild/linux-loong64@0.25.4':
     resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.9':
-    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1141,12 +1117,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.9':
-    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.4':
     resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
@@ -1155,12 +1125,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.4':
     resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.9':
-    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1177,12 +1141,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.9':
-    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.4':
     resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
@@ -1191,12 +1149,6 @@ packages:
 
   '@esbuild/linux-s390x@0.25.4':
     resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.9':
-    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1213,12 +1165,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.9':
-    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.4':
     resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
     engines: {node: '>=18'}
@@ -1227,12 +1173,6 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.4':
     resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.25.9':
-    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1249,12 +1189,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.9':
-    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.27.4':
     resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
     engines: {node: '>=18'}
@@ -1263,12 +1197,6 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.4':
     resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.25.9':
-    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1285,23 +1213,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.9':
-    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openbsd-x64@0.27.4':
     resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.25.9':
-    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
 
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
@@ -1311,12 +1227,6 @@ packages:
 
   '@esbuild/sunos-x64@0.25.4':
     resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.25.9':
-    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1333,12 +1243,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.25.9':
-    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
@@ -1351,12 +1255,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.9':
-    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.4':
     resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
@@ -1365,12 +1263,6 @@ packages:
 
   '@esbuild/win32-x64@0.25.4':
     resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.9':
-    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2292,9 +2184,6 @@ packages:
 
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3278,11 +3167,6 @@ packages:
 
   esbuild@0.25.4:
     resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.25.9:
-    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5461,46 +5345,6 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.1.5:
-    resolution: {integrity: sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5838,8 +5682,8 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -5848,18 +5692,9 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/parser@7.28.5':
-    dependencies:
-      '@babel/types': 7.28.5
-
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.0':
     dependencies:
@@ -5956,16 +5791,10 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.9':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
   '@esbuild/android-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
@@ -5974,16 +5803,10 @@ snapshots:
   '@esbuild/android-arm@0.25.4':
     optional: true
 
-  '@esbuild/android-arm@0.25.9':
-    optional: true
-
   '@esbuild/android-arm@0.27.4':
     optional: true
 
   '@esbuild/android-x64@0.25.4':
-    optional: true
-
-  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/android-x64@0.27.4':
@@ -5992,16 +5815,10 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.4':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.9':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
   '@esbuild/darwin-x64@0.25.4':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
@@ -6010,16 +5827,10 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.4':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.9':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.4':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
@@ -6028,16 +5839,10 @@ snapshots:
   '@esbuild/linux-arm64@0.25.4':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.9':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
   '@esbuild/linux-arm@0.25.4':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
@@ -6046,16 +5851,10 @@ snapshots:
   '@esbuild/linux-ia32@0.25.4':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.9':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
   '@esbuild/linux-loong64@0.25.4':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
@@ -6064,16 +5863,10 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.4':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.9':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.4':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
@@ -6082,16 +5875,10 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.4':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.9':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
   '@esbuild/linux-s390x@0.25.4':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
@@ -6100,16 +5887,10 @@ snapshots:
   '@esbuild/linux-x64@0.25.4':
     optional: true
 
-  '@esbuild/linux-x64@0.25.9':
-    optional: true
-
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
@@ -6118,16 +5899,10 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.9':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
@@ -6136,13 +5911,7 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.4':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.9':
-    optional: true
-
   '@esbuild/openbsd-x64@0.27.4':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.9':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
@@ -6151,16 +5920,10 @@ snapshots:
   '@esbuild/sunos-x64@0.25.4':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.9':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
   '@esbuild/win32-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.9':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
@@ -6169,16 +5932,10 @@ snapshots:
   '@esbuild/win32-ia32@0.25.4':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.9':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
   '@esbuild/win32-x64@0.25.4':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -6236,7 +5993,7 @@ snapshots:
       '@eslint/core': 0.15.2
       '@eslint/plugin-kit': 0.3.5
       github-slugger: 2.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-frontmatter: 2.0.1
       mdast-util-gfm: 3.1.0
       micromark-extension-frontmatter: 2.0.0
@@ -6703,7 +6460,7 @@ snapshots:
 
   '@praha/byethrow@0.6.3':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
 
   '@publint/pack@0.1.2': {}
 
@@ -6901,8 +6658,6 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@speed-highlight/core@1.2.7': {}
-
-  '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -7344,7 +7099,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       pathe: 2.0.3
 
   bail@2.0.2: {}
@@ -7847,35 +7602,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.4
       '@esbuild/win32-ia32': 0.25.4
       '@esbuild/win32-x64': 0.25.4
-
-  esbuild@0.25.9:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.9
-      '@esbuild/android-arm': 0.25.9
-      '@esbuild/android-arm64': 0.25.9
-      '@esbuild/android-x64': 0.25.9
-      '@esbuild/darwin-arm64': 0.25.9
-      '@esbuild/darwin-x64': 0.25.9
-      '@esbuild/freebsd-arm64': 0.25.9
-      '@esbuild/freebsd-x64': 0.25.9
-      '@esbuild/linux-arm': 0.25.9
-      '@esbuild/linux-arm64': 0.25.9
-      '@esbuild/linux-ia32': 0.25.9
-      '@esbuild/linux-loong64': 0.25.9
-      '@esbuild/linux-mips64el': 0.25.9
-      '@esbuild/linux-ppc64': 0.25.9
-      '@esbuild/linux-riscv64': 0.25.9
-      '@esbuild/linux-s390x': 0.25.9
-      '@esbuild/linux-x64': 0.25.9
-      '@esbuild/netbsd-arm64': 0.25.9
-      '@esbuild/netbsd-x64': 0.25.9
-      '@esbuild/openbsd-arm64': 0.25.9
-      '@esbuild/openbsd-x64': 0.25.9
-      '@esbuild/openharmony-arm64': 0.25.9
-      '@esbuild/sunos-x64': 0.25.9
-      '@esbuild/win32-arm64': 0.25.9
-      '@esbuild/win32-ia32': 0.25.9
-      '@esbuild/win32-x64': 0.25.9
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -8930,7 +8656,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -8939,7 +8665,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8949,7 +8675,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8958,14 +8684,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -9612,7 +9338,7 @@ snapshots:
 
   pnpm-workspace-yaml@1.1.1:
     dependencies:
-      yaml: 2.8.1
+      yaml: 2.8.3
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -9836,8 +9562,8 @@ snapshots:
   rolldown-plugin-dts@0.18.0(@typescript/native-preview@7.0.0-dev.20260107.1)(rolldown@1.0.0-beta.51)(typescript@5.9.2):
     dependencies:
       '@babel/generator': 7.28.5
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       ast-kit: 2.2.0
       birpc: 2.8.0
       dts-resolver: 2.1.3
@@ -10415,7 +10141,7 @@ snapshots:
       ast-kit: 2.2.0
       magic-string-ast: 1.0.2
       unplugin: 2.3.10
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
       vite-node: 3.2.4(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -10490,7 +10216,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10504,20 +10230,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vite@7.1.5(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.25.9
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.50.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.5.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      yaml: 2.8.3
 
   vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
@@ -10737,7 +10449,7 @@ snapshots:
   yaml-eslint-parser@1.3.0:
     dependencies:
       eslint-visitor-keys: 3.4.3
-      yaml: 2.8.1
+      yaml: 2.8.3
 
   yaml@2.8.1: {}
 


### PR DESCRIPTION
## Summary

Adds `@ccusage/codebuff` — a companion CLI that mirrors `@ccusage/amp`, `@ccusage/codex`, `@ccusage/opencode`, and `@ccusage/pi` to analyze local usage for [Codebuff](https://codebuff.com) (the agent formerly known as Manicode).

- Reports: `daily`, `monthly`, `session` — each supports `--json` and `--compact`.
- Default command when invoked with no subcommand: `daily`.
- Bin: `ccusage-codebuff` (e.g. `npx @ccusage/codebuff@latest daily`).

## Data Source

Codebuff persists per-chat history at:

```
~/.config/manicode/                       # legacy name, still on disk
  projects/<projectBasename>/
    chats/<chatId>/
      chat-messages.json                  # serialized ChatMessage[]
      run-state.json                      # SDK RunState snapshot (used for cwd)
```

`chatId` is the chat's ISO-8601 timestamp with `:` replaced by `-` for filesystem safety (`2025-12-14T10-00-00.000Z`). Dev and staging channels (`manicode-dev`, `manicode-staging`) use the same layout and are walked automatically when present.

## Token / Credit Extraction

Assistant-message usage can land in several places depending on routing. The loader tries, in order:

1. `message.metadata.usage` (direct Codebuff provider).
2. `message.metadata.codebuff.usage` (Codebuff-tagged payload).
3. `message.metadata.runState.sessionState.mainAgentState.messageHistory[*].providerOptions` — where RunState-stashed OpenRouter calls record totals under `providerOptions.usage` or `providerOptions.codebuff.usage`.

Both camelCase and snake_case shapes are accepted (`inputTokens`/`input_tokens`/`promptTokens`, etc.). Credits are read from `message.credits`.

## Pricing

- Uses LiteLLM's public pricing dataset via `@ccusage/internal/pricing`.
- Pre-fetch macro keeps models with prefixes: `claude-`, `anthropic/`, `gpt-`, `o1`/`o3`/`o4`, `openai/`, `azure/`, `gemini-`, `google/`, `grok-`, `xai/`, `mistral*/`, `deepseek/`, `qwen/`, `openrouter/`.
- Unknown models fall back to zero-cost pricing.

## Environment

- `CODEBUFF_DATA_DIR` — override the base directory. Point it at a single channel root such as `~/.config/manicode-dev`.
- `LOG_LEVEL` — standard consola verbosity (0=silent … 5=trace).

## Verification

Run from the repo root:

```
pnpm install
pnpm --filter @ccusage/codebuff lint
pnpm --filter @ccusage/codebuff typecheck
pnpm --filter @ccusage/codebuff test --run
pnpm --filter @ccusage/codebuff build
```

All green locally:

- Lint: clean.
- Typecheck: clean.
- Tests: `2 files, 7 tests passed` (data-loader × 4, pricing × 3).
- Build: `tsdown` produces `dist/index.js` (~361 kB).
- End-to-end: running `node ./dist/index.js daily --json` against real Codebuff data returns well-formed JSON with per-day credits and cost.
- Full monorepo `pnpm -r test --run` still passes (252 + 18 + 10 + 7 + 6 + 12 + 7 + 3 = all prior suites + the 7 new tests).

## Notes

- Apps are bundled, so all runtime deps are in `devDependencies`, matching `@ccusage/amp` exactly.
- Commands, table layout, compact mode, colors, and totals row are consistent with `@ccusage/amp`.
- `CLAUDE.md` documents the data sources, extraction order, and testing conventions so future contributors can evolve the package without re-deriving the provider quirks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ccusage-codebuff CLI with daily, monthly, and session commands for aggregating token/credit usage and costs; supports --json and --compact and renders formatted terminal tables. Auto-discovers and normalizes persisted chat history across channels/projects for per-chat and per-session reporting; daily is the default command.

* **Pricing**
  * Integrates external model pricing to compute per-event and total costs; unknown models fall back to zero-cost with a warning.

* **Documentation**
  * Added user docs covering CLI usage, on-disk layout, env vars, output flags, and examples.

* **Tooling**
  * Added package manifest, build, lint, TypeScript, test configs, logger, and unit tests for parsing/pricing/CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->