### PR TITLE
feat(copilot): add GitHub Copilot CLI usage tracking app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # nix
 .direnv
 !.envrc
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This is a monorepo containing multiple packages. For package-specific guidance, 
 - **Main CLI Package**: @apps/ccusage/CLAUDE.md - Core ccusage CLI tool and library
 - **Codex CLI Package**: @apps/codex/CLAUDE.md - OpenAI Codex usage tracking CLI
 - **OpenCode CLI Package**: @apps/opencode/CLAUDE.md - OpenCode usage tracking CLI
+- **Copilot CLI Package**: @apps/copilot/CLAUDE.md - GitHub Copilot CLI usage tracking
 - **MCP Server Package**: @apps/mcp/CLAUDE.md - MCP server implementation for ccusage data
 - **Documentation**: @docs/CLAUDE.md - VitePress-based documentation website
 

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -41,6 +41,10 @@ Companion tool for analyzing [pi-agent](https://github.com/badlogic/pi-mono) ses
 
 Companion tool for analyzing [Amp](https://ampcode.com/) session usage. Track token usage, costs, and credits from your Amp CLI sessions with daily, monthly, and session-based reports.
 
+### 🤖 [@ccusage/copilot](https://www.npmjs.com/package/@ccusage/copilot) - GitHub Copilot CLI Usage Analyzer
+
+Companion tool for analyzing [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) session usage. Track token usage and costs with dual pricing modes: premium request costs or API-equivalent rates.
+
 ### 🔌 [@ccusage/mcp](https://www.npmjs.com/package/@ccusage/mcp) - MCP Server Integration
 
 Model Context Protocol server that exposes ccusage data to Claude Desktop and other MCP-compatible tools. Enable real-time usage tracking directly in your AI workflows.
@@ -73,6 +77,7 @@ npx @ccusage/codex@latest       # OpenAI Codex usage tracking
 npx @ccusage/opencode@latest    # OpenCode usage tracking
 npx @ccusage/pi@latest          # Pi-agent usage tracking
 npx @ccusage/amp@latest         # Amp usage tracking
+npx @ccusage/copilot@latest     # GitHub Copilot CLI usage tracking
 npx @ccusage/mcp@latest         # MCP Server
 ```
 

--- a/apps/copilot/CLAUDE.md
+++ b/apps/copilot/CLAUDE.md
@@ -1,0 +1,64 @@
+# Copilot CLI Notes
+
+## Log Sources
+
+- Copilot CLI session data is stored under `${COPILOT_CONFIG_DIR:-~/.copilot}/session-state/`.
+- Each session is stored as a directory named with the session UUID (e.g., `session-state/{uuid}/`).
+- Usage data is extracted from `events.jsonl` files within each session directory.
+- Session metadata is available from `session.start` events and `workspace.yaml` files.
+
+## Data Format
+
+- `events.jsonl`: JSON Lines format, one event per line.
+- Key event types:
+  - `session.start` — session metadata (sessionId, copilotVersion, startTime, context)
+  - `session.shutdown` — aggregated per-model token metrics (primary usage data source)
+  - `session.resume` — session resume marker
+  - `assistant.usage` — per-request usage (ephemeral, NOT persisted to disk)
+
+## Token Fields (from session.shutdown modelMetrics)
+
+- `inputTokens`: total input tokens sent to the model.
+- `outputTokens`: output tokens (completion text).
+- `cacheReadTokens`: tokens read from cache.
+- `cacheWriteTokens`: tokens written to cache.
+- `totalTokens`: sum of all token types.
+
+## Premium Requests
+
+- Copilot CLI tracks costs as premium request counts (not USD directly).
+- Each model's `requests.cost` represents the number of premium requests consumed.
+- `requests.count` is the total number of API requests made to that model.
+- `totalPremiumRequests` in shutdown data is the session-wide premium request total.
+
+## Models
+
+Copilot CLI supports both Anthropic Claude and OpenAI GPT models:
+
+- Claude: claude-haiku-4.5, claude-sonnet-4, claude-sonnet-4.5, claude-sonnet-4.6, claude-opus-4.5, claude-opus-4.6, claude-opus-4.6-1m, claude-opus-4.7
+- GPT: gpt-5.1, gpt-5.2, gpt-5.4
+- Other: goldeneye
+
+## Cost Calculation
+
+- Pricing is pulled from LiteLLM's public JSON (`model_prices_and_context_window.json`).
+- Both Claude and GPT model pricing prefixes are supported.
+- Cost formula per model:
+  - Input: `inputTokens / 1_000_000 * input_cost_per_mtoken`
+  - Cached input read: `cacheReadTokens / 1_000_000 * cached_input_cost_per_mtoken`
+  - Cache creation: `cacheWriteTokens / 1_000_000 * cache_creation_cost_per_mtoken`
+  - Output: `outputTokens / 1_000_000 * output_cost_per_mtoken`
+
+## CLI Usage
+
+- Treat Copilot as a sibling to `apps/ccusage`, `apps/codex`, `apps/amp`, etc.
+- Reuse shared packages (`@ccusage/terminal`, `@ccusage/internal`) wherever possible.
+- Copilot is packaged as a bundled CLI. Keep every runtime dependency in `devDependencies`.
+- Entry point uses Gunshi framework with subcommands: `daily`, `monthly`, `session`.
+- Shared args defined in `_shared-args.ts` (json, since, until, timezone, locale, offline, compact, mode, order, breakdown, color/noColor).
+- Date utilities in `_date-utils.ts` (timezone-aware grouping, date filtering).
+- Data discovery relies on `COPILOT_CONFIG_DIR` environment variable.
+
+## Environment Variables
+
+- `COPILOT_CONFIG_DIR` — override default Copilot data directory (default: `~/.copilot`)

--- a/apps/copilot/README.md
+++ b/apps/copilot/README.md
@@ -1,0 +1,117 @@
+<div align="center">
+    <img src="https://cdn.jsdelivr.net/gh/ryoppippi/ccusage@main/docs/public/logo.svg" alt="ccusage logo" width="256" height="256">
+    <h1>@ccusage/copilot</h1>
+</div>
+
+<p align="center">
+    <a href="https://socket.dev/api/npm/package/@ccusage/copilot"><img src="https://socket.dev/api/badge/npm/package/@ccusage/copilot" alt="Socket Badge" /></a>
+    <a href="https://npmjs.com/package/@ccusage/copilot"><img src="https://img.shields.io/npm/v/@ccusage/copilot?color=yellow" alt="npm version" /></a>
+    <a href="https://packagephobia.com/result?p=@ccusage/copilot"><img src="https://packagephobia.com/badge?p=@ccusage/copilot" alt="install size" /></a>
+    <a href="https://deepwiki.com/ryoppippi/ccusage"><img src="https://img.shields.io/badge/DeepWiki-ryoppippi%2Fccusage-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==" alt="DeepWiki"></a>
+</p>
+
+> Analyze [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) usage logs with the same reporting experience as `ccusage`.
+
+## Quick Start
+
+```bash
+# Recommended - always include @latest
+npx @ccusage/copilot@latest --help
+bunx @ccusage/copilot@latest --help  # ⚠️ MUST include @latest with bunx
+
+# Alternative package runners
+pnpm dlx @ccusage/copilot
+pnpx @ccusage/copilot
+```
+
+### Recommended: Shell Alias
+
+Since `npx @ccusage/copilot@latest` is quite long to type repeatedly, we strongly recommend setting up a shell alias:
+
+```bash
+# bash/zsh: alias ccusage-copilot='bunx @ccusage/copilot@latest'
+# fish:     alias ccusage-copilot 'bunx @ccusage/copilot@latest'
+
+# Then simply run:
+ccusage-copilot daily
+ccusage-copilot monthly --json
+```
+
+## Usage
+
+```bash
+# Daily usage report (default command)
+ccusage-copilot daily
+
+# Monthly summary
+ccusage-copilot monthly
+
+# Per-session breakdown
+ccusage-copilot session
+
+# JSON output
+ccusage-copilot daily --json
+
+# Compact table for narrow terminals
+ccusage-copilot daily --compact
+
+# Filter by date range
+ccusage-copilot daily --since 2026-04-01 --until 2026-04-30
+
+# Reverse sort order
+ccusage-copilot daily --order desc
+
+# Show per-model breakdown
+ccusage-copilot daily --breakdown --mode api
+
+# Use specific timezone
+ccusage-copilot daily --timezone America/New_York
+
+# Use cached pricing (offline)
+ccusage-copilot daily --mode api --offline
+```
+
+## Pricing Modes
+
+Use `--mode` to control how costs are calculated:
+
+```bash
+# Premium request pricing (default) — what you actually pay on Copilot
+ccusage-copilot daily --mode premium
+
+# API-equivalent pricing — what it would cost at Anthropic/OpenAI API rates
+ccusage-copilot daily --mode api
+```
+
+- **`premium`** (default): Uses GitHub Copilot's premium request counts × $0.04 (overage rate). The `requests.cost` field already includes model multipliers.
+- **`api`**: Calculates hypothetical costs using official Anthropic/OpenAI API rates via LiteLLM. Useful for understanding the value of your Copilot subscription.
+
+JSON output always includes both `premiumCostUSD` and `apiCostUSD` regardless of selected mode.
+
+## Data Source
+
+Copilot CLI stores session data at:
+
+```text
+~/.copilot/
+  session-state/
+    {sessionId}/              # UUID directory per session
+      events.jsonl            # JSON Lines event stream
+      workspace.yaml          # session metadata
+```
+
+## Environment Variables
+
+- `COPILOT_CONFIG_DIR` — override the base Copilot directory (default: `~/.copilot`)
+- `LOG_LEVEL` — control logging verbosity (0=silent … 5=trace)
+
+## Related
+
+Part of the [ccusage](https://github.com/ryoppippi/ccusage) family:
+
+- [`ccusage`](https://www.npmjs.com/package/ccusage) — Claude Code usage
+- [`@ccusage/codex`](https://www.npmjs.com/package/@ccusage/codex) — OpenAI Codex usage
+- [`@ccusage/opencode`](https://www.npmjs.com/package/@ccusage/opencode) — OpenCode usage
+- [`@ccusage/pi`](https://www.npmjs.com/package/@ccusage/pi) — Pi-agent usage
+- [`@ccusage/amp`](https://www.npmjs.com/package/@ccusage/amp) — Amp usage
+- [`@ccusage/copilot`](https://www.npmjs.com/package/@ccusage/copilot) — GitHub Copilot CLI usage

--- a/apps/copilot/eslint.config.js
+++ b/apps/copilot/eslint.config.js
@@ -1,0 +1,16 @@
+import { ryoppippi } from '@ryoppippi/eslint-config';
+
+/** @type {import('eslint').Linter.FlatConfig[]} */
+const config = ryoppippi(
+	{
+		type: 'app',
+		stylistic: false,
+	},
+	{
+		rules: {
+			'test/no-importing-vitest-globals': 'error',
+		},
+	},
+);
+
+export default config;

--- a/apps/copilot/package.json
+++ b/apps/copilot/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@ccusage/copilot",
+	"version": "18.0.11",
+	"description": "Usage analysis tool for GitHub Copilot CLI sessions",
+	"homepage": "https://github.com/ryoppippi/ccusage#readme",
+	"bugs": {
+		"url": "https://github.com/ryoppippi/ccusage/issues"
+	},
+	"license": "MIT",
+	"author": "ryoppippi",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ryoppippi/ccusage.git",
+		"directory": "apps/copilot"
+	},
+	"funding": "https://github.com/ryoppippi/ccusage?sponsor=1",
+	"bin": {
+		"ccusage-copilot": "./src/index.ts"
+	},
+	"files": [
+		"dist"
+	],
+	"type": "module",
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"publishConfig": {
+		"bin": {
+			"ccusage-copilot": "./dist/index.js"
+		}
+	},
+	"engines": {
+		"node": ">=20.19.4"
+	}
+}

--- a/apps/copilot/package.json
+++ b/apps/copilot/package.json
@@ -1,28 +1,28 @@
 {
 	"name": "@ccusage/copilot",
+	"type": "module",
 	"version": "18.0.11",
 	"description": "Usage analysis tool for GitHub Copilot CLI sessions",
-	"homepage": "https://github.com/ryoppippi/ccusage#readme",
-	"bugs": {
-		"url": "https://github.com/ryoppippi/ccusage/issues"
-	},
-	"license": "MIT",
 	"author": "ryoppippi",
+	"license": "MIT",
+	"funding": "https://github.com/ryoppippi/ccusage?sponsor=1",
+	"homepage": "https://github.com/ryoppippi/ccusage#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/ryoppippi/ccusage.git",
 		"directory": "apps/copilot"
 	},
-	"funding": "https://github.com/ryoppippi/ccusage?sponsor=1",
+	"bugs": {
+		"url": "https://github.com/ryoppippi/ccusage/issues"
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
 	"bin": {
 		"ccusage-copilot": "./src/index.ts"
 	},
 	"files": [
 		"dist"
 	],
-	"type": "module",
-	"main": "./dist/index.js",
-	"module": "./dist/index.js",
 	"publishConfig": {
 		"bin": {
 			"ccusage-copilot": "./dist/index.js"
@@ -30,5 +30,35 @@
 	},
 	"engines": {
 		"node": ">=20.19.4"
+	},
+	"scripts": {
+		"build": "tsdown",
+		"format": "pnpm run lint --fix",
+		"lint": "eslint --cache .",
+		"prepack": "pnpm run build && clean-pkg-json",
+		"prerelease": "pnpm run lint && pnpm run typecheck && pnpm run build",
+		"start": "bun ./src/index.ts",
+		"test": "TZ=UTC vitest",
+		"typecheck": "tsgo --noEmit"
+	},
+	"devDependencies": {
+		"@ccusage/internal": "workspace:*",
+		"@ccusage/terminal": "workspace:*",
+		"@praha/byethrow": "catalog:runtime",
+		"@ryoppippi/eslint-config": "catalog:lint",
+		"@typescript/native-preview": "catalog:types",
+		"clean-pkg-json": "catalog:release",
+		"eslint": "catalog:lint",
+		"fast-sort": "catalog:runtime",
+		"fs-fixture": "catalog:testing",
+		"gunshi": "catalog:runtime",
+		"path-type": "catalog:runtime",
+		"picocolors": "catalog:runtime",
+		"tinyglobby": "catalog:runtime",
+		"tsdown": "catalog:build",
+		"unplugin-macros": "catalog:build",
+		"unplugin-unused": "catalog:build",
+		"valibot": "catalog:runtime",
+		"vitest": "catalog:testing"
 	}
 }

--- a/apps/copilot/src/_consts.ts
+++ b/apps/copilot/src/_consts.ts
@@ -1,0 +1,63 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+/**
+ * Environment variable name for custom Copilot data directory
+ */
+export const COPILOT_CONFIG_DIR_ENV = 'COPILOT_CONFIG_DIR';
+
+/**
+ * Default Copilot data directory path (~/.copilot)
+ */
+const DEFAULT_COPILOT_PATH = '.copilot';
+
+/**
+ * User home directory
+ */
+const USER_HOME_DIR = homedir();
+
+/**
+ * Default Copilot data directory (absolute path)
+ */
+export const DEFAULT_COPILOT_DIR = path.join(USER_HOME_DIR, DEFAULT_COPILOT_PATH);
+
+/**
+ * Copilot session-state subdirectory name
+ */
+export const SESSION_STATE_DIR_NAME = 'session-state';
+
+/**
+ * Events filename within each session directory
+ */
+export const EVENTS_FILENAME = 'events.jsonl';
+
+/**
+ * Workspace metadata filename within each session directory
+ */
+export const WORKSPACE_FILENAME = 'workspace.yaml';
+
+/**
+ * Million constant for pricing calculations
+ */
+export const MILLION = 1_000_000;
+
+/**
+ * Cost per premium request in USD (GitHub Copilot overage rate)
+ */
+export const PREMIUM_REQUEST_COST_USD = 0.04;
+
+/**
+ * Available pricing modes
+ */
+export const PRICING_MODES = ['premium', 'api'] as const;
+export type PricingMode = (typeof PRICING_MODES)[number];
+
+/**
+ * Default timezone (system local)
+ */
+export const DEFAULT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC';
+
+/**
+ * Default locale for formatting
+ */
+export const DEFAULT_LOCALE = 'en-US';

--- a/apps/copilot/src/_date-utils.ts
+++ b/apps/copilot/src/_date-utils.ts
@@ -92,37 +92,6 @@ export function isWithinRange(dateKey: string, since?: string, until?: string): 
 	return true;
 }
 
-/**
- * Format a date key for display using locale
- */
-export function formatDisplayDate(dateKey: string, locale?: string, timezone?: string): string {
-	const tz = safeTimeZone(timezone);
-	const date = new Date(`${dateKey}T00:00:00`);
-	const formatter = new Intl.DateTimeFormat(locale ?? 'en-US', {
-		year: 'numeric',
-		month: 'short',
-		day: 'numeric',
-		timeZone: tz,
-	});
-	return formatter.format(date);
-}
-
-/**
- * Format a month key for display using locale
- */
-export function formatDisplayMonth(monthKey: string, locale?: string): string {
-	const [yearStr = '0', monthStr = '1'] = monthKey.split('-');
-	const year = Number.parseInt(yearStr, 10);
-	const month = Number.parseInt(monthStr, 10);
-	const date = new Date(Date.UTC(year, month - 1, 1));
-	const formatter = new Intl.DateTimeFormat(locale ?? 'en-US', {
-		year: 'numeric',
-		month: 'short',
-		timeZone: 'UTC',
-	});
-	return formatter.format(date);
-}
-
 if (import.meta.vitest != null) {
 	describe('normalizeFilterDate', () => {
 		it('normalizes YYYYMMDD to YYYY-MM-DD', () => {

--- a/apps/copilot/src/_date-utils.ts
+++ b/apps/copilot/src/_date-utils.ts
@@ -1,0 +1,206 @@
+/**
+ * @fileoverview Date utilities for timezone-aware grouping and filtering
+ */
+
+function safeTimeZone(timezone?: string): string {
+	if (timezone == null || timezone.trim() === '') {
+		return Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC';
+	}
+
+	try {
+		Intl.DateTimeFormat('en-US', { timeZone: timezone });
+		return timezone;
+	} catch {
+		return 'UTC';
+	}
+}
+
+/**
+ * Convert a timestamp to a YYYY-MM-DD date key in the given timezone
+ */
+export function toDateKey(timestamp: string, timezone?: string): string {
+	const tz = safeTimeZone(timezone);
+	const date = new Date(timestamp);
+	const formatter = new Intl.DateTimeFormat('en-CA', {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		timeZone: tz,
+	});
+	return formatter.format(date);
+}
+
+/**
+ * Convert a timestamp to a YYYY-MM month key in the given timezone
+ */
+export function toMonthKey(timestamp: string, timezone?: string): string {
+	const tz = safeTimeZone(timezone);
+	const date = new Date(timestamp);
+	const year = new Intl.DateTimeFormat('en-US', { year: 'numeric', timeZone: tz }).format(date);
+	const month = new Intl.DateTimeFormat('en-US', { month: '2-digit', timeZone: tz }).format(date);
+	return `${year}-${month}`;
+}
+
+/**
+ * Normalize a filter date from YYYYMMDD or YYYY-MM-DD to YYYY-MM-DD
+ */
+export function normalizeFilterDate(value?: string): string | undefined {
+	if (value == null) {
+		return undefined;
+	}
+
+	const compact = value.replaceAll('-', '').trim();
+
+	// Accept YYYY-MM format (6 digits)
+	if (/^\d{6}$/.test(compact)) {
+		return `${compact.slice(0, 4)}-${compact.slice(4, 6)}`;
+	}
+
+	// Accept YYYY-MM-DD or YYYYMMDD format (8 digits)
+	if (/^\d{8}$/.test(compact)) {
+		return `${compact.slice(0, 4)}-${compact.slice(4, 6)}-${compact.slice(6, 8)}`;
+	}
+
+	throw new Error(`Invalid date format: ${value}. Expected YYYY-MM-DD, YYYY-MM, or YYYYMMDD.`);
+}
+
+/**
+ * Expand a YYYY-MM until bound to YYYY-MM-31 for day-level comparisons.
+ * Full YYYY-MM-DD values pass through unchanged.
+ */
+export function expandUntilForDayComparison(until?: string): string | undefined {
+	if (until == null) {
+		return undefined;
+	}
+	// YYYY-MM (7 chars) needs padding for day-level comparison
+	if (/^\d{4}-\d{2}$/.test(until)) {
+		return `${until}-31`;
+	}
+	return until;
+}
+
+/**
+ * Check if a date key falls within a range (inclusive)
+ */
+export function isWithinRange(dateKey: string, since?: string, until?: string): boolean {
+	if (since != null && dateKey < since) {
+		return false;
+	}
+	if (until != null && dateKey > until) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Format a date key for display using locale
+ */
+export function formatDisplayDate(dateKey: string, locale?: string, timezone?: string): string {
+	const tz = safeTimeZone(timezone);
+	const date = new Date(`${dateKey}T00:00:00`);
+	const formatter = new Intl.DateTimeFormat(locale ?? 'en-US', {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		timeZone: tz,
+	});
+	return formatter.format(date);
+}
+
+/**
+ * Format a month key for display using locale
+ */
+export function formatDisplayMonth(monthKey: string, locale?: string): string {
+	const [yearStr = '0', monthStr = '1'] = monthKey.split('-');
+	const year = Number.parseInt(yearStr, 10);
+	const month = Number.parseInt(monthStr, 10);
+	const date = new Date(Date.UTC(year, month - 1, 1));
+	const formatter = new Intl.DateTimeFormat(locale ?? 'en-US', {
+		year: 'numeric',
+		month: 'short',
+		timeZone: 'UTC',
+	});
+	return formatter.format(date);
+}
+
+if (import.meta.vitest != null) {
+	describe('normalizeFilterDate', () => {
+		it('normalizes YYYYMMDD to YYYY-MM-DD', () => {
+			expect(normalizeFilterDate('20260315')).toBe('2026-03-15');
+		});
+
+		it('passes through YYYY-MM-DD', () => {
+			expect(normalizeFilterDate('2026-03-15')).toBe('2026-03-15');
+		});
+
+		it('normalizes YYYY-MM to YYYY-MM', () => {
+			expect(normalizeFilterDate('2026-04')).toBe('2026-04');
+		});
+
+		it('returns undefined for undefined input', () => {
+			expect(normalizeFilterDate(undefined)).toBeUndefined();
+		});
+
+		it('throws on invalid format', () => {
+			expect(() => normalizeFilterDate('2026-3')).toThrow('Invalid date format');
+		});
+	});
+
+	describe('expandUntilForDayComparison', () => {
+		it('expands YYYY-MM to YYYY-MM-31', () => {
+			expect(expandUntilForDayComparison('2026-04')).toBe('2026-04-31');
+		});
+
+		it('passes through YYYY-MM-DD unchanged', () => {
+			expect(expandUntilForDayComparison('2026-04-15')).toBe('2026-04-15');
+		});
+
+		it('returns undefined for undefined', () => {
+			expect(expandUntilForDayComparison(undefined)).toBeUndefined();
+		});
+	});
+
+	describe('toDateKey', () => {
+		it('converts UTC timestamp to date key in UTC', () => {
+			expect(toDateKey('2026-03-15T10:00:00Z', 'UTC')).toBe('2026-03-15');
+		});
+
+		it('handles timezone offset at day boundary', () => {
+			// 2026-03-31T20:00Z is April 1 in Asia/Kolkata (UTC+5:30)
+			expect(toDateKey('2026-03-31T20:00:00Z', 'Asia/Kolkata')).toBe('2026-04-01');
+		});
+	});
+
+	describe('toMonthKey', () => {
+		it('converts timestamp to month key', () => {
+			expect(toMonthKey('2026-03-15T10:00:00Z', 'UTC')).toBe('2026-03');
+		});
+
+		it('handles timezone offset at month boundary', () => {
+			expect(toMonthKey('2026-03-31T20:00:00Z', 'Asia/Kolkata')).toBe('2026-04');
+		});
+	});
+
+	describe('isWithinRange', () => {
+		it('returns true when in range', () => {
+			expect(isWithinRange('2026-03-15', '2026-03-01', '2026-03-31')).toBe(true);
+		});
+
+		it('returns false when before since', () => {
+			expect(isWithinRange('2026-02-28', '2026-03-01', '2026-03-31')).toBe(false);
+		});
+
+		it('returns false when after until', () => {
+			expect(isWithinRange('2026-04-01', '2026-03-01', '2026-03-31')).toBe(false);
+		});
+
+		it('returns true when no bounds', () => {
+			expect(isWithinRange('2026-03-15')).toBe(true);
+		});
+
+		it('inclusive boundaries', () => {
+			expect(isWithinRange('2026-03-01', '2026-03-01', '2026-03-31')).toBe(true);
+			expect(isWithinRange('2026-03-31', '2026-03-01', '2026-03-31')).toBe(true);
+		});
+	});
+}

--- a/apps/copilot/src/_macro.ts
+++ b/apps/copilot/src/_macro.ts
@@ -1,0 +1,22 @@
+import type { LiteLLMModelPricing } from '@ccusage/internal/pricing';
+import {
+	createPricingDataset,
+	fetchLiteLLMPricingDataset,
+	filterPricingDataset,
+} from '@ccusage/internal/pricing-fetch-utils';
+
+const COPILOT_MODEL_PREFIXES = ['claude-', 'anthropic/', 'gpt-', 'openai/'];
+
+function isCopilotModel(modelName: string, _pricing: LiteLLMModelPricing): boolean {
+	return COPILOT_MODEL_PREFIXES.some((prefix) => modelName.startsWith(prefix));
+}
+
+export async function prefetchCopilotPricing(): Promise<Record<string, LiteLLMModelPricing>> {
+	try {
+		const dataset = await fetchLiteLLMPricingDataset();
+		return filterPricingDataset(dataset, isCopilotModel);
+	} catch (error) {
+		console.warn('Failed to prefetch Copilot pricing data, proceeding with empty cache.', error);
+		return createPricingDataset();
+	}
+}

--- a/apps/copilot/src/_shared-args.ts
+++ b/apps/copilot/src/_shared-args.ts
@@ -11,12 +11,12 @@ export const sharedArgs = {
 	since: {
 		type: 'string',
 		short: 's',
-		description: 'Filter from date (YYYY-MM-DD or YYYYMMDD)',
+		description: 'Filter from date (YYYY-MM, YYYY-MM-DD, or YYYYMMDD)',
 	},
 	until: {
 		type: 'string',
 		short: 'u',
-		description: 'Filter until date (inclusive)',
+		description: 'Filter until date (inclusive, YYYY-MM, YYYY-MM-DD, or YYYYMMDD)',
 	},
 	timezone: {
 		type: 'string',

--- a/apps/copilot/src/_shared-args.ts
+++ b/apps/copilot/src/_shared-args.ts
@@ -1,0 +1,71 @@
+import type { Args } from 'gunshi';
+import { DEFAULT_LOCALE, DEFAULT_TIMEZONE } from './_consts.ts';
+
+export const sharedArgs = {
+	json: {
+		type: 'boolean',
+		short: 'j',
+		description: 'Output report as JSON',
+		default: false,
+	},
+	since: {
+		type: 'string',
+		short: 's',
+		description: 'Filter from date (YYYY-MM-DD or YYYYMMDD)',
+	},
+	until: {
+		type: 'string',
+		short: 'u',
+		description: 'Filter until date (inclusive)',
+	},
+	timezone: {
+		type: 'string',
+		short: 'z',
+		description: 'Timezone for date grouping (IANA)',
+		default: DEFAULT_TIMEZONE,
+	},
+	locale: {
+		type: 'string',
+		short: 'l',
+		description: 'Locale for formatting',
+		default: DEFAULT_LOCALE,
+	},
+	offline: {
+		type: 'boolean',
+		short: 'O',
+		description: 'Use cached pricing data instead of fetching from LiteLLM',
+		default: false,
+		negatable: true,
+	},
+	compact: {
+		type: 'boolean',
+		description: 'Force compact table layout for narrow terminals',
+		default: false,
+	},
+	mode: {
+		type: 'string',
+		short: 'm',
+		description: 'Pricing mode: "premium" (default, $0.04/request) or "api" (official API rates)',
+		default: 'premium',
+	},
+	order: {
+		type: 'string',
+		short: 'o',
+		description: 'Sort order: "asc" (default) or "desc"',
+		default: 'asc',
+	},
+	breakdown: {
+		type: 'boolean',
+		short: 'b',
+		description: 'Show per-model breakdown for each entry',
+		default: false,
+	},
+	color: {
+		type: 'boolean',
+		description: 'Enable colored output (default: auto). FORCE_COLOR=1 has the same effect.',
+	},
+	noColor: {
+		type: 'boolean',
+		description: 'Disable colored output (default: auto). NO_COLOR=1 has the same effect.',
+	},
+} as const satisfies Args;

--- a/apps/copilot/src/_types.ts
+++ b/apps/copilot/src/_types.ts
@@ -42,39 +42,6 @@ export type ModelUsage = TokenUsageDelta & {
 };
 
 /**
- * Daily usage summary
- */
-export type DailyUsageSummary = {
-	date: string;
-	firstTimestamp: string;
-	costUSD: number;
-	models: Map<string, ModelUsage>;
-} & TokenUsageDelta;
-
-/**
- * Monthly usage summary
- */
-export type MonthlyUsageSummary = {
-	month: string;
-	firstTimestamp: string;
-	costUSD: number;
-	models: Map<string, ModelUsage>;
-} & TokenUsageDelta;
-
-/**
- * Session usage summary
- */
-export type SessionUsageSummary = {
-	sessionId: string;
-	repository: string;
-	cwd: string;
-	firstTimestamp: string;
-	lastTimestamp: string;
-	costUSD: number;
-	models: Map<string, ModelUsage>;
-} & TokenUsageDelta;
-
-/**
  * Model pricing information
  */
 export type ModelPricing = {
@@ -89,49 +56,4 @@ export type ModelPricing = {
  */
 export type PricingSource = {
 	getPricing: (model: string) => Promise<ModelPricing>;
-};
-
-/**
- * Daily report row for JSON output
- */
-export type DailyReportRow = {
-	date: string;
-	inputTokens: number;
-	outputTokens: number;
-	cacheReadTokens: number;
-	cacheWriteTokens: number;
-	totalTokens: number;
-	costUSD: number;
-	models: Record<string, ModelUsage>;
-};
-
-/**
- * Monthly report row for JSON output
- */
-export type MonthlyReportRow = {
-	month: string;
-	inputTokens: number;
-	outputTokens: number;
-	cacheReadTokens: number;
-	cacheWriteTokens: number;
-	totalTokens: number;
-	costUSD: number;
-	models: Record<string, ModelUsage>;
-};
-
-/**
- * Session report row for JSON output
- */
-export type SessionReportRow = {
-	sessionId: string;
-	repository: string;
-	cwd: string;
-	lastActivity: string;
-	inputTokens: number;
-	outputTokens: number;
-	cacheReadTokens: number;
-	cacheWriteTokens: number;
-	totalTokens: number;
-	costUSD: number;
-	models: Record<string, ModelUsage>;
 };

--- a/apps/copilot/src/_types.ts
+++ b/apps/copilot/src/_types.ts
@@ -1,0 +1,137 @@
+/**
+ * Token usage delta for a single event
+ */
+export type TokenUsageDelta = {
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalTokens: number;
+};
+
+/**
+ * Token usage event extracted from a session.shutdown's modelMetrics
+ */
+export type TokenUsageEvent = TokenUsageDelta & {
+	timestamp: string;
+	sessionId: string;
+	model: string;
+	requestCount: number;
+	premiumRequestCost: number;
+};
+
+/**
+ * Session metadata extracted from session.start and workspace.yaml
+ */
+export type SessionMetadata = {
+	sessionId: string;
+	cwd: string;
+	gitRoot?: string;
+	repository?: string;
+	branch?: string;
+	copilotVersion: string;
+	startTime: string;
+};
+
+/**
+ * Model usage summary with token counts
+ */
+export type ModelUsage = TokenUsageDelta & {
+	requestCount: number;
+	premiumRequestCost: number;
+};
+
+/**
+ * Daily usage summary
+ */
+export type DailyUsageSummary = {
+	date: string;
+	firstTimestamp: string;
+	costUSD: number;
+	models: Map<string, ModelUsage>;
+} & TokenUsageDelta;
+
+/**
+ * Monthly usage summary
+ */
+export type MonthlyUsageSummary = {
+	month: string;
+	firstTimestamp: string;
+	costUSD: number;
+	models: Map<string, ModelUsage>;
+} & TokenUsageDelta;
+
+/**
+ * Session usage summary
+ */
+export type SessionUsageSummary = {
+	sessionId: string;
+	repository: string;
+	cwd: string;
+	firstTimestamp: string;
+	lastTimestamp: string;
+	costUSD: number;
+	models: Map<string, ModelUsage>;
+} & TokenUsageDelta;
+
+/**
+ * Model pricing information
+ */
+export type ModelPricing = {
+	inputCostPerMToken: number;
+	cachedInputCostPerMToken: number;
+	cacheCreationCostPerMToken: number;
+	outputCostPerMToken: number;
+};
+
+/**
+ * Pricing source interface
+ */
+export type PricingSource = {
+	getPricing: (model: string) => Promise<ModelPricing>;
+};
+
+/**
+ * Daily report row for JSON output
+ */
+export type DailyReportRow = {
+	date: string;
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalTokens: number;
+	costUSD: number;
+	models: Record<string, ModelUsage>;
+};
+
+/**
+ * Monthly report row for JSON output
+ */
+export type MonthlyReportRow = {
+	month: string;
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalTokens: number;
+	costUSD: number;
+	models: Record<string, ModelUsage>;
+};
+
+/**
+ * Session report row for JSON output
+ */
+export type SessionReportRow = {
+	sessionId: string;
+	repository: string;
+	cwd: string;
+	lastActivity: string;
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalTokens: number;
+	costUSD: number;
+	models: Record<string, ModelUsage>;
+};

--- a/apps/copilot/src/commands/daily.ts
+++ b/apps/copilot/src/commands/daily.ts
@@ -39,7 +39,6 @@ export const dailyCommand = define({
 		}
 		const pricingMode: PricingMode = modeValue;
 		const timezone = ctx.values.timezone;
-		// locale reserved for future formatting
 		const sortOrder = ctx.values.order === 'desc' ? 'desc' : 'asc';
 		const showBreakdown = Boolean(ctx.values.breakdown);
 
@@ -72,10 +71,6 @@ export const dailyCommand = define({
 		}
 
 		using pricingSource = new CopilotPricingSource({ offline: Boolean(ctx.values.offline) });
-
-		if (jsonOutput) {
-			logger.level = 0;
-		}
 
 		// Group events by date
 		const eventsByDate = new Map<string, TokenUsageEvent[]>();

--- a/apps/copilot/src/commands/daily.ts
+++ b/apps/copilot/src/commands/daily.ts
@@ -1,0 +1,315 @@
+import type { PricingMode } from '../_consts.ts';
+import type { TokenUsageEvent } from '../_types.ts';
+import process from 'node:process';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	pushBreakdownRows,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { PREMIUM_REQUEST_COST_USD } from '../_consts.ts';
+import {
+	expandUntilForDayComparison,
+	isWithinRange,
+	normalizeFilterDate,
+	toDateKey,
+} from '../_date-utils.ts';
+import { sharedArgs } from '../_shared-args.ts';
+import { loadCopilotUsageEvents } from '../data-loader.ts';
+import { logger } from '../logger.ts';
+import { CopilotPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 8;
+
+export const dailyCommand = define({
+	name: 'daily',
+	description: 'Show Copilot CLI token usage grouped by day',
+	args: sharedArgs,
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+		const modeValue = ctx.values.mode ?? 'premium';
+		if (modeValue !== 'premium' && modeValue !== 'api') {
+			console.error(`Invalid mode "${modeValue}". Use "premium" or "api".`);
+			process.exitCode = 1;
+			return;
+		}
+		const pricingMode: PricingMode = modeValue;
+		const timezone = ctx.values.timezone;
+		// locale reserved for future formatting
+		const sortOrder = ctx.values.order === 'desc' ? 'desc' : 'asc';
+		const showBreakdown = Boolean(ctx.values.breakdown);
+
+		let since: string | undefined;
+		let until: string | undefined;
+		if (ctx.values.since != null) {
+			since = normalizeFilterDate(ctx.values.since);
+		}
+		if (ctx.values.until != null) {
+			until = expandUntilForDayComparison(normalizeFilterDate(ctx.values.until));
+		}
+
+		const { events, missingDirectories } = await loadCopilotUsageEvents();
+
+		for (const missing of missingDirectories) {
+			logger.warn(`Copilot session-state directory not found: ${missing}`);
+		}
+
+		if (jsonOutput) {
+			logger.level = 0;
+		}
+
+		if (events.length === 0) {
+			const output = jsonOutput
+				? JSON.stringify({ daily: [], totals: null, mode: pricingMode, missingDirectories })
+				: 'No Copilot CLI usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using pricingSource = new CopilotPricingSource({ offline: Boolean(ctx.values.offline) });
+
+		if (jsonOutput) {
+			logger.level = 0;
+		}
+
+		// Group events by date
+		const eventsByDate = new Map<string, TokenUsageEvent[]>();
+		for (const event of events) {
+			const date = toDateKey(event.timestamp, timezone);
+			if (!isWithinRange(date, since, until)) {
+				continue;
+			}
+			const existing = eventsByDate.get(date);
+			if (existing != null) {
+				existing.push(event);
+			} else {
+				eventsByDate.set(date, [event]);
+			}
+		}
+
+		const dailyData: Array<{
+			date: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheReadTokens: number;
+			cacheWriteTokens: number;
+			totalTokens: number;
+			premiumRequests: number;
+			premiumCostUSD: number;
+			apiCostUSD: number;
+			modelsUsed: string[];
+			modelBreakdowns: Array<{
+				model: string;
+				inputTokens: number;
+				outputTokens: number;
+				cacheReadTokens: number;
+				cacheWriteTokens: number;
+				cost: number;
+			}>;
+		}> = [];
+
+		for (const [date, dayEvents] of eventsByDate) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheReadTokens = 0;
+			let cacheWriteTokens = 0;
+			let premiumRequests = 0;
+			let apiCostUSD = 0;
+			const modelsSet = new Set<string>();
+			const modelMap = new Map<
+				string,
+				{
+					inputTokens: number;
+					outputTokens: number;
+					cacheReadTokens: number;
+					cacheWriteTokens: number;
+					cost: number;
+				}
+			>();
+
+			for (const event of dayEvents) {
+				inputTokens += event.inputTokens;
+				outputTokens += event.outputTokens;
+				cacheReadTokens += event.cacheReadTokens;
+				cacheWriteTokens += event.cacheWriteTokens;
+				premiumRequests += event.premiumRequestCost;
+
+				let eventCost = 0;
+				if (pricingMode === 'api' || jsonOutput) {
+					eventCost = await pricingSource.calculateCost(event.model, {
+						inputTokens: event.inputTokens,
+						outputTokens: event.outputTokens,
+						cacheReadTokens: event.cacheReadTokens,
+						cacheWriteTokens: event.cacheWriteTokens,
+					});
+					apiCostUSD += eventCost;
+				}
+
+				// In premium mode, use premium request cost for breakdowns
+				const breakdownCost =
+					pricingMode === 'premium'
+						? event.premiumRequestCost * PREMIUM_REQUEST_COST_USD
+						: eventCost;
+
+				// Track per-model breakdown (always, for --breakdown flag)
+				const existing = modelMap.get(event.model);
+				if (existing != null) {
+					existing.inputTokens += event.inputTokens;
+					existing.outputTokens += event.outputTokens;
+					existing.cacheReadTokens += event.cacheReadTokens;
+					existing.cacheWriteTokens += event.cacheWriteTokens;
+					existing.cost += breakdownCost;
+				} else {
+					modelMap.set(event.model, {
+						inputTokens: event.inputTokens,
+						outputTokens: event.outputTokens,
+						cacheReadTokens: event.cacheReadTokens,
+						cacheWriteTokens: event.cacheWriteTokens,
+						cost: breakdownCost,
+					});
+				}
+				modelsSet.add(event.model);
+			}
+
+			const totalTokens = inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens;
+
+			dailyData.push({
+				date,
+				inputTokens,
+				outputTokens,
+				cacheReadTokens,
+				cacheWriteTokens,
+				totalTokens,
+				premiumRequests,
+				premiumCostUSD: premiumRequests * PREMIUM_REQUEST_COST_USD,
+				apiCostUSD,
+				modelsUsed: Array.from(modelsSet),
+				modelBreakdowns: Array.from(modelMap.entries()).map(([model, data]) => ({
+					model,
+					...data,
+				})),
+			});
+		}
+
+		if (sortOrder === 'desc') {
+			dailyData.sort((a, b) => b.date.localeCompare(a.date));
+		} else {
+			dailyData.sort((a, b) => a.date.localeCompare(b.date));
+		}
+
+		const totals = {
+			inputTokens: dailyData.reduce((sum, d) => sum + d.inputTokens, 0),
+			outputTokens: dailyData.reduce((sum, d) => sum + d.outputTokens, 0),
+			cacheReadTokens: dailyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
+			cacheWriteTokens: dailyData.reduce((sum, d) => sum + d.cacheWriteTokens, 0),
+			totalTokens: dailyData.reduce((sum, d) => sum + d.totalTokens, 0),
+			premiumRequests: dailyData.reduce((sum, d) => sum + d.premiumRequests, 0),
+			premiumCostUSD: dailyData.reduce((sum, d) => sum + d.premiumCostUSD, 0),
+			apiCostUSD: dailyData.reduce((sum, d) => sum + d.apiCostUSD, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify(
+					{
+						daily: dailyData,
+						totals,
+						mode: pricingMode,
+						missingDirectories,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		const modeLabel = pricingMode === 'premium' ? 'Premium Requests' : 'API Equivalent';
+		// eslint-disable-next-line no-console
+		console.log(`\n📊 Copilot CLI Token Usage Report - Daily (${modeLabel})\n`);
+
+		const costHeader = pricingMode === 'premium' ? 'Cost (PR)' : 'Cost (API)';
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: [
+				'Date',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Write',
+				'Cache Read',
+				'Total Tokens',
+				costHeader,
+			],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Date', 'Models', 'Input', 'Output', costHeader],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+		});
+
+		for (const data of dailyData) {
+			const costValue =
+				pricingMode === 'premium'
+					? formatCurrency(data.premiumCostUSD)
+					: formatCurrency(data.apiCostUSD);
+
+			table.push([
+				data.date,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheWriteTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				costValue,
+			]);
+
+			if (showBreakdown) {
+				pushBreakdownRows(
+					table,
+					data.modelBreakdowns.map((b) => ({
+						modelName: b.model,
+						inputTokens: b.inputTokens,
+						outputTokens: b.outputTokens,
+						cacheCreationTokens: b.cacheWriteTokens,
+						cacheReadTokens: b.cacheReadTokens,
+						cost: b.cost,
+					})),
+					1,
+				);
+			}
+		}
+
+		const totalCost = pricingMode === 'premium' ? totals.premiumCostUSD : totals.apiCostUSD;
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheWriteTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatCurrency(totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/copilot/src/commands/index.ts
+++ b/apps/copilot/src/commands/index.ts
@@ -1,0 +1,3 @@
+export { dailyCommand } from './daily.ts';
+export { monthlyCommand } from './monthly.ts';
+export { sessionCommand } from './session.ts';

--- a/apps/copilot/src/commands/monthly.ts
+++ b/apps/copilot/src/commands/monthly.ts
@@ -74,10 +74,6 @@ export const monthlyCommand = define({
 
 		using pricingSource = new CopilotPricingSource({ offline: Boolean(ctx.values.offline) });
 
-		if (jsonOutput) {
-			logger.level = 0;
-		}
-
 		// Group events by month, filtering by full date range first
 		const eventsByMonth = new Map<string, TokenUsageEvent[]>();
 		for (const event of events) {

--- a/apps/copilot/src/commands/monthly.ts
+++ b/apps/copilot/src/commands/monthly.ts
@@ -1,0 +1,315 @@
+import type { PricingMode } from '../_consts.ts';
+import type { TokenUsageEvent } from '../_types.ts';
+import process from 'node:process';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	pushBreakdownRows,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { PREMIUM_REQUEST_COST_USD } from '../_consts.ts';
+import {
+	expandUntilForDayComparison,
+	isWithinRange,
+	normalizeFilterDate,
+	toDateKey,
+	toMonthKey,
+} from '../_date-utils.ts';
+import { sharedArgs } from '../_shared-args.ts';
+import { loadCopilotUsageEvents } from '../data-loader.ts';
+import { logger } from '../logger.ts';
+import { CopilotPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 8;
+
+export const monthlyCommand = define({
+	name: 'monthly',
+	description: 'Show Copilot CLI token usage grouped by month',
+	args: sharedArgs,
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+		const modeValue = ctx.values.mode ?? 'premium';
+		if (modeValue !== 'premium' && modeValue !== 'api') {
+			console.error(`Invalid mode "${modeValue}". Use "premium" or "api".`);
+			process.exitCode = 1;
+			return;
+		}
+		const pricingMode: PricingMode = modeValue;
+		const timezone = ctx.values.timezone;
+		const sortOrder = ctx.values.order === 'desc' ? 'desc' : 'asc';
+		const showBreakdown = Boolean(ctx.values.breakdown);
+
+		// Keep full-precision dates for event-level filtering
+		let sinceFull: string | undefined;
+		let untilFull: string | undefined;
+		if (ctx.values.since != null) {
+			sinceFull = normalizeFilterDate(ctx.values.since);
+		}
+		if (ctx.values.until != null) {
+			untilFull = expandUntilForDayComparison(normalizeFilterDate(ctx.values.until));
+		}
+
+		const { events, missingDirectories } = await loadCopilotUsageEvents();
+
+		for (const missing of missingDirectories) {
+			logger.warn(`Copilot session-state directory not found: ${missing}`);
+		}
+
+		if (jsonOutput) {
+			logger.level = 0;
+		}
+
+		if (events.length === 0) {
+			const output = jsonOutput
+				? JSON.stringify({ monthly: [], totals: null, mode: pricingMode, missingDirectories })
+				: 'No Copilot CLI usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using pricingSource = new CopilotPricingSource({ offline: Boolean(ctx.values.offline) });
+
+		if (jsonOutput) {
+			logger.level = 0;
+		}
+
+		// Group events by month, filtering by full date range first
+		const eventsByMonth = new Map<string, TokenUsageEvent[]>();
+		for (const event of events) {
+			const dateKey = toDateKey(event.timestamp, timezone);
+			if (!isWithinRange(dateKey, sinceFull, untilFull)) {
+				continue;
+			}
+			const month = toMonthKey(event.timestamp, timezone);
+			const existing = eventsByMonth.get(month);
+			if (existing != null) {
+				existing.push(event);
+			} else {
+				eventsByMonth.set(month, [event]);
+			}
+		}
+
+		const monthlyData: Array<{
+			month: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheReadTokens: number;
+			cacheWriteTokens: number;
+			totalTokens: number;
+			premiumRequests: number;
+			premiumCostUSD: number;
+			apiCostUSD: number;
+			modelsUsed: string[];
+			modelBreakdowns: Array<{
+				model: string;
+				inputTokens: number;
+				outputTokens: number;
+				cacheReadTokens: number;
+				cacheWriteTokens: number;
+				cost: number;
+			}>;
+		}> = [];
+
+		for (const [month, monthEvents] of eventsByMonth) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheReadTokens = 0;
+			let cacheWriteTokens = 0;
+			let premiumRequests = 0;
+			let apiCostUSD = 0;
+			const modelsSet = new Set<string>();
+			const modelMap = new Map<
+				string,
+				{
+					inputTokens: number;
+					outputTokens: number;
+					cacheReadTokens: number;
+					cacheWriteTokens: number;
+					cost: number;
+				}
+			>();
+
+			for (const event of monthEvents) {
+				inputTokens += event.inputTokens;
+				outputTokens += event.outputTokens;
+				cacheReadTokens += event.cacheReadTokens;
+				cacheWriteTokens += event.cacheWriteTokens;
+				premiumRequests += event.premiumRequestCost;
+
+				let eventCost = 0;
+				if (pricingMode === 'api' || jsonOutput) {
+					eventCost = await pricingSource.calculateCost(event.model, {
+						inputTokens: event.inputTokens,
+						outputTokens: event.outputTokens,
+						cacheReadTokens: event.cacheReadTokens,
+						cacheWriteTokens: event.cacheWriteTokens,
+					});
+					apiCostUSD += eventCost;
+				}
+
+				const breakdownCost =
+					pricingMode === 'premium'
+						? event.premiumRequestCost * PREMIUM_REQUEST_COST_USD
+						: eventCost;
+
+				const existing = modelMap.get(event.model);
+				if (existing != null) {
+					existing.inputTokens += event.inputTokens;
+					existing.outputTokens += event.outputTokens;
+					existing.cacheReadTokens += event.cacheReadTokens;
+					existing.cacheWriteTokens += event.cacheWriteTokens;
+					existing.cost += breakdownCost;
+				} else {
+					modelMap.set(event.model, {
+						inputTokens: event.inputTokens,
+						outputTokens: event.outputTokens,
+						cacheReadTokens: event.cacheReadTokens,
+						cacheWriteTokens: event.cacheWriteTokens,
+						cost: breakdownCost,
+					});
+				}
+				modelsSet.add(event.model);
+			}
+
+			const totalTokens = inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens;
+
+			monthlyData.push({
+				month,
+				inputTokens,
+				outputTokens,
+				cacheReadTokens,
+				cacheWriteTokens,
+				totalTokens,
+				premiumRequests,
+				premiumCostUSD: premiumRequests * PREMIUM_REQUEST_COST_USD,
+				apiCostUSD,
+				modelsUsed: Array.from(modelsSet),
+				modelBreakdowns: Array.from(modelMap.entries()).map(([model, data]) => ({
+					model,
+					...data,
+				})),
+			});
+		}
+
+		if (sortOrder === 'desc') {
+			monthlyData.sort((a, b) => b.month.localeCompare(a.month));
+		} else {
+			monthlyData.sort((a, b) => a.month.localeCompare(b.month));
+		}
+
+		const totals = {
+			inputTokens: monthlyData.reduce((sum, d) => sum + d.inputTokens, 0),
+			outputTokens: monthlyData.reduce((sum, d) => sum + d.outputTokens, 0),
+			cacheReadTokens: monthlyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
+			cacheWriteTokens: monthlyData.reduce((sum, d) => sum + d.cacheWriteTokens, 0),
+			totalTokens: monthlyData.reduce((sum, d) => sum + d.totalTokens, 0),
+			premiumRequests: monthlyData.reduce((sum, d) => sum + d.premiumRequests, 0),
+			premiumCostUSD: monthlyData.reduce((sum, d) => sum + d.premiumCostUSD, 0),
+			apiCostUSD: monthlyData.reduce((sum, d) => sum + d.apiCostUSD, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify(
+					{
+						monthly: monthlyData,
+						totals,
+						mode: pricingMode,
+						missingDirectories,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		const modeLabel = pricingMode === 'premium' ? 'Premium Requests' : 'API Equivalent';
+		// eslint-disable-next-line no-console
+		console.log(`\n📊 Copilot CLI Token Usage Report - Monthly (${modeLabel})\n`);
+
+		const costHeader = pricingMode === 'premium' ? 'Cost (PR)' : 'Cost (API)';
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: [
+				'Month',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Write',
+				'Cache Read',
+				'Total Tokens',
+				costHeader,
+			],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Month', 'Models', 'Input', 'Output', costHeader],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+		});
+
+		for (const data of monthlyData) {
+			const costValue =
+				pricingMode === 'premium'
+					? formatCurrency(data.premiumCostUSD)
+					: formatCurrency(data.apiCostUSD);
+
+			table.push([
+				data.month,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheWriteTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				costValue,
+			]);
+
+			if (showBreakdown) {
+				pushBreakdownRows(
+					table,
+					data.modelBreakdowns.map((b) => ({
+						modelName: b.model,
+						inputTokens: b.inputTokens,
+						outputTokens: b.outputTokens,
+						cacheCreationTokens: b.cacheWriteTokens,
+						cacheReadTokens: b.cacheReadTokens,
+						cost: b.cost,
+					})),
+					1,
+				);
+			}
+		}
+
+		const totalCost = pricingMode === 'premium' ? totals.premiumCostUSD : totals.apiCostUSD;
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheWriteTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatCurrency(totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/copilot/src/commands/session.ts
+++ b/apps/copilot/src/commands/session.ts
@@ -73,10 +73,6 @@ export const sessionCommand = define({
 
 		using pricingSource = new CopilotPricingSource({ offline: Boolean(ctx.values.offline) });
 
-		if (jsonOutput) {
-			logger.level = 0;
-		}
-
 		// Group events by session, filtering by date range
 		const eventsBySession = new Map<string, TokenUsageEvent[]>();
 		for (const event of events) {

--- a/apps/copilot/src/commands/session.ts
+++ b/apps/copilot/src/commands/session.ts
@@ -1,0 +1,338 @@
+import type { PricingMode } from '../_consts.ts';
+import type { TokenUsageEvent } from '../_types.ts';
+import path from 'node:path';
+import process from 'node:process';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	pushBreakdownRows,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { PREMIUM_REQUEST_COST_USD } from '../_consts.ts';
+import {
+	expandUntilForDayComparison,
+	isWithinRange,
+	normalizeFilterDate,
+	toDateKey,
+} from '../_date-utils.ts';
+import { sharedArgs } from '../_shared-args.ts';
+import { loadCopilotUsageEvents } from '../data-loader.ts';
+import { logger } from '../logger.ts';
+import { CopilotPricingSource } from '../pricing.ts';
+
+const TABLE_COLUMN_COUNT = 8;
+
+export const sessionCommand = define({
+	name: 'session',
+	description: 'Show Copilot CLI token usage grouped by session',
+	args: sharedArgs,
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+		const modeValue = ctx.values.mode ?? 'premium';
+		if (modeValue !== 'premium' && modeValue !== 'api') {
+			console.error(`Invalid mode "${modeValue}". Use "premium" or "api".`);
+			process.exitCode = 1;
+			return;
+		}
+		const pricingMode: PricingMode = modeValue;
+		const timezone = ctx.values.timezone;
+		const sortOrder = ctx.values.order === 'desc' ? 'desc' : 'asc';
+		const showBreakdown = Boolean(ctx.values.breakdown);
+
+		let since: string | undefined;
+		let until: string | undefined;
+		if (ctx.values.since != null) {
+			since = normalizeFilterDate(ctx.values.since);
+		}
+		if (ctx.values.until != null) {
+			until = expandUntilForDayComparison(normalizeFilterDate(ctx.values.until));
+		}
+
+		const { events, sessions, missingDirectories } = await loadCopilotUsageEvents();
+
+		for (const missing of missingDirectories) {
+			logger.warn(`Copilot session-state directory not found: ${missing}`);
+		}
+
+		if (jsonOutput) {
+			logger.level = 0;
+		}
+
+		if (events.length === 0) {
+			const output = jsonOutput
+				? JSON.stringify({ sessions: [], totals: null, mode: pricingMode, missingDirectories })
+				: 'No Copilot CLI usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using pricingSource = new CopilotPricingSource({ offline: Boolean(ctx.values.offline) });
+
+		if (jsonOutput) {
+			logger.level = 0;
+		}
+
+		// Group events by session, filtering by date range
+		const eventsBySession = new Map<string, TokenUsageEvent[]>();
+		for (const event of events) {
+			const dateKey = toDateKey(event.timestamp, timezone);
+			if (!isWithinRange(dateKey, since, until)) {
+				continue;
+			}
+			const existing = eventsBySession.get(event.sessionId);
+			if (existing != null) {
+				existing.push(event);
+			} else {
+				eventsBySession.set(event.sessionId, [event]);
+			}
+		}
+
+		const sessionData: Array<{
+			sessionId: string;
+			repository: string;
+			cwd: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheReadTokens: number;
+			cacheWriteTokens: number;
+			totalTokens: number;
+			premiumRequests: number;
+			premiumCostUSD: number;
+			apiCostUSD: number;
+			modelsUsed: string[];
+			modelBreakdowns: Array<{
+				model: string;
+				inputTokens: number;
+				outputTokens: number;
+				cacheReadTokens: number;
+				cacheWriteTokens: number;
+				cost: number;
+			}>;
+			lastActivity: string;
+		}> = [];
+
+		for (const [sessionId, sessionEvents] of eventsBySession) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheReadTokens = 0;
+			let cacheWriteTokens = 0;
+			let premiumRequests = 0;
+			let apiCostUSD = 0;
+			const modelsSet = new Set<string>();
+			const modelMap = new Map<
+				string,
+				{
+					inputTokens: number;
+					outputTokens: number;
+					cacheReadTokens: number;
+					cacheWriteTokens: number;
+					cost: number;
+				}
+			>();
+			let lastActivity = sessionEvents[0]!.timestamp;
+
+			for (const event of sessionEvents) {
+				inputTokens += event.inputTokens;
+				outputTokens += event.outputTokens;
+				cacheReadTokens += event.cacheReadTokens;
+				cacheWriteTokens += event.cacheWriteTokens;
+				premiumRequests += event.premiumRequestCost;
+
+				let eventCost = 0;
+				if (pricingMode === 'api' || jsonOutput) {
+					eventCost = await pricingSource.calculateCost(event.model, {
+						inputTokens: event.inputTokens,
+						outputTokens: event.outputTokens,
+						cacheReadTokens: event.cacheReadTokens,
+						cacheWriteTokens: event.cacheWriteTokens,
+					});
+					apiCostUSD += eventCost;
+				}
+
+				const breakdownCost =
+					pricingMode === 'premium'
+						? event.premiumRequestCost * PREMIUM_REQUEST_COST_USD
+						: eventCost;
+
+				const existing = modelMap.get(event.model);
+				if (existing != null) {
+					existing.inputTokens += event.inputTokens;
+					existing.outputTokens += event.outputTokens;
+					existing.cacheReadTokens += event.cacheReadTokens;
+					existing.cacheWriteTokens += event.cacheWriteTokens;
+					existing.cost += breakdownCost;
+				} else {
+					modelMap.set(event.model, {
+						inputTokens: event.inputTokens,
+						outputTokens: event.outputTokens,
+						cacheReadTokens: event.cacheReadTokens,
+						cacheWriteTokens: event.cacheWriteTokens,
+						cost: breakdownCost,
+					});
+				}
+				modelsSet.add(event.model);
+
+				if (event.timestamp > lastActivity) {
+					lastActivity = event.timestamp;
+				}
+			}
+
+			const totalTokens = inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens;
+			const sessionMeta = sessions.get(sessionId);
+
+			sessionData.push({
+				sessionId,
+				repository: sessionMeta?.repository ?? '',
+				cwd: sessionMeta?.cwd ?? '',
+				inputTokens,
+				outputTokens,
+				cacheReadTokens,
+				cacheWriteTokens,
+				totalTokens,
+				premiumRequests,
+				premiumCostUSD: premiumRequests * PREMIUM_REQUEST_COST_USD,
+				apiCostUSD,
+				modelsUsed: Array.from(modelsSet),
+				modelBreakdowns: Array.from(modelMap.entries()).map(([model, data]) => ({
+					model,
+					...data,
+				})),
+				lastActivity,
+			});
+		}
+
+		if (sortOrder === 'desc') {
+			sessionData.sort((a, b) => b.lastActivity.localeCompare(a.lastActivity));
+		} else {
+			sessionData.sort((a, b) => a.lastActivity.localeCompare(b.lastActivity));
+		}
+
+		const totals = {
+			inputTokens: sessionData.reduce((sum, s) => sum + s.inputTokens, 0),
+			outputTokens: sessionData.reduce((sum, s) => sum + s.outputTokens, 0),
+			cacheReadTokens: sessionData.reduce((sum, s) => sum + s.cacheReadTokens, 0),
+			cacheWriteTokens: sessionData.reduce((sum, s) => sum + s.cacheWriteTokens, 0),
+			totalTokens: sessionData.reduce((sum, s) => sum + s.totalTokens, 0),
+			premiumRequests: sessionData.reduce((sum, s) => sum + s.premiumRequests, 0),
+			premiumCostUSD: sessionData.reduce((sum, s) => sum + s.premiumCostUSD, 0),
+			apiCostUSD: sessionData.reduce((sum, s) => sum + s.apiCostUSD, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify(
+					{
+						sessions: sessionData,
+						totals,
+						mode: pricingMode,
+						missingDirectories,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		const modeLabel = pricingMode === 'premium' ? 'Premium Requests' : 'API Equivalent';
+		// eslint-disable-next-line no-console
+		console.log(`\n📊 Copilot CLI Token Usage Report - Sessions (${modeLabel})\n`);
+
+		const costHeader = pricingMode === 'premium' ? 'Cost (PR)' : 'Cost (API)';
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: [
+				'Session',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Write',
+				'Cache Read',
+				'Total Tokens',
+				costHeader,
+			],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Session', 'Models', 'Input', 'Output', costHeader],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+		});
+
+		for (const data of sessionData) {
+			// Handle both POSIX and Windows paths regardless of current platform
+			const normalizedCwd = data.cwd.replaceAll('\\', '/');
+			const cwdBasename = path.posix.basename(normalizedCwd);
+			const displayLabel =
+				data.repository !== ''
+					? data.repository
+					: cwdBasename !== ''
+						? cwdBasename
+						: data.sessionId.slice(0, 8);
+
+			const truncatedLabel =
+				displayLabel.length > 30 ? `${displayLabel.slice(0, 27)}...` : displayLabel;
+
+			const costValue =
+				pricingMode === 'premium'
+					? formatCurrency(data.premiumCostUSD)
+					: formatCurrency(data.apiCostUSD);
+
+			table.push([
+				truncatedLabel,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheWriteTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				costValue,
+			]);
+
+			if (showBreakdown) {
+				pushBreakdownRows(
+					table,
+					data.modelBreakdowns.map((b) => ({
+						modelName: b.model,
+						inputTokens: b.inputTokens,
+						outputTokens: b.outputTokens,
+						cacheCreationTokens: b.cacheWriteTokens,
+						cacheReadTokens: b.cacheReadTokens,
+						cost: b.cost,
+					})),
+					1,
+				);
+			}
+		}
+
+		const totalCost = pricingMode === 'premium' ? totals.premiumCostUSD : totals.apiCostUSD;
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheWriteTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatCurrency(totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/copilot/src/data-loader.ts
+++ b/apps/copilot/src/data-loader.ts
@@ -1,0 +1,654 @@
+/**
+ * @fileoverview Data loading utilities for GitHub Copilot CLI usage analysis
+ *
+ * This module provides functions for loading and parsing Copilot CLI usage data
+ * from events.jsonl files stored in Copilot session-state directories.
+ * Copilot CLI stores data in ~/.copilot/session-state/{sessionId}/events.jsonl
+ *
+ * Usage data is extracted from session.shutdown events, which contain
+ * aggregated per-model token metrics for each session segment.
+ *
+ * @module data-loader
+ */
+
+import type { SessionMetadata, TokenUsageEvent } from './_types.ts';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { Result } from '@praha/byethrow';
+import { createFixture } from 'fs-fixture';
+import { isDirectorySync } from 'path-type';
+import * as v from 'valibot';
+import {
+	COPILOT_CONFIG_DIR_ENV,
+	DEFAULT_COPILOT_DIR,
+	EVENTS_FILENAME,
+	SESSION_STATE_DIR_NAME,
+	WORKSPACE_FILENAME,
+} from './_consts.ts';
+import { logger } from './logger.ts';
+
+/**
+ * session.start event context schema
+ */
+const sessionStartContextSchema = v.object({
+	cwd: v.string(),
+	gitRoot: v.optional(v.string()),
+	repository: v.optional(v.string()),
+	branch: v.optional(v.string()),
+});
+
+/**
+ * session.start event data schema
+ */
+const sessionStartDataSchema = v.object({
+	sessionId: v.string(),
+	version: v.number(),
+	producer: v.string(),
+	copilotVersion: v.string(),
+	startTime: v.string(),
+	selectedModel: v.optional(v.string()),
+	context: v.optional(sessionStartContextSchema),
+});
+
+/**
+ * Model metrics usage schema within session.shutdown
+ */
+const modelUsageSchema = v.object({
+	inputTokens: v.optional(v.number(), 0),
+	outputTokens: v.optional(v.number(), 0),
+	cacheReadTokens: v.optional(v.number(), 0),
+	cacheWriteTokens: v.optional(v.number(), 0),
+});
+
+/**
+ * Model metrics requests schema within session.shutdown
+ */
+const modelRequestsSchema = v.object({
+	count: v.optional(v.number(), 0),
+	cost: v.optional(v.number(), 0),
+});
+
+/**
+ * Per-model metrics schema within session.shutdown
+ */
+const modelMetricsEntrySchema = v.object({
+	requests: v.optional(modelRequestsSchema),
+	usage: v.optional(modelUsageSchema),
+});
+
+/**
+ * session.shutdown event data schema
+ */
+const sessionShutdownDataSchema = v.object({
+	shutdownType: v.optional(v.string()),
+	totalPremiumRequests: v.optional(v.number()),
+	totalApiDurationMs: v.optional(v.number()),
+	currentModel: v.optional(v.string()),
+	modelMetrics: v.optional(v.record(v.string(), modelMetricsEntrySchema)),
+});
+
+/**
+ * Generic event wrapper schema (type discriminated)
+ */
+const eventSchema = v.object({
+	id: v.string(),
+	timestamp: v.string(),
+	type: v.string(),
+	data: v.optional(v.unknown()),
+	parentId: v.optional(v.nullable(v.string())),
+});
+
+type ParsedEvent = v.InferOutput<typeof eventSchema>;
+
+/**
+ * Get Copilot data directory
+ * @returns Path to Copilot data directory, or null if not found
+ */
+export function getCopilotPath(): string | null {
+	const envPath = process.env[COPILOT_CONFIG_DIR_ENV];
+	if (envPath != null && envPath.trim() !== '') {
+		const normalizedPath = path.resolve(envPath);
+		if (isDirectorySync(normalizedPath)) {
+			return normalizedPath;
+		}
+		// Env var is set but invalid — warn and don't fall through to default
+		logger.warn(
+			`${COPILOT_CONFIG_DIR_ENV} is set to "${envPath}" but the directory does not exist. Ignoring.`,
+		);
+		return null;
+	}
+
+	if (isDirectorySync(DEFAULT_COPILOT_DIR)) {
+		return DEFAULT_COPILOT_DIR;
+	}
+
+	return null;
+}
+
+/**
+ * Parse a single line of events.jsonl
+ */
+function parseEventLine(line: string): ParsedEvent | null {
+	const trimmed = line.trim();
+	if (trimmed === '') {
+		return null;
+	}
+
+	const parseResult = Result.try({
+		try: () => JSON.parse(trimmed) as unknown,
+		catch: (error) => error,
+	})();
+
+	if (Result.isFailure(parseResult)) {
+		return null;
+	}
+
+	const validationResult = v.safeParse(eventSchema, parseResult.value);
+	if (!validationResult.success) {
+		return null;
+	}
+
+	return validationResult.output;
+}
+
+/**
+ * Extract session metadata from a session.start event
+ */
+function extractSessionMetadata(sessionId: string, event: ParsedEvent): SessionMetadata | null {
+	const dataResult = v.safeParse(sessionStartDataSchema, event.data);
+	if (!dataResult.success) {
+		return null;
+	}
+
+	const data = dataResult.output;
+	return {
+		sessionId,
+		cwd: data.context?.cwd ?? '',
+		gitRoot: data.context?.gitRoot,
+		repository: data.context?.repository,
+		branch: data.context?.branch,
+		copilotVersion: data.copilotVersion,
+		startTime: data.startTime,
+	};
+}
+
+/**
+ * Extract token usage events from a session.shutdown event
+ */
+function extractUsageEvents(sessionId: string, event: ParsedEvent): TokenUsageEvent[] {
+	const dataResult = v.safeParse(sessionShutdownDataSchema, event.data);
+	if (!dataResult.success) {
+		return [];
+	}
+
+	const data = dataResult.output;
+	const modelMetrics = data.modelMetrics;
+	if (modelMetrics == null) {
+		return [];
+	}
+
+	const events: TokenUsageEvent[] = [];
+
+	for (const [model, metrics] of Object.entries(modelMetrics)) {
+		const usage = metrics.usage;
+		if (usage == null) {
+			continue;
+		}
+
+		const inputTokens = usage.inputTokens ?? 0;
+		const outputTokens = usage.outputTokens ?? 0;
+		const cacheReadTokens = usage.cacheReadTokens ?? 0;
+		const cacheWriteTokens = usage.cacheWriteTokens ?? 0;
+
+		if (
+			inputTokens === 0 &&
+			outputTokens === 0 &&
+			cacheReadTokens === 0 &&
+			cacheWriteTokens === 0 &&
+			(metrics.requests?.count ?? 0) === 0
+		) {
+			continue;
+		}
+
+		events.push({
+			timestamp: event.timestamp,
+			sessionId,
+			model,
+			inputTokens,
+			outputTokens,
+			cacheReadTokens,
+			cacheWriteTokens,
+			totalTokens: inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens,
+			requestCount: metrics.requests?.count ?? 0,
+			premiumRequestCost: metrics.requests?.cost ?? 0,
+		});
+	}
+
+	return events;
+}
+
+/**
+ * Parse workspace.yaml for session metadata (simple key: value format)
+ */
+async function parseWorkspaceYaml(
+	sessionDir: string,
+	sessionId: string,
+): Promise<SessionMetadata | null> {
+	const workspacePath = path.join(sessionDir, WORKSPACE_FILENAME);
+
+	const readResult = await Result.try({
+		try: readFile(workspacePath, 'utf-8'),
+		catch: (error) => error,
+	});
+
+	if (Result.isFailure(readResult)) {
+		return null;
+	}
+
+	const fields: Record<string, string> = {};
+	for (const line of readResult.value.split('\n')) {
+		const colonIndex = line.indexOf(':');
+		if (colonIndex > 0) {
+			const key = line.slice(0, colonIndex).trim();
+			const value = line.slice(colonIndex + 1).trim();
+			fields[key] = value;
+		}
+	}
+
+	return {
+		sessionId,
+		cwd: fields.cwd ?? '',
+		gitRoot: fields.git_root,
+		repository: fields.repository,
+		branch: fields.branch,
+		copilotVersion: '',
+		startTime: fields.created_at ?? '',
+	};
+}
+
+/**
+ * Load events from a single session directory
+ */
+async function loadSessionEvents(
+	sessionDir: string,
+	sessionId: string,
+): Promise<{ events: TokenUsageEvent[]; metadata: SessionMetadata | null }> {
+	const eventsPath = path.join(sessionDir, EVENTS_FILENAME);
+
+	const readResult = await Result.try({
+		try: readFile(eventsPath, 'utf-8'),
+		catch: (error) => error,
+	});
+
+	if (Result.isFailure(readResult)) {
+		logger.debug('Failed to read events file', { eventsPath, error: readResult.error });
+		return { events: [], metadata: null };
+	}
+
+	const lines = readResult.value.split('\n');
+	const events: TokenUsageEvent[] = [];
+	let metadata: SessionMetadata | null = null;
+
+	for (const line of lines) {
+		const event = parseEventLine(line);
+		if (event == null) {
+			continue;
+		}
+
+		if (event.type === 'session.start' && metadata == null) {
+			metadata = extractSessionMetadata(sessionId, event);
+		} else if (event.type === 'session.shutdown') {
+			const shutdownEvents = extractUsageEvents(sessionId, event);
+			events.push(...shutdownEvents);
+		}
+	}
+
+	// Enrich metadata from workspace.yaml (has repository/branch when session.start may not)
+	const workspaceMetadata = await parseWorkspaceYaml(sessionDir, sessionId);
+	if (workspaceMetadata != null) {
+		if (metadata == null) {
+			metadata = workspaceMetadata;
+		} else {
+			metadata.repository = metadata.repository ?? workspaceMetadata.repository;
+			metadata.gitRoot = metadata.gitRoot ?? workspaceMetadata.gitRoot;
+			metadata.branch = metadata.branch ?? workspaceMetadata.branch;
+			if (metadata.cwd === '') {
+				metadata.cwd = workspaceMetadata.cwd;
+			}
+		}
+	}
+
+	return { events, metadata };
+}
+
+export type LoadOptions = {
+	sessionStateDirs?: string[];
+};
+
+export type LoadResult = {
+	events: TokenUsageEvent[];
+	sessions: Map<string, SessionMetadata>;
+	missingDirectories: string[];
+};
+
+/**
+ * Load all Copilot CLI usage events from session-state directories
+ */
+export async function loadCopilotUsageEvents(options: LoadOptions = {}): Promise<LoadResult> {
+	const copilotPath = getCopilotPath();
+	const providedDirs =
+		options.sessionStateDirs != null && options.sessionStateDirs.length > 0
+			? options.sessionStateDirs.map((dir) => path.resolve(dir))
+			: undefined;
+
+	const defaultSessionStateDir =
+		copilotPath != null ? path.join(copilotPath, SESSION_STATE_DIR_NAME) : null;
+
+	// When env var is set but invalid, report the expected session-state path as missing
+	const envPath = process.env[COPILOT_CONFIG_DIR_ENV];
+	const envSessionStateDir =
+		envPath != null && envPath.trim() !== '' && copilotPath == null
+			? path.join(path.resolve(envPath), SESSION_STATE_DIR_NAME)
+			: null;
+
+	const sessionStateDirs =
+		providedDirs ??
+		(defaultSessionStateDir != null
+			? [defaultSessionStateDir]
+			: envSessionStateDir != null
+				? [envSessionStateDir]
+				: []);
+
+	const events: TokenUsageEvent[] = [];
+	const sessions = new Map<string, SessionMetadata>();
+	const missingDirectories: string[] = [];
+
+	for (const dir of sessionStateDirs) {
+		if (!isDirectorySync(dir)) {
+			missingDirectories.push(dir);
+			continue;
+		}
+
+		const readResult = await Result.try({
+			try: readdir(dir),
+			catch: (error) => error,
+		});
+
+		if (Result.isFailure(readResult)) {
+			logger.debug('Failed to read session-state directory', { dir, error: readResult.error });
+			continue;
+		}
+
+		const entries = readResult.value;
+
+		for (const entry of entries) {
+			const sessionDir = path.join(dir, entry);
+			if (!isDirectorySync(sessionDir)) {
+				continue;
+			}
+
+			const { events: sessionEvents, metadata } = await loadSessionEvents(sessionDir, entry);
+
+			if (metadata != null) {
+				sessions.set(entry, metadata);
+			}
+
+			events.push(...sessionEvents);
+		}
+	}
+
+	// Sort events by timestamp
+	events.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+	return { events, sessions, missingDirectories };
+}
+
+if (import.meta.vitest != null) {
+	describe('loadCopilotUsageEvents', () => {
+		it('parses events.jsonl and extracts usage events from session.shutdown', async () => {
+			const eventsContent = [
+				JSON.stringify({
+					id: 'evt-1',
+					timestamp: '2026-03-15T10:00:00.000Z',
+					type: 'session.start',
+					parentId: null,
+					data: {
+						sessionId: 'test-session-001',
+						version: 1,
+						producer: 'copilot-agent',
+						copilotVersion: '1.0.0',
+						startTime: '2026-03-15T10:00:00.000Z',
+						context: {
+							cwd: '/home/user/project',
+							gitRoot: '/home/user/project',
+							repository: 'user/project',
+							branch: 'main',
+						},
+					},
+				}),
+				JSON.stringify({
+					id: 'evt-2',
+					timestamp: '2026-03-15T11:00:00.000Z',
+					type: 'session.shutdown',
+					parentId: 'evt-1',
+					data: {
+						shutdownType: 'routine',
+						totalPremiumRequests: 5,
+						totalApiDurationMs: 30000,
+						currentModel: 'claude-opus-4.6-1m',
+						modelMetrics: {
+							'claude-opus-4.6-1m': {
+								requests: { count: 3, cost: 5 },
+								usage: {
+									inputTokens: 10000,
+									outputTokens: 500,
+									cacheReadTokens: 8000,
+									cacheWriteTokens: 0,
+								},
+							},
+							'claude-sonnet-4.5': {
+								requests: { count: 2, cost: 0 },
+								usage: {
+									inputTokens: 5000,
+									outputTokens: 200,
+									cacheReadTokens: 3000,
+									cacheWriteTokens: 0,
+								},
+							},
+						},
+					},
+				}),
+			].join('\n');
+
+			await using fixture = await createFixture({
+				'session-state': {
+					'test-session-001': {
+						'events.jsonl': eventsContent,
+					},
+				},
+			});
+
+			const { events, sessions, missingDirectories } = await loadCopilotUsageEvents({
+				sessionStateDirs: [fixture.getPath('session-state')],
+			});
+
+			expect(missingDirectories).toEqual([]);
+			expect(events).toHaveLength(2);
+
+			const opusEvent = events.find((e) => e.model === 'claude-opus-4.6-1m')!;
+			expect(opusEvent.sessionId).toBe('test-session-001');
+			expect(opusEvent.inputTokens).toBe(10000);
+			expect(opusEvent.outputTokens).toBe(500);
+			expect(opusEvent.cacheReadTokens).toBe(8000);
+			expect(opusEvent.requestCount).toBe(3);
+			expect(opusEvent.premiumRequestCost).toBe(5);
+
+			const sonnetEvent = events.find((e) => e.model === 'claude-sonnet-4.5')!;
+			expect(sonnetEvent.inputTokens).toBe(5000);
+			expect(sonnetEvent.outputTokens).toBe(200);
+			expect(sonnetEvent.cacheReadTokens).toBe(3000);
+
+			const session = sessions.get('test-session-001')!;
+			expect(session.repository).toBe('user/project');
+			expect(session.cwd).toBe('/home/user/project');
+			expect(session.copilotVersion).toBe('1.0.0');
+		});
+
+		it('handles missing directories gracefully', async () => {
+			const { events, missingDirectories } = await loadCopilotUsageEvents({
+				sessionStateDirs: ['/nonexistent/path'],
+			});
+
+			expect(events).toEqual([]);
+			expect(missingDirectories).toContain(path.resolve('/nonexistent/path'));
+		});
+
+		it('handles malformed JSONL gracefully', async () => {
+			await using fixture = await createFixture({
+				'session-state': {
+					'bad-session': {
+						'events.jsonl': 'not valid json\n{also bad\n',
+					},
+				},
+			});
+
+			const { events } = await loadCopilotUsageEvents({
+				sessionStateDirs: [fixture.getPath('session-state')],
+			});
+
+			expect(events).toEqual([]);
+		});
+
+		it('handles sessions with empty modelMetrics', async () => {
+			const eventsContent = [
+				JSON.stringify({
+					id: 'evt-1',
+					timestamp: '2026-03-15T10:00:00.000Z',
+					type: 'session.start',
+					parentId: null,
+					data: {
+						sessionId: 'empty-session',
+						version: 1,
+						producer: 'copilot-agent',
+						copilotVersion: '1.0.0',
+						startTime: '2026-03-15T10:00:00.000Z',
+					},
+				}),
+				JSON.stringify({
+					id: 'evt-2',
+					timestamp: '2026-03-15T10:01:00.000Z',
+					type: 'session.shutdown',
+					parentId: 'evt-1',
+					data: {
+						shutdownType: 'routine',
+						totalPremiumRequests: 0,
+						totalApiDurationMs: 0,
+						currentModel: 'claude-opus-4.6-1m',
+						modelMetrics: {},
+					},
+				}),
+			].join('\n');
+
+			await using fixture = await createFixture({
+				'session-state': {
+					'empty-session': {
+						'events.jsonl': eventsContent,
+					},
+				},
+			});
+
+			const { events, sessions } = await loadCopilotUsageEvents({
+				sessionStateDirs: [fixture.getPath('session-state')],
+			});
+
+			expect(events).toEqual([]);
+			expect(sessions.get('empty-session')).toBeDefined();
+		});
+
+		it('handles multiple shutdowns in one session (resume/shutdown cycles)', async () => {
+			const eventsContent = [
+				JSON.stringify({
+					id: 'evt-1',
+					timestamp: '2026-03-15T10:00:00.000Z',
+					type: 'session.start',
+					parentId: null,
+					data: {
+						sessionId: 'multi-shutdown',
+						version: 1,
+						producer: 'copilot-agent',
+						copilotVersion: '1.0.0',
+						startTime: '2026-03-15T10:00:00.000Z',
+						context: { cwd: '/home/user/project' },
+					},
+				}),
+				JSON.stringify({
+					id: 'evt-2',
+					timestamp: '2026-03-15T12:00:00.000Z',
+					type: 'session.shutdown',
+					parentId: 'evt-1',
+					data: {
+						shutdownType: 'routine',
+						modelMetrics: {
+							'claude-opus-4.6-1m': {
+								requests: { count: 5, cost: 3 },
+								usage: {
+									inputTokens: 20000,
+									outputTokens: 1000,
+									cacheReadTokens: 15000,
+									cacheWriteTokens: 0,
+								},
+							},
+						},
+					},
+				}),
+				JSON.stringify({
+					id: 'evt-3',
+					timestamp: '2026-03-16T09:00:00.000Z',
+					type: 'session.shutdown',
+					parentId: 'evt-1',
+					data: {
+						shutdownType: 'routine',
+						modelMetrics: {
+							'gpt-5.4': {
+								requests: { count: 2, cost: 0 },
+								usage: {
+									inputTokens: 8000,
+									outputTokens: 400,
+									cacheReadTokens: 5000,
+									cacheWriteTokens: 0,
+								},
+							},
+						},
+					},
+				}),
+			].join('\n');
+
+			await using fixture = await createFixture({
+				'session-state': {
+					'multi-shutdown': {
+						'events.jsonl': eventsContent,
+					},
+				},
+			});
+
+			const { events } = await loadCopilotUsageEvents({
+				sessionStateDirs: [fixture.getPath('session-state')],
+			});
+
+			expect(events).toHaveLength(2);
+
+			// First shutdown on March 15
+			const firstEvent = events[0]!;
+			expect(firstEvent.model).toBe('claude-opus-4.6-1m');
+			expect(firstEvent.timestamp).toBe('2026-03-15T12:00:00.000Z');
+			expect(firstEvent.inputTokens).toBe(20000);
+
+			// Second shutdown on March 16
+			const secondEvent = events[1]!;
+			expect(secondEvent.model).toBe('gpt-5.4');
+			expect(secondEvent.timestamp).toBe('2026-03-16T09:00:00.000Z');
+			expect(secondEvent.inputTokens).toBe(8000);
+		});
+	});
+}

--- a/apps/copilot/src/data-loader.ts
+++ b/apps/copilot/src/data-loader.ts
@@ -196,10 +196,10 @@ function extractUsageEvents(sessionId: string, event: ParsedEvent): TokenUsageEv
 			continue;
 		}
 
-		const inputTokens = usage.inputTokens ?? 0;
-		const outputTokens = usage.outputTokens ?? 0;
-		const cacheReadTokens = usage.cacheReadTokens ?? 0;
-		const cacheWriteTokens = usage.cacheWriteTokens ?? 0;
+		const inputTokens = usage.inputTokens;
+		const outputTokens = usage.outputTokens;
+		const cacheReadTokens = usage.cacheReadTokens;
+		const cacheWriteTokens = usage.cacheWriteTokens;
 
 		if (
 			inputTokens === 0 &&

--- a/apps/copilot/src/index.ts
+++ b/apps/copilot/src/index.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { run } from './run.ts';
+
+// eslint-disable-next-line antfu/no-top-level-await
+await run();

--- a/apps/copilot/src/logger.ts
+++ b/apps/copilot/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@ccusage/internal/logger';
+
+export const logger = createLogger('@ccusage/copilot');

--- a/apps/copilot/src/pricing.ts
+++ b/apps/copilot/src/pricing.ts
@@ -1,0 +1,222 @@
+import type { LiteLLMModelPricing } from '@ccusage/internal/pricing';
+import type { ModelPricing, PricingSource } from './_types.ts';
+import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
+import { Result } from '@praha/byethrow';
+import { MILLION } from './_consts.ts';
+import { prefetchCopilotPricing } from './_macro.ts' with { type: 'macro' };
+import { logger } from './logger.ts';
+
+const COPILOT_PROVIDER_PREFIXES = ['anthropic/', 'openai/'];
+const ZERO_MODEL_PRICING = {
+	inputCostPerMToken: 0,
+	cachedInputCostPerMToken: 0,
+	cacheCreationCostPerMToken: 0,
+	outputCostPerMToken: 0,
+} as const satisfies ModelPricing;
+
+function toPerMillion(value: number | undefined, fallback?: number): number {
+	const perToken = value ?? fallback ?? 0;
+	return perToken * MILLION;
+}
+
+/**
+ * Normalize Copilot CLI model names to LiteLLM format.
+ *
+ * Copilot uses dot-notation (claude-opus-4.6) while LiteLLM uses
+ * dash-notation (claude-opus-4-6). Also strips variant suffixes
+ * like "-1m" that don't have separate LiteLLM entries.
+ */
+export function normalizeCopilotModelName(model: string): string {
+	// Strip known variant suffixes (e.g., "-1m" for extended context)
+	let normalized = model.replace(/-1m$/i, '');
+
+	// For Claude models: convert dots to dashes in version numbers
+	// e.g., "claude-opus-4.6" → "claude-opus-4-6"
+	// But NOT for GPT models where dots are standard (gpt-5.4 works as-is)
+	if (normalized.startsWith('claude-')) {
+		normalized = normalized.replace(/(\d+)\.(\d+)/g, '$1-$2');
+	}
+
+	return normalized;
+}
+
+export type CopilotPricingSourceOptions = {
+	offline?: boolean;
+	offlineLoader?: () => Promise<Record<string, LiteLLMModelPricing>>;
+};
+
+const PREFETCHED_COPILOT_PRICING = prefetchCopilotPricing();
+
+export class CopilotPricingSource implements PricingSource, Disposable {
+	private readonly fetcher: LiteLLMPricingFetcher;
+
+	constructor(options: CopilotPricingSourceOptions = {}) {
+		this.fetcher = new LiteLLMPricingFetcher({
+			offline: options.offline ?? false,
+			offlineLoader: options.offlineLoader ?? (async () => PREFETCHED_COPILOT_PRICING),
+			logger,
+			providerPrefixes: COPILOT_PROVIDER_PREFIXES,
+		});
+	}
+
+	[Symbol.dispose](): void {
+		this.fetcher[Symbol.dispose]();
+	}
+
+	async getPricing(model: string): Promise<ModelPricing> {
+		const normalized = normalizeCopilotModelName(model);
+		const directLookup = await this.fetcher.getModelPricing(normalized);
+		if (Result.isFailure(directLookup)) {
+			throw directLookup.error;
+		}
+
+		const pricing = directLookup.value;
+		if (pricing == null) {
+			logger.warn(
+				`Pricing not found for model ${model} (normalized: ${normalized}); defaulting to zero-cost pricing.`,
+			);
+			return ZERO_MODEL_PRICING;
+		}
+
+		return {
+			inputCostPerMToken: toPerMillion(pricing.input_cost_per_token),
+			cachedInputCostPerMToken: toPerMillion(
+				pricing.cache_read_input_token_cost,
+				pricing.input_cost_per_token,
+			),
+			cacheCreationCostPerMToken: toPerMillion(
+				pricing.cache_creation_input_token_cost,
+				pricing.input_cost_per_token,
+			),
+			outputCostPerMToken: toPerMillion(pricing.output_cost_per_token),
+		};
+	}
+
+	async calculateCost(
+		model: string,
+		tokens: {
+			inputTokens: number;
+			outputTokens: number;
+			cacheWriteTokens?: number;
+			cacheReadTokens?: number;
+		},
+	): Promise<number> {
+		const normalized = normalizeCopilotModelName(model);
+		const result = await this.fetcher.calculateCostFromTokens(
+			{
+				input_tokens: tokens.inputTokens,
+				output_tokens: tokens.outputTokens,
+				cache_creation_input_tokens: tokens.cacheWriteTokens,
+				cache_read_input_tokens: tokens.cacheReadTokens,
+			},
+			normalized,
+		);
+
+		if (Result.isFailure(result)) {
+			logger.warn(
+				`Failed to calculate cost for model ${model} (normalized: ${normalized}):`,
+				result.error,
+			);
+			return 0;
+		}
+
+		return result.value;
+	}
+}
+
+if (import.meta.vitest != null) {
+	describe('normalizeCopilotModelName', () => {
+		it('converts dots to dashes for Claude models', () => {
+			expect(normalizeCopilotModelName('claude-opus-4.6')).toBe('claude-opus-4-6');
+			expect(normalizeCopilotModelName('claude-sonnet-4.5')).toBe('claude-sonnet-4-5');
+			expect(normalizeCopilotModelName('claude-haiku-4.5')).toBe('claude-haiku-4-5');
+		});
+
+		it('strips -1m variant suffix', () => {
+			expect(normalizeCopilotModelName('claude-opus-4.6-1m')).toBe('claude-opus-4-6');
+		});
+
+		it('preserves GPT model names (dots are standard)', () => {
+			expect(normalizeCopilotModelName('gpt-5.4')).toBe('gpt-5.4');
+			expect(normalizeCopilotModelName('gpt-5.2')).toBe('gpt-5.2');
+			expect(normalizeCopilotModelName('gpt-5.1')).toBe('gpt-5.1');
+		});
+
+		it('passes through unknown models unchanged', () => {
+			expect(normalizeCopilotModelName('goldeneye')).toBe('goldeneye');
+		});
+	});
+
+	describe('CopilotPricingSource', () => {
+		it('converts LiteLLM pricing to per-million costs', async () => {
+			using source = new CopilotPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'claude-opus-4-6': {
+						input_cost_per_token: 1e-6,
+						output_cost_per_token: 5e-6,
+						cache_read_input_token_cost: 1e-7,
+						cache_creation_input_token_cost: 1.25e-6,
+					},
+				}),
+			});
+
+			// Pass the Copilot model name — normalization should resolve it
+			const pricing = await source.getPricing('claude-opus-4.6');
+			expect(pricing.inputCostPerMToken).toBeCloseTo(1);
+			expect(pricing.outputCostPerMToken).toBeCloseTo(5);
+			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.1);
+			expect(pricing.cacheCreationCostPerMToken).toBeCloseTo(1.25);
+		});
+
+		it('resolves -1m variant to base model pricing', async () => {
+			using source = new CopilotPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'claude-opus-4-6': {
+						input_cost_per_token: 5e-6,
+						output_cost_per_token: 2.5e-5,
+					},
+				}),
+			});
+
+			const pricing = await source.getPricing('claude-opus-4.6-1m');
+			expect(pricing.inputCostPerMToken).toBeCloseTo(5);
+			expect(pricing.outputCostPerMToken).toBeCloseTo(25);
+		});
+
+		it('calculates cost from tokens with normalized model name', async () => {
+			using source = new CopilotPricingSource({
+				offline: true,
+				offlineLoader: async () => ({
+					'claude-opus-4-6': {
+						input_cost_per_token: 1e-6,
+						output_cost_per_token: 5e-6,
+						cache_read_input_token_cost: 1e-7,
+						cache_creation_input_token_cost: 1.25e-6,
+					},
+				}),
+			});
+
+			const cost = await source.calculateCost('claude-opus-4.6', {
+				inputTokens: 1000,
+				outputTokens: 500,
+				cacheReadTokens: 200,
+				cacheWriteTokens: 100,
+			});
+
+			const expected = 1000 * 1e-6 + 500 * 5e-6 + 200 * 1e-7 + 100 * 1.25e-6;
+			expect(cost).toBeCloseTo(expected);
+		});
+
+		it('falls back to zero pricing for unknown models', async () => {
+			using source = new CopilotPricingSource({
+				offline: true,
+				offlineLoader: async () => ({}),
+			});
+
+			const pricing = await source.getPricing('unknown-model');
+			expect(pricing).toEqual(ZERO_MODEL_PRICING);
+		});
+	});
+}

--- a/apps/copilot/src/run.ts
+++ b/apps/copilot/src/run.ts
@@ -1,0 +1,29 @@
+import process from 'node:process';
+import { cli } from 'gunshi';
+import { description, name, version } from '../package.json';
+import { dailyCommand, monthlyCommand, sessionCommand } from './commands/index.ts';
+
+const subCommands = new Map([
+	['daily', dailyCommand],
+	['monthly', monthlyCommand],
+	['session', sessionCommand],
+]);
+
+const mainCommand = dailyCommand;
+
+export async function run(): Promise<void> {
+	// When invoked through npx, the binary name might be passed as the first argument
+	// Filter it out if it matches the expected binary name
+	let args = process.argv.slice(2);
+	if (args[0] === 'ccusage-copilot') {
+		args = args.slice(1);
+	}
+
+	await cli(args, mainCommand, {
+		name,
+		version,
+		description,
+		subCommands,
+		renderHeader: null,
+	});
+}

--- a/apps/copilot/tsconfig.json
+++ b/apps/copilot/tsconfig.json
@@ -1,0 +1,25 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"lib": ["ESNext"],
+		"moduleDetection": "force",
+		"module": "Preserve",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"types": ["vitest/globals", "vitest/importMeta"],
+		"allowImportingTsExtensions": true,
+		"allowJs": false,
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": false,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noEmit": true,
+		"verbatimModuleSyntax": true,
+		"erasableSyntaxOnly": true,
+		"skipLibCheck": true
+	},
+	"exclude": ["dist"]
+}

--- a/apps/copilot/tsdown.config.ts
+++ b/apps/copilot/tsdown.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'tsdown';
+import Macros from 'unplugin-macros/rolldown';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	outDir: 'dist',
+	format: 'esm',
+	clean: true,
+	sourcemap: false,
+	minify: 'dce-only',
+	treeshake: true,
+	dts: false,
+	publint: true,
+	unused: true,
+	fixedExtension: false,
+	nodeProtocol: true,
+	plugins: [
+		Macros({
+			include: ['src/index.ts', 'src/pricing.ts'],
+		}),
+	],
+	define: {
+		'import.meta.vitest': 'undefined',
+	},
+});

--- a/apps/copilot/vitest.config.ts
+++ b/apps/copilot/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		includeSource: ['src/**/*.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+		},
+	},
+	define: {
+		'import.meta.vitest': 'undefined',
+	},
+});

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -89,6 +89,10 @@ export default defineConfig({
 					items: [{ text: 'Overview', link: '/guide/opencode/' }],
 				},
 				{
+					text: 'Copilot CLI (Beta)',
+					items: [{ text: 'Overview', link: '/guide/copilot/' }],
+				},
+				{
 					text: 'Configuration',
 					items: [
 						{ text: 'Overview', link: '/guide/configuration' },

--- a/docs/guide/copilot/index.md
+++ b/docs/guide/copilot/index.md
@@ -1,0 +1,163 @@
+# Copilot CLI Overview
+
+The `@ccusage/copilot` package analyzes [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) session usage, tracking token counts and costs across both Claude and GPT models.
+
+## What is Copilot CLI?
+
+GitHub Copilot CLI is a terminal-based AI coding agent that supports multiple model providers (Anthropic Claude, OpenAI GPT). The `@ccusage/copilot` package reads the local session data to give you a clear view of your usage.
+
+## Installation & Launch
+
+```bash
+# Recommended - always include @latest
+npx @ccusage/copilot@latest --help
+bunx @ccusage/copilot@latest --help  # ⚠️ MUST include @latest with bunx
+
+# Alternative package runners
+pnpm dlx @ccusage/copilot --help
+pnpx @ccusage/copilot --help
+```
+
+::: warning ⚠️ Critical for bunx users
+Bun's bunx prioritizes binaries matching the package name suffix when given a scoped package. **Always use `bunx @ccusage/copilot@latest` with the version tag** to force bunx to fetch and run the correct package.
+:::
+
+### Recommended: Shell Alias
+
+Since `npx @ccusage/copilot@latest` is quite long to type repeatedly, we strongly recommend setting up a shell alias for convenience:
+
+```bash
+# bash/zsh: alias ccusage-copilot='bunx @ccusage/copilot@latest'
+# fish:     alias ccusage-copilot 'bunx @ccusage/copilot@latest'
+
+# Then simply run:
+ccusage-copilot daily
+ccusage-copilot monthly --json
+```
+
+::: tip
+After adding the alias to your shell config file (`.bashrc`, `.zshrc`, or `config.fish`), restart your shell or run `source` on the config file to apply the changes.
+:::
+
+## Commands
+
+### Daily Report
+
+```bash
+ccusage-copilot daily              # Table output
+ccusage-copilot daily --json       # JSON output
+ccusage-copilot daily --compact    # Compact table for narrow terminals
+```
+
+### Monthly Report
+
+```bash
+ccusage-copilot monthly
+ccusage-copilot monthly --json
+```
+
+### Session Report
+
+```bash
+ccusage-copilot session            # Grouped by session with repository context
+ccusage-copilot session --json
+```
+
+## Pricing Modes
+
+Use `--mode` to control how costs are calculated:
+
+```bash
+ccusage-copilot daily --mode premium    # Default: premium request pricing
+ccusage-copilot daily --mode api        # API-equivalent pricing
+```
+
+### Premium Mode (Default)
+
+Calculates cost using GitHub Copilot's premium request system: `premiumRequestCost × $0.04` (overage rate). The `requests.cost` field from Copilot data already includes model multipliers (e.g., Opus 4.7 = 7.5×, Sonnet = 1×, Haiku = 0.33×).
+
+### API Mode
+
+Calculates the hypothetical cost if the same tokens were used through Anthropic/OpenAI APIs directly. Uses official pricing from LiteLLM's pricing database. Useful for understanding the value of your Copilot subscription.
+
+::: info
+JSON output always includes both `premiumCostUSD` and `apiCostUSD` regardless of selected mode.
+:::
+
+## Data Source
+
+Copilot CLI stores session data at `~/.copilot/session-state/`. Each session directory contains an `events.jsonl` file with JSON Lines events. Usage data is extracted from:
+
+- **`session.start`** — Session metadata (cwd, repository, branch, copilotVersion)
+- **`session.shutdown`** — Per-model aggregated token metrics (inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, premium request counts)
+
+## Additional Options
+
+### Date Filtering
+
+```bash
+ccusage-copilot daily --since 2026-04-01 --until 2026-04-30
+ccusage-copilot monthly --since 2026-04 --until 2026-04
+```
+
+Accepts `YYYY-MM`, `YYYY-MM-DD`, or `YYYYMMDD` format. For monthly reports, dates are filtered at day granularity before grouping by month.
+
+### Timezone
+
+```bash
+ccusage-copilot daily --timezone America/New_York
+ccusage-copilot daily -z Asia/Kolkata
+```
+
+Controls which calendar day/month events are grouped into. Defaults to your system timezone.
+
+### Sort Order
+
+```bash
+ccusage-copilot daily --order desc    # Most recent first
+ccusage-copilot session --order asc   # Oldest first (default)
+```
+
+### Model Breakdown
+
+```bash
+ccusage-copilot daily --breakdown --mode api
+```
+
+Shows per-model token and cost breakdown beneath each row.
+
+### Offline Pricing
+
+```bash
+ccusage-copilot daily --mode api --offline
+```
+
+Uses build-time cached pricing data instead of fetching from LiteLLM.
+
+### Color Control
+
+```bash
+ccusage-copilot daily --color        # Force colors
+ccusage-copilot daily --no-color     # Disable colors
+```
+
+Colors are auto-detected by default. Also respects `FORCE_COLOR=1` and `NO_COLOR=1` environment variables.
+
+## Supported Models
+
+The package supports all models available in Copilot CLI:
+
+- **Claude**: claude-haiku-4.5, claude-sonnet-4/4.5/4.6, claude-opus-4.5/4.6/4.6-1m/4.7
+- **GPT**: gpt-5.1, gpt-5.2, gpt-5.4
+- **Other**: goldeneye
+
+Model names are automatically normalized for LiteLLM pricing lookup:
+- Dot-to-dash conversion: `claude-opus-4.6` → `claude-opus-4-6`
+- Variant suffix removal: `claude-opus-4.6-1m` → `claude-opus-4-6`
+
+## Environment Variables
+
+| Variable             | Description                            | Default      |
+| -------------------- | -------------------------------------- | ------------ |
+| `COPILOT_CONFIG_DIR` | Override Copilot data directory        | `~/.copilot` |
+| `LOG_LEVEL`          | Logging verbosity (0=silent … 5=trace) | —            |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,63 @@ importers:
         specifier: catalog:testing
         version: 4.1.2(@types/node@24.5.1)(happy-dom@16.8.1)(vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3))
 
+  apps/copilot:
+    devDependencies:
+      '@ccusage/internal':
+        specifier: workspace:*
+        version: link:../../packages/internal
+      '@ccusage/terminal':
+        specifier: workspace:*
+        version: link:../../packages/terminal
+      '@praha/byethrow':
+        specifier: catalog:runtime
+        version: 0.6.3
+      '@ryoppippi/eslint-config':
+        specifier: catalog:lint
+        version: 0.4.0(@vue/compiler-sfc@3.5.30)(eslint-plugin-format@2.0.1(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.1.2(@types/node@24.5.1)(happy-dom@16.8.1)(vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)))
+      '@typescript/native-preview':
+        specifier: catalog:types
+        version: 7.0.0-dev.20260107.1
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.3.0
+      eslint:
+        specifier: catalog:lint
+        version: 9.35.0(jiti@2.6.1)
+      fast-sort:
+        specifier: catalog:runtime
+        version: 3.4.1
+      fs-fixture:
+        specifier: catalog:testing
+        version: 2.8.1
+      gunshi:
+        specifier: catalog:runtime
+        version: 0.26.3
+      path-type:
+        specifier: catalog:runtime
+        version: 6.0.0
+      picocolors:
+        specifier: catalog:runtime
+        version: 1.1.1
+      tinyglobby:
+        specifier: catalog:runtime
+        version: 0.2.15
+      tsdown:
+        specifier: catalog:build
+        version: 0.16.6(@typescript/native-preview@7.0.0-dev.20260107.1)(publint@0.3.12)(synckit@0.11.12)(typescript@5.9.2)(unplugin-unused@0.5.3)
+      unplugin-macros:
+        specifier: catalog:build
+        version: 0.18.2(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
+      unplugin-unused:
+        specifier: catalog:build
+        version: 0.5.3
+      valibot:
+        specifier: catalog:runtime
+        version: 1.1.0(typescript@5.9.2)
+      vitest:
+        specifier: catalog:testing
+        version: 4.1.2(@types/node@24.5.1)(happy-dom@16.8.1)(vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3))
+
   apps/mcp:
     dependencies:
       '@ccusage/codex':
@@ -2292,9 +2349,6 @@ packages:
 
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -6703,7 +6757,7 @@ snapshots:
 
   '@praha/byethrow@0.6.3':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
 
   '@publint/pack@0.1.2': {}
 
@@ -6901,8 +6955,6 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@speed-highlight/core@1.2.7': {}
-
-  '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 


### PR DESCRIPTION
## Summary

Closes #956

Adds `@ccusage/copilot` — a companion CLI that mirrors `@ccusage/amp`, `@ccusage/codex`, `@ccusage/opencode`, and `@ccusage/pi` to analyze local usage for [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli).

- Reports: `daily`, `monthly`, `session` — each supports `--json` and `--compact`.
- Default command when invoked with no subcommand: `daily`.
- Bin: `ccusage-copilot` (e.g. `npx @ccusage/copilot@latest daily`).

## Data Source

Copilot CLI persists session data at:

```
~/.copilot/
  session-state/
    {sessionId}/                          # UUID directory per session
      events.jsonl                        # JSON Lines event stream
      workspace.yaml                      # session metadata (cwd, repo, branch)
```

Usage data is extracted from two event types in `events.jsonl`:
- `session.start` — metadata (sessionId, copilotVersion, cwd, repository, branch)
- `session.shutdown` — per-model aggregated token metrics in `modelMetrics`:
  - `usage.inputTokens`, `usage.outputTokens`, `usage.cacheReadTokens`, `usage.cacheWriteTokens`
  - `requests.count` (API calls), `requests.cost` (premium requests consumed, includes model multiplier)

## Dual Pricing Modes

Unique to this package: a `--mode` flag selecting how costs are calculated.

- **`premium`** (default): `premiumRequestCost × $0.04` — uses GitHub Copilot's overage rate. The `requests.cost` field already includes model multipliers (e.g., Opus 4.7 = 7.5×, Sonnet = 1×).
- **`api`**: Official API-equivalent cost from Anthropic/OpenAI via LiteLLM token pricing. Useful for understanding the value of the Copilot subscription.

JSON output always includes both `premiumCostUSD` and `apiCostUSD` regardless of selected mode.

## Model Name Normalization

Copilot CLI uses dot-notation while LiteLLM uses dashes:
- `claude-opus-4.6` → `claude-opus-4-6`
- `claude-opus-4.6-1m` → `claude-opus-4-6` (variant suffix stripped)
- `gpt-5.4` → `gpt-5.4` (passthrough, already works in LiteLLM)

Models observed: claude-haiku-4.5, claude-sonnet-4/4.5/4.6, claude-opus-4.5/4.6/4.6-1m/4.7, gpt-5.1/5.2/5.4, goldeneye

## Environment

- `COPILOT_CONFIG_DIR` — override the base Copilot directory (default: `~/.copilot`).
- `LOG_LEVEL` — standard consola verbosity (0=silent … 5=trace).

## Usage

```bash
# Daily usage (premium request pricing, default)
npx @ccusage/copilot@latest daily

# Monthly usage with API-equivalent pricing
npx @ccusage/copilot@latest monthly --mode api

# Session breakdown as JSON
npx @ccusage/copilot@latest session --json

# Compact table for narrow terminals
npx @ccusage/copilot@latest daily --compact
```

## Verification

Run from the repo root:

```
pnpm install
pnpm --filter @ccusage/copilot lint
pnpm --filter @ccusage/copilot typecheck
pnpm --filter @ccusage/copilot test --run
pnpm --filter @ccusage/copilot build
```

All green locally:

- Lint: clean.
- Typecheck: clean.
- Tests: `2 files, 13 tests passed` (data-loader × 5, pricing × 8 including normalization).
- Build: `tsdown` produces `dist/index.js` (~299 kB).
- End-to-end: running `node ./dist/index.js daily --json` against real Copilot data returns well-formed JSON with 46 sessions and 828M input tokens.

## Notes

- Apps are bundled, so all runtime deps are in `devDependencies`, matching `@ccusage/amp` exactly.
- Commands, table layout, compact mode, colors, and totals row are consistent with `@ccusage/amp`.
- `CLAUDE.md` documents the data sources, token fields, model names, and environment variables.
- Tiered pricing (200k threshold) for Claude models is handled automatically by `@ccusage/internal/pricing`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the @ccusage/copilot CLI with daily, monthly, and session reports; supports premium vs API pricing, per-model breakdowns, JSON/table/compact outputs, timezone-aware date grouping, since/until filtering, ordering, offline pricing, and warnings for missing Copilot session data.

* **Documentation**
  * Added README, detailed guide page, and monorepo index entry with install/quick-start, examples, supported models, pricing mode docs, and env var notes.

* **Tests & Tooling**
  * Added package manifest, lint/test/build configs, Vitest setup, and updated .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->