### PR TITLE
feat(opencode): support date range filters

### DIFF
--- a/apps/opencode/src/_shared-args.ts
+++ b/apps/opencode/src/_shared-args.ts
@@ -1,0 +1,27 @@
+import type { Args } from 'gunshi';
+import * as v from 'valibot';
+
+const filterDateRegex = /^\d{8}$/;
+const filterDateSchema = v.pipe(
+	v.string(),
+	v.regex(filterDateRegex, 'Date must be in YYYYMMDD format'),
+);
+
+function parseDateArg(value: string): string {
+	return v.parse(filterDateSchema, value);
+}
+
+export const dateFilterArgs = {
+	since: {
+		type: 'custom',
+		short: 's',
+		description: 'Filter from date (YYYYMMDD format)',
+		parse: parseDateArg,
+	},
+	until: {
+		type: 'custom',
+		short: 'u',
+		description: 'Filter until date (YYYYMMDD format)',
+		parse: parseDateArg,
+	},
+} as const satisfies Args;

--- a/apps/opencode/src/_shared-args.ts
+++ b/apps/opencode/src/_shared-args.ts
@@ -11,6 +11,12 @@ function parseDateArg(value: string): string {
 	return v.parse(filterDateSchema, value);
 }
 
+/**
+ * Shared date-range CLI flags for OpenCode reports.
+ *
+ * Both `since` and `until` accept `YYYYMMDD` strings and use `parseDateArg`
+ * for the same format validation before satisfying Gunshi's `Args` shape.
+ */
 export const dateFilterArgs = {
 	since: {
 		type: 'custom',
@@ -25,3 +31,25 @@ export const dateFilterArgs = {
 		parse: parseDateArg,
 	},
 } as const satisfies Args;
+
+if (import.meta.vitest != null) {
+	const { describe, expect, it } = import.meta.vitest;
+
+	describe('dateFilterArgs', () => {
+		it('should parse main-mode compatible since and until args', () => {
+			expect(dateFilterArgs.since.short).toBe('s');
+			expect(dateFilterArgs.since.description).toBe('Filter from date (YYYYMMDD format)');
+			expect(dateFilterArgs.since.parse('20240102')).toBe('20240102');
+			expect(() => dateFilterArgs.since.parse('2024-01-02')).toThrow(
+				'Date must be in YYYYMMDD format',
+			);
+
+			expect(dateFilterArgs.until.short).toBe('u');
+			expect(dateFilterArgs.until.description).toBe('Filter until date (YYYYMMDD format)');
+			expect(dateFilterArgs.until.parse('20240103')).toBe('20240103');
+			expect(() => dateFilterArgs.until.parse('2024-01-03')).toThrow(
+				'Date must be in YYYYMMDD format',
+			);
+		});
+	});
+}

--- a/apps/opencode/src/commands/daily.ts
+++ b/apps/opencode/src/commands/daily.ts
@@ -10,6 +10,7 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
+import { dateFilterArgs } from '../_shared-args.ts';
 import { calculateCostForEntry } from '../cost-utils.ts';
 import { loadOpenCodeMessages } from '../data-loader.ts';
 import { logger } from '../logger.ts';
@@ -20,6 +21,7 @@ export const dailyCommand = define({
 	name: 'daily',
 	description: 'Show OpenCode token usage grouped by day',
 	args: {
+		...dateFilterArgs,
 		json: {
 			type: 'boolean',
 			short: 'j',
@@ -33,7 +35,10 @@ export const dailyCommand = define({
 	async run(ctx) {
 		const jsonOutput = Boolean(ctx.values.json);
 
-		const entries = await loadOpenCodeMessages();
+		const entries = await loadOpenCodeMessages({
+			since: ctx.values.since,
+			until: ctx.values.until,
+		});
 
 		if (entries.length === 0) {
 			const output = jsonOutput

--- a/apps/opencode/src/commands/index.ts
+++ b/apps/opencode/src/commands/index.ts
@@ -1,20 +1,18 @@
+import { dateFilterArgs } from '../_shared-args.ts';
 import { dailyCommand } from './daily.ts';
 import { monthlyCommand } from './monthly.ts';
 import { sessionCommand } from './session.ts';
 import { weeklyCommand } from './weekly.ts';
 
-export { dailyCommand } from './daily.ts';
-export { monthlyCommand } from './monthly.ts';
-export { sessionCommand } from './session.ts';
-export { weeklyCommand } from './weekly.ts';
+export { dailyCommand, monthlyCommand, sessionCommand, weeklyCommand };
 
 if (import.meta.vitest != null) {
 	const { describe, expect, it } = import.meta.vitest;
 
 	type DateArg = {
-		short: string;
-		description: string;
-		parse: (value: string) => string;
+		readonly short: string;
+		readonly description: string;
+		readonly parse: (value: string) => string;
 	};
 	type CommandWithDateArgs = {
 		args: {
@@ -29,18 +27,11 @@ if (import.meta.vitest != null) {
 			['weekly', weeklyCommand],
 			['monthly', monthlyCommand],
 			['session', sessionCommand],
-		])('should expose main-mode compatible since and until args for %s', (_name, command) => {
+		])('should expose shared since and until args for %s', (_name, command) => {
 			const args = (command as CommandWithDateArgs).args;
 
-			expect(args.since?.short).toBe('s');
-			expect(args.since?.description).toBe('Filter from date (YYYYMMDD format)');
-			expect(args.since?.parse('20240102')).toBe('20240102');
-			expect(() => args.since?.parse('2024-01-02')).toThrow('Date must be in YYYYMMDD format');
-
-			expect(args.until?.short).toBe('u');
-			expect(args.until?.description).toBe('Filter until date (YYYYMMDD format)');
-			expect(args.until?.parse('20240103')).toBe('20240103');
-			expect(() => args.until?.parse('2024-01-03')).toThrow('Date must be in YYYYMMDD format');
+			expect(args.since).toBe(dateFilterArgs.since);
+			expect(args.until).toBe(dateFilterArgs.until);
 		});
 	});
 }

--- a/apps/opencode/src/commands/index.ts
+++ b/apps/opencode/src/commands/index.ts
@@ -1,4 +1,46 @@
-export { dailyCommand } from './daily';
-export { monthlyCommand } from './monthly';
-export { sessionCommand } from './session';
-export { weeklyCommand } from './weekly';
+import { dailyCommand } from './daily.ts';
+import { monthlyCommand } from './monthly.ts';
+import { sessionCommand } from './session.ts';
+import { weeklyCommand } from './weekly.ts';
+
+export { dailyCommand } from './daily.ts';
+export { monthlyCommand } from './monthly.ts';
+export { sessionCommand } from './session.ts';
+export { weeklyCommand } from './weekly.ts';
+
+if (import.meta.vitest != null) {
+	const { describe, expect, it } = import.meta.vitest;
+
+	type DateArg = {
+		short: string;
+		description: string;
+		parse: (value: string) => string;
+	};
+	type CommandWithDateArgs = {
+		args: {
+			since?: DateArg;
+			until?: DateArg;
+		};
+	};
+
+	describe('OpenCode command date filter arguments', () => {
+		it.each([
+			['daily', dailyCommand],
+			['weekly', weeklyCommand],
+			['monthly', monthlyCommand],
+			['session', sessionCommand],
+		])('should expose main-mode compatible since and until args for %s', (_name, command) => {
+			const args = (command as CommandWithDateArgs).args;
+
+			expect(args.since?.short).toBe('s');
+			expect(args.since?.description).toBe('Filter from date (YYYYMMDD format)');
+			expect(args.since?.parse('20240102')).toBe('20240102');
+			expect(() => args.since?.parse('2024-01-02')).toThrow('Date must be in YYYYMMDD format');
+
+			expect(args.until?.short).toBe('u');
+			expect(args.until?.description).toBe('Filter until date (YYYYMMDD format)');
+			expect(args.until?.parse('20240103')).toBe('20240103');
+			expect(() => args.until?.parse('2024-01-03')).toThrow('Date must be in YYYYMMDD format');
+		});
+	});
+}

--- a/apps/opencode/src/commands/monthly.ts
+++ b/apps/opencode/src/commands/monthly.ts
@@ -10,6 +10,7 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
+import { dateFilterArgs } from '../_shared-args.ts';
 import { calculateCostForEntry } from '../cost-utils.ts';
 import { loadOpenCodeMessages } from '../data-loader.ts';
 import { logger } from '../logger.ts';
@@ -20,6 +21,7 @@ export const monthlyCommand = define({
 	name: 'monthly',
 	description: 'Show OpenCode token usage grouped by month',
 	args: {
+		...dateFilterArgs,
 		json: {
 			type: 'boolean',
 			short: 'j',
@@ -33,7 +35,10 @@ export const monthlyCommand = define({
 	async run(ctx) {
 		const jsonOutput = Boolean(ctx.values.json);
 
-		const entries = await loadOpenCodeMessages();
+		const entries = await loadOpenCodeMessages({
+			since: ctx.values.since,
+			until: ctx.values.until,
+		});
 
 		if (entries.length === 0) {
 			const output = jsonOutput

--- a/apps/opencode/src/commands/session.ts
+++ b/apps/opencode/src/commands/session.ts
@@ -10,6 +10,7 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
+import { dateFilterArgs } from '../_shared-args.ts';
 import { calculateCostForEntry } from '../cost-utils.ts';
 import { loadOpenCodeMessages, loadOpenCodeSessions } from '../data-loader.ts';
 import { logger } from '../logger.ts';
@@ -20,6 +21,7 @@ export const sessionCommand = define({
 	name: 'session',
 	description: 'Show OpenCode token usage grouped by session',
 	args: {
+		...dateFilterArgs,
 		json: {
 			type: 'boolean',
 			short: 'j',
@@ -34,7 +36,10 @@ export const sessionCommand = define({
 		const jsonOutput = Boolean(ctx.values.json);
 
 		const [entries, sessionMetadataMap] = await Promise.all([
-			loadOpenCodeMessages(),
+			loadOpenCodeMessages({
+				since: ctx.values.since,
+				until: ctx.values.until,
+			}),
 			loadOpenCodeSessions(),
 		]);
 

--- a/apps/opencode/src/commands/weekly.ts
+++ b/apps/opencode/src/commands/weekly.ts
@@ -10,6 +10,7 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
+import { dateFilterArgs } from '../_shared-args.ts';
 import { calculateCostForEntry } from '../cost-utils.ts';
 import { loadOpenCodeMessages } from '../data-loader.ts';
 import { logger } from '../logger.ts';
@@ -45,6 +46,7 @@ export const weeklyCommand = define({
 	name: 'weekly',
 	description: 'Show OpenCode token usage grouped by week (ISO week format)',
 	args: {
+		...dateFilterArgs,
 		json: {
 			type: 'boolean',
 			short: 'j',
@@ -58,7 +60,10 @@ export const weeklyCommand = define({
 	async run(ctx) {
 		const jsonOutput = Boolean(ctx.values.json);
 
-		const entries = await loadOpenCodeMessages();
+		const entries = await loadOpenCodeMessages({
+			since: ctx.values.since,
+			until: ctx.values.until,
+		});
 
 		if (entries.length === 0) {
 			const output = jsonOutput

--- a/apps/opencode/src/data-loader.ts
+++ b/apps/opencode/src/data-loader.ts
@@ -123,6 +123,12 @@ export type LoadedSessionMetadata = {
 	directory: string;
 };
 
+/**
+ * Date range options for loading OpenCode messages.
+ *
+ * `since` and `until` use `YYYYMMDD` strings so the loader can apply the same
+ * lexicographic date comparison semantics as the main CLI.
+ */
 export type LoadOpenCodeMessagesOptions = {
 	since?: string;
 	until?: string;
@@ -495,6 +501,27 @@ if (import.meta.vitest != null) {
 				});
 
 				expect(getSortedIsoTimestamps(entries)).toEqual(['2024-01-02T12:00:00.000Z']);
+			} finally {
+				await rm(root, { recursive: true, force: true });
+			}
+		});
+
+		it('should return no OpenCode messages for non-overlapping date ranges', async () => {
+			const root = await createOpenCodeMessageFixture([
+				createTestMessage('msg_20240101', '2024-01-01T12:00:00.000Z'),
+				createTestMessage('msg_20240102', '2024-01-02T12:00:00.000Z'),
+				createTestMessage('msg_20240103', '2024-01-03T12:00:00.000Z'),
+			]);
+
+			try {
+				vi.stubEnv(OPENCODE_CONFIG_DIR_ENV, root);
+
+				const entries = await loadOpenCodeMessages({
+					since: '20240104',
+					until: '20240105',
+				});
+
+				expect(getSortedIsoTimestamps(entries)).toEqual([]);
 			} finally {
 				await rm(root, { recursive: true, force: true });
 			}

--- a/apps/opencode/src/data-loader.ts
+++ b/apps/opencode/src/data-loader.ts
@@ -8,8 +8,8 @@
  * @module data-loader
  */
 
-import { readFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { isDirectorySync } from 'path-type';
@@ -123,6 +123,11 @@ export type LoadedSessionMetadata = {
 	directory: string;
 };
 
+export type LoadOpenCodeMessagesOptions = {
+	since?: string;
+	until?: string;
+};
+
 /**
  * Get OpenCode data directory
  * @returns Path to OpenCode data directory, or null if not found
@@ -185,6 +190,26 @@ function convertOpenCodeMessageToUsageEntry(
 		model: message.modelID ?? 'unknown',
 		costUSD: message.cost ?? null,
 	};
+}
+
+function filterOpenCodeMessagesByDateRange(
+	entries: LoadedUsageEntry[],
+	options?: LoadOpenCodeMessagesOptions,
+): LoadedUsageEntry[] {
+	if (options?.since == null && options?.until == null) {
+		return entries;
+	}
+
+	return entries.filter((entry) => {
+		const dateStr = entry.timestamp.toISOString().substring(0, 10).replace(/-/g, '');
+		if (options.since != null && dateStr < options.since) {
+			return false;
+		}
+		if (options.until != null && dateStr > options.until) {
+			return false;
+		}
+		return true;
+	});
 }
 
 async function loadOpenCodeSession(
@@ -252,7 +277,9 @@ export async function loadOpenCodeSessions(): Promise<Map<string, LoadedSessionM
  * Load all OpenCode messages
  * @returns Array of LoadedUsageEntry for aggregation
  */
-export async function loadOpenCodeMessages(): Promise<LoadedUsageEntry[]> {
+export async function loadOpenCodeMessages(
+	options?: LoadOpenCodeMessagesOptions,
+): Promise<LoadedUsageEntry[]> {
 	const openCodePath = getOpenCodePath();
 	if (openCodePath == null) {
 		return [];
@@ -305,11 +332,54 @@ export async function loadOpenCodeMessages(): Promise<LoadedUsageEntry[]> {
 		entries.push(entry);
 	}
 
-	return entries;
+	return filterOpenCodeMessagesByDateRange(entries, options);
 }
 
 if (import.meta.vitest != null) {
-	const { describe, it, expect } = import.meta.vitest;
+	const { describe, it, expect, afterEach, vi } = import.meta.vitest;
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	async function createOpenCodeMessageFixture(
+		messages: Array<v.InferOutput<typeof openCodeMessageSchema>>,
+	): Promise<string> {
+		const root = await mkdtemp(path.join(tmpdir(), 'opencode-data-'));
+		const messagesDir = path.join(root, 'storage', 'message');
+		await mkdir(messagesDir, { recursive: true });
+
+		await Promise.all(
+			messages.map(async (message) =>
+				writeFile(path.join(messagesDir, `${message.id}.json`), JSON.stringify(message)),
+			),
+		);
+
+		return root;
+	}
+
+	function createTestMessage(
+		id: string,
+		timestamp: string,
+	): v.InferOutput<typeof openCodeMessageSchema> {
+		return {
+			id,
+			sessionID: 'session-test' as v.InferOutput<typeof sessionIdSchema>,
+			providerID: 'anthropic',
+			modelID: 'claude-sonnet-4-5' as v.InferOutput<typeof modelNameSchema>,
+			time: {
+				created: Date.parse(timestamp),
+			},
+			tokens: {
+				input: 100,
+				output: 50,
+			},
+		};
+	}
+
+	function getSortedIsoTimestamps(entries: LoadedUsageEntry[]): string[] {
+		return entries.map((entry) => entry.timestamp.toISOString()).sort();
+	}
 
 	describe('data-loader', () => {
 		it('should convert OpenCode message to LoadedUsageEntry', () => {
@@ -365,6 +435,69 @@ if (import.meta.vitest != null) {
 			expect(entry.usage.cacheReadInputTokens).toBe(0);
 			expect(entry.usage.cacheCreationInputTokens).toBe(0);
 			expect(entry.costUSD).toBe(null);
+		});
+
+		it('should filter OpenCode messages by since date', async () => {
+			const root = await createOpenCodeMessageFixture([
+				createTestMessage('msg_20240101', '2024-01-01T12:00:00.000Z'),
+				createTestMessage('msg_20240102', '2024-01-02T12:00:00.000Z'),
+				createTestMessage('msg_20240103', '2024-01-03T12:00:00.000Z'),
+			]);
+
+			try {
+				vi.stubEnv(OPENCODE_CONFIG_DIR_ENV, root);
+
+				const entries = await loadOpenCodeMessages({ since: '20240102' });
+
+				expect(getSortedIsoTimestamps(entries)).toEqual([
+					'2024-01-02T12:00:00.000Z',
+					'2024-01-03T12:00:00.000Z',
+				]);
+			} finally {
+				await rm(root, { recursive: true, force: true });
+			}
+		});
+
+		it('should filter OpenCode messages by until date', async () => {
+			const root = await createOpenCodeMessageFixture([
+				createTestMessage('msg_20240101', '2024-01-01T12:00:00.000Z'),
+				createTestMessage('msg_20240102', '2024-01-02T12:00:00.000Z'),
+				createTestMessage('msg_20240103', '2024-01-03T12:00:00.000Z'),
+			]);
+
+			try {
+				vi.stubEnv(OPENCODE_CONFIG_DIR_ENV, root);
+
+				const entries = await loadOpenCodeMessages({ until: '20240102' });
+
+				expect(getSortedIsoTimestamps(entries)).toEqual([
+					'2024-01-01T12:00:00.000Z',
+					'2024-01-02T12:00:00.000Z',
+				]);
+			} finally {
+				await rm(root, { recursive: true, force: true });
+			}
+		});
+
+		it('should filter OpenCode messages by since and until dates', async () => {
+			const root = await createOpenCodeMessageFixture([
+				createTestMessage('msg_20240101', '2024-01-01T12:00:00.000Z'),
+				createTestMessage('msg_20240102', '2024-01-02T12:00:00.000Z'),
+				createTestMessage('msg_20240103', '2024-01-03T12:00:00.000Z'),
+			]);
+
+			try {
+				vi.stubEnv(OPENCODE_CONFIG_DIR_ENV, root);
+
+				const entries = await loadOpenCodeMessages({
+					since: '20240102',
+					until: '20240102',
+				});
+
+				expect(getSortedIsoTimestamps(entries)).toEqual(['2024-01-02T12:00:00.000Z']);
+			} finally {
+				await rm(root, { recursive: true, force: true });
+			}
 		});
 	});
 }


### PR DESCRIPTION
## Summary
- Add `--since/-s` and `--until/-u` filters to OpenCode daily, weekly, monthly, and session reports.
- Filter OpenCode messages by timestamp before aggregation using the same `YYYYMMDD` closed-range semantics as the main CLI.
- Add in-source tests for command argument compatibility and message date filtering.

## Test Plan
- [x] `pnpm --filter @ccusage/opencode run format`
- [x] `pnpm --filter @ccusage/opencode run typecheck`
- [x] `pnpm --filter @ccusage/opencode run test`
- [x] `pnpm --filter @ccusage/opencode run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added date range filtering to all commands with new --since / --until options (short: -s / -u) to restrict output to a specific period.
  * Date inputs must use YYYYMMDD (e.g., 20240115); invalid formats produce a clear validation error.
* **Tests**
  * Added automated tests covering date parsing/validation and filtering behavior to ensure correct results for various ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->