### PR TITLE
feat(terminal): add --watch mode for resize-responsive table display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # nix
 .direnv
 !.envrc
+.worktrees/

--- a/apps/ccusage/src/_shared-args.ts
+++ b/apps/ccusage/src/_shared-args.ts
@@ -110,6 +110,12 @@ export const sharedArgs = {
 		description: 'Force compact mode for narrow displays (better for screenshots)',
 		default: false,
 	},
+	watch: {
+		type: 'boolean',
+		short: 'w',
+		description: 'Watch mode — re-renders table on terminal resize (alternate screen)',
+		default: false,
+	},
 } as const satisfies Args;
 
 /**

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -7,6 +7,7 @@ import {
 	formatUsageDataRow,
 	pushBreakdownRows,
 } from '@ccusage/terminal/table';
+import { createWatchSession } from '@ccusage/terminal/watch';
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
@@ -134,8 +135,10 @@ export const dailyCommand = define({
 				log(JSON.stringify(jsonOutput, null, 2));
 			}
 		} else {
-			// Print header
-			logger.box('Claude Code Token Usage Report - Daily');
+			// Print header (only in static mode, not watch mode)
+			if (!mergedOptions.watch) {
+				logger.box('Claude Code Token Usage Report - Daily');
+			}
 
 			// Create table with compact mode support
 			const tableConfig: UsageReportConfig = {
@@ -144,35 +147,63 @@ export const dailyCommand = define({
 					formatDateCompact(dateStr, mergedOptions.timezone, mergedOptions.locale ?? undefined),
 				forceCompact: ctx.values.compact,
 			};
-			const table = createUsageReportTable(tableConfig);
 
-			// Add daily data - group by project if instances flag is used
-			if (Boolean(mergedOptions.instances) && dailyData.some((d) => d.project != null)) {
-				// Group data by project for visual separation
-				const projectGroups = groupDataByProject(dailyData);
+			/**
+			 * Builds a populated table string from the loaded data.
+			 * Called once for static output, or on each resize in watch mode.
+			 */
+			const buildTable = (): string => {
+				const table = createUsageReportTable(tableConfig);
 
-				let isFirstProject = true;
-				for (const [projectName, projectData] of Object.entries(projectGroups)) {
-					// Add project section header
-					if (!isFirstProject) {
-						// Add empty row for visual separation between projects
-						table.push(['', '', '', '', '', '', '', '']);
+				// Add daily data - group by project if instances flag is used
+				if (Boolean(mergedOptions.instances) && dailyData.some((d) => d.project != null)) {
+					// Group data by project for visual separation
+					const projectGroups = groupDataByProject(dailyData);
+
+					let isFirstProject = true;
+					for (const [projectName, projectData] of Object.entries(projectGroups)) {
+						// Add project section header
+						if (!isFirstProject) {
+							// Add empty row for visual separation between projects
+							table.push(['', '', '', '', '', '', '', '']);
+						}
+
+						// Add project header row
+						table.push([
+							pc.cyan(`Project: ${formatProjectName(projectName, projectAliases)}`),
+							'',
+							'',
+							'',
+							'',
+							'',
+							'',
+							'',
+						]);
+
+						// Add data rows for this project
+						for (const data of projectData) {
+							const row = formatUsageDataRow(data.date, {
+								inputTokens: data.inputTokens,
+								outputTokens: data.outputTokens,
+								cacheCreationTokens: data.cacheCreationTokens,
+								cacheReadTokens: data.cacheReadTokens,
+								totalCost: data.totalCost,
+								modelsUsed: data.modelsUsed,
+							});
+							table.push(row);
+
+							// Add model breakdown rows if flag is set
+							if (mergedOptions.breakdown) {
+								pushBreakdownRows(table, data.modelBreakdowns);
+							}
+						}
+
+						isFirstProject = false;
 					}
-
-					// Add project header row
-					table.push([
-						pc.cyan(`Project: ${formatProjectName(projectName, projectAliases)}`),
-						'',
-						'',
-						'',
-						'',
-						'',
-						'',
-						'',
-					]);
-
-					// Add data rows for this project
-					for (const data of projectData) {
+				} else {
+					// Standard display without project grouping
+					for (const data of dailyData) {
+						// Main row
 						const row = formatUsageDataRow(data.date, {
 							inputTokens: data.inputTokens,
 							outputTokens: data.outputTokens,
@@ -188,49 +219,39 @@ export const dailyCommand = define({
 							pushBreakdownRows(table, data.modelBreakdowns);
 						}
 					}
-
-					isFirstProject = false;
 				}
+
+				// Add empty row for visual separation before totals
+				addEmptySeparatorRow(table, 8);
+
+				// Add totals
+				const totalsRow = formatTotalsRow({
+					inputTokens: totals.inputTokens,
+					outputTokens: totals.outputTokens,
+					cacheCreationTokens: totals.cacheCreationTokens,
+					cacheReadTokens: totals.cacheReadTokens,
+					totalCost: totals.totalCost,
+				});
+				table.push(totalsRow);
+
+				return table.toString();
+			};
+
+			if (mergedOptions.watch) {
+				// Watch mode — re-render on terminal resize
+				await createWatchSession(buildTable, { showHelpHint: true });
 			} else {
-				// Standard display without project grouping
-				for (const data of dailyData) {
-					// Main row
-					const row = formatUsageDataRow(data.date, {
-						inputTokens: data.inputTokens,
-						outputTokens: data.outputTokens,
-						cacheCreationTokens: data.cacheCreationTokens,
-						cacheReadTokens: data.cacheReadTokens,
-						totalCost: data.totalCost,
-						modelsUsed: data.modelsUsed,
-					});
-					table.push(row);
+				const output = buildTable();
+				log(output);
 
-					// Add model breakdown rows if flag is set
-					if (mergedOptions.breakdown) {
-						pushBreakdownRows(table, data.modelBreakdowns);
-					}
+				// Show guidance message if in compact mode
+				// Check terminal width directly since compact mode is determined during toString()
+				const terminalWidth =
+					Number.parseInt(process.env.COLUMNS ?? '', 10) || process.stdout.columns || 120;
+				if (ctx.values.compact || terminalWidth < 100) {
+					logger.info('\nRunning in Compact Mode');
+					logger.info('Expand terminal width to see cache metrics and total tokens');
 				}
-			}
-
-			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
-
-			// Add totals
-			const totalsRow = formatTotalsRow({
-				inputTokens: totals.inputTokens,
-				outputTokens: totals.outputTokens,
-				cacheCreationTokens: totals.cacheCreationTokens,
-				cacheReadTokens: totals.cacheReadTokens,
-				totalCost: totals.totalCost,
-			});
-			table.push(totalsRow);
-
-			log(table.toString());
-
-			// Show guidance message if in compact mode
-			if (table.isCompactMode()) {
-				logger.info('\nRunning in Compact Mode');
-				logger.info('Expand terminal width to see cache metrics and total tokens');
 			}
 		}
 	},

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -6,7 +6,8 @@
 	"description": "Terminal utilities for ccusage",
 	"exports": {
 		"./table": "./src/table.ts",
-		"./utils": "./src/utils.ts"
+		"./utils": "./src/utils.ts",
+		"./watch": "./src/watch.ts"
 	},
 	"scripts": {
 		"format": "pnpm run lint --fix",

--- a/packages/terminal/src/watch.ts
+++ b/packages/terminal/src/watch.ts
@@ -1,0 +1,242 @@
+import type { Buffer } from 'node:buffer';
+import type { WriteStream } from 'node:tty';
+import process from 'node:process';
+import { Writable } from 'node:stream';
+import * as ansiEscapes from 'ansi-escapes';
+import { TerminalManager } from './utils.ts';
+
+/**
+ * Options for configuring a watch session
+ */
+export type WatchSessionOptions = {
+	/** Show "Press q or Ctrl+C to exit" hint at the bottom */
+	showHelpHint?: boolean;
+	/** Output stream override (defaults to process.stdout). Useful for testing. */
+	stream?: WriteStream;
+};
+
+/**
+ * Creates a watch session that re-renders content on terminal resize.
+ *
+ * Uses alternate screen buffer to preserve scrollback history.
+ * Handles cleanup on all exit paths (signals, exceptions, keypress).
+ *
+ * @param renderFn - Function that returns the content to display.
+ *   Called on initial render and each terminal resize.
+ * @param options - Watch session configuration
+ * @returns Promise that resolves when the session ends
+ */
+export async function createWatchSession(
+	renderFn: () => string,
+	options?: WatchSessionOptions,
+): Promise<void> {
+	const stream = options?.stream ?? (process.stdout as WriteStream);
+	const terminal = new TerminalManager(stream);
+
+	// Non-TTY fallback: print once and return
+	if (!terminal.isTTY) {
+		terminal.write(`${renderFn()}\n`);
+		return Promise.resolve();
+	}
+
+	let cleanupDone = false;
+	let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+	let exitResolve: (() => void) | null = null;
+
+	// Use a mutable ref to break the define-before-use cycle between render ↔ cleanup ↔ onResize
+	let onResizeRef: (() => void) | null = null;
+
+	const cleanup = (): void => {
+		if (cleanupDone) {
+			return;
+		}
+		cleanupDone = true;
+
+		// Clear debounce timer
+		if (resizeTimer != null) {
+			clearTimeout(resizeTimer);
+			resizeTimer = null;
+		}
+
+		// Remove resize listener
+		if (onResizeRef != null) {
+			stream.off('resize', onResizeRef);
+		}
+
+		// Restore stdin
+		if (process.stdin.isTTY) {
+			try {
+				process.stdin.setRawMode(false);
+				process.stdin.pause();
+			} catch {
+				// stdin may already be destroyed
+			}
+		}
+
+		// Restore terminal state
+		terminal.cleanup();
+
+		// Resolve the keep-alive promise
+		if (exitResolve != null) {
+			exitResolve();
+		}
+	};
+
+	const render = (): void => {
+		try {
+			terminal.startBuffering();
+			terminal.write(ansiEscapes.clearScreen);
+			terminal.write(ansiEscapes.cursorTo(0, 0));
+			terminal.write(renderFn());
+			if (options?.showHelpHint === true) {
+				terminal.write('\n\nPress q or Ctrl+C to exit');
+			}
+			terminal.flush();
+		} catch (error) {
+			cleanup();
+			throw error;
+		}
+	};
+
+	// Debounced resize handler (75ms trailing edge)
+	const onResize = (): void => {
+		if (resizeTimer != null) {
+			clearTimeout(resizeTimer);
+		}
+		resizeTimer = setTimeout(render, 75);
+	};
+	onResizeRef = onResize;
+
+	// Signal handlers for graceful cleanup
+	const onSignal = (): void => {
+		cleanup();
+		process.exit(0);
+	};
+
+	const onError = (error: unknown): void => {
+		cleanup();
+		// Re-throw after cleanup so the error is still visible
+		throw error;
+	};
+
+	// Register cleanup on all exit paths
+	process.once('SIGINT', onSignal);
+	process.once('SIGTERM', onSignal);
+	process.once('SIGHUP', onSignal);
+	process.on('exit', () => {
+		// Synchronous cleanup only — last chance to restore terminal
+		if (!cleanupDone) {
+			cleanupDone = true;
+			terminal.cleanup();
+		}
+	});
+	process.once('uncaughtException', onError);
+	process.once('unhandledRejection', onError);
+
+	// Enter watch mode
+	terminal.enableSyncMode();
+	terminal.enterAlternateScreen();
+	terminal.hideCursor();
+
+	// Initial render
+	render();
+
+	// Listen for resize events
+	stream.on('resize', onResize);
+
+	// Set up keypress detection (only if stdin is a TTY)
+	if (process.stdin.isTTY) {
+		process.stdin.setRawMode(true);
+		process.stdin.resume();
+		process.stdin.on('data', (data: Buffer) => {
+			const key = data.toString();
+			// q or Ctrl+C
+			if (key === 'q' || key === 'Q' || data[0] === 0x03) {
+				cleanup();
+				process.exit(0);
+			}
+		});
+	}
+
+	// Keep process alive until cleanup resolves
+	return new Promise<void>((resolve) => {
+		exitResolve = resolve;
+	});
+}
+
+/**
+ * Creates a mock TTY WriteStream for testing
+ */
+function createMockTTYStream(): WriteStream {
+	const stream = new Writable({
+		write(_chunk: Buffer, _encoding: BufferEncoding, callback: () => void) {
+			callback();
+		},
+	});
+	Object.assign(stream, { isTTY: true, columns: 120, rows: 40 });
+	return stream as unknown as WriteStream;
+}
+
+/**
+ * Creates a mock non-TTY WriteStream for testing
+ */
+function createMockNonTTYStream(): { stream: WriteStream; output: string } {
+	let output = '';
+	const stream = new Writable({
+		write(chunk: Buffer, _encoding: BufferEncoding, callback: () => void) {
+			output += chunk.toString();
+			callback();
+		},
+	});
+	Object.assign(stream, { isTTY: false });
+	return {
+		stream: stream as unknown as WriteStream,
+		get output() {
+			return output;
+		},
+	};
+}
+
+if (import.meta.vitest != null) {
+	describe('createWatchSession', () => {
+		it('should render once and return for non-TTY output', async () => {
+			const mock = createMockNonTTYStream();
+
+			await createWatchSession(() => 'hello world', { stream: mock.stream });
+			expect(mock.output).toBe('hello world\n');
+		});
+
+		it('should accept showHelpHint option without crashing for non-TTY', async () => {
+			const mock = createMockNonTTYStream();
+
+			await createWatchSession(() => 'test', { showHelpHint: true, stream: mock.stream });
+			// Non-TTY should just output the render, no hint
+			expect(mock.output).toBe('test\n');
+		});
+	});
+
+	describe('TerminalManager used by watch', () => {
+		it('should create TerminalManager with mock TTY stream', () => {
+			const stream = createMockTTYStream();
+			const manager = new TerminalManager(stream);
+			expect(manager.isTTY).toBe(true);
+			expect(manager.width).toBe(120);
+			expect(manager.height).toBe(40);
+		});
+
+		it('should report non-TTY correctly', () => {
+			const { stream } = createMockNonTTYStream();
+			const manager = new TerminalManager(stream);
+			expect(manager.isTTY).toBe(false);
+		});
+
+		it('should handle cleanup idempotently', () => {
+			const stream = createMockTTYStream();
+			const manager = new TerminalManager(stream);
+			// Multiple cleanups should not throw
+			manager.cleanup();
+			manager.cleanup();
+			manager.cleanup();
+		});
+	});
+}


### PR DESCRIPTION
## Summary

Closes #961

Adds a `--watch / -w` flag that keeps table output alive in an alternate screen buffer and re-renders on terminal resize (`SIGWINCH`). Currently wired up in the `daily` command as proof of concept — other commands can adopt with ~5 line changes each.

## What it does

When you run `ccusage daily --watch`:
1. Data is loaded once
2. Table is rendered in an alternate screen buffer (like vim/less)
3. On terminal resize, the table re-renders at the new width — compact mode columns automatically drop/add as the width crosses thresholds
4. Press `q` or `Ctrl+C` to exit cleanly — scrollback history is preserved

Without `--watch`, behavior is unchanged (static one-shot output).

## Implementation

### New: `packages/terminal/src/watch.ts`

A reusable `createWatchSession(renderFn, options?)` utility that:
- Enters alternate screen buffer with DEC synchronized output for flicker-free rendering
- Debounces resize events (75ms trailing edge) to prevent lag during drag-resize
- Guards `stdin.setRawMode()` with `isTTY` check (handles piped stdin)
- Falls back to single static render for non-TTY output (pipes)
- Robust cleanup on all exit paths: SIGINT, SIGTERM, SIGHUP, uncaughtException, unhandledRejection, process.exit
- Idempotent cleanup (safe to call multiple times)

### Changed files

| File | Change |
|------|--------|
| `packages/terminal/src/watch.ts` | **NEW** — `createWatchSession` utility + 5 tests |
| `packages/terminal/package.json` | Added `./watch` export |
| `apps/ccusage/src/_shared-args.ts` | Added `--watch / -w` flag |
| `apps/ccusage/src/commands/daily.ts` | Wired up watch mode |

## Edge cases

- `--watch` + `--json`: Watch is silently ignored (JSON output does not benefit from resize re-rendering)
- Non-TTY stdout (piped): Falls back to single render, no alternate screen
- Non-TTY stdin + TTY stdout: Watch mode works, but no keypress detection — exits via SIGINT only

## Design decisions

- **Resize only, no polling**: Re-renders existing data on resize. No periodic data refresh.
- **Alternate screen**: Preserves scrollback. Standard TUI pattern (like vim/less).
- **Shared utility**: Lives in `packages/terminal` for reuse across all apps/commands.
- **Proof of concept**: Only `daily` wired up in this PR. Other commands adopt later.

## Verification

- `pnpm run format` — ✅ clean
- `pnpm typecheck` — ✅ clean
- `pnpm run test` — ✅ 345 passed, 14 pre-existing failures (MCP/config tests)