### PR TITLE
feat(apps/hermes): add Hermes Agent usage analyzer

### DIFF
--- a/apps/hermes/README.md
+++ b/apps/hermes/README.md
@@ -1,0 +1,87 @@
+<div align="center">
+    <img src="https://cdn.jsdelivr.net/gh/ryoppippi/ccusage@main/docs/public/logo.svg" alt="ccusage logo" width="256" height="256">
+    <h1>@ccusage/hermes</h1>
+</div>
+
+> Analyze [Hermes Agent](https://hermes-agent.nousresearch.com/) usage from the local SQLite database with the same reporting experience as `ccusage`.
+
+## Quick Start
+
+```bash
+# Recommended - always include @latest
+npx @ccusage/hermes@latest --help
+bunx @ccusage/hermes@latest --help
+
+# Alternative package runners
+pnpm dlx @ccusage/hermes
+pnpx @ccusage/hermes
+```
+
+### Recommended: Shell Alias
+
+```bash
+# bash/zsh: alias ccusage-hermes='bunx @ccusage/hermes@latest'
+# fish:     alias ccusage-hermes 'bunx @ccusage/hermes@latest'
+
+# Then simply run:
+ccusage-hermes daily
+ccusage-hermes monthly --json
+```
+
+> 💡 The CLI looks for Hermes usage data under `HERMES_DATA_DIR` (defaults to `~/.hermes`).
+
+## Common Commands
+
+```bash
+# Daily usage grouped by date (default command)
+npx @ccusage/hermes@latest daily
+
+# Weekly usage grouped by ISO week
+npx @ccusage/hermes@latest weekly
+
+# Monthly usage grouped by month
+npx @ccusage/hermes@latest monthly
+
+# Session-level detailed report
+npx @ccusage/hermes@latest session
+
+# JSON output for scripting
+npx @ccusage/hermes@latest daily --json
+
+# Compact mode for screenshots/sharing
+npx @ccusage/hermes@latest daily --compact
+```
+
+Useful environment variables:
+
+- `HERMES_DATA_DIR` – override the Hermes data directory (defaults to `~/.hermes`)
+- `LOG_LEVEL` – control consola log verbosity (0 silent … 5 trace)
+
+## Features
+
+- 📊 **Daily Reports**: View token usage and costs aggregated by date
+- 📅 **Weekly Reports**: View usage grouped by ISO week (YYYY-Www)
+- 🗓️ **Monthly Reports**: View usage aggregated by month (YYYY-MM)
+- 💬 **Session Reports**: View usage grouped by conversation sessions
+- 📈 **Responsive Tables**: Automatic layout adjustment for terminal width
+- 🤖 **Model Tracking**: See which models you're using across providers
+- 💵 **Accurate Cost Calculation**: Uses LiteLLM pricing database to calculate costs from token data
+- 🔄 **Cache Token Support**: Tracks and displays cache creation and cache read tokens separately
+- 📄 **JSON Output**: Export data in structured JSON format with `--json`
+- 📱 **Compact Mode**: Use `--compact` flag for narrow terminals, perfect for screenshots
+
+## Cost Calculation
+
+Hermes stores `estimated_cost_usd` and `actual_cost_usd` in the session table. When these are present and greater than zero, they are used directly. Otherwise, costs are calculated from token usage data using the LiteLLM pricing database.
+
+## Data Location
+
+Hermes stores usage data in:
+
+- **Database**: `~/.hermes/state.db` (SQLite)
+- **Table**: `sessions`
+- **Key columns**: `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `model`, `started_at`
+
+## License
+
+MIT © [@ryoppippi](https://github.com/ryoppippi)

--- a/apps/hermes/eslint.config.js
+++ b/apps/hermes/eslint.config.js
@@ -1,0 +1,16 @@
+import { ryoppippi } from '@ryoppippi/eslint-config';
+
+/** @type {import('eslint').Linter.FlatConfig[]} */
+const config = ryoppippi(
+	{
+		type: 'app',
+		stylistic: false,
+	},
+	{
+		rules: {
+			'test/no-importing-vitest-globals': 'error',
+		},
+	},
+);
+
+export default config;

--- a/apps/hermes/package.json
+++ b/apps/hermes/package.json
@@ -31,7 +31,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=22.13.0"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/apps/hermes/package.json
+++ b/apps/hermes/package.json
@@ -1,0 +1,66 @@
+{
+	"name": "@ccusage/hermes",
+	"type": "module",
+	"version": "18.0.11",
+	"description": "Usage analysis tool for Hermes Agent sessions",
+	"contributors": [
+		"ryoppippi"
+	],
+	"license": "MIT",
+	"funding": "https://github.com/ryoppippi/ccusage?sponsor=1",
+	"homepage": "https://github.com/ryoppippi/ccusage#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ryoppippi/ccusage.git",
+		"directory": "apps/hermes"
+	},
+	"bugs": {
+		"url": "https://github.com/ryoppippi/ccusage/issues"
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"bin": {
+		"ccusage-hermes": "./src/index.ts"
+	},
+	"files": [
+		"dist"
+	],
+	"publishConfig": {
+		"bin": {
+			"ccusage-hermes": "./dist/index.js"
+		}
+	},
+	"engines": {
+		"node": ">=20.19.4"
+	},
+	"scripts": {
+		"build": "tsdown",
+		"format": "pnpm run lint --fix",
+		"lint": "eslint --cache .",
+		"prepack": "pnpm run build && clean-pkg-json",
+		"prerelease": "pnpm run lint && pnpm run typecheck && pnpm run build",
+		"start": "bun ./src/index.ts",
+		"test": "TZ=UTC vitest",
+		"typecheck": "tsgo --noEmit"
+	},
+	"devDependencies": {
+		"@ccusage/internal": "workspace:*",
+		"@ccusage/terminal": "workspace:*",
+		"@praha/byethrow": "catalog:runtime",
+		"@ryoppippi/eslint-config": "catalog:lint",
+		"@typescript/native-preview": "catalog:types",
+		"clean-pkg-json": "catalog:release",
+		"es-toolkit": "catalog:runtime",
+		"eslint": "catalog:lint",
+		"fast-sort": "catalog:runtime",
+		"fs-fixture": "catalog:testing",
+		"gunshi": "catalog:runtime",
+		"path-type": "catalog:runtime",
+		"picocolors": "catalog:runtime",
+		"tsdown": "catalog:build",
+		"unplugin-macros": "catalog:build",
+		"unplugin-unused": "catalog:build",
+		"valibot": "catalog:runtime",
+		"vitest": "catalog:testing"
+	}
+}

--- a/apps/hermes/src/aggregate-utils.ts
+++ b/apps/hermes/src/aggregate-utils.ts
@@ -1,0 +1,72 @@
+import type { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
+import { calculateCostForEntry } from './cost-utils.ts';
+import type { LoadedUsageEntry } from './data-loader.ts';
+
+export const TABLE_COLUMN_COUNT = 8;
+
+export type AggregatedRow = {
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationTokens: number;
+	cacheReadTokens: number;
+	totalTokens: number;
+	totalCost: number;
+	modelsUsed: string[];
+};
+
+/**
+ * Aggregate token usage and cost for a group of entries.
+ */
+export async function aggregateGroup(
+	entries: LoadedUsageEntry[],
+	fetcher: LiteLLMPricingFetcher,
+): Promise<AggregatedRow> {
+	let inputTokens = 0;
+	let outputTokens = 0;
+	let cacheCreationTokens = 0;
+	let cacheReadTokens = 0;
+	let totalCost = 0;
+	const modelsSet = new Set<string>();
+
+	for (const entry of entries) {
+		inputTokens += entry.usage.inputTokens;
+		outputTokens += entry.usage.outputTokens;
+		cacheCreationTokens += entry.usage.cacheCreationInputTokens;
+		cacheReadTokens += entry.usage.cacheReadInputTokens;
+		totalCost += await calculateCostForEntry(entry, fetcher);
+		modelsSet.add(entry.model);
+	}
+
+	return {
+		inputTokens,
+		outputTokens,
+		cacheCreationTokens,
+		cacheReadTokens,
+		totalTokens: inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens,
+		totalCost,
+		modelsUsed: Array.from(modelsSet),
+	};
+}
+
+export type Totals = {
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationTokens: number;
+	cacheReadTokens: number;
+	totalTokens: number;
+	totalCost: number;
+};
+
+/**
+ * Compute totals from an array of aggregated rows.
+ */
+export function computeTotals(rows: Array<Pick<AggregatedRow, 'inputTokens' | 'outputTokens' | 'cacheCreationTokens' | 'cacheReadTokens' | 'totalTokens' | 'totalCost'>>): Totals {
+	return {
+		inputTokens: rows.reduce((sum, d) => sum + d.inputTokens, 0),
+		outputTokens: rows.reduce((sum, d) => sum + d.outputTokens, 0),
+		cacheCreationTokens: rows.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
+		cacheReadTokens: rows.reduce((sum, d) => sum + d.cacheReadTokens, 0),
+		totalTokens: rows.reduce((sum, d) => sum + d.totalTokens, 0),
+		totalCost: rows.reduce((sum, d) => sum + d.totalCost, 0),
+	};
+}

--- a/apps/hermes/src/commands/daily.ts
+++ b/apps/hermes/src/commands/daily.ts
@@ -1,0 +1,177 @@
+import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatDateCompact,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { groupBy } from 'es-toolkit';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { calculateCostForEntry } from '../cost-utils.ts';
+import { loadHermesSessions } from '../data-loader.ts';
+import { logger } from '../logger.ts';
+
+const TABLE_COLUMN_COUNT = 8;
+
+export const dailyCommand = define({
+	name: 'daily',
+	description: 'Show Hermes token usage grouped by day',
+	args: {
+		json: {
+			type: 'boolean',
+			short: 'j',
+			description: 'Output in JSON format',
+		},
+		compact: {
+			type: 'boolean',
+			description: 'Force compact table mode',
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+
+		const entries = loadHermesSessions();
+
+		if (entries.length === 0) {
+			const output = jsonOutput
+				? JSON.stringify({ daily: [], totals: null })
+				: 'No Hermes usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using fetcher = new LiteLLMPricingFetcher({ offline: false, logger });
+
+		const entriesByDate = groupBy(entries, (entry) => entry.timestamp.toISOString().split('T')[0]!);
+
+		const dailyData: Array<{
+			date: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationTokens: number;
+			cacheReadTokens: number;
+			totalTokens: number;
+			totalCost: number;
+			modelsUsed: string[];
+		}> = [];
+
+		for (const [date, dayEntries] of Object.entries(entriesByDate)) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheCreationTokens = 0;
+			let cacheReadTokens = 0;
+			let totalCost = 0;
+			const modelsSet = new Set<string>();
+
+			for (const entry of dayEntries) {
+				inputTokens += entry.usage.inputTokens;
+				outputTokens += entry.usage.outputTokens;
+				cacheCreationTokens += entry.usage.cacheCreationInputTokens;
+				cacheReadTokens += entry.usage.cacheReadInputTokens;
+				totalCost += await calculateCostForEntry(entry, fetcher);
+				modelsSet.add(entry.model);
+			}
+
+			const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
+
+			dailyData.push({
+				date,
+				inputTokens,
+				outputTokens,
+				cacheCreationTokens,
+				cacheReadTokens,
+				totalTokens,
+				totalCost,
+				modelsUsed: Array.from(modelsSet),
+			});
+		}
+
+		dailyData.sort((a, b) => a.date.localeCompare(b.date));
+
+		const totals = {
+			inputTokens: dailyData.reduce((sum, d) => sum + d.inputTokens, 0),
+			outputTokens: dailyData.reduce((sum, d) => sum + d.outputTokens, 0),
+			cacheCreationTokens: dailyData.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
+			cacheReadTokens: dailyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
+			totalTokens: dailyData.reduce((sum, d) => sum + d.totalTokens, 0),
+			totalCost: dailyData.reduce((sum, d) => sum + d.totalCost, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify(
+					{
+						daily: dailyData,
+						totals,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log('\n📊 Hermes Token Usage Report - Daily\n');
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: [
+				'Date',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Create',
+				'Cache Read',
+				'Total Tokens',
+				'Cost (USD)',
+			],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Date', 'Models', 'Input', 'Output', 'Cost (USD)'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+			dateFormatter: (dateStr: string) => formatDateCompact(dateStr),
+		});
+
+		for (const data of dailyData) {
+			table.push([
+				data.date,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheCreationTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				formatCurrency(data.totalCost),
+			]);
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatCurrency(totals.totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/hermes/src/commands/daily.ts
+++ b/apps/hermes/src/commands/daily.ts
@@ -10,11 +10,16 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
-import { calculateCostForEntry } from '../cost-utils.ts';
+import { aggregateGroup, computeTotals, TABLE_COLUMN_COUNT } from '../aggregate-utils.ts';
 import { loadHermesSessions } from '../data-loader.ts';
 import { logger } from '../logger.ts';
 
-const TABLE_COLUMN_COUNT = 8;
+function formatDateUTC(date: Date): string {
+	const year = date.getUTCFullYear();
+	const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+	const day = String(date.getUTCDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+}
 
 export const dailyCommand = define({
 	name: 'daily',
@@ -46,7 +51,7 @@ export const dailyCommand = define({
 
 		using fetcher = new LiteLLMPricingFetcher({ offline: false, logger });
 
-		const entriesByDate = groupBy(entries, (entry) => entry.timestamp.toISOString().split('T')[0]!);
+		const entriesByDate = groupBy(entries, (entry) => formatDateUTC(entry.timestamp));
 
 		const dailyData: Array<{
 			date: string;
@@ -60,46 +65,13 @@ export const dailyCommand = define({
 		}> = [];
 
 		for (const [date, dayEntries] of Object.entries(entriesByDate)) {
-			let inputTokens = 0;
-			let outputTokens = 0;
-			let cacheCreationTokens = 0;
-			let cacheReadTokens = 0;
-			let totalCost = 0;
-			const modelsSet = new Set<string>();
-
-			for (const entry of dayEntries) {
-				inputTokens += entry.usage.inputTokens;
-				outputTokens += entry.usage.outputTokens;
-				cacheCreationTokens += entry.usage.cacheCreationInputTokens;
-				cacheReadTokens += entry.usage.cacheReadInputTokens;
-				totalCost += await calculateCostForEntry(entry, fetcher);
-				modelsSet.add(entry.model);
-			}
-
-			const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
-
-			dailyData.push({
-				date,
-				inputTokens,
-				outputTokens,
-				cacheCreationTokens,
-				cacheReadTokens,
-				totalTokens,
-				totalCost,
-				modelsUsed: Array.from(modelsSet),
-			});
+			const agg = await aggregateGroup(dayEntries, fetcher);
+			dailyData.push({ date, ...agg });
 		}
 
 		dailyData.sort((a, b) => a.date.localeCompare(b.date));
 
-		const totals = {
-			inputTokens: dailyData.reduce((sum, d) => sum + d.inputTokens, 0),
-			outputTokens: dailyData.reduce((sum, d) => sum + d.outputTokens, 0),
-			cacheCreationTokens: dailyData.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
-			cacheReadTokens: dailyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
-			totalTokens: dailyData.reduce((sum, d) => sum + d.totalTokens, 0),
-			totalCost: dailyData.reduce((sum, d) => sum + d.totalCost, 0),
-		};
+		const totals = computeTotals(dailyData);
 
 		if (jsonOutput) {
 			// eslint-disable-next-line no-console

--- a/apps/hermes/src/commands/index.ts
+++ b/apps/hermes/src/commands/index.ts
@@ -1,0 +1,4 @@
+export { dailyCommand } from './daily.ts';
+export { monthlyCommand } from './monthly.ts';
+export { sessionCommand } from './session.ts';
+export { weeklyCommand } from './weekly.ts';

--- a/apps/hermes/src/commands/monthly.ts
+++ b/apps/hermes/src/commands/monthly.ts
@@ -9,11 +9,15 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
-import { calculateCostForEntry } from '../cost-utils.ts';
+import { aggregateGroup, computeTotals, TABLE_COLUMN_COUNT } from '../aggregate-utils.ts';
 import { loadHermesSessions } from '../data-loader.ts';
 import { logger } from '../logger.ts';
 
-const TABLE_COLUMN_COUNT = 8;
+function formatMonthUTC(date: Date): string {
+	const year = date.getUTCFullYear();
+	const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+	return `${year}-${month}`;
+}
 
 export const monthlyCommand = define({
 	name: 'monthly',
@@ -45,10 +49,7 @@ export const monthlyCommand = define({
 
 		using fetcher = new LiteLLMPricingFetcher({ offline: false, logger });
 
-		const entriesByMonth = groupBy(
-			entries,
-			(entry) => `${entry.timestamp.getFullYear()}-${String(entry.timestamp.getMonth() + 1).padStart(2, '0')}`,
-		);
+		const entriesByMonth = groupBy(entries, (entry) => formatMonthUTC(entry.timestamp));
 
 		const monthlyData: Array<{
 			month: string;
@@ -62,46 +63,13 @@ export const monthlyCommand = define({
 		}> = [];
 
 		for (const [month, monthEntries] of Object.entries(entriesByMonth)) {
-			let inputTokens = 0;
-			let outputTokens = 0;
-			let cacheCreationTokens = 0;
-			let cacheReadTokens = 0;
-			let totalCost = 0;
-			const modelsSet = new Set<string>();
-
-			for (const entry of monthEntries) {
-				inputTokens += entry.usage.inputTokens;
-				outputTokens += entry.usage.outputTokens;
-				cacheCreationTokens += entry.usage.cacheCreationInputTokens;
-				cacheReadTokens += entry.usage.cacheReadInputTokens;
-				totalCost += await calculateCostForEntry(entry, fetcher);
-				modelsSet.add(entry.model);
-			}
-
-			const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
-
-			monthlyData.push({
-				month,
-				inputTokens,
-				outputTokens,
-				cacheCreationTokens,
-				cacheReadTokens,
-				totalTokens,
-				totalCost,
-				modelsUsed: Array.from(modelsSet),
-			});
+			const agg = await aggregateGroup(monthEntries, fetcher);
+			monthlyData.push({ month, ...agg });
 		}
 
 		monthlyData.sort((a, b) => a.month.localeCompare(b.month));
 
-		const totals = {
-			inputTokens: monthlyData.reduce((sum, d) => sum + d.inputTokens, 0),
-			outputTokens: monthlyData.reduce((sum, d) => sum + d.outputTokens, 0),
-			cacheCreationTokens: monthlyData.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
-			cacheReadTokens: monthlyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
-			totalTokens: monthlyData.reduce((sum, d) => sum + d.totalTokens, 0),
-			totalCost: monthlyData.reduce((sum, d) => sum + d.totalCost, 0),
-		};
+		const totals = computeTotals(monthlyData);
 
 		if (jsonOutput) {
 			// eslint-disable-next-line no-console

--- a/apps/hermes/src/commands/monthly.ts
+++ b/apps/hermes/src/commands/monthly.ts
@@ -1,0 +1,178 @@
+import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatNumber,
+	formatModelsDisplayMultiline,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { groupBy } from 'es-toolkit';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { calculateCostForEntry } from '../cost-utils.ts';
+import { loadHermesSessions } from '../data-loader.ts';
+import { logger } from '../logger.ts';
+
+const TABLE_COLUMN_COUNT = 8;
+
+export const monthlyCommand = define({
+	name: 'monthly',
+	description: 'Show Hermes token usage grouped by month',
+	args: {
+		json: {
+			type: 'boolean',
+			short: 'j',
+			description: 'Output in JSON format',
+		},
+		compact: {
+			type: 'boolean',
+			description: 'Force compact table mode',
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+
+		const entries = loadHermesSessions();
+
+		if (entries.length === 0) {
+			const output = jsonOutput
+				? JSON.stringify({ monthly: [], totals: null })
+				: 'No Hermes usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using fetcher = new LiteLLMPricingFetcher({ offline: false, logger });
+
+		const entriesByMonth = groupBy(
+			entries,
+			(entry) => `${entry.timestamp.getFullYear()}-${String(entry.timestamp.getMonth() + 1).padStart(2, '0')}`,
+		);
+
+		const monthlyData: Array<{
+			month: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationTokens: number;
+			cacheReadTokens: number;
+			totalTokens: number;
+			totalCost: number;
+			modelsUsed: string[];
+		}> = [];
+
+		for (const [month, monthEntries] of Object.entries(entriesByMonth)) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheCreationTokens = 0;
+			let cacheReadTokens = 0;
+			let totalCost = 0;
+			const modelsSet = new Set<string>();
+
+			for (const entry of monthEntries) {
+				inputTokens += entry.usage.inputTokens;
+				outputTokens += entry.usage.outputTokens;
+				cacheCreationTokens += entry.usage.cacheCreationInputTokens;
+				cacheReadTokens += entry.usage.cacheReadInputTokens;
+				totalCost += await calculateCostForEntry(entry, fetcher);
+				modelsSet.add(entry.model);
+			}
+
+			const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
+
+			monthlyData.push({
+				month,
+				inputTokens,
+				outputTokens,
+				cacheCreationTokens,
+				cacheReadTokens,
+				totalTokens,
+				totalCost,
+				modelsUsed: Array.from(modelsSet),
+			});
+		}
+
+		monthlyData.sort((a, b) => a.month.localeCompare(b.month));
+
+		const totals = {
+			inputTokens: monthlyData.reduce((sum, d) => sum + d.inputTokens, 0),
+			outputTokens: monthlyData.reduce((sum, d) => sum + d.outputTokens, 0),
+			cacheCreationTokens: monthlyData.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
+			cacheReadTokens: monthlyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
+			totalTokens: monthlyData.reduce((sum, d) => sum + d.totalTokens, 0),
+			totalCost: monthlyData.reduce((sum, d) => sum + d.totalCost, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify(
+					{
+						monthly: monthlyData,
+						totals,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log('\n📊 Hermes Token Usage Report - Monthly\n');
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: [
+				'Month',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Create',
+				'Cache Read',
+				'Total Tokens',
+				'Cost (USD)',
+			],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Month', 'Models', 'Input', 'Output', 'Cost (USD)'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+		});
+
+		for (const data of monthlyData) {
+			table.push([
+				data.month,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheCreationTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				formatCurrency(data.totalCost),
+			]);
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatCurrency(totals.totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/hermes/src/commands/session.ts
+++ b/apps/hermes/src/commands/session.ts
@@ -10,11 +10,25 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
-import { calculateCostForEntry } from '../cost-utils.ts';
+import { aggregateGroup, computeTotals, TABLE_COLUMN_COUNT } from '../aggregate-utils.ts';
 import { loadHermesSessions, loadHermesSessionMetadata } from '../data-loader.ts';
 import { logger } from '../logger.ts';
 
-const TABLE_COLUMN_COUNT = 8;
+const ROOT_SENTINEL = Symbol('root');
+
+type SessionData = {
+	sessionID: string;
+	sessionTitle: string;
+	parentID: string | null;
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationTokens: number;
+	cacheReadTokens: number;
+	totalTokens: number;
+	totalCost: number;
+	modelsUsed: string[];
+	lastActivity: Date;
+};
 
 export const sessionCommand = define({
 	name: 'session',
@@ -51,73 +65,30 @@ export const sessionCommand = define({
 
 		const entriesBySession = groupBy(entries, (entry) => entry.sessionID);
 
-		type SessionData = {
-			sessionID: string;
-			sessionTitle: string;
-			parentID: string | null;
-			inputTokens: number;
-			outputTokens: number;
-			cacheCreationTokens: number;
-			cacheReadTokens: number;
-			totalTokens: number;
-			totalCost: number;
-			modelsUsed: string[];
-			lastActivity: Date;
-		};
-
 		const sessionData: SessionData[] = [];
 
 		for (const [sessionID, sessionEntries] of Object.entries(entriesBySession)) {
-			let inputTokens = 0;
-			let outputTokens = 0;
-			let cacheCreationTokens = 0;
-			let cacheReadTokens = 0;
-			let totalCost = 0;
-			const modelsSet = new Set<string>();
+			const agg = await aggregateGroup(sessionEntries, fetcher);
+			const metadata = sessionMetadataMap.get(sessionID);
 			let lastActivity = sessionEntries[0]!.timestamp;
-
 			for (const entry of sessionEntries) {
-				inputTokens += entry.usage.inputTokens;
-				outputTokens += entry.usage.outputTokens;
-				cacheCreationTokens += entry.usage.cacheCreationInputTokens;
-				cacheReadTokens += entry.usage.cacheReadInputTokens;
-				totalCost += await calculateCostForEntry(entry, fetcher);
-				modelsSet.add(entry.model);
-
 				if (entry.timestamp > lastActivity) {
 					lastActivity = entry.timestamp;
 				}
 			}
 
-			const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
-
-			const metadata = sessionMetadataMap.get(sessionID);
-
 			sessionData.push({
 				sessionID,
 				sessionTitle: metadata?.title ?? sessionID,
 				parentID: metadata?.parentID ?? null,
-				inputTokens,
-				outputTokens,
-				cacheCreationTokens,
-				cacheReadTokens,
-				totalTokens,
-				totalCost,
-				modelsUsed: Array.from(modelsSet),
+				...agg,
 				lastActivity,
 			});
 		}
 
 		sessionData.sort((a, b) => a.lastActivity.getTime() - b.lastActivity.getTime());
 
-		const totals = {
-			inputTokens: sessionData.reduce((sum, s) => sum + s.inputTokens, 0),
-			outputTokens: sessionData.reduce((sum, s) => sum + s.outputTokens, 0),
-			cacheCreationTokens: sessionData.reduce((sum, s) => sum + s.cacheCreationTokens, 0),
-			cacheReadTokens: sessionData.reduce((sum, s) => sum + s.cacheReadTokens, 0),
-			totalTokens: sessionData.reduce((sum, s) => sum + s.totalTokens, 0),
-			totalCost: sessionData.reduce((sum, s) => sum + s.totalCost, 0),
-		};
+		const totals = computeTotals(sessionData);
 
 		if (jsonOutput) {
 			// eslint-disable-next-line no-console
@@ -157,59 +128,49 @@ export const sessionCommand = define({
 			dateFormatter: (dateStr: string) => formatDateCompact(dateStr),
 		});
 
-		const sessionsByParent = groupBy(sessionData, (s) => s.parentID ?? 'root');
-		const parentSessions = sessionsByParent.root ?? [];
-		delete sessionsByParent.root;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const sessionsByParent = groupBy(sessionData, (s) => s.parentID ?? (ROOT_SENTINEL as any));
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const parentSessions: SessionData[] = (sessionsByParent as any)[ROOT_SENTINEL] ?? [];
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		delete (sessionsByParent as any)[ROOT_SENTINEL];
 
-		for (const parentSession of parentSessions) {
-			const isParent = sessionsByParent[parentSession.sessionID] != null;
-			const displayTitle = isParent
-				? pc.bold(parentSession.sessionTitle)
-				: parentSession.sessionTitle;
+		function renderSessionRow(session: SessionData, indent: string): void {
+			const subSessions = (sessionsByParent as Record<string, SessionData[]>)[session.sessionID];
+			const hasChildren = subSessions != null && subSessions.length > 0;
+			const displayTitle = hasChildren ? pc.bold(session.sessionTitle) : session.sessionTitle;
 
 			table.push([
-				displayTitle,
-				formatModelsDisplayMultiline(parentSession.modelsUsed),
-				formatNumber(parentSession.inputTokens),
-				formatNumber(parentSession.outputTokens),
-				formatNumber(parentSession.cacheCreationTokens),
-				formatNumber(parentSession.cacheReadTokens),
-				formatNumber(parentSession.totalTokens),
-				formatCurrency(parentSession.totalCost),
+				`${indent}${displayTitle}`,
+				formatModelsDisplayMultiline(session.modelsUsed),
+				formatNumber(session.inputTokens),
+				formatNumber(session.outputTokens),
+				formatNumber(session.cacheCreationTokens),
+				formatNumber(session.cacheReadTokens),
+				formatNumber(session.totalTokens),
+				formatCurrency(session.totalCost),
 			]);
 
-			const subSessions = sessionsByParent[parentSession.sessionID];
-			if (subSessions != null && subSessions.length > 0) {
-				for (const subSession of subSessions) {
-					table.push([
-						`  ↳ ${subSession.sessionTitle}`,
-						formatModelsDisplayMultiline(subSession.modelsUsed),
-						formatNumber(subSession.inputTokens),
-						formatNumber(subSession.outputTokens),
-						formatNumber(subSession.cacheCreationTokens),
-						formatNumber(subSession.cacheReadTokens),
-						formatNumber(subSession.totalTokens),
-						formatCurrency(subSession.totalCost),
-					]);
+			if (hasChildren) {
+				let subtotalInputTokens = session.inputTokens;
+				let subtotalOutputTokens = session.outputTokens;
+				let subtotalCacheCreationTokens = session.cacheCreationTokens;
+				let subtotalCacheReadTokens = session.cacheReadTokens;
+				let subtotalTotalTokens = session.totalTokens;
+				let subtotalCost = session.totalCost;
+
+				for (const sub of subSessions) {
+					renderSessionRow(sub, `${indent}  ↓ `);
+					subtotalInputTokens += sub.inputTokens;
+					subtotalOutputTokens += sub.outputTokens;
+					subtotalCacheCreationTokens += sub.cacheCreationTokens;
+					subtotalCacheReadTokens += sub.cacheReadTokens;
+					subtotalTotalTokens += sub.totalTokens;
+					subtotalCost += sub.totalCost;
 				}
 
-				const subtotalInputTokens =
-					parentSession.inputTokens + subSessions.reduce((sum, s) => sum + s.inputTokens, 0);
-				const subtotalOutputTokens =
-					parentSession.outputTokens + subSessions.reduce((sum, s) => sum + s.outputTokens, 0);
-				const subtotalCacheCreationTokens =
-					parentSession.cacheCreationTokens +
-					subSessions.reduce((sum, s) => sum + s.cacheCreationTokens, 0);
-				const subtotalCacheReadTokens =
-					parentSession.cacheReadTokens +
-					subSessions.reduce((sum, s) => sum + s.cacheReadTokens, 0);
-				const subtotalTotalTokens =
-					parentSession.totalTokens + subSessions.reduce((sum, s) => sum + s.totalTokens, 0);
-				const subtotalCost =
-					parentSession.totalCost + subSessions.reduce((sum, s) => sum + s.totalCost, 0);
-
 				table.push([
-					pc.dim('  Total (with subagents)'),
+					`${indent}  ${pc.dim('Total (with subagents)')}`,
 					'',
 					pc.yellow(formatNumber(subtotalInputTokens)),
 					pc.yellow(formatNumber(subtotalOutputTokens)),
@@ -218,6 +179,23 @@ export const sessionCommand = define({
 					pc.yellow(formatNumber(subtotalTotalTokens)),
 					pc.yellow(formatCurrency(subtotalCost)),
 				]);
+			}
+		}
+
+		for (const parentSession of parentSessions) {
+			renderSessionRow(parentSession, '');
+		}
+
+		// Render any orphaned sessions that were never attached to a parent
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const remainingKeys = Object.keys(sessionsByParent).filter((k) => k !== (ROOT_SENTINEL as any).toString());
+		for (const key of remainingKeys) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const orphans = (sessionsByParent as any)[key];
+			if (orphans != null && orphans.length > 0) {
+				for (const orphan of orphans) {
+					renderSessionRow(orphan, '');
+				}
 			}
 		}
 

--- a/apps/hermes/src/commands/session.ts
+++ b/apps/hermes/src/commands/session.ts
@@ -1,0 +1,246 @@
+import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatDateCompact,
+	formatModelsDisplayMultiline,
+	formatNumber,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { groupBy } from 'es-toolkit';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { calculateCostForEntry } from '../cost-utils.ts';
+import { loadHermesSessions, loadHermesSessionMetadata } from '../data-loader.ts';
+import { logger } from '../logger.ts';
+
+const TABLE_COLUMN_COUNT = 8;
+
+export const sessionCommand = define({
+	name: 'session',
+	description: 'Show Hermes token usage grouped by session',
+	args: {
+		json: {
+			type: 'boolean',
+			short: 'j',
+			description: 'Output in JSON format',
+		},
+		compact: {
+			type: 'boolean',
+			description: 'Force compact table mode',
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+
+		const [entries, sessionMetadataMap] = [
+			loadHermesSessions(),
+			loadHermesSessionMetadata(),
+		];
+
+		if (entries.length === 0) {
+			const output = jsonOutput
+				? JSON.stringify({ sessions: [], totals: null })
+				: 'No Hermes usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using fetcher = new LiteLLMPricingFetcher({ offline: false, logger });
+
+		const entriesBySession = groupBy(entries, (entry) => entry.sessionID);
+
+		type SessionData = {
+			sessionID: string;
+			sessionTitle: string;
+			parentID: string | null;
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationTokens: number;
+			cacheReadTokens: number;
+			totalTokens: number;
+			totalCost: number;
+			modelsUsed: string[];
+			lastActivity: Date;
+		};
+
+		const sessionData: SessionData[] = [];
+
+		for (const [sessionID, sessionEntries] of Object.entries(entriesBySession)) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheCreationTokens = 0;
+			let cacheReadTokens = 0;
+			let totalCost = 0;
+			const modelsSet = new Set<string>();
+			let lastActivity = sessionEntries[0]!.timestamp;
+
+			for (const entry of sessionEntries) {
+				inputTokens += entry.usage.inputTokens;
+				outputTokens += entry.usage.outputTokens;
+				cacheCreationTokens += entry.usage.cacheCreationInputTokens;
+				cacheReadTokens += entry.usage.cacheReadInputTokens;
+				totalCost += await calculateCostForEntry(entry, fetcher);
+				modelsSet.add(entry.model);
+
+				if (entry.timestamp > lastActivity) {
+					lastActivity = entry.timestamp;
+				}
+			}
+
+			const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
+
+			const metadata = sessionMetadataMap.get(sessionID);
+
+			sessionData.push({
+				sessionID,
+				sessionTitle: metadata?.title ?? sessionID,
+				parentID: metadata?.parentID ?? null,
+				inputTokens,
+				outputTokens,
+				cacheCreationTokens,
+				cacheReadTokens,
+				totalTokens,
+				totalCost,
+				modelsUsed: Array.from(modelsSet),
+				lastActivity,
+			});
+		}
+
+		sessionData.sort((a, b) => a.lastActivity.getTime() - b.lastActivity.getTime());
+
+		const totals = {
+			inputTokens: sessionData.reduce((sum, s) => sum + s.inputTokens, 0),
+			outputTokens: sessionData.reduce((sum, s) => sum + s.outputTokens, 0),
+			cacheCreationTokens: sessionData.reduce((sum, s) => sum + s.cacheCreationTokens, 0),
+			cacheReadTokens: sessionData.reduce((sum, s) => sum + s.cacheReadTokens, 0),
+			totalTokens: sessionData.reduce((sum, s) => sum + s.totalTokens, 0),
+			totalCost: sessionData.reduce((sum, s) => sum + s.totalCost, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify(
+					{
+						sessions: sessionData,
+						totals,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log('\n📊 Hermes Token Usage Report - Sessions\n');
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: [
+				'Session',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Create',
+				'Cache Read',
+				'Total Tokens',
+				'Cost (USD)',
+			],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Session', 'Models', 'Input', 'Output', 'Cost (USD)'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+			dateFormatter: (dateStr: string) => formatDateCompact(dateStr),
+		});
+
+		const sessionsByParent = groupBy(sessionData, (s) => s.parentID ?? 'root');
+		const parentSessions = sessionsByParent.root ?? [];
+		delete sessionsByParent.root;
+
+		for (const parentSession of parentSessions) {
+			const isParent = sessionsByParent[parentSession.sessionID] != null;
+			const displayTitle = isParent
+				? pc.bold(parentSession.sessionTitle)
+				: parentSession.sessionTitle;
+
+			table.push([
+				displayTitle,
+				formatModelsDisplayMultiline(parentSession.modelsUsed),
+				formatNumber(parentSession.inputTokens),
+				formatNumber(parentSession.outputTokens),
+				formatNumber(parentSession.cacheCreationTokens),
+				formatNumber(parentSession.cacheReadTokens),
+				formatNumber(parentSession.totalTokens),
+				formatCurrency(parentSession.totalCost),
+			]);
+
+			const subSessions = sessionsByParent[parentSession.sessionID];
+			if (subSessions != null && subSessions.length > 0) {
+				for (const subSession of subSessions) {
+					table.push([
+						`  ↳ ${subSession.sessionTitle}`,
+						formatModelsDisplayMultiline(subSession.modelsUsed),
+						formatNumber(subSession.inputTokens),
+						formatNumber(subSession.outputTokens),
+						formatNumber(subSession.cacheCreationTokens),
+						formatNumber(subSession.cacheReadTokens),
+						formatNumber(subSession.totalTokens),
+						formatCurrency(subSession.totalCost),
+					]);
+				}
+
+				const subtotalInputTokens =
+					parentSession.inputTokens + subSessions.reduce((sum, s) => sum + s.inputTokens, 0);
+				const subtotalOutputTokens =
+					parentSession.outputTokens + subSessions.reduce((sum, s) => sum + s.outputTokens, 0);
+				const subtotalCacheCreationTokens =
+					parentSession.cacheCreationTokens +
+					subSessions.reduce((sum, s) => sum + s.cacheCreationTokens, 0);
+				const subtotalCacheReadTokens =
+					parentSession.cacheReadTokens +
+					subSessions.reduce((sum, s) => sum + s.cacheReadTokens, 0);
+				const subtotalTotalTokens =
+					parentSession.totalTokens + subSessions.reduce((sum, s) => sum + s.totalTokens, 0);
+				const subtotalCost =
+					parentSession.totalCost + subSessions.reduce((sum, s) => sum + s.totalCost, 0);
+
+				table.push([
+					pc.dim('  Total (with subagents)'),
+					'',
+					pc.yellow(formatNumber(subtotalInputTokens)),
+					pc.yellow(formatNumber(subtotalOutputTokens)),
+					pc.yellow(formatNumber(subtotalCacheCreationTokens)),
+					pc.yellow(formatNumber(subtotalCacheReadTokens)),
+					pc.yellow(formatNumber(subtotalTotalTokens)),
+					pc.yellow(formatCurrency(subtotalCost)),
+				]);
+			}
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatCurrency(totals.totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/hermes/src/commands/weekly.ts
+++ b/apps/hermes/src/commands/weekly.ts
@@ -1,0 +1,184 @@
+import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
+import {
+	addEmptySeparatorRow,
+	formatCurrency,
+	formatNumber,
+	formatModelsDisplayMultiline,
+	ResponsiveTable,
+} from '@ccusage/terminal/table';
+import { groupBy } from 'es-toolkit';
+import { define } from 'gunshi';
+import pc from 'picocolors';
+import { calculateCostForEntry } from '../cost-utils.ts';
+import { loadHermesSessions } from '../data-loader.ts';
+import { logger } from '../logger.ts';
+
+const TABLE_COLUMN_COUNT = 8;
+
+function getISOWeek(date: Date): string {
+	const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+	const dayNum = d.getUTCDay() || 7;
+	d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+	const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+	const weekNo = Math.ceil(((+d - +yearStart) / 86400000 + 1) / 7);
+	return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`;
+}
+
+export const weeklyCommand = define({
+	name: 'weekly',
+	description: 'Show Hermes token usage grouped by ISO week',
+	args: {
+		json: {
+			type: 'boolean',
+			short: 'j',
+			description: 'Output in JSON format',
+		},
+		compact: {
+			type: 'boolean',
+			description: 'Force compact table mode',
+		},
+	},
+	async run(ctx) {
+		const jsonOutput = Boolean(ctx.values.json);
+
+		const entries = loadHermesSessions();
+
+		if (entries.length === 0) {
+			const output = jsonOutput
+				? JSON.stringify({ weekly: [], totals: null })
+				: 'No Hermes usage data found.';
+			// eslint-disable-next-line no-console
+			console.log(output);
+			return;
+		}
+
+		using fetcher = new LiteLLMPricingFetcher({ offline: false, logger });
+
+		const entriesByWeek = groupBy(entries, (entry) => getISOWeek(entry.timestamp));
+
+		const weeklyData: Array<{
+			week: string;
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationTokens: number;
+			cacheReadTokens: number;
+			totalTokens: number;
+			totalCost: number;
+			modelsUsed: string[];
+		}> = [];
+
+		for (const [week, weekEntries] of Object.entries(entriesByWeek)) {
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let cacheCreationTokens = 0;
+			let cacheReadTokens = 0;
+			let totalCost = 0;
+			const modelsSet = new Set<string>();
+
+			for (const entry of weekEntries) {
+				inputTokens += entry.usage.inputTokens;
+				outputTokens += entry.usage.outputTokens;
+				cacheCreationTokens += entry.usage.cacheCreationInputTokens;
+				cacheReadTokens += entry.usage.cacheReadInputTokens;
+				totalCost += await calculateCostForEntry(entry, fetcher);
+				modelsSet.add(entry.model);
+			}
+
+			const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
+
+			weeklyData.push({
+				week,
+				inputTokens,
+				outputTokens,
+				cacheCreationTokens,
+				cacheReadTokens,
+				totalTokens,
+				totalCost,
+				modelsUsed: Array.from(modelsSet),
+			});
+		}
+
+		weeklyData.sort((a, b) => a.week.localeCompare(b.week));
+
+		const totals = {
+			inputTokens: weeklyData.reduce((sum, d) => sum + d.inputTokens, 0),
+			outputTokens: weeklyData.reduce((sum, d) => sum + d.outputTokens, 0),
+			cacheCreationTokens: weeklyData.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
+			cacheReadTokens: weeklyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
+			totalTokens: weeklyData.reduce((sum, d) => sum + d.totalTokens, 0),
+			totalCost: weeklyData.reduce((sum, d) => sum + d.totalCost, 0),
+		};
+
+		if (jsonOutput) {
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify(
+					{
+						weekly: weeklyData,
+						totals,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log('\n📊 Hermes Token Usage Report - Weekly\n');
+
+		const table: ResponsiveTable = new ResponsiveTable({
+			head: [
+				'Week',
+				'Models',
+				'Input',
+				'Output',
+				'Cache Create',
+				'Cache Read',
+				'Total Tokens',
+				'Cost (USD)',
+			],
+			colAligns: ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
+			compactHead: ['Week', 'Models', 'Input', 'Output', 'Cost (USD)'],
+			compactColAligns: ['left', 'left', 'right', 'right', 'right'],
+			compactThreshold: 100,
+			forceCompact: Boolean(ctx.values.compact),
+			style: { head: ['cyan'] },
+		});
+
+		for (const data of weeklyData) {
+			table.push([
+				data.week,
+				formatModelsDisplayMultiline(data.modelsUsed),
+				formatNumber(data.inputTokens),
+				formatNumber(data.outputTokens),
+				formatNumber(data.cacheCreationTokens),
+				formatNumber(data.cacheReadTokens),
+				formatNumber(data.totalTokens),
+				formatCurrency(data.totalCost),
+			]);
+		}
+
+		addEmptySeparatorRow(table, TABLE_COLUMN_COUNT);
+		table.push([
+			pc.yellow('Total'),
+			'',
+			pc.yellow(formatNumber(totals.inputTokens)),
+			pc.yellow(formatNumber(totals.outputTokens)),
+			pc.yellow(formatNumber(totals.cacheCreationTokens)),
+			pc.yellow(formatNumber(totals.cacheReadTokens)),
+			pc.yellow(formatNumber(totals.totalTokens)),
+			pc.yellow(formatCurrency(totals.totalCost)),
+		]);
+
+		// eslint-disable-next-line no-console
+		console.log(table.toString());
+
+		if (table.isCompactMode()) {
+			// eslint-disable-next-line no-console
+			console.log('\nRunning in Compact Mode');
+			// eslint-disable-next-line no-console
+			console.log('Expand terminal width to see cache metrics and total tokens');
+		}
+	},
+});

--- a/apps/hermes/src/commands/weekly.ts
+++ b/apps/hermes/src/commands/weekly.ts
@@ -9,14 +9,12 @@ import {
 import { groupBy } from 'es-toolkit';
 import { define } from 'gunshi';
 import pc from 'picocolors';
-import { calculateCostForEntry } from '../cost-utils.ts';
+import { aggregateGroup, computeTotals, TABLE_COLUMN_COUNT } from '../aggregate-utils.ts';
 import { loadHermesSessions } from '../data-loader.ts';
 import { logger } from '../logger.ts';
 
-const TABLE_COLUMN_COUNT = 8;
-
 function getISOWeek(date: Date): string {
-	const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+	const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
 	const dayNum = d.getUTCDay() || 7;
 	d.setUTCDate(d.getUTCDate() + 4 - dayNum);
 	const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
@@ -68,46 +66,13 @@ export const weeklyCommand = define({
 		}> = [];
 
 		for (const [week, weekEntries] of Object.entries(entriesByWeek)) {
-			let inputTokens = 0;
-			let outputTokens = 0;
-			let cacheCreationTokens = 0;
-			let cacheReadTokens = 0;
-			let totalCost = 0;
-			const modelsSet = new Set<string>();
-
-			for (const entry of weekEntries) {
-				inputTokens += entry.usage.inputTokens;
-				outputTokens += entry.usage.outputTokens;
-				cacheCreationTokens += entry.usage.cacheCreationInputTokens;
-				cacheReadTokens += entry.usage.cacheReadInputTokens;
-				totalCost += await calculateCostForEntry(entry, fetcher);
-				modelsSet.add(entry.model);
-			}
-
-			const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
-
-			weeklyData.push({
-				week,
-				inputTokens,
-				outputTokens,
-				cacheCreationTokens,
-				cacheReadTokens,
-				totalTokens,
-				totalCost,
-				modelsUsed: Array.from(modelsSet),
-			});
+			const agg = await aggregateGroup(weekEntries, fetcher);
+			weeklyData.push({ week, ...agg });
 		}
 
 		weeklyData.sort((a, b) => a.week.localeCompare(b.week));
 
-		const totals = {
-			inputTokens: weeklyData.reduce((sum, d) => sum + d.inputTokens, 0),
-			outputTokens: weeklyData.reduce((sum, d) => sum + d.outputTokens, 0),
-			cacheCreationTokens: weeklyData.reduce((sum, d) => sum + d.cacheCreationTokens, 0),
-			cacheReadTokens: weeklyData.reduce((sum, d) => sum + d.cacheReadTokens, 0),
-			totalTokens: weeklyData.reduce((sum, d) => sum + d.totalTokens, 0),
-			totalCost: weeklyData.reduce((sum, d) => sum + d.totalCost, 0),
-		};
+		const totals = computeTotals(weeklyData);
 
 		if (jsonOutput) {
 			// eslint-disable-next-line no-console

--- a/apps/hermes/src/cost-utils.ts
+++ b/apps/hermes/src/cost-utils.ts
@@ -1,0 +1,42 @@
+import type { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
+import type { LoadedUsageEntry } from './data-loader.ts';
+import { Result } from '@praha/byethrow';
+
+/**
+ * Model aliases for Hermes-specific model names that don't exist in LiteLLM.
+ * Maps Hermes model names to their LiteLLM equivalents for pricing lookup.
+ */
+const MODEL_ALIASES: Record<string, string> = {
+	'kimi-k2.6': 'kimi-k2-6',
+	'glm-5.1': 'glm-4-plus',
+};
+
+function resolveModelName(modelName: string): string {
+	return MODEL_ALIASES[modelName] ?? modelName;
+}
+
+/**
+ * Calculate cost for a single usage entry
+ * Uses pre-calculated cost if available, otherwise calculates from tokens
+ */
+export async function calculateCostForEntry(
+	entry: LoadedUsageEntry,
+	fetcher: LiteLLMPricingFetcher,
+): Promise<number> {
+	if (entry.costUSD != null && entry.costUSD > 0) {
+		return entry.costUSD;
+	}
+
+	const resolvedModel = resolveModelName(entry.model);
+	const result = await fetcher.calculateCostFromTokens(
+		{
+			input_tokens: entry.usage.inputTokens,
+			output_tokens: entry.usage.outputTokens,
+			cache_creation_input_tokens: entry.usage.cacheCreationInputTokens,
+			cache_read_input_tokens: entry.usage.cacheReadInputTokens,
+		},
+		resolvedModel,
+	);
+
+	return Result.unwrap(result, 0);
+}

--- a/apps/hermes/src/cost-utils.ts
+++ b/apps/hermes/src/cost-utils.ts
@@ -6,10 +6,7 @@ import { Result } from '@praha/byethrow';
  * Model aliases for Hermes-specific model names that don't exist in LiteLLM.
  * Maps Hermes model names to their LiteLLM equivalents for pricing lookup.
  */
-const MODEL_ALIASES: Record<string, string> = {
-	'kimi-k2.6': 'kimi-k2-6',
-	'glm-5.1': 'glm-4-plus',
-};
+const MODEL_ALIASES: Record<string, string> = {};
 
 function resolveModelName(modelName: string): string {
 	return MODEL_ALIASES[modelName] ?? modelName;
@@ -38,5 +35,6 @@ export async function calculateCostForEntry(
 		resolvedModel,
 	);
 
-	return Result.unwrap(result, 0);
+	if (Result.isFailure(result)) return 0;
+	return result.value;
 }

--- a/apps/hermes/src/data-loader.ts
+++ b/apps/hermes/src/data-loader.ts
@@ -54,8 +54,11 @@ export type LoadedSessionMetadata = {
 };
 
 function safeNumber(value: unknown): number {
-	if (typeof value === 'number') return value;
-	if (typeof value === 'string') return Number.parseFloat(value);
+	if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+	if (typeof value === 'string') {
+		const parsed = Number.parseFloat(value.trim());
+		return Number.isFinite(parsed) ? parsed : 0;
+	}
 	return 0;
 }
 

--- a/apps/hermes/src/data-loader.ts
+++ b/apps/hermes/src/data-loader.ts
@@ -1,0 +1,222 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { DatabaseSync } from 'node:sqlite';
+import { isDirectorySync } from 'path-type';
+import { logger } from './logger.ts';
+
+const DEFAULT_HERMES_PATH = '.hermes';
+const HERMES_STATE_DB = 'state.db';
+const HERMES_CONFIG_DIR_ENV = 'HERMES_DATA_DIR';
+
+/**
+ * Resolve the Hermes data directory.
+ * 1. Check HERMES_DATA_DIR env var
+ * 2. Fallback to ~/.hermes
+ */
+function getHermesPath(): string | null {
+	const envPath = process.env[HERMES_CONFIG_DIR_ENV]?.trim();
+	if (envPath != null && envPath !== '' && isDirectorySync(envPath)) {
+		return path.resolve(envPath);
+	}
+
+	const defaultPath = path.join(homedir(), DEFAULT_HERMES_PATH);
+	if (isDirectorySync(defaultPath)) {
+		return defaultPath;
+	}
+
+	return null;
+}
+
+function getStateDbPath(): string | null {
+	const hermesPath = getHermesPath();
+	if (hermesPath == null) return null;
+	return path.join(hermesPath, HERMES_STATE_DB);
+}
+
+export type LoadedUsageEntry = {
+	timestamp: Date;
+	sessionID: string;
+	usage: {
+		inputTokens: number;
+		outputTokens: number;
+		cacheCreationInputTokens: number;
+		cacheReadInputTokens: number;
+	};
+	model: string;
+	costUSD: number | null;
+};
+
+export type LoadedSessionMetadata = {
+	id: string;
+	parentID: string | null;
+	title: string;
+};
+
+function safeNumber(value: unknown): number {
+	if (typeof value === 'number') return value;
+	if (typeof value === 'string') return Number.parseFloat(value);
+	return 0;
+}
+
+function safeString(value: unknown): string | null {
+	if (typeof value === 'string') return value;
+	return null;
+}
+
+/**
+ * Normalize Hermes model names for LiteLLM pricing lookup.
+ * - Replace spaces with dashes
+ * - Strip provider prefixes (antigravity/, opencode-go/, kiro/, etc.)
+ */
+function normalizeModelName(raw: string): string {
+	let model = raw.trim().replace(/\s+/g, '-');
+	// Strip known provider prefixes
+	const prefixes = ['antigravity/', 'opencode-go/', 'kiro/', 'nous/', 'openrouter/'];
+	for (const prefix of prefixes) {
+		if (model.startsWith(prefix)) {
+			model = model.slice(prefix.length);
+			break;
+		}
+	}
+	return model;
+}
+
+/**
+ * Load usage entries from Hermes SQLite database.
+ * Each session row becomes one usage entry with aggregated token counts.
+ */
+export function loadHermesSessions(): LoadedUsageEntry[] {
+	const dbPath = getStateDbPath();
+	if (dbPath == null) {
+		logger.warn('Hermes data directory not found. Set HERMES_DATA_DIR or ensure ~/.hermes exists.');
+		return [];
+	}
+
+	let db: DatabaseSync | undefined;
+	try {
+		db = new DatabaseSync(dbPath, { readOnly: true });
+	} catch (err) {
+		logger.warn(`Failed to open Hermes database at ${dbPath}:`, err);
+		return [];
+	}
+
+	try {
+		const stmt = db.prepare(`
+			SELECT
+				id,
+				started_at,
+				model,
+				input_tokens,
+				output_tokens,
+				cache_read_tokens,
+				cache_write_tokens,
+				estimated_cost_usd,
+				actual_cost_usd
+			FROM sessions
+			WHERE started_at IS NOT NULL
+				AND (input_tokens > 0 OR output_tokens > 0)
+			ORDER BY started_at ASC
+		`);
+
+		const rows = stmt.all() as Array<Record<string, unknown>>;
+		const entries: LoadedUsageEntry[] = [];
+		const seen = new Set<string>();
+
+		for (const row of rows) {
+			const sessionID = safeString(row.id);
+			if (sessionID == null) continue;
+
+			// Deduplicate by session ID
+			if (seen.has(sessionID)) continue;
+			seen.add(sessionID);
+
+			const startedAt = safeNumber(row.started_at);
+			const timestamp = new Date(startedAt * 1000);
+
+			const rawModel = safeString(row.model);
+			const model = rawModel != null ? normalizeModelName(rawModel) : 'unknown';
+
+			const actualCost = safeNumber(row.actual_cost_usd);
+			const estimatedCost = safeNumber(row.estimated_cost_usd);
+			const costUSD = actualCost > 0 ? actualCost : estimatedCost > 0 ? estimatedCost : null;
+
+			entries.push({
+				timestamp,
+				sessionID,
+				usage: {
+					inputTokens: safeNumber(row.input_tokens),
+					outputTokens: safeNumber(row.output_tokens),
+					cacheCreationInputTokens: safeNumber(row.cache_write_tokens),
+					cacheReadInputTokens: safeNumber(row.cache_read_tokens),
+				},
+				model,
+				costUSD,
+			});
+		}
+
+		return entries;
+	} catch (err) {
+		logger.warn('Failed to query Hermes sessions:', err);
+		return [];
+	} finally {
+		try {
+			db.close();
+		} catch {
+			// ignore close errors
+		}
+	}
+}
+
+/**
+ * Load session metadata from Hermes SQLite database.
+ * Returns a Map keyed by session ID.
+ */
+export function loadHermesSessionMetadata(): Map<string, LoadedSessionMetadata> {
+	const dbPath = getStateDbPath();
+	if (dbPath == null) {
+		return new Map();
+	}
+
+	let db: DatabaseSync | undefined;
+	try {
+		db = new DatabaseSync(dbPath, { readOnly: true });
+	} catch {
+		return new Map();
+	}
+
+	try {
+		const stmt = db.prepare(`
+			SELECT
+				id,
+				parent_session_id,
+				title
+			FROM sessions
+			WHERE id IS NOT NULL
+		`);
+
+		const rows = stmt.all() as Array<Record<string, unknown>>;
+		const map = new Map<string, LoadedSessionMetadata>();
+
+		for (const row of rows) {
+			const id = safeString(row.id);
+			if (id == null) continue;
+
+			map.set(id, {
+				id,
+				parentID: safeString(row.parent_session_id),
+				title: safeString(row.title) ?? id,
+			});
+		}
+
+		return map;
+	} catch {
+		return new Map();
+	} finally {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+	}
+}

--- a/apps/hermes/src/index.ts
+++ b/apps/hermes/src/index.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+/**
+ * @fileoverview Main entry point for ccusage-hermes CLI tool
+ *
+ * This is the main entry point for the Hermes usage analysis command-line interface.
+ * It provides analysis of Hermes Agent usage data from the local SQLite database.
+ *
+ * @module index
+ */
+
+/* eslint-disable antfu/no-top-level-await */
+import { run } from './run.ts';
+
+await run();

--- a/apps/hermes/src/logger.ts
+++ b/apps/hermes/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@ccusage/internal/logger';
+
+export const logger = createLogger('@ccusage/hermes');

--- a/apps/hermes/src/run.ts
+++ b/apps/hermes/src/run.ts
@@ -1,0 +1,30 @@
+import process from 'node:process';
+import { cli } from 'gunshi';
+import { description, name, version } from '../package.json';
+import { dailyCommand, monthlyCommand, sessionCommand, weeklyCommand } from './commands/index.ts';
+
+const subCommands = new Map([
+	['daily', dailyCommand],
+	['monthly', monthlyCommand],
+	['session', sessionCommand],
+	['weekly', weeklyCommand],
+]);
+
+const mainCommand = dailyCommand;
+
+export async function run(): Promise<void> {
+	// When invoked through npx, the binary name might be passed as the first argument
+	// Filter it out if it matches the expected binary name
+	let args = process.argv.slice(2);
+	if (args[0] === 'ccusage-hermes') {
+		args = args.slice(1);
+	}
+
+	await cli(args, mainCommand, {
+		name,
+		version,
+		description,
+		subCommands,
+		renderHeader: null,
+	});
+}

--- a/apps/hermes/tsconfig.json
+++ b/apps/hermes/tsconfig.json
@@ -1,0 +1,25 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"lib": ["ESNext"],
+		"moduleDetection": "force",
+		"module": "Preserve",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"types": ["vitest/globals", "vitest/importMeta"],
+		"allowImportingTsExtensions": true,
+		"allowJs": false,
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": false,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noEmit": true,
+		"verbatimModuleSyntax": true,
+		"erasableSyntaxOnly": true,
+		"skipLibCheck": true
+	},
+	"exclude": ["dist"]
+}

--- a/apps/hermes/tsdown.config.ts
+++ b/apps/hermes/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	format: ['esm'],
+	clean: true,
+	dts: false,
+	shims: true,
+	platform: 'node',
+	target: 'node20',
+	fixedExtension: false,
+});

--- a/apps/hermes/tsdown.config.ts
+++ b/apps/hermes/tsdown.config.ts
@@ -9,4 +9,7 @@ export default defineConfig({
 	platform: 'node',
 	target: 'node20',
 	fixedExtension: false,
+	define: {
+		'import.meta.vitest': 'undefined',
+	},
 });

--- a/apps/hermes/vitest.config.ts
+++ b/apps/hermes/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		includeSource: ['src/**/*.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+		},
+	},
+	define: {
+		'import.meta.vitest': 'undefined',
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,63 @@ importers:
         specifier: catalog:testing
         version: 4.1.2(@types/node@24.5.1)(happy-dom@16.8.1)(vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3))
 
+  apps/hermes:
+    devDependencies:
+      '@ccusage/internal':
+        specifier: workspace:*
+        version: link:../../packages/internal
+      '@ccusage/terminal':
+        specifier: workspace:*
+        version: link:../../packages/terminal
+      '@praha/byethrow':
+        specifier: catalog:runtime
+        version: 0.6.3
+      '@ryoppippi/eslint-config':
+        specifier: catalog:lint
+        version: 0.4.0(@vue/compiler-sfc@3.5.30)(eslint-plugin-format@2.0.1(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.1.2(@types/node@24.5.1)(happy-dom@16.8.1)(vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)))
+      '@typescript/native-preview':
+        specifier: catalog:types
+        version: 7.0.0-dev.20260107.1
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.3.0
+      es-toolkit:
+        specifier: catalog:runtime
+        version: 1.39.10
+      eslint:
+        specifier: catalog:lint
+        version: 9.35.0(jiti@2.6.1)
+      fast-sort:
+        specifier: catalog:runtime
+        version: 3.4.1
+      fs-fixture:
+        specifier: catalog:testing
+        version: 2.8.1
+      gunshi:
+        specifier: catalog:runtime
+        version: 0.26.3
+      path-type:
+        specifier: catalog:runtime
+        version: 6.0.0
+      picocolors:
+        specifier: catalog:runtime
+        version: 1.1.1
+      tsdown:
+        specifier: catalog:build
+        version: 0.16.6(@typescript/native-preview@7.0.0-dev.20260107.1)(publint@0.3.12)(synckit@0.11.12)(typescript@5.9.2)(unplugin-unused@0.5.3)
+      unplugin-macros:
+        specifier: catalog:build
+        version: 0.18.2(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
+      unplugin-unused:
+        specifier: catalog:build
+        version: 0.5.3
+      valibot:
+        specifier: catalog:runtime
+        version: 1.1.0(typescript@5.9.2)
+      vitest:
+        specifier: catalog:testing
+        version: 4.1.2(@types/node@24.5.1)(happy-dom@16.8.1)(vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3))
+
   apps/mcp:
     dependencies:
       '@ccusage/codex':
@@ -809,19 +866,10 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -925,12 +973,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.25.9':
-    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
     engines: {node: '>=18'}
@@ -939,12 +981,6 @@ packages:
 
   '@esbuild/android-arm64@0.25.4':
     resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.25.9':
-    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -961,12 +997,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.25.9':
-    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.27.4':
     resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
     engines: {node: '>=18'}
@@ -975,12 +1005,6 @@ packages:
 
   '@esbuild/android-x64@0.25.4':
     resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.9':
-    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -997,12 +1021,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.25.9':
-    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.4':
     resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
@@ -1011,12 +1029,6 @@ packages:
 
   '@esbuild/darwin-x64@0.25.4':
     resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.9':
-    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1033,12 +1045,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.25.9':
-    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.4':
     resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
@@ -1047,12 +1053,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.4':
     resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.9':
-    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1069,12 +1069,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.25.9':
-    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.4':
     resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
@@ -1083,12 +1077,6 @@ packages:
 
   '@esbuild/linux-arm@0.25.4':
     resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.9':
-    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1105,12 +1093,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.9':
-    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.4':
     resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
@@ -1119,12 +1101,6 @@ packages:
 
   '@esbuild/linux-loong64@0.25.4':
     resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.9':
-    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1141,12 +1117,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.9':
-    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.4':
     resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
@@ -1155,12 +1125,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.4':
     resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.9':
-    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1177,12 +1141,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.9':
-    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.4':
     resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
@@ -1191,12 +1149,6 @@ packages:
 
   '@esbuild/linux-s390x@0.25.4':
     resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.9':
-    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1213,12 +1165,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.9':
-    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.4':
     resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
     engines: {node: '>=18'}
@@ -1227,12 +1173,6 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.4':
     resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.25.9':
-    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1249,12 +1189,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.9':
-    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.27.4':
     resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
     engines: {node: '>=18'}
@@ -1263,12 +1197,6 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.4':
     resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.25.9':
-    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1285,23 +1213,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.9':
-    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openbsd-x64@0.27.4':
     resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.25.9':
-    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
 
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
@@ -1311,12 +1227,6 @@ packages:
 
   '@esbuild/sunos-x64@0.25.4':
     resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.25.9':
-    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1333,12 +1243,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.25.9':
-    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
@@ -1351,12 +1255,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.9':
-    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.4':
     resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
@@ -1365,12 +1263,6 @@ packages:
 
   '@esbuild/win32-x64@0.25.4':
     resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.9':
-    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2292,9 +2184,6 @@ packages:
 
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3278,11 +3167,6 @@ packages:
 
   esbuild@0.25.4:
     resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.25.9:
-    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5461,46 +5345,6 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.1.5:
-    resolution: {integrity: sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5838,8 +5682,8 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -5848,18 +5692,9 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/parser@7.28.5':
-    dependencies:
-      '@babel/types': 7.28.5
-
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.0':
     dependencies:
@@ -5956,16 +5791,10 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.9':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
   '@esbuild/android-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
@@ -5974,16 +5803,10 @@ snapshots:
   '@esbuild/android-arm@0.25.4':
     optional: true
 
-  '@esbuild/android-arm@0.25.9':
-    optional: true
-
   '@esbuild/android-arm@0.27.4':
     optional: true
 
   '@esbuild/android-x64@0.25.4':
-    optional: true
-
-  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/android-x64@0.27.4':
@@ -5992,16 +5815,10 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.4':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.9':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
   '@esbuild/darwin-x64@0.25.4':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
@@ -6010,16 +5827,10 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.4':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.9':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.4':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
@@ -6028,16 +5839,10 @@ snapshots:
   '@esbuild/linux-arm64@0.25.4':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.9':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
   '@esbuild/linux-arm@0.25.4':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
@@ -6046,16 +5851,10 @@ snapshots:
   '@esbuild/linux-ia32@0.25.4':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.9':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
   '@esbuild/linux-loong64@0.25.4':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
@@ -6064,16 +5863,10 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.4':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.9':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.4':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
@@ -6082,16 +5875,10 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.4':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.9':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
   '@esbuild/linux-s390x@0.25.4':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
@@ -6100,16 +5887,10 @@ snapshots:
   '@esbuild/linux-x64@0.25.4':
     optional: true
 
-  '@esbuild/linux-x64@0.25.9':
-    optional: true
-
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
@@ -6118,16 +5899,10 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.9':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
@@ -6136,13 +5911,7 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.4':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.9':
-    optional: true
-
   '@esbuild/openbsd-x64@0.27.4':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.9':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
@@ -6151,16 +5920,10 @@ snapshots:
   '@esbuild/sunos-x64@0.25.4':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.9':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
   '@esbuild/win32-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.9':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
@@ -6169,16 +5932,10 @@ snapshots:
   '@esbuild/win32-ia32@0.25.4':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.9':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
   '@esbuild/win32-x64@0.25.4':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -6236,7 +5993,7 @@ snapshots:
       '@eslint/core': 0.15.2
       '@eslint/plugin-kit': 0.3.5
       github-slugger: 2.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-frontmatter: 2.0.1
       mdast-util-gfm: 3.1.0
       micromark-extension-frontmatter: 2.0.0
@@ -6703,7 +6460,7 @@ snapshots:
 
   '@praha/byethrow@0.6.3':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
 
   '@publint/pack@0.1.2': {}
 
@@ -6901,8 +6658,6 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@speed-highlight/core@1.2.7': {}
-
-  '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -7344,7 +7099,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       pathe: 2.0.3
 
   bail@2.0.2: {}
@@ -7847,35 +7602,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.4
       '@esbuild/win32-ia32': 0.25.4
       '@esbuild/win32-x64': 0.25.4
-
-  esbuild@0.25.9:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.9
-      '@esbuild/android-arm': 0.25.9
-      '@esbuild/android-arm64': 0.25.9
-      '@esbuild/android-x64': 0.25.9
-      '@esbuild/darwin-arm64': 0.25.9
-      '@esbuild/darwin-x64': 0.25.9
-      '@esbuild/freebsd-arm64': 0.25.9
-      '@esbuild/freebsd-x64': 0.25.9
-      '@esbuild/linux-arm': 0.25.9
-      '@esbuild/linux-arm64': 0.25.9
-      '@esbuild/linux-ia32': 0.25.9
-      '@esbuild/linux-loong64': 0.25.9
-      '@esbuild/linux-mips64el': 0.25.9
-      '@esbuild/linux-ppc64': 0.25.9
-      '@esbuild/linux-riscv64': 0.25.9
-      '@esbuild/linux-s390x': 0.25.9
-      '@esbuild/linux-x64': 0.25.9
-      '@esbuild/netbsd-arm64': 0.25.9
-      '@esbuild/netbsd-x64': 0.25.9
-      '@esbuild/openbsd-arm64': 0.25.9
-      '@esbuild/openbsd-x64': 0.25.9
-      '@esbuild/openharmony-arm64': 0.25.9
-      '@esbuild/sunos-x64': 0.25.9
-      '@esbuild/win32-arm64': 0.25.9
-      '@esbuild/win32-ia32': 0.25.9
-      '@esbuild/win32-x64': 0.25.9
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -8930,7 +8656,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -8939,7 +8665,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8949,7 +8675,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8958,14 +8684,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -9612,7 +9338,7 @@ snapshots:
 
   pnpm-workspace-yaml@1.1.1:
     dependencies:
-      yaml: 2.8.1
+      yaml: 2.8.3
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -9836,8 +9562,8 @@ snapshots:
   rolldown-plugin-dts@0.18.0(@typescript/native-preview@7.0.0-dev.20260107.1)(rolldown@1.0.0-beta.51)(typescript@5.9.2):
     dependencies:
       '@babel/generator': 7.28.5
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       ast-kit: 2.2.0
       birpc: 2.8.0
       dts-resolver: 2.1.3
@@ -10415,7 +10141,7 @@ snapshots:
       ast-kit: 2.2.0
       magic-string-ast: 1.0.2
       unplugin: 2.3.10
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
       vite-node: 3.2.4(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -10490,7 +10216,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10504,20 +10230,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vite@7.1.5(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.25.9
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.50.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.5.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      yaml: 2.8.3
 
   vite@7.3.1(@types/node@24.5.1)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
@@ -10737,7 +10449,7 @@ snapshots:
   yaml-eslint-parser@1.3.0:
     dependencies:
       eslint-visitor-keys: 3.4.3
-      yaml: 2.8.1
+      yaml: 2.8.3
 
   yaml@2.8.1: {}
 


### PR DESCRIPTION
## Summary

Adds `@ccusage/hermes` package that reads token usage from Hermes Agent's local SQLite database and provides the same reporting experience as the existing OpenCode and Pi apps.

## Features

- Daily / Weekly / Monthly / Session reports
- Reads from `~/.hermes/state.db` using `node:sqlite`
- LiteLLM pricing integration with model name normalization
- Parent/subagent session grouping
- JSON and compact output modes
- Supports `HERMES_DATA_DIR` env override

## New Files

```
apps/hermes/
├── package.json
├── README.md
├── tsconfig.json
├── tsdown.config.ts
├── vitest.config.ts
├── eslint.config.js
└── src/
    ├── index.ts
    ├── run.ts
    ├── logger.ts
    ├── data-loader.ts
    ├── cost-utils.ts
    └── commands/
        ├── index.ts
        ├── daily.ts
        ├── weekly.ts
        ├── monthly.ts
        └── session.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the @ccusage/hermes CLI for analyzing Hermes Agent usage (daily, weekly, monthly, session views).
  * Added subcommands to group token usage and cost by day/week/month/session with --json and --compact output options.
  * Environment-driven behavior via HERMES_DATA_DIR and LOG_LEVEL.

* **Documentation**
  * Added comprehensive README with Quick Start, command examples, env vars, cost behavior notes, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->