### PR TITLE
feat(codex): support multiple CODEX_HOME roots

### DIFF
--- a/apps/codex/CLAUDE.md
+++ b/apps/codex/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Log Sources
 
-- Codex session usage is recorded under `${CODEX_HOME:-~/.codex}/sessions/` (the CLI resolves `CODEX_HOME` and falls back to `~/.codex`).
+- Codex session usage is recorded under `${CODEX_HOME:-~/.codex}/sessions/` (the CLI resolves `CODEX_HOME` and falls back to `~/.codex`). `CODEX_HOME` may be a comma-separated list of Codex home roots for aggregate reports.
 - Each JSONL line is an `event_msg` with `payload.type === "token_count"`.
 - `payload.info.total_token_usage` holds cumulative totals; `payload.info.last_token_usage` is the delta for the most recent turn.
 - When only cumulative totals are present, we subtract the previous totals to recover a per-event delta.
@@ -47,7 +47,7 @@ Parsing normalizes every event through these rules. When we have to synthesize t
 - Treat Codex as a sibling to `apps/ccusage`; whenever possible reuse the same shared packages (`@ccusage/terminal`, pricing helpers, logging), command names, and flag semantics. Diverge only when Codex-specific data forces it and document the reason inline.
 - Codex is packaged as a bundled CLI. Keep every runtime dependency in `devDependencies` so the bundle includes the code that ships.
 - Entry point remains Gunshi-based; only `daily` subcommand is wired for now.
-- Session discovery relies solely on `CODEX_HOME`; there is no explicit `--dir` override.
+- Session discovery relies solely on `CODEX_HOME`; there is no explicit `--dir` override, but `CODEX_HOME` itself may contain multiple comma-separated roots.
 - `--json` toggles structured output; totals include aggregated tokens and USD cost.
 - Table view lists models per day with their token totals in parentheses.
 

--- a/apps/codex/CLAUDE.md
+++ b/apps/codex/CLAUDE.md
@@ -15,7 +15,7 @@
 - `reasoning_output_tokens`: structured reasoning tokens counted separately by OpenAI.
 - `total_tokens`: either provided directly or, for legacy entries, recomputed as `input + output` (reasoning is informational and already included in `output`).
 
--## Cost Calculation
+## Cost Calculation
 
 - Pricing is pulled from LiteLLM's public JSON (`model_prices_and_context_window.json`).
 - The CLI trusts the model metadata emitted in each `turn_context`. Sessions missing that metadata (observed in early September 2025 builds) fall back to `gpt-5` so the tokens remain visible, but the pricing should be considered approximate. These events are tagged with `isFallbackModel === true` and surface as `isFallback` in aggregated JSON.

--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -76,7 +76,7 @@ npx @ccusage/codex@latest sessions
 Useful environment variables:
 
 - `CODEX_HOME` – override the root directory that contains Codex session folders, or provide multiple homes as a comma-separated list
-- `LOG_LEVEL` – controla consola log verbosity (0 silent … 5 trace)
+- `LOG_LEVEL` – controls consola log verbosity (0 silent … 5 trace)
 
 ```bash
 # Aggregate multiple Codex homes in one report

--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -49,7 +49,7 @@ ccusage-codex daily
 ccusage-codex monthly --json
 ```
 
-> 💡 The CLI looks for Codex session JSONL files under `CODEX_HOME` (defaults to `~/.codex`).
+> 💡 The CLI looks for Codex session JSONL files under `CODEX_HOME` (defaults to `~/.codex`). You can aggregate multiple Codex homes by setting `CODEX_HOME` to a comma-separated list.
 
 ## Common Commands
 
@@ -75,8 +75,13 @@ npx @ccusage/codex@latest sessions
 
 Useful environment variables:
 
-- `CODEX_HOME` – override the root directory that contains Codex session folders
+- `CODEX_HOME` – override the root directory that contains Codex session folders, or provide multiple homes as a comma-separated list
 - `LOG_LEVEL` – controla consola log verbosity (0 silent … 5 trace)
+
+```bash
+# Aggregate multiple Codex homes in one report
+CODEX_HOME="$HOME/.codex,$HOME/.codex-work,/Volumes/archive/codex" ccusage-codex daily
+```
 
 ℹ️ The CLI now relies on the model metadata recorded in each `turn_context`. Sessions emitted during early September 2025 that lack this metadata are skipped to avoid mispricing. Newer builds of the Codex CLI restore the model field, and aliases such as `gpt-5-codex` automatically resolve to the correct LiteLLM pricing entry.
 📦 For legacy JSONL files that never emitted `turn_context` metadata, the CLI falls back to treating the tokens as `gpt-5` so that usage still appears in reports (pricing is therefore approximate for those sessions). In JSON output you will also see `"isFallback": true` on those model entries.

--- a/apps/codex/src/_types.ts
+++ b/apps/codex/src/_types.ts
@@ -9,6 +9,7 @@ export type TokenUsageDelta = {
 export type TokenUsageEvent = TokenUsageDelta & {
 	timestamp: string;
 	sessionId: string;
+	sourceRoot?: string;
 	model?: string;
 	isFallbackModel?: boolean;
 };
@@ -33,6 +34,7 @@ export type MonthlyUsageSummary = {
 
 export type SessionUsageSummary = {
 	sessionId: string;
+	sourceRoot?: string;
 	firstTimestamp: string;
 	lastTimestamp: string;
 	costUSD: number;
@@ -78,6 +80,7 @@ export type MonthlyReportRow = {
 
 export type SessionReportRow = {
 	sessionId: string;
+	sourceRoot?: string;
 	lastActivity: string;
 	sessionFile: string;
 	directory: string;

--- a/apps/codex/src/data-loader.ts
+++ b/apps/codex/src/data-loader.ts
@@ -184,23 +184,95 @@ export type LoadResult = {
 	missingDirectories: string[];
 };
 
-export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<LoadResult> {
-	const providedDirs =
-		options.sessionDirs != null && options.sessionDirs.length > 0
-			? options.sessionDirs.map((dir) => path.resolve(dir))
-			: undefined;
+type SessionDirectory = {
+	path: string;
+	sourceRoot?: string;
+};
 
-	const codexHomeEnv = process.env[CODEX_HOME_ENV]?.trim();
-	const codexHome =
-		codexHomeEnv != null && codexHomeEnv !== '' ? path.resolve(codexHomeEnv) : DEFAULT_CODEX_DIR;
-	const defaultSessionsDir = path.join(codexHome, DEFAULT_SESSION_SUBDIR);
-	const sessionDirs = providedDirs ?? [defaultSessionsDir];
+function splitConfiguredPaths(value: string): string[] {
+	return value
+		.split(',')
+		.map((entry) => entry.trim())
+		.filter((entry) => entry !== '');
+}
+
+function dedupeSessionDirectories(directories: SessionDirectory[]): SessionDirectory[] {
+	const seen = new Set<string>();
+	const deduped: SessionDirectory[] = [];
+
+	for (const directory of directories) {
+		const normalizedPath = path.resolve(directory.path);
+		if (seen.has(normalizedPath)) {
+			continue;
+		}
+
+		seen.add(normalizedPath);
+		deduped.push({
+			path: normalizedPath,
+			sourceRoot: directory.sourceRoot,
+		});
+	}
+
+	return deduped;
+}
+
+function buildSourceRootLabels(rootPaths: string[]): Map<string, string> {
+	if (rootPaths.length < 2) {
+		return new Map();
+	}
+
+	const basenameCounts = new Map<string, number>();
+	for (const rootPath of rootPaths) {
+		const resolvedBasename = path.basename(rootPath);
+		const basename = resolvedBasename === '' ? rootPath : resolvedBasename;
+		basenameCounts.set(basename, (basenameCounts.get(basename) ?? 0) + 1);
+	}
+
+	return new Map(
+		rootPaths.map((rootPath) => {
+			const resolvedBasename = path.basename(rootPath);
+			const basename = resolvedBasename === '' ? rootPath : resolvedBasename;
+			const label = (basenameCounts.get(basename) ?? 0) > 1 ? rootPath : basename;
+			return [rootPath, label];
+		}),
+	);
+}
+
+function resolveSessionDirectories(options: LoadOptions = {}): SessionDirectory[] {
+	if (options.sessionDirs != null && options.sessionDirs.length > 0) {
+		return dedupeSessionDirectories(options.sessionDirs.map((dir) => ({ path: dir })));
+	}
+
+	const codexHomeEnv = process.env[CODEX_HOME_ENV]?.trim() ?? '';
+	if (codexHomeEnv !== '') {
+		const rootPaths = Array.from(
+			new Set(splitConfiguredPaths(codexHomeEnv).map((rootPath) => path.resolve(rootPath))),
+		);
+		const sourceLabels = buildSourceRootLabels(rootPaths);
+
+		return dedupeSessionDirectories(
+			rootPaths.map((rootPath) => ({
+				path: path.join(rootPath, DEFAULT_SESSION_SUBDIR),
+				sourceRoot: sourceLabels.get(rootPath),
+			})),
+		);
+	}
+
+	return [
+		{
+			path: path.join(DEFAULT_CODEX_DIR, DEFAULT_SESSION_SUBDIR),
+		},
+	];
+}
+
+export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<LoadResult> {
+	const sessionDirs = resolveSessionDirectories(options);
 
 	const events: TokenUsageEvent[] = [];
 	const missingDirectories: string[] = [];
 
-	for (const dir of sessionDirs) {
-		const directoryPath = path.resolve(dir);
+	for (const sessionDir of sessionDirs) {
+		const directoryPath = sessionDir.path;
 		const statResult = await Result.try({
 			try: stat(directoryPath),
 			catch: (error) => error,
@@ -339,6 +411,7 @@ export async function loadTokenUsageEvents(options: LoadOptions = {}): Promise<L
 
 				const event: TokenUsageEvent = {
 					sessionId,
+					sourceRoot: sessionDir.sourceRoot,
 					timestamp,
 					model,
 					inputTokens: delta.inputTokens,
@@ -483,6 +556,69 @@ if (import.meta.vitest != null) {
 			expect(events).toHaveLength(1);
 			expect(events[0]!.model).toBe('gpt-5');
 			expect(events[0]!.isFallbackModel).toBe(true);
+		});
+
+		it('aggregates multiple codex homes from CODEX_HOME and deduplicates roots', async () => {
+			await using firstHome = await createFixture({
+				sessions: {
+					'alpha.jsonl': JSON.stringify({
+						timestamp: '2025-09-15T13:00:00.000Z',
+						type: 'event_msg',
+						payload: {
+							type: 'token_count',
+							info: {
+								model: 'gpt-5',
+								last_token_usage: {
+									input_tokens: 1_000,
+									cached_input_tokens: 0,
+									output_tokens: 200,
+									reasoning_output_tokens: 0,
+									total_tokens: 1_200,
+								},
+							},
+						},
+					}),
+				},
+			});
+			await using secondHome = await createFixture({
+				sessions: {
+					'beta.jsonl': JSON.stringify({
+						timestamp: '2025-09-16T13:00:00.000Z',
+						type: 'event_msg',
+						payload: {
+							type: 'token_count',
+							info: {
+								model: 'gpt-5-mini',
+								last_token_usage: {
+									input_tokens: 500,
+									cached_input_tokens: 50,
+									output_tokens: 100,
+									reasoning_output_tokens: 0,
+									total_tokens: 600,
+								},
+							},
+						},
+					}),
+				},
+			});
+
+			try {
+				vi.stubEnv(
+					CODEX_HOME_ENV,
+					`${firstHome.path},${secondHome.path},${firstHome.path},/nonexistent/codex-home`,
+				);
+
+				const { events, missingDirectories } = await loadTokenUsageEvents();
+
+				expect(events).toHaveLength(2);
+				expect(new Set(events.map((event) => event.sessionId))).toEqual(new Set(['alpha', 'beta']));
+				expect(new Set(events.map((event) => event.sourceRoot)).size).toBe(2);
+				expect(missingDirectories).toEqual([
+					path.resolve('/nonexistent/codex-home', DEFAULT_SESSION_SUBDIR),
+				]);
+			} finally {
+				vi.unstubAllEnvs();
+			}
 		});
 	});
 }

--- a/apps/codex/src/session-report.ts
+++ b/apps/codex/src/session-report.ts
@@ -17,9 +17,14 @@ export type SessionReportOptions = {
 	pricingSource: PricingSource;
 };
 
-function createSummary(sessionId: string, initialTimestamp: string): SessionUsageSummary {
+function createSummary(
+	sessionId: string,
+	sourceRoot: string | undefined,
+	initialTimestamp: string,
+): SessionUsageSummary {
 	return {
 		sessionId,
+		sourceRoot,
 		firstTimestamp: initialTimestamp,
 		lastTimestamp: initialTimestamp,
 		inputTokens: 0,
@@ -52,6 +57,9 @@ export async function buildSessionReport(
 		if (sessionId === '') {
 			continue;
 		}
+		const trimmedSourceRoot = event.sourceRoot?.trim();
+		const sourceRoot =
+			trimmedSourceRoot == null || trimmedSourceRoot === '' ? undefined : trimmedSourceRoot;
 
 		const rawModelName = event.model;
 		if (rawModelName == null) {
@@ -67,9 +75,11 @@ export async function buildSessionReport(
 			continue;
 		}
 
-		const summary = summaries.get(sessionId) ?? createSummary(sessionId, event.timestamp);
-		if (!summaries.has(sessionId)) {
-			summaries.set(sessionId, summary);
+		const summaryKey = sourceRoot == null ? sessionId : `${sourceRoot}\u0000${sessionId}`;
+		const summary =
+			summaries.get(summaryKey) ?? createSummary(sessionId, sourceRoot, event.timestamp);
+		if (!summaries.has(summaryKey)) {
+			summaries.set(summaryKey, summary);
 		}
 
 		addUsage(summary, event);
@@ -128,12 +138,19 @@ export async function buildSessionReport(
 		}
 
 		const separatorIndex = summary.sessionId.lastIndexOf('/');
-		const directory = separatorIndex >= 0 ? summary.sessionId.slice(0, separatorIndex) : '';
+		const relativeDirectory = separatorIndex >= 0 ? summary.sessionId.slice(0, separatorIndex) : '';
+		const directory =
+			summary.sourceRoot == null || summary.sourceRoot === ''
+				? relativeDirectory
+				: relativeDirectory === ''
+					? summary.sourceRoot
+					: `${summary.sourceRoot}/${relativeDirectory}`;
 		const sessionFile =
 			separatorIndex >= 0 ? summary.sessionId.slice(separatorIndex + 1) : summary.sessionId;
 
 		rows.push({
 			sessionId: summary.sessionId,
+			sourceRoot: summary.sourceRoot,
 			lastActivity: summary.lastTimestamp,
 			sessionFile,
 			directory,
@@ -232,6 +249,54 @@ if (import.meta.vitest != null) {
 				(100 / 1_000_000) * 0.06 +
 				(200 / 1_000_000) * 2;
 			expect(second.costUSD).toBeCloseTo(expectedCost, 10);
+		});
+
+		it('keeps identical session ids from different codex homes separate', async () => {
+			const stubPricingSource: PricingSource = {
+				async getPricing(): Promise<ModelPricing> {
+					return {
+						inputCostPerMToken: 1.25,
+						cachedInputCostPerMToken: 0.125,
+						outputCostPerMToken: 10,
+					};
+				},
+			};
+
+			const report = await buildSessionReport(
+				[
+					{
+						sessionId: 'project/shared-session',
+						sourceRoot: 'codex-a',
+						timestamp: '2025-09-12T01:00:00.000Z',
+						model: 'gpt-5',
+						inputTokens: 1_000,
+						cachedInputTokens: 0,
+						outputTokens: 500,
+						reasoningOutputTokens: 0,
+						totalTokens: 1_500,
+					},
+					{
+						sessionId: 'project/shared-session',
+						sourceRoot: 'codex-b',
+						timestamp: '2025-09-12T02:00:00.000Z',
+						model: 'gpt-5',
+						inputTokens: 400,
+						cachedInputTokens: 0,
+						outputTokens: 200,
+						reasoningOutputTokens: 0,
+						totalTokens: 600,
+					},
+				],
+				{
+					pricingSource: stubPricingSource,
+				},
+			);
+
+			expect(report).toHaveLength(2);
+			expect(report[0]?.directory).toBe('codex-a/project');
+			expect(report[0]?.sessionFile).toBe('shared-session');
+			expect(report[1]?.directory).toBe('codex-b/project');
+			expect(report[1]?.sessionFile).toBe('shared-session');
 		});
 	});
 }

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -44,7 +44,7 @@ After adding the alias to your shell config file (`.bashrc`, `.zshrc`, or `confi
 
 ## Data Source
 
-The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to `~/.codex`). Each file represents a single Codex CLI session and contains running token totals that the tool converts into per-day or per-month deltas.
+The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to `~/.codex`). `CODEX_HOME` can also be a comma-separated list when you want to aggregate multiple Codex homes. Each file represents a single Codex CLI session and contains running token totals that the tool converts into per-day or per-month deltas.
 
 ## What Gets Calculated
 
@@ -57,10 +57,15 @@ The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to 
 
 ## Environment Variables
 
-| Variable     | Description                                                  |
-| ------------ | ------------------------------------------------------------ |
-| `CODEX_HOME` | Override the root directory containing Codex session folders |
-| `LOG_LEVEL`  | Adjust consola verbosity (0 silent … 5 trace)                |
+| Variable     | Description                                                                                                       |
+| ------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `CODEX_HOME` | Override the root directory containing Codex session folders, or provide multiple roots as a comma-separated list |
+| `LOG_LEVEL`  | Adjust consola verbosity (0 silent … 5 trace)                                                                     |
+
+```bash
+# Aggregate multiple Codex homes
+CODEX_HOME="$HOME/.codex,$HOME/.codex-work,/Volumes/archive/codex" ccusage-codex daily
+```
 
 When Codex emits a model alias (for example `gpt-5-codex`), the CLI automatically resolves it to the canonical LiteLLM pricing entry. No manual override is needed.
 


### PR DESCRIPTION
## Summary
- support comma-separated `CODEX_HOME` values for aggregating multiple Codex homes
- keep daily and monthly reports aggregated without changing their UI
- preserve source-root information in session reports so rows from different homes stay distinct
- document the multi-home behavior and add coverage for aggregation + session separation

## Testing
- pnpm --filter @ccusage/codex test
- pnpm --filter @ccusage/codex typecheck
- pnpm --filter @ccusage/codex lint
- manual check with `/Volumes/usb_main/home/index_ailuntz/codex_macmini3` + `/Volumes/usb_main/home/index_ailuntz/codex_macmini2`

Closes #968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aggregate usage from multiple Codex homes by setting CODEX_HOME to a comma-separated list.
  * Sessions are labeled by their originating root and reported separately when the same session ID exists in different homes.

* **Documentation**
  * Updated docs and README with examples and CLI notes for multi-root CODEX_HOME configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->