### PR TITLE
fix(opencode): read from SQLite DB after post-Feb 2026 storage migration

### DIFF
--- a/apps/opencode/CLAUDE.md
+++ b/apps/opencode/CLAUDE.md
@@ -2,9 +2,11 @@
 
 ## Log Sources
 
-- OpenCode session usage is recorded under `${OPENCODE_DATA_DIR:-~/.local/share/opencode}/storage/message/` (the CLI resolves `OPENCODE_DATA_DIR` and falls back to `~/.local/share/opencode`).
-- Each message is stored as an individual JSON file (not JSONL like Claude or Codex).
-- Message structure includes `tokens.input`, `tokens.output`, `tokens.cache.read`, and `tokens.cache.write`.
+- OpenCode session usage is recorded in **two storage formats** depending on OpenCode version:
+  1. **File-based (pre-Feb 2026):** Individual JSON files under `${OPENCODE_DATA_DIR:-~/.local/share/opencode}/storage/message/`
+  2. **SQLite (post-Feb 2026):** `${OPENCODE_DATA_DIR:-~/.local/share/opencode}/opencode.db` — assistant messages in the `message` table with token data embedded as JSON in the `data` column
+- Both sources are read and merged automatically. The SQLite DB is opened read-only.
+- `OPENCODE_DATA_DIR` environment variable overrides the default path for both sources.
 
 ## Token Fields
 

--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -49,6 +49,7 @@
 		"@ccusage/terminal": "workspace:*",
 		"@praha/byethrow": "catalog:runtime",
 		"@ryoppippi/eslint-config": "catalog:lint",
+		"@types/bun": "catalog:types",
 		"@typescript/native-preview": "catalog:types",
 		"clean-pkg-json": "catalog:release",
 		"es-toolkit": "catalog:runtime",

--- a/apps/opencode/src/__mocks__/bun-sqlite.ts
+++ b/apps/opencode/src/__mocks__/bun-sqlite.ts
@@ -1,0 +1,10 @@
+// Stub for bun:sqlite used during Vitest (Node.js) test runs.
+// The real implementation is Bun's built-in Database; this stub lets
+// tests import data-loader.ts without crashing on an unavailable built-in.
+export class Database {
+	constructor(_path: string, _options?: { readonly?: boolean }) {}
+	query(_sql: string) {
+		return { all: () => [] as never[] };
+	}
+	close() {}
+}

--- a/apps/opencode/src/data-loader.ts
+++ b/apps/opencode/src/data-loader.ts
@@ -2,8 +2,9 @@
  * @fileoverview Data loading utilities for OpenCode usage analysis
  *
  * This module provides functions for loading and parsing OpenCode usage data
- * from JSON message files stored in OpenCode data directories.
- * OpenCode stores usage data in ~/.local/share/opencode/storage/message/
+ * from two sources:
+ *   1. JSON message files in ~/.local/share/opencode/storage/message/ (pre-Feb 2026)
+ *   2. SQLite database at ~/.local/share/opencode/opencode.db (post-Feb 2026 migration)
  *
  * @module data-loader
  */
@@ -12,9 +13,12 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
-import { isDirectorySync } from 'path-type';
+import { Result } from '@praha/byethrow';
+import { Database } from 'bun:sqlite';
+import { isDirectorySync, isFileSync } from 'path-type';
 import { glob } from 'tinyglobby';
 import * as v from 'valibot';
+import { logger } from './logger.ts';
 
 /**
  * Default OpenCode data directory path (~/.local/share/opencode)
@@ -31,6 +35,11 @@ const OPENCODE_STORAGE_DIR_NAME = 'storage';
  */
 const OPENCODE_MESSAGES_DIR_NAME = 'message';
 const OPENCODE_SESSIONS_DIR_NAME = 'session';
+
+/**
+ * OpenCode SQLite database filename (introduced ~Feb 2026, replacing file-based storage)
+ */
+const OPENCODE_DB_NAME = 'opencode.db';
 
 /**
  * Environment variable for specifying custom OpenCode data directory
@@ -147,6 +156,151 @@ export function getOpenCodePath(): string | null {
 }
 
 /**
+ * Get path to the OpenCode SQLite database, or null if it doesn't exist.
+ */
+function getOpenCodeDbPath(): string | null {
+	const openCodePath = getOpenCodePath();
+	if (openCodePath == null) {
+		return null;
+	}
+	const dbPath = path.join(openCodePath, OPENCODE_DB_NAME);
+	return isFileSync(dbPath) ? dbPath : null;
+}
+
+/** Row shape returned by the SQLite message query */
+type DbMessageRow = {
+	id: string;
+	session_id: string;
+	provider_id: string | null;
+	model_id: string | null;
+	time_created: number | null;
+	input_tokens: number | null;
+	output_tokens: number | null;
+	cache_read: number | null;
+	cache_write: number | null;
+	cost: number | null;
+};
+
+/** Row shape returned by the SQLite session query */
+type DbSessionRow = {
+	id: string;
+	parent_id: string | null;
+	title: string | null;
+	project_id: string | null;
+	directory: string | null;
+};
+
+/**
+ * Load usage entries from the OpenCode SQLite database.
+ * Returns an empty array if the DB is absent or unreadable.
+ */
+async function loadOpenCodeMessagesFromDb(): Promise<Array<LoadedUsageEntry & { id: string }>> {
+	const dbPath = getOpenCodeDbPath();
+	if (dbPath == null) {
+		return [];
+	}
+
+	const queryResult = Result.try({
+		try: (): DbMessageRow[] => {
+			const db = new Database(dbPath, { readonly: true });
+			try {
+				return db
+					.query<DbMessageRow, []>(
+						`SELECT
+							id,
+							session_id,
+							json_extract(data, '$.providerID') AS provider_id,
+							json_extract(data, '$.modelID')    AS model_id,
+							json_extract(data, '$.time.created') AS time_created,
+							json_extract(data, '$.tokens.input')       AS input_tokens,
+							json_extract(data, '$.tokens.output')      AS output_tokens,
+							json_extract(data, '$.tokens.cache.read')  AS cache_read,
+							json_extract(data, '$.tokens.cache.write') AS cache_write,
+							json_extract(data, '$.cost') AS cost
+						FROM message
+						WHERE json_extract(data, '$.role') = 'assistant'
+						  AND json_extract(data, '$.modelID') IS NOT NULL
+						  AND json_extract(data, '$.time.created') IS NOT NULL
+						  AND (
+						        json_extract(data, '$.tokens.input')  > 0
+						     OR json_extract(data, '$.tokens.output') > 0
+						  )`,
+					)
+					.all();
+			} finally {
+				db.close();
+			}
+		},
+		catch: (error) => error,
+	})();
+
+	if (Result.isFailure(queryResult)) {
+		logger.warn('Failed to load usage from OpenCode SQLite database', queryResult.error);
+		return [];
+	}
+
+	return queryResult.value
+		.filter((row) => row.provider_id != null && row.model_id != null)
+		.map((row) => ({
+			id: row.id,
+			timestamp: new Date(row.time_created!),
+			sessionID: row.session_id,
+			usage: {
+				inputTokens: row.input_tokens ?? 0,
+				outputTokens: row.output_tokens ?? 0,
+				cacheCreationInputTokens: row.cache_write ?? 0,
+				cacheReadInputTokens: row.cache_read ?? 0,
+			},
+			model: row.model_id!,
+			costUSD: row.cost ?? null,
+		}));
+}
+
+/**
+ * Load session metadata from the OpenCode SQLite database.
+ * Returns an empty map if the DB is absent or unreadable.
+ */
+async function loadOpenCodeSessionsFromDb(): Promise<Map<string, LoadedSessionMetadata>> {
+	const dbPath = getOpenCodeDbPath();
+	if (dbPath == null) {
+		return new Map();
+	}
+
+	const queryResult = Result.try({
+		try: (): DbSessionRow[] => {
+			const db = new Database(dbPath, { readonly: true });
+			try {
+				return db
+					.query<DbSessionRow, []>(
+						`SELECT id, parent_id, title, project_id, directory FROM session`,
+					)
+					.all();
+			} finally {
+				db.close();
+			}
+		},
+		catch: (error) => error,
+	})();
+
+	if (Result.isFailure(queryResult)) {
+		logger.warn('Failed to load sessions from OpenCode SQLite database', queryResult.error);
+		return new Map();
+	}
+
+	const sessionMap = new Map<string, LoadedSessionMetadata>();
+	for (const row of queryResult.value) {
+		sessionMap.set(row.id, {
+			id: row.id,
+			parentID: row.parent_id ?? null,
+			title: row.title ?? row.id,
+			projectID: row.project_id ?? 'unknown',
+			directory: row.directory ?? 'unknown',
+		});
+	}
+	return sessionMap;
+}
+
+/**
  * Load OpenCode message from JSON file
  * @param filePath - Path to message JSON file
  * @returns Parsed message data or null on failure
@@ -213,99 +367,99 @@ function convertOpenCodeSessionToMetadata(
 
 export async function loadOpenCodeSessions(): Promise<Map<string, LoadedSessionMetadata>> {
 	const openCodePath = getOpenCodePath();
-	if (openCodePath == null) {
-		return new Map();
-	}
 
-	const sessionsDir = path.join(
-		openCodePath,
-		OPENCODE_STORAGE_DIR_NAME,
-		OPENCODE_SESSIONS_DIR_NAME,
-	);
+	const [fileSessionMap, dbSessionMap] = await Promise.all([
+		// File-based sessions (pre-Feb 2026)
+		(async () => {
+			if (openCodePath == null) {
+				return new Map<string, LoadedSessionMetadata>();
+			}
+			const sessionsDir = path.join(
+				openCodePath,
+				OPENCODE_STORAGE_DIR_NAME,
+				OPENCODE_SESSIONS_DIR_NAME,
+			);
+			if (!isDirectorySync(sessionsDir)) {
+				return new Map<string, LoadedSessionMetadata>();
+			}
 
-	if (!isDirectorySync(sessionsDir)) {
-		return new Map();
-	}
+			const sessionFiles = await glob('**/*.json', { cwd: sessionsDir, absolute: true });
+			const sessionMap = new Map<string, LoadedSessionMetadata>();
+			for (const filePath of sessionFiles) {
+				const session = await loadOpenCodeSession(filePath);
+				if (session == null) {
+					continue;
+				}
+				const metadata = convertOpenCodeSessionToMetadata(session);
+				sessionMap.set(metadata.id, metadata);
+			}
+			return sessionMap;
+		})(),
+		// SQLite-based sessions (post-Feb 2026 migration)
+		loadOpenCodeSessionsFromDb(),
+	]);
 
-	const sessionFiles = await glob('**/*.json', {
-		cwd: sessionsDir,
-		absolute: true,
-	});
-
-	const sessionMap = new Map<string, LoadedSessionMetadata>();
-
-	for (const filePath of sessionFiles) {
-		const session = await loadOpenCodeSession(filePath);
-
-		if (session == null) {
-			continue;
-		}
-
-		const metadata = convertOpenCodeSessionToMetadata(session);
-		sessionMap.set(metadata.id, metadata);
-	}
-
-	return sessionMap;
+	// Merge: DB entries take precedence for any ID that appears in both
+	return new Map([...fileSessionMap, ...dbSessionMap]);
 }
 
 /**
- * Load all OpenCode messages
+ * Load all OpenCode messages from both file-based storage and SQLite database.
  * @returns Array of LoadedUsageEntry for aggregation
  */
 export async function loadOpenCodeMessages(): Promise<LoadedUsageEntry[]> {
 	const openCodePath = getOpenCodePath();
-	if (openCodePath == null) {
-		return [];
-	}
 
-	const messagesDir = path.join(
-		openCodePath,
-		OPENCODE_STORAGE_DIR_NAME,
-		OPENCODE_MESSAGES_DIR_NAME,
-	);
+	const [fileEntries, dbEntries] = await Promise.all([
+		// File-based messages (pre-Feb 2026)
+		(async () => {
+			if (openCodePath == null) {
+				return [];
+			}
+			const messagesDir = path.join(
+				openCodePath,
+				OPENCODE_STORAGE_DIR_NAME,
+				OPENCODE_MESSAGES_DIR_NAME,
+			);
+			if (!isDirectorySync(messagesDir)) {
+				return [];
+			}
 
-	if (!isDirectorySync(messagesDir)) {
-		return [];
-	}
+			const messageFiles = await glob('**/*.json', { cwd: messagesDir, absolute: true });
+			const entries: Array<LoadedUsageEntry & { id: string }> = [];
 
-	// Find all message JSON files
-	const messageFiles = await glob('**/*.json', {
-		cwd: messagesDir,
-		absolute: true,
-	});
+			for (const filePath of messageFiles) {
+				const message = await loadOpenCodeMessage(filePath);
+				if (message == null) {
+					continue;
+				}
+				if (message.tokens == null || (message.tokens.input === 0 && message.tokens.output === 0)) {
+					continue;
+				}
+				if (message.providerID == null || message.modelID == null) {
+					continue;
+				}
+				entries.push({ id: message.id, ...convertOpenCodeMessageToUsageEntry(message) });
+			}
+			return entries;
+		})(),
+		// SQLite-based messages (post-Feb 2026 migration)
+		loadOpenCodeMessagesFromDb(),
+	]);
 
-	const entries: LoadedUsageEntry[] = [];
+	// Deduplicate by message ID — DB entries take precedence over file entries
 	const dedupeSet = new Set<string>();
+	const result: LoadedUsageEntry[] = [];
 
-	for (const filePath of messageFiles) {
-		const message = await loadOpenCodeMessage(filePath);
-
-		if (message == null) {
+	for (const { id, ...usageEntry } of [...dbEntries, ...fileEntries]) {
+		if (dedupeSet.has(id)) {
 			continue;
 		}
-
-		// Skip messages with no tokens
-		if (message.tokens == null || (message.tokens.input === 0 && message.tokens.output === 0)) {
-			continue;
-		}
-
-		// Skip if no provider or model
-		if (message.providerID == null || message.modelID == null) {
-			continue;
-		}
-
-		// Deduplicate by message ID
-		const dedupeKey = `${message.id}`;
-		if (dedupeSet.has(dedupeKey)) {
-			continue;
-		}
-		dedupeSet.add(dedupeKey);
-
-		const entry = convertOpenCodeMessageToUsageEntry(message);
-		entries.push(entry);
+		dedupeSet.add(id);
+		result.push(usageEntry);
 	}
 
-	return entries;
+	return result;
 }
 
 if (import.meta.vitest != null) {

--- a/apps/opencode/tsconfig.json
+++ b/apps/opencode/tsconfig.json
@@ -6,7 +6,7 @@
 		"module": "Preserve",
 		"moduleResolution": "bundler",
 		"resolveJsonModule": true,
-		"types": ["vitest/globals", "vitest/importMeta"],
+		"types": ["vitest/globals", "vitest/importMeta", "bun"],
 		"allowImportingTsExtensions": true,
 		"allowJs": false,
 		"strict": true,

--- a/apps/opencode/vitest.config.ts
+++ b/apps/opencode/vitest.config.ts
@@ -12,4 +12,10 @@ export default defineConfig({
 	define: {
 		'import.meta.vitest': 'undefined',
 	},
+	resolve: {
+		alias: {
+			// bun:sqlite is a Bun built-in; stub it for Vitest (Node.js) test runs
+			'bun:sqlite': new URL('./src/__mocks__/bun-sqlite.ts', import.meta.url).pathname,
+		},
+	},
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,13 +182,6 @@ catalogs:
 importers:
 
   .:
-    dependencies:
-      bun:
-        specifier: runtime:^1.3.9
-        version: runtime:1.3.12
-      node:
-        specifier: runtime:^24.13.0
-        version: runtime:24.15.0
     devDependencies:
       '@gunshi/docs':
         specifier: catalog:llm-docs
@@ -515,6 +508,9 @@ importers:
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.30)(eslint-plugin-format@2.0.1(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.1.2(@types/node@24.5.1)(happy-dom@16.8.1)(vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)))
+      '@types/bun':
+        specifier: catalog:types
+        version: 1.3.5
       '@typescript/native-preview':
         specifier: catalog:types
         version: 7.0.0-dev.20260107.1
@@ -1521,79 +1517,67 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -1839,112 +1823,96 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-gnu@0.45.0':
     resolution: {integrity: sha512-jLjoLfe+hGfjhA8hNBSdw85yCA8ePKq7ME4T+g6P9caQXvmt6IhE2X7iVjnVdkmYUWEzZrxlh4p6RkDmAMJY/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.35.0':
     resolution: {integrity: sha512-5Okqi+uhYFxwKz8hcnUftNNwdm8BCkf6GSCbcz9xJxYMm87k1E4p7PEmAAbhLTk7cjSdDre6TDL0pDzNX+Y22Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-arm64-musl@0.45.0':
     resolution: {integrity: sha512-XQKXZIKYJC3GQJ8FnD3iMntpw69Wd9kDDK/Xt79p6xnFYlGGxSNv2vIBvRTDg5CKByWFWWZLCRDOXoP/m6YN4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.35.0':
     resolution: {integrity: sha512-9k66pbZQXM/lBJWys3Xbc5yhl4JexyfqkEf/tvtq8976VIJnLAAL3M127xHA3ifYSqxdVHfVGTg84eiBHCGcNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.45.0':
     resolution: {integrity: sha512-+g5RiG+xOkdrCWkKodv407nTvMq4vYM18Uox2MhZBm/YoqFxxJpWKsloskFFG5NU13HGPw1wzYjjOVcyd9moCA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.35.0':
     resolution: {integrity: sha512-aUcY9ofKPtjO52idT6t0SAQvEF6ctjzUQa1lLp7GDsRpSBvuTrBQGeq0rYKz3gN8dMIQ7mtMdGD9tT4LhR8jAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.45.0':
     resolution: {integrity: sha512-V7dXKoSyEbWAkkSF4JJNtF+NJZDmJoSarSoP30WCsB3X636Rehd3CvxBj49FIJxEBFWhvcUjGSHVeU8Erck1bQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.35.0':
     resolution: {integrity: sha512-C6yhY5Hvc2sGM+mCPek9ZLe5xRUOC/BvhAt2qIWFAeXMn4il04EYIjl3DsWiJr0xDMTJhvMOmD55xTRPlNp39w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-riscv64-musl@0.45.0':
     resolution: {integrity: sha512-Vdelft1sAEYojVGgcODEFXSWYQYlIvoyIGWebKCuUibd1tvS1TjTx413xG2ZLuHpYj45CkN/ztMLMX6jrgqpgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.35.0':
     resolution: {integrity: sha512-RG2hlvOMK4OMZpO3mt8MpxLQ0AAezlFqhn5mI/g5YrVbPFyoCv9a34AAvbSJS501ocOxlFIRcKEuw5hFvddf9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-s390x-gnu@0.45.0':
     resolution: {integrity: sha512-RR7xKgNpqwENnK0aYCGYg0JycY2n93J0reNjHyes+I9Gq52dH95x+CBlnlAQHCPfz6FGnKA9HirgUl14WO6o7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.35.0':
     resolution: {integrity: sha512-wzmh90Pwvqj9xOKHJjkQYBpydRkaXG77ZvDz+iFDRRQpnqIEqGm5gmim2s6vnZIkDGsvKCuTdtxm0GFmBjM1+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.45.0':
     resolution: {integrity: sha512-U/QQ0+BQNSHxjuXR/utvXnQ50Vu5kUuqEomZvQ1/3mhgbBiMc2WU9q5kZ5WwLp3gnFIx9ibkveoRSe2EZubkqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.35.0':
     resolution: {integrity: sha512-+HCqYCJPCUy5I+b2cf+gUVaApfgtoQT3HdnSg/l7NIcLHOhKstlYaGyrFZLmUpQt4WkFbpGKZZayG6zjRU0KFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-x64-musl@0.45.0':
     resolution: {integrity: sha512-o5TLOUCF0RWQjsIS06yVC+kFgp092/yLe6qBGSUvtnmTVw9gxjpdQSXc3VN5Cnive4K11HNstEZF8ROKHfDFSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.35.0':
     resolution: {integrity: sha512-kFYmWfR9YL78XyO5ws+1dsxNvZoD973qfVMNFOS4e9bcHXGF7DvGC2tY5UDFwyMCeB33t3sDIuGONKggnVNSJA==}
@@ -2058,28 +2026,24 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.51':
     resolution: {integrity: sha512-EQFXTgHxxTzv3t5EmjUP/DfxzFYx9sMndfLsYaAY4DWF6KsK1fXGYsiupif6qPTViPC9eVmRm78q0pZU/kuIPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.51':
     resolution: {integrity: sha512-p5P6Xpa68w3yFaAdSzIZJbj+AfuDnMDqNSeglBXM7UlJT14Q4zwK+rV+8Mhp9MiUb4XFISZtbI/seBprhkQbiQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.51':
     resolution: {integrity: sha512-sNVVyLa8HB8wkFipdfz1s6i0YWinwpbMWk5hO5S+XAYH2UH67YzUT13gs6wZTKg2x/3gtgXzYnHyF5wMIqoDAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.51':
     resolution: {integrity: sha512-e/JMTz9Q8+T3g/deEi8DK44sFWZWGKr9AOCW5e8C8SCVWzAXqYXAG7FXBWBNzWEZK0Rcwo9TQHTQ9Q0gXgdCaA==}
@@ -2150,67 +2114,56 @@ packages:
     resolution: {integrity: sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.50.2':
     resolution: {integrity: sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.50.2':
     resolution: {integrity: sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.50.2':
     resolution: {integrity: sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.50.2':
     resolution: {integrity: sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.50.2':
     resolution: {integrity: sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.2':
     resolution: {integrity: sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.50.2':
     resolution: {integrity: sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.50.2':
     resolution: {integrity: sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.50.2':
     resolution: {integrity: sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.50.2':
     resolution: {integrity: sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.50.2':
     resolution: {integrity: sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==}
@@ -2787,95 +2740,6 @@ packages:
 
   bun-types@1.3.5:
     resolution: {integrity: sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw==}
-
-  bun@runtime:1.3.12:
-    resolution:
-      type: variations
-      variants:
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-bEu4fdAT7RqNahbjV6PQlJWf1VMLTXBh9/NoDDx86hw=
-            prefix: bun-darwin-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-darwin-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: darwin
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-D1jFOj55R/HmJtL40oX5fBS3ytzKnAnrr8CunTW1jD0=
-            prefix: bun-darwin-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-darwin-x64.zip
-          targets:
-            - cpu: x64
-              os: darwin
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-cxuquUW8RxwXJI6jdeZvcUQoedJZXFQEWz6GH06LmrE=
-            prefix: bun-linux-aarch64-musl
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-linux-aarch64-musl.zip
-          targets:
-            - cpu: arm64
-              os: linux
-              libc: musl
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-xAvA68oRvefXWvSXplSodNDH/Y1qjWAxwXPBDJBkKXs=
-            prefix: bun-linux-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-linux-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-Wp+aIQLUvQ1SELT2vTRRUdIxBiOUcIUXfBswboWH3OY=
-            prefix: bun-linux-x64-musl
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-linux-x64-musl.zip
-          targets:
-            - cpu: x64
-              os: linux
-              libc: musl
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-Edw+4RvBaV4UlzfGyj1WGTAs9DRua4pux5iJZ+8B3cU=
-            prefix: bun-linux-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-linux-x64.zip
-          targets:
-            - cpu: x64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: bun.exe
-            integrity: sha256-bKwk6rQejX5rObTdO0vKXqDRGh9D+UEmvf9uhJ+ff1E=
-            prefix: bun-windows-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-windows-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: win32
-        - resolution:
-            archive: zip
-            bin: bun.exe
-            integrity: sha256-hB/5xd/8qjomINHj+H7lAPMqTKgwsAHK3no0eWCdSok=
-            prefix: bun-windows-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-windows-x64.zip
-          targets:
-            - cpu: x64
-              os: win32
-    version: 1.3.12
-    hasBin: true
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -4425,96 +4289,6 @@ packages:
 
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
-
-  node@runtime:24.15.0:
-    resolution:
-      type: variations
-      variants:
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-3UvHfctfTJoslkNzm7WTUAzLCUE+xCyqD47w5e8RYJU=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-aix-ppc64.tar.gz
-          targets:
-            - cpu: ppc64
-              os: aix
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-NyMxuWl3mrXRW5SYhPxur4jVr+h73ouogdZAC5EA/8Q=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-/9XuKTRnkn8+5zGlU+uI/R9Iz3TuvC10prq+SvIoZzs=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-c6/CNNVYwkkZh19RwtHqACoq2k6m+DYBo4OGn++mTu0=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-sfiJAKSxY2XqulYmkwT8Edp1gdvwNVLUSV+azh/AX20=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-ppc64le.tar.gz
-          targets:
-            - cpu: ppc64le
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-+YVFVDnVL+m43mqPbQe/7MxzbepSfofqyv5ajXUWo4A=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-s390x.tar.gz
-          targets:
-            - cpu: s390x
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-RINoctmuxJ8ea1KpqSKHLbmisC0jWmFqVoG2qF/sjYk=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-yet0Au2ibiun5EtnJ/yFqN5WxQlbH3Hr0wYokiEaoRY=
-            prefix: node-v24.15.0-win-arm64
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-arm64.zip
-          targets:
-            - cpu: arm64
-              os: win32
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-zFFJ6r1Td5zh573FQBZDYi0MfmgAreGJKKdn6UC7DmI=
-            prefix: node-v24.15.0-win-x64
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-x64.zip
-          targets:
-            - cpu: x64
-              os: win32
-    version: 24.15.0
-    hasBin: true
 
   nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
@@ -7443,8 +7217,6 @@ snapshots:
     dependencies:
       '@types/node': 24.5.1
 
-  bun@runtime:1.3.12: {}
-
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -9365,8 +9137,6 @@ snapshots:
     optional: true
 
   node-releases@2.0.21: {}
-
-  node@runtime:24.15.0: {}
 
   nopt@5.0.0:
     dependencies:


### PR DESCRIPTION
OpenCode migrated from file-based JSON storage to SQLite (~opencode.db) around February 2026. This adds a parallel SQLite reader using bun:sqlite so both pre- and post-migration usage data is included in reports.

Fixes #845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenCode data loading now supports and automatically merges multiple storage formats (file and database).

* **Documentation**
  * Rewrote Log Sources docs to explain dual-format storage behavior and configurable data directory.

* **Tests**
  * Added a test-friendly mock for the database module and updated test config to use it.

* **Chores**
  * Added development type definitions to improve tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->