### PR TITLE
feat: add --human/-H flag for human-readable token display across all apps

### DIFF
--- a/apps/amp/src/commands/daily.ts
+++ b/apps/amp/src/commands/daily.ts
@@ -41,9 +41,15 @@ export const dailyCommand = define({
 			type: 'boolean',
 			description: 'Force compact table mode',
 		},
+		human: {
+			type: 'boolean',
+			short: 'H',
+			description: 'Display token counts in human-readable format (K/M/B suffixes)',
+		},
 	},
 	async run(ctx) {
 		const jsonOutput = Boolean(ctx.values.json);
+		const humanReadable = Boolean(ctx.values.human);
 
 		const { events } = await loadAmpUsageEvents();
 
@@ -168,11 +174,11 @@ export const dailyCommand = define({
 			table.push([
 				data.date,
 				formatModelsDisplayMultiline(data.modelsUsed),
-				formatNumber(data.inputTokens),
-				formatNumber(data.outputTokens),
-				formatNumber(data.cacheCreationTokens),
-				formatNumber(data.cacheReadTokens),
-				formatNumber(data.totalTokens),
+				formatNumber(data.inputTokens, humanReadable),
+				formatNumber(data.outputTokens, humanReadable),
+				formatNumber(data.cacheCreationTokens, humanReadable),
+				formatNumber(data.cacheReadTokens, humanReadable),
+				formatNumber(data.totalTokens, humanReadable),
 				data.credits.toFixed(2),
 				formatCurrency(data.totalCost),
 			]);
@@ -182,11 +188,11 @@ export const dailyCommand = define({
 		table.push([
 			pc.yellow('Total'),
 			'',
-			pc.yellow(formatNumber(totals.inputTokens)),
-			pc.yellow(formatNumber(totals.outputTokens)),
-			pc.yellow(formatNumber(totals.cacheCreationTokens)),
-			pc.yellow(formatNumber(totals.cacheReadTokens)),
-			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatNumber(totals.inputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.outputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheReadTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.totalTokens, humanReadable)),
 			pc.yellow(totals.credits.toFixed(2)),
 			pc.yellow(formatCurrency(totals.totalCost)),
 		]);

--- a/apps/amp/src/commands/monthly.ts
+++ b/apps/amp/src/commands/monthly.ts
@@ -41,9 +41,15 @@ export const monthlyCommand = define({
 			type: 'boolean',
 			description: 'Force compact table mode',
 		},
+		human: {
+			type: 'boolean',
+			short: 'H',
+			description: 'Display token counts in human-readable format (K/M/B suffixes)',
+		},
 	},
 	async run(ctx) {
 		const jsonOutput = Boolean(ctx.values.json);
+		const humanReadable = Boolean(ctx.values.human);
 
 		const { events } = await loadAmpUsageEvents();
 
@@ -168,11 +174,11 @@ export const monthlyCommand = define({
 			table.push([
 				data.month,
 				formatModelsDisplayMultiline(data.modelsUsed),
-				formatNumber(data.inputTokens),
-				formatNumber(data.outputTokens),
-				formatNumber(data.cacheCreationTokens),
-				formatNumber(data.cacheReadTokens),
-				formatNumber(data.totalTokens),
+				formatNumber(data.inputTokens, humanReadable),
+				formatNumber(data.outputTokens, humanReadable),
+				formatNumber(data.cacheCreationTokens, humanReadable),
+				formatNumber(data.cacheReadTokens, humanReadable),
+				formatNumber(data.totalTokens, humanReadable),
 				data.credits.toFixed(2),
 				formatCurrency(data.totalCost),
 			]);
@@ -182,11 +188,11 @@ export const monthlyCommand = define({
 		table.push([
 			pc.yellow('Total'),
 			'',
-			pc.yellow(formatNumber(totals.inputTokens)),
-			pc.yellow(formatNumber(totals.outputTokens)),
-			pc.yellow(formatNumber(totals.cacheCreationTokens)),
-			pc.yellow(formatNumber(totals.cacheReadTokens)),
-			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatNumber(totals.inputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.outputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheReadTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.totalTokens, humanReadable)),
 			pc.yellow(totals.credits.toFixed(2)),
 			pc.yellow(formatCurrency(totals.totalCost)),
 		]);

--- a/apps/amp/src/commands/session.ts
+++ b/apps/amp/src/commands/session.ts
@@ -40,9 +40,15 @@ export const sessionCommand = define({
 			type: 'boolean',
 			description: 'Force compact table mode',
 		},
+		human: {
+			type: 'boolean',
+			short: 'H',
+			description: 'Display token counts in human-readable format (K/M/B suffixes)',
+		},
 	},
 	async run(ctx) {
 		const jsonOutput = Boolean(ctx.values.json);
+		const humanReadable = Boolean(ctx.values.human);
 
 		const { events, threads } = await loadAmpUsageEvents();
 
@@ -180,11 +186,11 @@ export const sessionCommand = define({
 			table.push([
 				displayTitle,
 				formatModelsDisplayMultiline(data.modelsUsed),
-				formatNumber(data.inputTokens),
-				formatNumber(data.outputTokens),
-				formatNumber(data.cacheCreationTokens),
-				formatNumber(data.cacheReadTokens),
-				formatNumber(data.totalTokens),
+				formatNumber(data.inputTokens, humanReadable),
+				formatNumber(data.outputTokens, humanReadable),
+				formatNumber(data.cacheCreationTokens, humanReadable),
+				formatNumber(data.cacheReadTokens, humanReadable),
+				formatNumber(data.totalTokens, humanReadable),
 				data.credits.toFixed(2),
 				formatCurrency(data.totalCost),
 			]);
@@ -194,11 +200,11 @@ export const sessionCommand = define({
 		table.push([
 			pc.yellow('Total'),
 			'',
-			pc.yellow(formatNumber(totals.inputTokens)),
-			pc.yellow(formatNumber(totals.outputTokens)),
-			pc.yellow(formatNumber(totals.cacheCreationTokens)),
-			pc.yellow(formatNumber(totals.cacheReadTokens)),
-			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatNumber(totals.inputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.outputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheReadTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.totalTokens, humanReadable)),
 			pc.yellow(totals.credits.toFixed(2)),
 			pc.yellow(formatCurrency(totals.totalCost)),
 		]);

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -97,6 +97,12 @@
 							"description": "Force compact mode for narrow displays (better for screenshots)",
 							"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 							"default": false
+						},
+						"human": {
+							"type": "boolean",
+							"description": "Display token counts in human-readable format (K/M/B suffixes)",
+							"markdownDescription": "Display token counts in human-readable format (K/M/B suffixes)",
+							"default": false
 						}
 					},
 					"additionalProperties": false,
@@ -193,6 +199,12 @@
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+									"default": false
+								},
+								"human": {
+									"type": "boolean",
+									"description": "Display token counts in human-readable format (K/M/B suffixes)",
+									"markdownDescription": "Display token counts in human-readable format (K/M/B suffixes)",
 									"default": false
 								},
 								"instances": {
@@ -302,6 +314,12 @@
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
+								},
+								"human": {
+									"type": "boolean",
+									"description": "Display token counts in human-readable format (K/M/B suffixes)",
+									"markdownDescription": "Display token counts in human-readable format (K/M/B suffixes)",
+									"default": false
 								}
 							},
 							"additionalProperties": false
@@ -393,6 +411,12 @@
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+									"default": false
+								},
+								"human": {
+									"type": "boolean",
+									"description": "Display token counts in human-readable format (K/M/B suffixes)",
+									"markdownDescription": "Display token counts in human-readable format (K/M/B suffixes)",
 									"default": false
 								},
 								"startOfWeek": {
@@ -495,6 +519,12 @@
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
 								},
+								"human": {
+									"type": "boolean",
+									"description": "Display token counts in human-readable format (K/M/B suffixes)",
+									"markdownDescription": "Display token counts in human-readable format (K/M/B suffixes)",
+									"default": false
+								},
 								"id": {
 									"type": "string",
 									"description": "Load usage data for a specific session ID",
@@ -590,6 +620,12 @@
 									"type": "boolean",
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+									"default": false
+								},
+								"human": {
+									"type": "boolean",
+									"description": "Display token counts in human-readable format (K/M/B suffixes)",
+									"markdownDescription": "Display token counts in human-readable format (K/M/B suffixes)",
 									"default": false
 								},
 								"active": {

--- a/apps/ccusage/src/_shared-args.ts
+++ b/apps/ccusage/src/_shared-args.ts
@@ -110,6 +110,12 @@ export const sharedArgs = {
 		description: 'Force compact mode for narrow displays (better for screenshots)',
 		default: false,
 	},
+	human: {
+		type: 'boolean',
+		short: 'H',
+		description: 'Display token counts in human-readable format (K/M/B suffixes)',
+		default: false,
+	},
 } as const satisfies Args;
 
 /**

--- a/apps/ccusage/src/commands/_session_id.ts
+++ b/apps/ccusage/src/commands/_session_id.ts
@@ -25,6 +25,7 @@ export type SessionIdContext = {
 export async function handleSessionIdLookup(
 	ctx: SessionIdContext,
 	useJson: boolean,
+	humanReadable = false,
 ): Promise<void> {
 	const sessionUsage = await loadSessionUsageById(ctx.values.id, {
 		mode: ctx.values.mode,
@@ -72,7 +73,7 @@ export async function handleSessionIdLookup(
 		const totalTokens = calculateSessionTotalTokens(sessionUsage.entries);
 
 		log(`Total Cost: ${formatCurrency(sessionUsage.totalCost)}`);
-		log(`Total Tokens: ${formatNumber(totalTokens)}`);
+		log(`Total Tokens: ${formatNumber(totalTokens, humanReadable)}`);
 		log(`Total Entries: ${sessionUsage.entries.length}`);
 		log('');
 
@@ -87,10 +88,10 @@ export async function handleSessionIdLookup(
 				table.push([
 					formatDateCompact(entry.timestamp, ctx.values.timezone, ctx.values.locale),
 					entry.message.model ?? 'unknown',
-					formatNumber(entry.message.usage.input_tokens),
-					formatNumber(entry.message.usage.output_tokens),
-					formatNumber(entry.message.usage.cache_creation_input_tokens ?? 0),
-					formatNumber(entry.message.usage.cache_read_input_tokens ?? 0),
+					formatNumber(entry.message.usage.input_tokens, humanReadable),
+					formatNumber(entry.message.usage.output_tokens, humanReadable),
+					formatNumber(entry.message.usage.cache_creation_input_tokens ?? 0, humanReadable),
+					formatNumber(entry.message.usage.cache_read_input_tokens ?? 0, humanReadable),
 					formatCurrency(entry.costUSD ?? 0),
 				]);
 			}

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -154,6 +154,7 @@ export const blocksCommand = define({
 
 		// --jq implies --json
 		const useJson = mergedOptions.json || mergedOptions.jq != null;
+		const humanReadable = Boolean(mergedOptions.human);
 		if (useJson) {
 			logger.level = 0;
 		}
@@ -200,7 +201,9 @@ export const blocksCommand = define({
 				}
 			}
 			if (!useJson && maxTokensFromAll > 0) {
-				logger.info(`Using max tokens from previous sessions: ${formatNumber(maxTokensFromAll)}`);
+				logger.info(
+					`Using max tokens from previous sessions: ${formatNumber(maxTokensFromAll, humanReadable)}`,
+				);
 			}
 		}
 
@@ -301,19 +304,19 @@ export const blocksCommand = define({
 				log(`Time Remaining: ${pc.green(`${Math.floor(remaining / 60)}h ${remaining % 60}m`)}\n`);
 
 				log(pc.bold('Current Usage:'));
-				log(`  Input Tokens:     ${formatNumber(block.tokenCounts.inputTokens)}`);
-				log(`  Output Tokens:    ${formatNumber(block.tokenCounts.outputTokens)}`);
+				log(`  Input Tokens:     ${formatNumber(block.tokenCounts.inputTokens, humanReadable)}`);
+				log(`  Output Tokens:    ${formatNumber(block.tokenCounts.outputTokens, humanReadable)}`);
 				log(`  Total Cost:       ${formatCurrency(block.costUSD)}\n`);
 
 				if (burnRate != null) {
 					log(pc.bold('Burn Rate:'));
-					log(`  Tokens/minute:    ${formatNumber(burnRate.tokensPerMinute)}`);
+					log(`  Tokens/minute:    ${formatNumber(burnRate.tokensPerMinute, humanReadable)}`);
 					log(`  Cost/hour:        ${formatCurrency(burnRate.costPerHour)}\n`);
 				}
 
 				if (projection != null) {
 					log(pc.bold('Projected Usage (if current rate continues):'));
-					log(`  Total Tokens:     ${formatNumber(projection.totalTokens)}`);
+					log(`  Total Tokens:     ${formatNumber(projection.totalTokens, humanReadable)}`);
 					log(`  Total Cost:       ${formatCurrency(projection.totalCost)}\n`);
 
 					if (ctx.values.tokenLimit != null) {
@@ -331,11 +334,11 @@ export const blocksCommand = define({
 										: pc.green('OK');
 
 							log(pc.bold('Token Limit Status:'));
-							log(`  Limit:            ${formatNumber(limit)} tokens`);
+							log(`  Limit:            ${formatNumber(limit, humanReadable)} tokens`);
 							log(
-								`  Current Usage:    ${formatNumber(currentTokens)} (${((currentTokens / limit) * 100).toFixed(1)}%)`,
+								`  Current Usage:    ${formatNumber(currentTokens, humanReadable)} (${((currentTokens / limit) * 100).toFixed(1)}%)`,
 							);
-							log(`  Remaining:        ${formatNumber(remainingTokens)} tokens`);
+							log(`  Remaining:        ${formatNumber(remainingTokens, humanReadable)} tokens`);
 							log(`  Projected Usage:  ${percentUsed.toFixed(1)}% ${status}`);
 						}
 					}
@@ -395,7 +398,7 @@ export const blocksCommand = define({
 							formatBlockTime(block, useCompactFormat, ctx.values.locale),
 							status,
 							formatModels(block.models),
-							formatNumber(totalTokens),
+							formatNumber(totalTokens, humanReadable),
 						];
 
 						// Add percentage if token limit is set
@@ -415,7 +418,7 @@ export const blocksCommand = define({
 								const currentTokens = getTotalTokens(block.tokenCounts);
 								const remainingTokens = Math.max(0, actualTokenLimit - currentTokens);
 								const remainingText =
-									remainingTokens > 0 ? formatNumber(remainingTokens) : pc.red('0');
+									remainingTokens > 0 ? formatNumber(remainingTokens, humanReadable) : pc.red('0');
 
 								// Calculate remaining percentage (how much of limit is left)
 								const remainingPercent =
@@ -425,7 +428,9 @@ export const blocksCommand = define({
 
 								const remainingRow = [
 									{
-										content: pc.gray(`(assuming ${formatNumber(actualTokenLimit)} token limit)`),
+										content: pc.gray(
+											`(assuming ${formatNumber(actualTokenLimit, humanReadable)} token limit)`,
+										),
 										hAlign: 'right' as const,
 									},
 									pc.blue('REMAINING'),
@@ -440,7 +445,7 @@ export const blocksCommand = define({
 							// PROJECTED row
 							const projection = projectBlockUsage(block);
 							if (projection != null) {
-								const projectedTokens = formatNumber(projection.totalTokens);
+								const projectedTokens = formatNumber(projection.totalTokens, humanReadable);
 								const projectedText =
 									actualTokenLimit != null &&
 									actualTokenLimit > 0 &&

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -134,6 +134,8 @@ export const dailyCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
+			const humanReadable = Boolean(mergedOptions.human);
+
 			// Print header
 			logger.box('Claude Code Token Usage Report - Daily');
 
@@ -173,19 +175,24 @@ export const dailyCommand = define({
 
 					// Add data rows for this project
 					for (const data of projectData) {
-						const row = formatUsageDataRow(data.date, {
-							inputTokens: data.inputTokens,
-							outputTokens: data.outputTokens,
-							cacheCreationTokens: data.cacheCreationTokens,
-							cacheReadTokens: data.cacheReadTokens,
-							totalCost: data.totalCost,
-							modelsUsed: data.modelsUsed,
-						});
+						const row = formatUsageDataRow(
+							data.date,
+							{
+								inputTokens: data.inputTokens,
+								outputTokens: data.outputTokens,
+								cacheCreationTokens: data.cacheCreationTokens,
+								cacheReadTokens: data.cacheReadTokens,
+								totalCost: data.totalCost,
+								modelsUsed: data.modelsUsed,
+							},
+							undefined,
+							humanReadable,
+						);
 						table.push(row);
 
 						// Add model breakdown rows if flag is set
 						if (mergedOptions.breakdown) {
-							pushBreakdownRows(table, data.modelBreakdowns);
+							pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 						}
 					}
 
@@ -195,19 +202,24 @@ export const dailyCommand = define({
 				// Standard display without project grouping
 				for (const data of dailyData) {
 					// Main row
-					const row = formatUsageDataRow(data.date, {
-						inputTokens: data.inputTokens,
-						outputTokens: data.outputTokens,
-						cacheCreationTokens: data.cacheCreationTokens,
-						cacheReadTokens: data.cacheReadTokens,
-						totalCost: data.totalCost,
-						modelsUsed: data.modelsUsed,
-					});
+					const row = formatUsageDataRow(
+						data.date,
+						{
+							inputTokens: data.inputTokens,
+							outputTokens: data.outputTokens,
+							cacheCreationTokens: data.cacheCreationTokens,
+							cacheReadTokens: data.cacheReadTokens,
+							totalCost: data.totalCost,
+							modelsUsed: data.modelsUsed,
+						},
+						undefined,
+						humanReadable,
+					);
 					table.push(row);
 
 					// Add model breakdown rows if flag is set
 					if (mergedOptions.breakdown) {
-						pushBreakdownRows(table, data.modelBreakdowns);
+						pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 					}
 				}
 			}
@@ -216,13 +228,17 @@ export const dailyCommand = define({
 			addEmptySeparatorRow(table, 8);
 
 			// Add totals
-			const totalsRow = formatTotalsRow({
-				inputTokens: totals.inputTokens,
-				outputTokens: totals.outputTokens,
-				cacheCreationTokens: totals.cacheCreationTokens,
-				cacheReadTokens: totals.cacheReadTokens,
-				totalCost: totals.totalCost,
-			});
+			const totalsRow = formatTotalsRow(
+				{
+					inputTokens: totals.inputTokens,
+					outputTokens: totals.outputTokens,
+					cacheCreationTokens: totals.cacheCreationTokens,
+					cacheReadTokens: totals.cacheReadTokens,
+					totalCost: totals.totalCost,
+				},
+				false,
+				humanReadable,
+			);
 			table.push(totalsRow);
 
 			log(table.toString());

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -94,6 +94,8 @@ export const monthlyCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
+			const humanReadable = Boolean(mergedOptions.human);
+
 			// Print header
 			logger.box('Claude Code Token Usage Report - Monthly');
 
@@ -113,19 +115,24 @@ export const monthlyCommand = define({
 			// Add monthly data
 			for (const data of monthlyData) {
 				// Main row
-				const row = formatUsageDataRow(data.month, {
-					inputTokens: data.inputTokens,
-					outputTokens: data.outputTokens,
-					cacheCreationTokens: data.cacheCreationTokens,
-					cacheReadTokens: data.cacheReadTokens,
-					totalCost: data.totalCost,
-					modelsUsed: data.modelsUsed,
-				});
+				const row = formatUsageDataRow(
+					data.month,
+					{
+						inputTokens: data.inputTokens,
+						outputTokens: data.outputTokens,
+						cacheCreationTokens: data.cacheCreationTokens,
+						cacheReadTokens: data.cacheReadTokens,
+						totalCost: data.totalCost,
+						modelsUsed: data.modelsUsed,
+					},
+					undefined,
+					humanReadable,
+				);
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 				}
 			}
 
@@ -133,13 +140,17 @@ export const monthlyCommand = define({
 			addEmptySeparatorRow(table, 8);
 
 			// Add totals
-			const totalsRow = formatTotalsRow({
-				inputTokens: totals.inputTokens,
-				outputTokens: totals.outputTokens,
-				cacheCreationTokens: totals.cacheCreationTokens,
-				cacheReadTokens: totals.cacheReadTokens,
-				totalCost: totals.totalCost,
-			});
+			const totalsRow = formatTotalsRow(
+				{
+					inputTokens: totals.inputTokens,
+					outputTokens: totals.outputTokens,
+					cacheCreationTokens: totals.cacheCreationTokens,
+					cacheReadTokens: totals.cacheReadTokens,
+					totalCost: totals.totalCost,
+				},
+				false,
+				humanReadable,
+			);
 			table.push(totalsRow);
 
 			log(table.toString());

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -47,6 +47,8 @@ export const sessionCommand = define({
 			logger.level = 0;
 		}
 
+		const humanReadable = Boolean(mergedOptions.human);
+
 		// Handle specific session ID lookup
 		if (mergedOptions.id != null) {
 			return handleSessionIdLookup(
@@ -61,6 +63,7 @@ export const sessionCommand = define({
 					},
 				},
 				useJson,
+				humanReadable,
 			);
 		}
 
@@ -155,13 +158,14 @@ export const sessionCommand = define({
 						modelsUsed: data.modelsUsed,
 					},
 					data.lastActivity,
+					humanReadable,
 				);
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (ctx.values.breakdown) {
 					// Session has 1 extra column before data and 1 trailing column
-					pushBreakdownRows(table, data.modelBreakdowns, 1, 1);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 1, humanReadable);
 				}
 			}
 
@@ -178,6 +182,7 @@ export const sessionCommand = define({
 					totalCost: totals.totalCost,
 				},
 				true,
+				humanReadable,
 			); // Include Last Activity column
 			table.push(totalsRow);
 

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -104,6 +104,8 @@ export const weeklyCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
+			const humanReadable = Boolean(mergedOptions.human);
+
 			// Print header
 			logger.box('Claude Code Token Usage Report - Weekly');
 
@@ -119,19 +121,24 @@ export const weeklyCommand = define({
 			// Add weekly data
 			for (const data of weeklyData) {
 				// Main row
-				const row = formatUsageDataRow(data.week, {
-					inputTokens: data.inputTokens,
-					outputTokens: data.outputTokens,
-					cacheCreationTokens: data.cacheCreationTokens,
-					cacheReadTokens: data.cacheReadTokens,
-					totalCost: data.totalCost,
-					modelsUsed: data.modelsUsed,
-				});
+				const row = formatUsageDataRow(
+					data.week,
+					{
+						inputTokens: data.inputTokens,
+						outputTokens: data.outputTokens,
+						cacheCreationTokens: data.cacheCreationTokens,
+						cacheReadTokens: data.cacheReadTokens,
+						totalCost: data.totalCost,
+						modelsUsed: data.modelsUsed,
+					},
+					undefined,
+					humanReadable,
+				);
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 				}
 			}
 
@@ -139,13 +146,17 @@ export const weeklyCommand = define({
 			addEmptySeparatorRow(table, 8);
 
 			// Add totals
-			const totalsRow = formatTotalsRow({
-				inputTokens: totals.inputTokens,
-				outputTokens: totals.outputTokens,
-				cacheCreationTokens: totals.cacheCreationTokens,
-				cacheReadTokens: totals.cacheReadTokens,
-				totalCost: totals.totalCost,
-			});
+			const totalsRow = formatTotalsRow(
+				{
+					inputTokens: totals.inputTokens,
+					outputTokens: totals.outputTokens,
+					cacheCreationTokens: totals.cacheCreationTokens,
+					cacheReadTokens: totals.cacheReadTokens,
+					totalCost: totals.totalCost,
+				},
+				false,
+				humanReadable,
+			);
 			table.push(totalsRow);
 
 			log(table.toString());

--- a/apps/codex/src/_shared-args.ts
+++ b/apps/codex/src/_shared-args.ts
@@ -42,6 +42,12 @@ export const sharedArgs = {
 		description: 'Force compact table layout for narrow terminals',
 		default: false,
 	},
+	human: {
+		type: 'boolean',
+		short: 'H',
+		description: 'Display token counts in human-readable format (K/M/B suffixes)',
+		default: false,
+	},
 	color: {
 		// --color and FORCE_COLOR=1 is handled by picocolors
 		type: 'boolean',

--- a/apps/codex/src/commands/daily.ts
+++ b/apps/codex/src/commands/daily.ts
@@ -30,6 +30,8 @@ export const dailyCommand = define({
 			logger.level = 0;
 		}
 
+		const humanReadable = Boolean(ctx.values.human);
+
 		let since: string | undefined;
 		let until: string | undefined;
 
@@ -152,11 +154,11 @@ export const dailyCommand = define({
 				table.push([
 					row.date,
 					formatModelsDisplayMultiline(formatModelsList(row.models)),
-					formatNumber(split.inputTokens),
-					formatNumber(split.outputTokens),
-					formatNumber(split.reasoningTokens),
-					formatNumber(split.cacheReadTokens),
-					formatNumber(row.totalTokens),
+					formatNumber(split.inputTokens, humanReadable),
+					formatNumber(split.outputTokens, humanReadable),
+					formatNumber(split.reasoningTokens, humanReadable),
+					formatNumber(split.cacheReadTokens, humanReadable),
+					formatNumber(row.totalTokens, humanReadable),
 					formatCurrency(row.costUSD),
 				]);
 			}
@@ -165,11 +167,11 @@ export const dailyCommand = define({
 			table.push([
 				pc.yellow('Total'),
 				'',
-				pc.yellow(formatNumber(totalsForDisplay.inputTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.outputTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.reasoningTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.cacheReadTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.totalTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.inputTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.outputTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.reasoningTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.cacheReadTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.totalTokens, humanReadable)),
 				pc.yellow(formatCurrency(totalsForDisplay.costUSD)),
 			]);
 

--- a/apps/codex/src/commands/monthly.ts
+++ b/apps/codex/src/commands/monthly.ts
@@ -30,6 +30,8 @@ export const monthlyCommand = define({
 			logger.level = 0;
 		}
 
+		const humanReadable = Boolean(ctx.values.human);
+
 		let since: string | undefined;
 		let until: string | undefined;
 
@@ -154,11 +156,11 @@ export const monthlyCommand = define({
 				table.push([
 					row.month,
 					formatModelsDisplayMultiline(formatModelsList(row.models)),
-					formatNumber(split.inputTokens),
-					formatNumber(split.outputTokens),
-					formatNumber(split.reasoningTokens),
-					formatNumber(split.cacheReadTokens),
-					formatNumber(row.totalTokens),
+					formatNumber(split.inputTokens, humanReadable),
+					formatNumber(split.outputTokens, humanReadable),
+					formatNumber(split.reasoningTokens, humanReadable),
+					formatNumber(split.cacheReadTokens, humanReadable),
+					formatNumber(row.totalTokens, humanReadable),
 					formatCurrency(row.costUSD),
 				]);
 			}
@@ -167,11 +169,11 @@ export const monthlyCommand = define({
 			table.push([
 				pc.yellow('Total'),
 				'',
-				pc.yellow(formatNumber(totalsForDisplay.inputTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.outputTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.reasoningTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.cacheReadTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.totalTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.inputTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.outputTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.reasoningTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.cacheReadTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.totalTokens, humanReadable)),
 				pc.yellow(formatCurrency(totalsForDisplay.costUSD)),
 			]);
 

--- a/apps/codex/src/commands/session.ts
+++ b/apps/codex/src/commands/session.ts
@@ -35,6 +35,8 @@ export const sessionCommand = define({
 			logger.level = 0;
 		}
 
+		const humanReadable = Boolean(ctx.values.human);
+
 		let since: string | undefined;
 		let until: string | undefined;
 
@@ -182,11 +184,11 @@ export const sessionCommand = define({
 					directoryDisplay,
 					shortSession,
 					formatModelsDisplayMultiline(formatModelsList(row.models)),
-					formatNumber(split.inputTokens),
-					formatNumber(split.outputTokens),
-					formatNumber(split.reasoningTokens),
-					formatNumber(split.cacheReadTokens),
-					formatNumber(row.totalTokens),
+					formatNumber(split.inputTokens, humanReadable),
+					formatNumber(split.outputTokens, humanReadable),
+					formatNumber(split.reasoningTokens, humanReadable),
+					formatNumber(split.cacheReadTokens, humanReadable),
+					formatNumber(row.totalTokens, humanReadable),
 					formatCurrency(row.costUSD),
 					formatDisplayDateTime(row.lastActivity, ctx.values.locale, ctx.values.timezone),
 				]);
@@ -198,11 +200,11 @@ export const sessionCommand = define({
 				'',
 				pc.yellow('Total'),
 				'',
-				pc.yellow(formatNumber(totalsForDisplay.inputTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.outputTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.reasoningTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.cacheReadTokens)),
-				pc.yellow(formatNumber(totalsForDisplay.totalTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.inputTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.outputTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.reasoningTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.cacheReadTokens, humanReadable)),
+				pc.yellow(formatNumber(totalsForDisplay.totalTokens, humanReadable)),
 				pc.yellow(formatCurrency(totalsForDisplay.costUSD)),
 				'',
 			]);

--- a/apps/opencode/src/commands/daily.ts
+++ b/apps/opencode/src/commands/daily.ts
@@ -29,9 +29,15 @@ export const dailyCommand = define({
 			type: 'boolean',
 			description: 'Force compact table mode',
 		},
+		human: {
+			type: 'boolean',
+			short: 'H',
+			description: 'Display token counts in human-readable format (K/M/B suffixes)',
+		},
 	},
 	async run(ctx) {
 		const jsonOutput = Boolean(ctx.values.json);
+		const humanReadable = Boolean(ctx.values.human);
 
 		const entries = await loadOpenCodeMessages();
 
@@ -143,11 +149,11 @@ export const dailyCommand = define({
 			table.push([
 				data.date,
 				formatModelsDisplayMultiline(data.modelsUsed),
-				formatNumber(data.inputTokens),
-				formatNumber(data.outputTokens),
-				formatNumber(data.cacheCreationTokens),
-				formatNumber(data.cacheReadTokens),
-				formatNumber(data.totalTokens),
+				formatNumber(data.inputTokens, humanReadable),
+				formatNumber(data.outputTokens, humanReadable),
+				formatNumber(data.cacheCreationTokens, humanReadable),
+				formatNumber(data.cacheReadTokens, humanReadable),
+				formatNumber(data.totalTokens, humanReadable),
 				formatCurrency(data.totalCost),
 			]);
 		}
@@ -156,11 +162,11 @@ export const dailyCommand = define({
 		table.push([
 			pc.yellow('Total'),
 			'',
-			pc.yellow(formatNumber(totals.inputTokens)),
-			pc.yellow(formatNumber(totals.outputTokens)),
-			pc.yellow(formatNumber(totals.cacheCreationTokens)),
-			pc.yellow(formatNumber(totals.cacheReadTokens)),
-			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatNumber(totals.inputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.outputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheReadTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.totalTokens, humanReadable)),
 			pc.yellow(formatCurrency(totals.totalCost)),
 		]);
 

--- a/apps/opencode/src/commands/monthly.ts
+++ b/apps/opencode/src/commands/monthly.ts
@@ -29,9 +29,15 @@ export const monthlyCommand = define({
 			type: 'boolean',
 			description: 'Force compact table mode',
 		},
+		human: {
+			type: 'boolean',
+			short: 'H',
+			description: 'Display token counts in human-readable format (K/M/B suffixes)',
+		},
 	},
 	async run(ctx) {
 		const jsonOutput = Boolean(ctx.values.json);
+		const humanReadable = Boolean(ctx.values.human);
 
 		const entries = await loadOpenCodeMessages();
 
@@ -143,11 +149,11 @@ export const monthlyCommand = define({
 			table.push([
 				data.month,
 				formatModelsDisplayMultiline(data.modelsUsed),
-				formatNumber(data.inputTokens),
-				formatNumber(data.outputTokens),
-				formatNumber(data.cacheCreationTokens),
-				formatNumber(data.cacheReadTokens),
-				formatNumber(data.totalTokens),
+				formatNumber(data.inputTokens, humanReadable),
+				formatNumber(data.outputTokens, humanReadable),
+				formatNumber(data.cacheCreationTokens, humanReadable),
+				formatNumber(data.cacheReadTokens, humanReadable),
+				formatNumber(data.totalTokens, humanReadable),
 				formatCurrency(data.totalCost),
 			]);
 		}
@@ -156,11 +162,11 @@ export const monthlyCommand = define({
 		table.push([
 			pc.yellow('Total'),
 			'',
-			pc.yellow(formatNumber(totals.inputTokens)),
-			pc.yellow(formatNumber(totals.outputTokens)),
-			pc.yellow(formatNumber(totals.cacheCreationTokens)),
-			pc.yellow(formatNumber(totals.cacheReadTokens)),
-			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatNumber(totals.inputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.outputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheReadTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.totalTokens, humanReadable)),
 			pc.yellow(formatCurrency(totals.totalCost)),
 		]);
 

--- a/apps/opencode/src/commands/session.ts
+++ b/apps/opencode/src/commands/session.ts
@@ -29,9 +29,15 @@ export const sessionCommand = define({
 			type: 'boolean',
 			description: 'Force compact table mode',
 		},
+		human: {
+			type: 'boolean',
+			short: 'H',
+			description: 'Display token counts in human-readable format (K/M/B suffixes)',
+		},
 	},
 	async run(ctx) {
 		const jsonOutput = Boolean(ctx.values.json);
+		const humanReadable = Boolean(ctx.values.human);
 
 		const [entries, sessionMetadataMap] = await Promise.all([
 			loadOpenCodeMessages(),
@@ -170,11 +176,11 @@ export const sessionCommand = define({
 			table.push([
 				displayTitle,
 				formatModelsDisplayMultiline(parentSession.modelsUsed),
-				formatNumber(parentSession.inputTokens),
-				formatNumber(parentSession.outputTokens),
-				formatNumber(parentSession.cacheCreationTokens),
-				formatNumber(parentSession.cacheReadTokens),
-				formatNumber(parentSession.totalTokens),
+				formatNumber(parentSession.inputTokens, humanReadable),
+				formatNumber(parentSession.outputTokens, humanReadable),
+				formatNumber(parentSession.cacheCreationTokens, humanReadable),
+				formatNumber(parentSession.cacheReadTokens, humanReadable),
+				formatNumber(parentSession.totalTokens, humanReadable),
 				formatCurrency(parentSession.totalCost),
 			]);
 
@@ -184,11 +190,11 @@ export const sessionCommand = define({
 					table.push([
 						`  ↳ ${subSession.sessionTitle}`,
 						formatModelsDisplayMultiline(subSession.modelsUsed),
-						formatNumber(subSession.inputTokens),
-						formatNumber(subSession.outputTokens),
-						formatNumber(subSession.cacheCreationTokens),
-						formatNumber(subSession.cacheReadTokens),
-						formatNumber(subSession.totalTokens),
+						formatNumber(subSession.inputTokens, humanReadable),
+						formatNumber(subSession.outputTokens, humanReadable),
+						formatNumber(subSession.cacheCreationTokens, humanReadable),
+						formatNumber(subSession.cacheReadTokens, humanReadable),
+						formatNumber(subSession.totalTokens, humanReadable),
 						formatCurrency(subSession.totalCost),
 					]);
 				}
@@ -211,11 +217,11 @@ export const sessionCommand = define({
 				table.push([
 					pc.dim('  Total (with subagents)'),
 					'',
-					pc.yellow(formatNumber(subtotalInputTokens)),
-					pc.yellow(formatNumber(subtotalOutputTokens)),
-					pc.yellow(formatNumber(subtotalCacheCreationTokens)),
-					pc.yellow(formatNumber(subtotalCacheReadTokens)),
-					pc.yellow(formatNumber(subtotalTotalTokens)),
+					pc.yellow(formatNumber(subtotalInputTokens, humanReadable)),
+					pc.yellow(formatNumber(subtotalOutputTokens, humanReadable)),
+					pc.yellow(formatNumber(subtotalCacheCreationTokens, humanReadable)),
+					pc.yellow(formatNumber(subtotalCacheReadTokens, humanReadable)),
+					pc.yellow(formatNumber(subtotalTotalTokens, humanReadable)),
 					pc.yellow(formatCurrency(subtotalCost)),
 				]);
 			}
@@ -225,11 +231,11 @@ export const sessionCommand = define({
 		table.push([
 			pc.yellow('Total'),
 			'',
-			pc.yellow(formatNumber(totals.inputTokens)),
-			pc.yellow(formatNumber(totals.outputTokens)),
-			pc.yellow(formatNumber(totals.cacheCreationTokens)),
-			pc.yellow(formatNumber(totals.cacheReadTokens)),
-			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatNumber(totals.inputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.outputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheReadTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.totalTokens, humanReadable)),
 			pc.yellow(formatCurrency(totals.totalCost)),
 		]);
 

--- a/apps/opencode/src/commands/weekly.ts
+++ b/apps/opencode/src/commands/weekly.ts
@@ -54,9 +54,15 @@ export const weeklyCommand = define({
 			type: 'boolean',
 			description: 'Force compact table mode',
 		},
+		human: {
+			type: 'boolean',
+			short: 'H',
+			description: 'Display token counts in human-readable format (K/M/B suffixes)',
+		},
 	},
 	async run(ctx) {
 		const jsonOutput = Boolean(ctx.values.json);
+		const humanReadable = Boolean(ctx.values.human);
 
 		const entries = await loadOpenCodeMessages();
 
@@ -168,11 +174,11 @@ export const weeklyCommand = define({
 			table.push([
 				data.week,
 				formatModelsDisplayMultiline(data.modelsUsed),
-				formatNumber(data.inputTokens),
-				formatNumber(data.outputTokens),
-				formatNumber(data.cacheCreationTokens),
-				formatNumber(data.cacheReadTokens),
-				formatNumber(data.totalTokens),
+				formatNumber(data.inputTokens, humanReadable),
+				formatNumber(data.outputTokens, humanReadable),
+				formatNumber(data.cacheCreationTokens, humanReadable),
+				formatNumber(data.cacheReadTokens, humanReadable),
+				formatNumber(data.totalTokens, humanReadable),
 				formatCurrency(data.totalCost),
 			]);
 		}
@@ -181,11 +187,11 @@ export const weeklyCommand = define({
 		table.push([
 			pc.yellow('Total'),
 			'',
-			pc.yellow(formatNumber(totals.inputTokens)),
-			pc.yellow(formatNumber(totals.outputTokens)),
-			pc.yellow(formatNumber(totals.cacheCreationTokens)),
-			pc.yellow(formatNumber(totals.cacheReadTokens)),
-			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatNumber(totals.inputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.outputTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.cacheReadTokens, humanReadable)),
+			pc.yellow(formatNumber(totals.totalTokens, humanReadable)),
 			pc.yellow(formatCurrency(totals.totalCost)),
 		]);
 

--- a/apps/pi/src/commands/daily.ts
+++ b/apps/pi/src/commands/daily.ts
@@ -48,6 +48,12 @@ export const dailyCommand = define({
 			description: 'Show model breakdown for each entry',
 			default: false,
 		},
+		human: {
+			type: 'boolean',
+			short: 'H',
+			description: 'Display token counts in human-readable format (K/M/B suffixes)',
+			default: false,
+		},
 	},
 	async run(ctx) {
 		const options = {
@@ -97,6 +103,8 @@ export const dailyCommand = define({
 				),
 			);
 		} else {
+			const humanReadable = Boolean(ctx.values.human);
+
 			logger.box('Pi-Agent Usage Report - Daily');
 
 			const table = createUsageReportTable({
@@ -105,30 +113,39 @@ export const dailyCommand = define({
 			});
 
 			for (const data of piData) {
-				const row = formatUsageDataRow(data.date, {
-					inputTokens: data.inputTokens,
-					outputTokens: data.outputTokens,
-					cacheCreationTokens: data.cacheCreationTokens,
-					cacheReadTokens: data.cacheReadTokens,
-					totalCost: data.totalCost,
-					modelsUsed: data.modelsUsed,
-				});
+				const row = formatUsageDataRow(
+					data.date,
+					{
+						inputTokens: data.inputTokens,
+						outputTokens: data.outputTokens,
+						cacheCreationTokens: data.cacheCreationTokens,
+						cacheReadTokens: data.cacheReadTokens,
+						totalCost: data.totalCost,
+						modelsUsed: data.modelsUsed,
+					},
+					undefined,
+					humanReadable,
+				);
 				table.push(row);
 
 				if (ctx.values.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 				}
 			}
 
 			addEmptySeparatorRow(table, 8);
 
-			const totalsRow = formatTotalsRow({
-				inputTokens: totals.inputTokens,
-				outputTokens: totals.outputTokens,
-				cacheCreationTokens: totals.cacheCreationTokens,
-				cacheReadTokens: totals.cacheReadTokens,
-				totalCost: totals.totalCost,
-			});
+			const totalsRow = formatTotalsRow(
+				{
+					inputTokens: totals.inputTokens,
+					outputTokens: totals.outputTokens,
+					cacheCreationTokens: totals.cacheCreationTokens,
+					cacheReadTokens: totals.cacheReadTokens,
+					totalCost: totals.totalCost,
+				},
+				false,
+				humanReadable,
+			);
 			table.push(totalsRow);
 
 			log(table.toString());

--- a/apps/pi/src/commands/monthly.ts
+++ b/apps/pi/src/commands/monthly.ts
@@ -48,6 +48,12 @@ export const monthlyCommand = define({
 			description: 'Show model breakdown for each entry',
 			default: false,
 		},
+		human: {
+			type: 'boolean',
+			short: 'H',
+			description: 'Display token counts in human-readable format (K/M/B suffixes)',
+			default: false,
+		},
 	},
 	async run(ctx) {
 		const options = {
@@ -97,6 +103,8 @@ export const monthlyCommand = define({
 				),
 			);
 		} else {
+			const humanReadable = Boolean(ctx.values.human);
+
 			logger.box('Pi-Agent Usage Report - Monthly');
 
 			const table = createUsageReportTable({
@@ -105,30 +113,39 @@ export const monthlyCommand = define({
 			});
 
 			for (const data of piData) {
-				const row = formatUsageDataRow(data.month, {
-					inputTokens: data.inputTokens,
-					outputTokens: data.outputTokens,
-					cacheCreationTokens: data.cacheCreationTokens,
-					cacheReadTokens: data.cacheReadTokens,
-					totalCost: data.totalCost,
-					modelsUsed: data.modelsUsed,
-				});
+				const row = formatUsageDataRow(
+					data.month,
+					{
+						inputTokens: data.inputTokens,
+						outputTokens: data.outputTokens,
+						cacheCreationTokens: data.cacheCreationTokens,
+						cacheReadTokens: data.cacheReadTokens,
+						totalCost: data.totalCost,
+						modelsUsed: data.modelsUsed,
+					},
+					undefined,
+					humanReadable,
+				);
 				table.push(row);
 
 				if (ctx.values.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 				}
 			}
 
 			addEmptySeparatorRow(table, 8);
 
-			const totalsRow = formatTotalsRow({
-				inputTokens: totals.inputTokens,
-				outputTokens: totals.outputTokens,
-				cacheCreationTokens: totals.cacheCreationTokens,
-				cacheReadTokens: totals.cacheReadTokens,
-				totalCost: totals.totalCost,
-			});
+			const totalsRow = formatTotalsRow(
+				{
+					inputTokens: totals.inputTokens,
+					outputTokens: totals.outputTokens,
+					cacheCreationTokens: totals.cacheCreationTokens,
+					cacheReadTokens: totals.cacheReadTokens,
+					totalCost: totals.totalCost,
+				},
+				false,
+				humanReadable,
+			);
 			table.push(totalsRow);
 
 			log(table.toString());

--- a/apps/pi/src/commands/session.ts
+++ b/apps/pi/src/commands/session.ts
@@ -49,6 +49,12 @@ export const sessionCommand = define({
 			description: 'Show model breakdown for each entry',
 			default: false,
 		},
+		human: {
+			type: 'boolean',
+			short: 'H',
+			description: 'Display token counts in human-readable format (K/M/B suffixes)',
+			default: false,
+		},
 	},
 	async run(ctx) {
 		const options = {
@@ -98,6 +104,8 @@ export const sessionCommand = define({
 				),
 			);
 		} else {
+			const humanReadable = Boolean(ctx.values.human);
+
 			logger.box('Pi-Agent Usage Report - Sessions');
 
 			const table = createUsageReportTable({
@@ -110,30 +118,39 @@ export const sessionCommand = define({
 				const truncatedName =
 					projectName.length > 25 ? `${projectName.slice(0, 22)}...` : projectName;
 
-				const row = formatUsageDataRow(truncatedName, {
-					inputTokens: data.inputTokens,
-					outputTokens: data.outputTokens,
-					cacheCreationTokens: data.cacheCreationTokens,
-					cacheReadTokens: data.cacheReadTokens,
-					totalCost: data.totalCost,
-					modelsUsed: data.modelsUsed,
-				});
+				const row = formatUsageDataRow(
+					truncatedName,
+					{
+						inputTokens: data.inputTokens,
+						outputTokens: data.outputTokens,
+						cacheCreationTokens: data.cacheCreationTokens,
+						cacheReadTokens: data.cacheReadTokens,
+						totalCost: data.totalCost,
+						modelsUsed: data.modelsUsed,
+					},
+					undefined,
+					humanReadable,
+				);
 				table.push(row);
 
 				if (ctx.values.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, 1, 0, humanReadable);
 				}
 			}
 
 			addEmptySeparatorRow(table, 8);
 
-			const totalsRow = formatTotalsRow({
-				inputTokens: totals.inputTokens,
-				outputTokens: totals.outputTokens,
-				cacheCreationTokens: totals.cacheCreationTokens,
-				cacheReadTokens: totals.cacheReadTokens,
-				totalCost: totals.totalCost,
-			});
+			const totalsRow = formatTotalsRow(
+				{
+					inputTokens: totals.inputTokens,
+					outputTokens: totals.outputTokens,
+					cacheCreationTokens: totals.cacheCreationTokens,
+					cacheReadTokens: totals.cacheReadTokens,
+					totalCost: totals.totalCost,
+				},
+				false,
+				humanReadable,
+			);
 			table.push(totalsRow);
 
 			log(table.toString());

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -352,11 +352,33 @@ export class ResponsiveTable {
 }
 
 /**
+ * Cached compact number formatter for human-readable display
+ */
+const compactFormatter = new Intl.NumberFormat('en-US', {
+	notation: 'compact',
+	compactDisplay: 'short',
+	maximumFractionDigits: 2,
+});
+
+/**
+ * Formats a number in human-readable compact notation (e.g., 1.23M, 500K)
+ * @param num - The number to format
+ * @returns Formatted number string with K/M/B/T suffixes
+ */
+export function formatNumberHuman(num: number): string {
+	return compactFormatter.format(num);
+}
+
+/**
  * Formats a number with locale-specific thousand separators
  * @param num - The number to format
+ * @param humanReadable - When true, uses compact notation (K/M/B suffixes)
  * @returns Formatted number string with commas as thousand separators
  */
-export function formatNumber(num: number): string {
+export function formatNumber(num: number, humanReadable = false): string {
+	if (humanReadable) {
+		return formatNumberHuman(num);
+	}
 	return num.toLocaleString('en-US');
 }
 
@@ -454,6 +476,7 @@ export function pushBreakdownRows(
 	}>,
 	extraColumns = 1,
 	trailingColumns = 0,
+	humanReadable = false,
 ): void {
 	for (const breakdown of breakdowns) {
 		const row: (string | number)[] = [`  └─ ${formatModelName(breakdown.modelName)}`];
@@ -471,11 +494,11 @@ export function pushBreakdownRows(
 			breakdown.cacheReadTokens;
 
 		row.push(
-			pc.gray(formatNumber(breakdown.inputTokens)),
-			pc.gray(formatNumber(breakdown.outputTokens)),
-			pc.gray(formatNumber(breakdown.cacheCreationTokens)),
-			pc.gray(formatNumber(breakdown.cacheReadTokens)),
-			pc.gray(formatNumber(totalTokens)),
+			pc.gray(formatNumber(breakdown.inputTokens, humanReadable)),
+			pc.gray(formatNumber(breakdown.outputTokens, humanReadable)),
+			pc.gray(formatNumber(breakdown.cacheCreationTokens, humanReadable)),
+			pc.gray(formatNumber(breakdown.cacheReadTokens, humanReadable)),
+			pc.gray(formatNumber(totalTokens, humanReadable)),
 			pc.gray(formatCurrency(breakdown.cost)),
 		);
 
@@ -577,6 +600,7 @@ export function formatUsageDataRow(
 	firstColumnValue: string,
 	data: UsageData,
 	lastActivity?: string,
+	humanReadable = false,
 ): (string | number)[] {
 	const totalTokens =
 		data.inputTokens + data.outputTokens + data.cacheCreationTokens + data.cacheReadTokens;
@@ -584,11 +608,11 @@ export function formatUsageDataRow(
 	const row: (string | number)[] = [
 		firstColumnValue,
 		data.modelsUsed != null ? formatModelsDisplayMultiline(data.modelsUsed) : '',
-		formatNumber(data.inputTokens),
-		formatNumber(data.outputTokens),
-		formatNumber(data.cacheCreationTokens),
-		formatNumber(data.cacheReadTokens),
-		formatNumber(totalTokens),
+		formatNumber(data.inputTokens, humanReadable),
+		formatNumber(data.outputTokens, humanReadable),
+		formatNumber(data.cacheCreationTokens, humanReadable),
+		formatNumber(data.cacheReadTokens, humanReadable),
+		formatNumber(totalTokens, humanReadable),
 		formatCurrency(data.totalCost),
 	];
 
@@ -608,6 +632,7 @@ export function formatUsageDataRow(
 export function formatTotalsRow(
 	totals: UsageData,
 	includeLastActivity = false,
+	humanReadable = false,
 ): (string | number)[] {
 	const totalTokens =
 		totals.inputTokens + totals.outputTokens + totals.cacheCreationTokens + totals.cacheReadTokens;
@@ -615,11 +640,11 @@ export function formatTotalsRow(
 	const row: (string | number)[] = [
 		pc.yellow('Total'),
 		'', // Empty for Models column in totals
-		pc.yellow(formatNumber(totals.inputTokens)),
-		pc.yellow(formatNumber(totals.outputTokens)),
-		pc.yellow(formatNumber(totals.cacheCreationTokens)),
-		pc.yellow(formatNumber(totals.cacheReadTokens)),
-		pc.yellow(formatNumber(totalTokens)),
+		pc.yellow(formatNumber(totals.inputTokens, humanReadable)),
+		pc.yellow(formatNumber(totals.outputTokens, humanReadable)),
+		pc.yellow(formatNumber(totals.cacheCreationTokens, humanReadable)),
+		pc.yellow(formatNumber(totals.cacheReadTokens, humanReadable)),
+		pc.yellow(formatNumber(totalTokens, humanReadable)),
 		pc.yellow(formatCurrency(totals.totalCost)),
 	];
 
@@ -1103,6 +1128,49 @@ if (import.meta.vitest != null) {
 		it('should use default locale when not specified', () => {
 			const result = formatDateCompact('2024-08-04');
 			expect(result).toBe('2024\n08-04');
+		});
+	});
+
+	describe('formatNumber', () => {
+		it('should format with comma separators by default', () => {
+			expect(formatNumber(1234567)).toBe('1,234,567');
+			expect(formatNumber(0)).toBe('0');
+			expect(formatNumber(999)).toBe('999');
+		});
+
+		it('should format in compact notation when humanReadable is true', () => {
+			expect(formatNumber(1234567, true)).toBe('1.23M');
+			expect(formatNumber(500000, true)).toBe('500K');
+			expect(formatNumber(999, true)).toBe('999');
+			expect(formatNumber(0, true)).toBe('0');
+		});
+
+		it('should use comma separators when humanReadable is false', () => {
+			expect(formatNumber(1234567, false)).toBe('1,234,567');
+		});
+	});
+
+	describe('formatNumberHuman', () => {
+		it('should format small numbers as-is', () => {
+			expect(formatNumberHuman(0)).toBe('0');
+			expect(formatNumberHuman(999)).toBe('999');
+		});
+
+		it('should format thousands with K suffix', () => {
+			expect(formatNumberHuman(1000)).toBe('1K');
+			expect(formatNumberHuman(2500)).toBe('2.5K');
+			expect(formatNumberHuman(99999)).toBe('100K');
+		});
+
+		it('should format millions with M suffix', () => {
+			expect(formatNumberHuman(1000000)).toBe('1M');
+			expect(formatNumberHuman(1500000)).toBe('1.5M');
+			expect(formatNumberHuman(1234567)).toBe('1.23M');
+		});
+
+		it('should format billions with B suffix', () => {
+			expect(formatNumberHuman(1000000000)).toBe('1B');
+			expect(formatNumberHuman(2500000000)).toBe('2.5B');
 		});
 	});
 }


### PR DESCRIPTION
## Summary

- Add `--human` / `-H` flag to all report commands across **all apps** (ccusage, codex, opencode, amp, pi)
- When enabled, token counts are displayed with K/M/B suffixes (e.g., `1.23M` instead of `1,234,567`)
- Uses `Intl.NumberFormat` with `notation: 'compact'` for standards-based formatting
- Includes unit tests for `formatNumberHuman` and `formatNumber` with humanReadable flag

## Details

Large token counts (millions+) are hard to scan visually. The `--human` flag provides a compact format:

| Raw | Human |
|---|---|
| 1,234,567 | 1.23M |
| 500,000 | 500K |
| 2,500 | 2.5K |
| 999 | 999 |

### Implementation

- New `formatNumberHuman()` function in `packages/terminal/src/table.ts` using cached `Intl.NumberFormat` instance
- Extended `formatNumber(num, humanReadable = false)` to delegate when flag is active
- Updated `formatUsageDataRow()`, `formatTotalsRow()`, and `pushBreakdownRows()` with optional `humanReadable` parameter
- All direct `formatNumber()` call sites across all apps receive the `humanReadable` flag
- JSON output remains unchanged

### Apps covered
- **ccusage**: daily, weekly, monthly, session, blocks, session-id lookup
- **codex**: daily, monthly, session
- **opencode**: daily, weekly, monthly, session (including sub-agent rows)
- **amp**: daily, monthly, session
- **pi**: daily, monthly, session

### Improvements over PR #940
- Covers **all 5 apps**, not just ccusage
- Uses `Intl.NumberFormat` with `notation: 'compact'` (standards-based, cached formatter instance)
- Every `formatNumber()` call site is covered, not just the helper functions

Closes #958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --human / -H flag across reporting commands (daily, weekly, monthly, session, blocks) to display token counts in compact human-readable form (K/M/B) in terminal/table output; JSON output unchanged.
* **Configuration**
  * New configuration option to set human-readable token formatting by default.
* **Tests**
  * Added unit tests for compact/compact-vs-default number formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->