### PR TITLE
feat(codex): add weekly report command

### DIFF
--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -46,6 +46,7 @@ Since `npx @ccusage/codex@latest` is quite long to type repeatedly, we strongly 
 
 # Then simply run:
 ccusage-codex daily
+ccusage-codex weekly
 ccusage-codex monthly --json
 ```
 
@@ -62,6 +63,9 @@ npx @ccusage/codex@latest daily --since 20250911 --until 20250917
 
 # JSON output for scripting
 npx @ccusage/codex@latest daily --json
+
+# Weekly usage grouped by week
+npx @ccusage/codex@latest weekly
 
 # Monthly usage grouped by month
 npx @ccusage/codex@latest monthly
@@ -86,7 +90,7 @@ Useful environment variables:
 - 📊 Responsive terminal tables shared with the `ccusage` CLI
 - 💵 Offline-first pricing cache with automatic LiteLLM refresh when needed
 - 🤖 Per-model token and cost aggregation, including cached token accounting
-- 📅 Daily and monthly rollups with identical CLI options
+- 📅 Daily, weekly, and monthly rollups with identical CLI options
 - 📄 JSON output for further processing or scripting
 
 ## Documentation

--- a/apps/codex/src/_consts.ts
+++ b/apps/codex/src/_consts.ts
@@ -12,3 +12,16 @@ export const DEFAULT_PRECISION = 2;
 export const MILLION = 1_000_000;
 
 export const PRICING_CACHE_TTL_MS = 1000 * 60 * 5; // 5 minutes
+
+export const WEEK_DAYS = [
+	'sunday',
+	'monday',
+	'tuesday',
+	'wednesday',
+	'thursday',
+	'friday',
+	'saturday',
+] as const;
+
+export type WeekDay = (typeof WEEK_DAYS)[number];
+export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;

--- a/apps/codex/src/_types.ts
+++ b/apps/codex/src/_types.ts
@@ -17,20 +17,6 @@ export type ModelUsage = TokenUsageDelta & {
 	isFallback?: boolean;
 };
 
-export type DailyUsageSummary = {
-	date: string;
-	firstTimestamp: string;
-	costUSD: number;
-	models: Map<string, ModelUsage>;
-} & TokenUsageDelta;
-
-export type MonthlyUsageSummary = {
-	month: string;
-	firstTimestamp: string;
-	costUSD: number;
-	models: Map<string, ModelUsage>;
-} & TokenUsageDelta;
-
 export type SessionUsageSummary = {
 	sessionId: string;
 	firstTimestamp: string;
@@ -67,6 +53,17 @@ export type DailyReportRow = {
 
 export type MonthlyReportRow = {
 	month: string;
+	inputTokens: number;
+	cachedInputTokens: number;
+	outputTokens: number;
+	reasoningOutputTokens: number;
+	totalTokens: number;
+	costUSD: number;
+	models: Record<string, ModelUsage>;
+};
+
+export type WeeklyReportRow = {
+	week: string;
 	inputTokens: number;
 	cachedInputTokens: number;
 	outputTokens: number;

--- a/apps/codex/src/bucketed-report.ts
+++ b/apps/codex/src/bucketed-report.ts
@@ -1,0 +1,127 @@
+import type { ModelUsage, PricingSource, TokenUsageDelta, TokenUsageEvent } from './_types.ts';
+import { isWithinRange } from './date-utils.ts';
+import { addUsage, calculateCostUSD, createEmptyUsage } from './token-utils.ts';
+
+type BucketSummary = {
+	bucket: string;
+	models: Map<string, ModelUsage>;
+} & TokenUsageDelta;
+
+type BucketedReportRow<BucketField extends string> = Record<BucketField, string> &
+	TokenUsageDelta & {
+		costUSD: number;
+		models: Record<string, ModelUsage>;
+	};
+
+export type BucketedReportOptions<BucketField extends string> = {
+	bucketField: BucketField;
+	events: TokenUsageEvent[];
+	getBucketKey: (timestamp: string, timezone?: string) => string;
+	getFilterDateKey: (timestamp: string, timezone?: string) => string;
+	pricingSource: PricingSource;
+	since?: string;
+	timezone?: string;
+	until?: string;
+};
+
+function createSummary(bucket: string): BucketSummary {
+	return {
+		bucket,
+		inputTokens: 0,
+		cachedInputTokens: 0,
+		outputTokens: 0,
+		reasoningOutputTokens: 0,
+		totalTokens: 0,
+		models: new Map(),
+	};
+}
+
+export async function buildBucketedReport<BucketField extends string>({
+	bucketField,
+	events,
+	getBucketKey,
+	getFilterDateKey,
+	pricingSource,
+	since,
+	timezone,
+	until,
+}: BucketedReportOptions<BucketField>): Promise<Array<BucketedReportRow<BucketField>>> {
+	const summaries = new Map<string, BucketSummary>();
+
+	for (const event of events) {
+		const modelName = event.model?.trim();
+		if (modelName == null || modelName === '') {
+			continue;
+		}
+
+		const dateKey = getFilterDateKey(event.timestamp, timezone);
+		if (!isWithinRange(dateKey, since, until)) {
+			continue;
+		}
+
+		const bucketKey = getBucketKey(event.timestamp, timezone);
+		const summary = summaries.get(bucketKey) ?? createSummary(bucketKey);
+		if (!summaries.has(bucketKey)) {
+			summaries.set(bucketKey, summary);
+		}
+
+		addUsage(summary, event);
+		const modelUsage: ModelUsage = summary.models.get(modelName) ?? {
+			...createEmptyUsage(),
+			isFallback: false,
+		};
+		if (!summary.models.has(modelName)) {
+			summary.models.set(modelName, modelUsage);
+		}
+		addUsage(modelUsage, event);
+		if (event.isFallbackModel === true) {
+			modelUsage.isFallback = true;
+		}
+	}
+
+	const uniqueModels = new Set<string>();
+	for (const summary of summaries.values()) {
+		for (const modelName of summary.models.keys()) {
+			uniqueModels.add(modelName);
+		}
+	}
+
+	const modelPricing = new Map<string, Awaited<ReturnType<PricingSource['getPricing']>>>();
+	for (const modelName of uniqueModels) {
+		modelPricing.set(modelName, await pricingSource.getPricing(modelName));
+	}
+
+	const rows: Array<BucketedReportRow<BucketField>> = [];
+	const sortedSummaries = Array.from(summaries.values()).sort((a, b) =>
+		a.bucket.localeCompare(b.bucket),
+	);
+
+	for (const summary of sortedSummaries) {
+		let costUSD = 0;
+		for (const [modelName, usage] of summary.models) {
+			const pricing = modelPricing.get(modelName);
+			if (pricing == null) {
+				continue;
+			}
+			costUSD += calculateCostUSD(usage, pricing);
+		}
+
+		const models: Record<string, ModelUsage> = {};
+		for (const [modelName, usage] of summary.models) {
+			models[modelName] = { ...usage };
+		}
+
+		rows.push({
+			[bucketField]: summary.bucket,
+			inputTokens: summary.inputTokens,
+			cachedInputTokens: summary.cachedInputTokens,
+			outputTokens: summary.outputTokens,
+			reasoningOutputTokens: summary.reasoningOutputTokens,
+			totalTokens: summary.totalTokens,
+			costUSD,
+			models,
+		} as BucketedReportRow<BucketField>);
+	}
+
+	return rows;
+}

--- a/apps/codex/src/commands/weekly.ts
+++ b/apps/codex/src/commands/weekly.ts
@@ -1,0 +1,197 @@
+import process from 'node:process';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatDateCompact,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { DEFAULT_TIMEZONE, WEEK_DAYS } from '../_consts.ts';
+import { sharedArgs } from '../_shared-args.ts';
+import { formatModelsList, splitUsageTokens } from '../command-utils.ts';
+import { loadTokenUsageEvents } from '../data-loader.ts';
+import { normalizeFilterDate } from '../date-utils.ts';
+import { log, logger } from '../logger.ts';
+import { CodexPricingSource } from '../pricing.ts';
+import { buildWeeklyReport } from '../weekly-report.ts';
+
+const TABLE_COLUMN_COUNT = 8;
+
+export const weeklyCommand = define({
+	name: 'weekly',
+	description: 'Show Codex token usage grouped by week',
+	args: {
+		...sharedArgs,
+		startOfWeek: {
+			type: 'enum',
+			short: 'w',
+			description: 'Day to start the week on',
+			default: 'sunday' as const,
+			choices: WEEK_DAYS,
+		},
+	},
+	toKebab: true,
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+		if (jsonOutput) {
+			logger.level = 0;
+		}
+
+		let since: string | undefined;
+		let until: string | undefined;
+
+		try {
+			since = normalizeFilterDate(ctx.values.since);
+			until = normalizeFilterDate(ctx.values.until);
+		} catch (error) {
+			logger.error(String(error));
+			process.exit(1);
+		}
+
+		const { events, missingDirectories } = await loadTokenUsageEvents();
+
+		for (const missing of missingDirectories) {
+			logger.warn(`Codex session directory not found: ${missing}`);
+		}
+
+		if (events.length === 0) {
+			log(jsonOutput ? JSON.stringify({ weekly: [], totals: null }) : 'No Codex usage data found.');
+			return;
+		}
+
+		const pricingSource = new CodexPricingSource({
+			offline: ctx.values.offline,
+		});
+		try {
+			const rows = await buildWeeklyReport(events, {
+				pricingSource,
+				timezone: ctx.values.timezone,
+				locale: ctx.values.locale,
+				since,
+				startOfWeek: ctx.values.startOfWeek,
+				until,
+			});
+
+			if (rows.length === 0) {
+				log(
+					jsonOutput
+						? JSON.stringify({ weekly: [], totals: null })
+						: 'No Codex usage data found for provided filters.',
+				);
+				return;
+			}
+
+			const totals = rows.reduce(
+				(acc, row) => {
+					acc.inputTokens += row.inputTokens;
+					acc.cachedInputTokens += row.cachedInputTokens;
+					acc.outputTokens += row.outputTokens;
+					acc.reasoningOutputTokens += row.reasoningOutputTokens;
+					acc.totalTokens += row.totalTokens;
+					acc.costUSD += row.costUSD;
+					return acc;
+				},
+				{
+					inputTokens: 0,
+					cachedInputTokens: 0,
+					outputTokens: 0,
+					reasoningOutputTokens: 0,
+					totalTokens: 0,
+					costUSD: 0,
+				},
+			);
+
+			if (jsonOutput) {
+				log(
+					JSON.stringify(
+						{
+							weekly: rows,
+							totals,
+						},
+						null,
+						2,
+					),
+				);
+				return;
+			}
+
+			logger.box(
+				`Codex Token Usage Report - Weekly (Timezone: ${ctx.values.timezone ?? DEFAULT_TIMEZONE})`,
+			);
+
+			const table: ResponsiveTable = new ResponsiveTable({
+				head: [
+					'Week',
+					'Models',
+					'Input',
+					'Output',
+					'Reasoning',
+					'Cache Read',
+					'Total Tokens',
+					'Cost (USD)',
+				],
+				colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
+				compactHead: ['Week', 'Models', 'Input', 'Output', 'Cost (USD)'],
+				compactColAligns: ['left', 'left', 'right', 'right', 'right'],
+				compactThreshold: 100,
+				forceCompact: ctx.values.compact,
+				style: { head: ['cyan'] },
+				dateFormatter: (dateStr: string) => formatDateCompact(dateStr),
+			});
+
+			const totalsForDisplay = {
+				inputTokens: 0,
+				outputTokens: 0,
+				reasoningTokens: 0,
+				cacheReadTokens: 0,
+				totalTokens: 0,
+				costUSD: 0,
+			};
+
+			for (const row of rows) {
+				const split = splitUsageTokens(row);
+				totalsForDisplay.inputTokens += split.inputTokens;
+				totalsForDisplay.outputTokens += split.outputTokens;
+				totalsForDisplay.reasoningTokens += split.reasoningTokens;
+				totalsForDisplay.cacheReadTokens += split.cacheReadTokens;
+				totalsForDisplay.totalTokens += row.totalTokens;
+				totalsForDisplay.costUSD += row.costUSD;
+
+				table.push([
+					row.week,
+					formatModelsDisplayMultiline(formatModelsList(row.models)),
+					formatNumber(split.inputTokens),
+					formatNumber(split.outputTokens),
+					formatNumber(split.reasoningTokens),
+					formatNumber(split.cacheReadTokens),
+					formatNumber(row.totalTokens),
+					formatCurrency(row.costUSD),
+				]);
+			}
+
+			addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+			table.push([
+				pc.yellow('Total'),
+				'',
+				pc.yellow(formatNumber(totalsForDisplay.inputTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.outputTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.reasoningTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.cacheReadTokens)),
+				pc.yellow(formatNumber(totalsForDisplay.totalTokens)),
+				pc.yellow(formatCurrency(totalsForDisplay.costUSD)),
+			]);
+
+			log(table.toString());
+
+			if (table.isCompactMode()) {
+				logger.info('\nRunning in Compact Mode');
+				logger.info('Expand terminal width to see cache metrics and total tokens');
+			}
+		} finally {
+			pricingSource[Symbol.dispose]();
+		}
+	},
+});

--- a/apps/codex/src/daily-report.ts
+++ b/apps/codex/src/daily-report.ts
@@ -1,13 +1,6 @@
-import type {
-	DailyReportRow,
-	DailyUsageSummary,
-	ModelPricing,
-	ModelUsage,
-	PricingSource,
-	TokenUsageEvent,
-} from './_types.ts';
-import { formatDisplayDate, isWithinRange, toDateKey } from './date-utils.ts';
-import { addUsage, calculateCostUSD, createEmptyUsage } from './token-utils.ts';
+import type { DailyReportRow, ModelPricing, PricingSource, TokenUsageEvent } from './_types.ts';
+import { buildBucketedReport } from './bucketed-report.ts';
+import { toDateKey } from './date-utils.ts';
 
 export type DailyReportOptions = {
 	timezone?: string;
@@ -17,108 +10,20 @@ export type DailyReportOptions = {
 	pricingSource: PricingSource;
 };
 
-function createSummary(date: string, initialTimestamp: string): DailyUsageSummary {
-	return {
-		date,
-		firstTimestamp: initialTimestamp,
-		inputTokens: 0,
-		cachedInputTokens: 0,
-		outputTokens: 0,
-		reasoningOutputTokens: 0,
-		totalTokens: 0,
-		costUSD: 0,
-		models: new Map(),
-	};
-}
-
 export async function buildDailyReport(
 	events: TokenUsageEvent[],
 	options: DailyReportOptions,
 ): Promise<DailyReportRow[]> {
-	const timezone = options.timezone;
-	const locale = options.locale;
-	const since = options.since;
-	const until = options.until;
-	const pricingSource = options.pricingSource;
-
-	const summaries = new Map<string, DailyUsageSummary>();
-
-	for (const event of events) {
-		const modelName = event.model?.trim();
-		if (modelName == null || modelName === '') {
-			continue;
-		}
-
-		const dateKey = toDateKey(event.timestamp, timezone);
-		if (!isWithinRange(dateKey, since, until)) {
-			continue;
-		}
-
-		const summary = summaries.get(dateKey) ?? createSummary(dateKey, event.timestamp);
-		if (!summaries.has(dateKey)) {
-			summaries.set(dateKey, summary);
-		}
-
-		addUsage(summary, event);
-		const modelUsage: ModelUsage = summary.models.get(modelName) ?? {
-			...createEmptyUsage(),
-			isFallback: false,
-		};
-		if (!summary.models.has(modelName)) {
-			summary.models.set(modelName, modelUsage);
-		}
-		addUsage(modelUsage, event);
-		if (event.isFallbackModel === true) {
-			modelUsage.isFallback = true;
-		}
-	}
-
-	const uniqueModels = new Set<string>();
-	for (const summary of summaries.values()) {
-		for (const modelName of summary.models.keys()) {
-			uniqueModels.add(modelName);
-		}
-	}
-
-	const modelPricing = new Map<string, Awaited<ReturnType<PricingSource['getPricing']>>>();
-	for (const modelName of uniqueModels) {
-		modelPricing.set(modelName, await pricingSource.getPricing(modelName));
-	}
-
-	const rows: DailyReportRow[] = [];
-
-	const sortedSummaries = Array.from(summaries.values()).sort((a, b) =>
-		a.date.localeCompare(b.date),
-	);
-	for (const summary of sortedSummaries) {
-		let cost = 0;
-		for (const [modelName, usage] of summary.models) {
-			const pricing = modelPricing.get(modelName);
-			if (pricing == null) {
-				continue;
-			}
-			cost += calculateCostUSD(usage, pricing);
-		}
-		summary.costUSD = cost;
-
-		const rowModels: Record<string, ModelUsage> = {};
-		for (const [modelName, usage] of summary.models) {
-			rowModels[modelName] = { ...usage };
-		}
-
-		rows.push({
-			date: formatDisplayDate(summary.date, locale, timezone),
-			inputTokens: summary.inputTokens,
-			cachedInputTokens: summary.cachedInputTokens,
-			outputTokens: summary.outputTokens,
-			reasoningOutputTokens: summary.reasoningOutputTokens,
-			totalTokens: summary.totalTokens,
-			costUSD: cost,
-			models: rowModels,
-		});
-	}
-
-	return rows;
+	return buildBucketedReport({
+		bucketField: 'date',
+		events,
+		getBucketKey: toDateKey,
+		getFilterDateKey: toDateKey,
+		pricingSource: options.pricingSource,
+		since: options.since,
+		timezone: options.timezone,
+		until: options.until,
+	});
 }
 
 if (import.meta.vitest != null) {
@@ -179,13 +84,14 @@ if (import.meta.vitest != null) {
 				{
 					pricingSource: stubPricingSource,
 					since: '2025-09-11',
+					timezone: 'UTC',
 					until: '2025-09-12',
 				},
 			);
 
 			expect(report).toHaveLength(2);
 			const first = report[0]!;
-			expect(first.date).toContain('2025');
+			expect(first.date).toBe('2025-09-11');
 			expect(first.inputTokens).toBe(1_400);
 			expect(first.cachedInputTokens).toBe(300);
 			expect(first.outputTokens).toBe(700);

--- a/apps/codex/src/monthly-report.ts
+++ b/apps/codex/src/monthly-report.ts
@@ -1,13 +1,6 @@
-import type {
-	ModelPricing,
-	ModelUsage,
-	MonthlyReportRow,
-	MonthlyUsageSummary,
-	PricingSource,
-	TokenUsageEvent,
-} from './_types.ts';
-import { formatDisplayMonth, isWithinRange, toDateKey, toMonthKey } from './date-utils.ts';
-import { addUsage, calculateCostUSD, createEmptyUsage } from './token-utils.ts';
+import type { ModelPricing, MonthlyReportRow, PricingSource, TokenUsageEvent } from './_types.ts';
+import { buildBucketedReport } from './bucketed-report.ts';
+import { toDateKey, toMonthKey } from './date-utils.ts';
 
 export type MonthlyReportOptions = {
 	timezone?: string;
@@ -17,109 +10,20 @@ export type MonthlyReportOptions = {
 	pricingSource: PricingSource;
 };
 
-function createSummary(month: string, initialTimestamp: string): MonthlyUsageSummary {
-	return {
-		month,
-		firstTimestamp: initialTimestamp,
-		inputTokens: 0,
-		cachedInputTokens: 0,
-		outputTokens: 0,
-		reasoningOutputTokens: 0,
-		totalTokens: 0,
-		costUSD: 0,
-		models: new Map(),
-	};
-}
-
 export async function buildMonthlyReport(
 	events: TokenUsageEvent[],
 	options: MonthlyReportOptions,
 ): Promise<MonthlyReportRow[]> {
-	const timezone = options.timezone;
-	const locale = options.locale;
-	const since = options.since;
-	const until = options.until;
-	const pricingSource = options.pricingSource;
-
-	const summaries = new Map<string, MonthlyUsageSummary>();
-
-	for (const event of events) {
-		const modelName = event.model?.trim();
-		if (modelName == null || modelName === '') {
-			continue;
-		}
-
-		const dateKey = toDateKey(event.timestamp, timezone);
-		if (!isWithinRange(dateKey, since, until)) {
-			continue;
-		}
-
-		const monthKey = toMonthKey(event.timestamp, timezone);
-		const summary = summaries.get(monthKey) ?? createSummary(monthKey, event.timestamp);
-		if (!summaries.has(monthKey)) {
-			summaries.set(monthKey, summary);
-		}
-
-		addUsage(summary, event);
-		const modelUsage: ModelUsage = summary.models.get(modelName) ?? {
-			...createEmptyUsage(),
-			isFallback: false,
-		};
-		if (!summary.models.has(modelName)) {
-			summary.models.set(modelName, modelUsage);
-		}
-		addUsage(modelUsage, event);
-		if (event.isFallbackModel === true) {
-			modelUsage.isFallback = true;
-		}
-	}
-
-	const uniqueModels = new Set<string>();
-	for (const summary of summaries.values()) {
-		for (const modelName of summary.models.keys()) {
-			uniqueModels.add(modelName);
-		}
-	}
-
-	const modelPricing = new Map<string, Awaited<ReturnType<PricingSource['getPricing']>>>();
-	for (const modelName of uniqueModels) {
-		modelPricing.set(modelName, await pricingSource.getPricing(modelName));
-	}
-
-	const rows: MonthlyReportRow[] = [];
-
-	const sortedSummaries = Array.from(summaries.values()).sort((a, b) =>
-		a.month.localeCompare(b.month),
-	);
-	for (const summary of sortedSummaries) {
-		let cost = 0;
-		for (const [modelName, usage] of summary.models) {
-			const pricing = modelPricing.get(modelName);
-			if (pricing == null) {
-				continue;
-			}
-			cost += calculateCostUSD(usage, pricing);
-		}
-		summary.costUSD = cost;
-
-		const rowModels: Record<string, ModelUsage> = {};
-		for (const [modelName, usage] of summary.models) {
-			rowModels[modelName] = { ...usage };
-		}
-
-		rows.push({
-			month: formatDisplayMonth(summary.month, locale, timezone),
-			inputTokens: summary.inputTokens,
-			cachedInputTokens: summary.cachedInputTokens,
-			outputTokens: summary.outputTokens,
-			reasoningOutputTokens: summary.reasoningOutputTokens,
-			totalTokens: summary.totalTokens,
-			costUSD: cost,
-			models: rowModels,
-		});
-	}
-
-	return rows;
+	return buildBucketedReport({
+		bucketField: 'month',
+		events,
+		getBucketKey: toMonthKey,
+		getFilterDateKey: toDateKey,
+		pricingSource: options.pricingSource,
+		since: options.since,
+		timezone: options.timezone,
+		until: options.until,
+	});
 }
 
 if (import.meta.vitest != null) {
@@ -180,12 +84,14 @@ if (import.meta.vitest != null) {
 				{
 					pricingSource: stubPricingSource,
 					since: '2025-08-01',
+					timezone: 'UTC',
 					until: '2025-09-30',
 				},
 			);
 
 			expect(report).toHaveLength(2);
 			const first = report[0]!;
+			expect(first.month).toBe('2025-08');
 			expect(first.inputTokens).toBe(1_400);
 			expect(first.cachedInputTokens).toBe(300);
 			expect(first.outputTokens).toBe(700);

--- a/apps/codex/src/run.ts
+++ b/apps/codex/src/run.ts
@@ -4,9 +4,11 @@ import { description, name, version } from '../package.json';
 import { dailyCommand } from './commands/daily.ts';
 import { monthlyCommand } from './commands/monthly.ts';
 import { sessionCommand } from './commands/session.ts';
+import { weeklyCommand } from './commands/weekly.ts';
 
 const subCommands = new Map([
 	['daily', dailyCommand],
+	['weekly', weeklyCommand],
 	['monthly', monthlyCommand],
 	['session', sessionCommand],
 ]);

--- a/apps/codex/src/weekly-report.ts
+++ b/apps/codex/src/weekly-report.ts
@@ -1,0 +1,183 @@
+import type { DayOfWeek, WeekDay } from './_consts.ts';
+import type { ModelPricing, PricingSource, TokenUsageEvent, WeeklyReportRow } from './_types.ts';
+import { buildBucketedReport } from './bucketed-report.ts';
+import { toDateKey } from './date-utils.ts';
+
+export type WeeklyReportOptions = {
+	timezone?: string;
+	locale?: string;
+	since?: string;
+	startOfWeek?: WeekDay;
+	until?: string;
+	pricingSource: PricingSource;
+};
+
+function getDayNumber(day: WeekDay): DayOfWeek {
+	const dayMap = {
+		sunday: 0,
+		monday: 1,
+		tuesday: 2,
+		wednesday: 3,
+		thursday: 4,
+		friday: 5,
+		saturday: 6,
+	} as const satisfies Record<WeekDay, DayOfWeek>;
+	return dayMap[day];
+}
+
+function toWeekKey(timestamp: string, timezone: string | undefined, startDay: DayOfWeek): string {
+	const dateKey = toDateKey(timestamp, timezone);
+	const [yearStr = '0', monthStr = '1', dayStr = '1'] = dateKey.split('-');
+	const year = Number.parseInt(yearStr, 10);
+	const month = Number.parseInt(monthStr, 10);
+	const day = Number.parseInt(dayStr, 10);
+	const date = new Date(Date.UTC(year, month - 1, day));
+	const shift = (date.getUTCDay() - startDay + 7) % 7;
+	date.setUTCDate(date.getUTCDate() - shift);
+	return date.toISOString().slice(0, 10);
+}
+
+export async function buildWeeklyReport(
+	events: TokenUsageEvent[],
+	options: WeeklyReportOptions,
+): Promise<WeeklyReportRow[]> {
+	const startDay = getDayNumber(options.startOfWeek ?? 'sunday');
+
+	return buildBucketedReport({
+		bucketField: 'week',
+		events,
+		getBucketKey: (timestamp, timezone) => toWeekKey(timestamp, timezone, startDay),
+		getFilterDateKey: toDateKey,
+		pricingSource: options.pricingSource,
+		since: options.since,
+		timezone: options.timezone,
+		until: options.until,
+	});
+}
+
+if (import.meta.vitest != null) {
+	describe('buildWeeklyReport', () => {
+		it('aggregates events by default Sunday week start date and calculates costs', async () => {
+			const pricing = new Map([
+				[
+					'gpt-5',
+					{ inputCostPerMToken: 1.25, cachedInputCostPerMToken: 0.125, outputCostPerMToken: 10 },
+				],
+				[
+					'gpt-5-mini',
+					{ inputCostPerMToken: 0.6, cachedInputCostPerMToken: 0.06, outputCostPerMToken: 2 },
+				],
+			]);
+			const stubPricingSource: PricingSource = {
+				async getPricing(model: string): Promise<ModelPricing> {
+					const value = pricing.get(model);
+					if (value == null) {
+						throw new Error(`Missing pricing for ${model}`);
+					}
+					return value;
+				},
+			};
+			const report = await buildWeeklyReport(
+				[
+					{
+						sessionId: 'session-1',
+						timestamp: '2025-09-08T12:00:00.000Z',
+						model: 'gpt-5',
+						inputTokens: 1_000,
+						cachedInputTokens: 200,
+						outputTokens: 500,
+						reasoningOutputTokens: 0,
+						totalTokens: 1_500,
+					},
+					{
+						sessionId: 'session-1',
+						timestamp: '2025-09-13T23:00:00.000Z',
+						model: 'gpt-5-mini',
+						inputTokens: 400,
+						cachedInputTokens: 100,
+						outputTokens: 200,
+						reasoningOutputTokens: 50,
+						totalTokens: 750,
+					},
+					{
+						sessionId: 'session-2',
+						timestamp: '2025-09-15T12:00:00.000Z',
+						model: 'gpt-5',
+						inputTokens: 2_000,
+						cachedInputTokens: 0,
+						outputTokens: 800,
+						reasoningOutputTokens: 0,
+						totalTokens: 2_800,
+					},
+				],
+				{
+					pricingSource: stubPricingSource,
+					since: '2025-09-08',
+					timezone: 'UTC',
+					until: '2025-09-15',
+				},
+			);
+
+			expect(report).toHaveLength(2);
+			const first = report[0]!;
+			expect(first.week).toBe('2025-09-07');
+			expect(first.inputTokens).toBe(1_400);
+			expect(first.cachedInputTokens).toBe(300);
+			expect(first.outputTokens).toBe(700);
+			expect(first.reasoningOutputTokens).toBe(50);
+			const expectedCost =
+				(800 / 1_000_000) * 1.25 +
+				(200 / 1_000_000) * 0.125 +
+				(500 / 1_000_000) * 10 +
+				(300 / 1_000_000) * 0.6 +
+				(100 / 1_000_000) * 0.06 +
+				(200 / 1_000_000) * 2;
+			expect(first.costUSD).toBeCloseTo(expectedCost, 10);
+		});
+
+		it('supports Monday-start weeks like Claude weekly --start-of-week monday', async () => {
+			const stubPricingSource: PricingSource = {
+				async getPricing(): Promise<ModelPricing> {
+					return {
+						inputCostPerMToken: 0,
+						cachedInputCostPerMToken: 0,
+						outputCostPerMToken: 0,
+					};
+				},
+			};
+			const report = await buildWeeklyReport(
+				[
+					{
+						sessionId: 'session-1',
+						timestamp: '2025-09-08T12:00:00.000Z',
+						model: 'gpt-5',
+						inputTokens: 1,
+						cachedInputTokens: 0,
+						outputTokens: 0,
+						reasoningOutputTokens: 0,
+						totalTokens: 1,
+					},
+					{
+						sessionId: 'session-1',
+						timestamp: '2025-09-14T12:00:00.000Z',
+						model: 'gpt-5',
+						inputTokens: 2,
+						cachedInputTokens: 0,
+						outputTokens: 0,
+						reasoningOutputTokens: 0,
+						totalTokens: 2,
+					},
+				],
+				{
+					pricingSource: stubPricingSource,
+					startOfWeek: 'monday',
+					timezone: 'UTC',
+				},
+			);
+
+			expect(report).toHaveLength(1);
+			expect(report[0]?.week).toBe('2025-09-08');
+			expect(report[0]?.inputTokens).toBe(3);
+		});
+	});
+}


### PR DESCRIPTION
## Summary
- add a Codex `weekly` subcommand registered alongside daily/monthly/session
- match Claude weekly semantics with Sunday as the default week start and `-w/--start-of-week` for configurable week starts
- aggregate Codex usage by week with the existing report columns and shared CLI options
- factor daily/monthly/weekly rollup aggregation through a shared Codex report builder
- document `weekly` in the Codex package README

## Tests
- `pnpm --filter @ccusage/codex test -- --run`
- `pnpm --filter @ccusage/codex typecheck`
- `pnpm --filter @ccusage/codex build`
- `pnpm --filter @ccusage/codex lint`
- `pnpm vitest run --changed`
- `node apps/codex/dist/index.js weekly --help`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a weekly rollup command to the CLI with timezone, locale, date-range filtering, JSON/table output, and a configurable start-of-week option.

* **Documentation**
  * Updated usage examples, aliases, and feature list to include weekly rollups.

* **Refactor**
  * Reporting internals unified into a shared bucketing engine powering daily/weekly/monthly rollups.

* **Tests**
  * Added/updated tests covering weekly grouping, start-of-week behavior, and timezone boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->