### PR TITLE
fix!: remove locale option

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -96,7 +96,6 @@ npx ccusage daily --since 20250525 --until 20250530
 npx ccusage daily --json  # JSON output
 npx ccusage daily --breakdown  # Per-model cost breakdown
 npx ccusage daily --timezone UTC  # Use UTC timezone
-npx ccusage daily --locale ja-JP  # Use Japanese locale for date/time formatting
 
 # Project analysis
 npx ccusage daily --instances  # Group by project/instance
@@ -130,7 +129,6 @@ npx ccusage monthly --compact  # Compact monthly report
 - 🔌 **MCP Integration**: Built-in Model Context Protocol server for integration with other tools
 - 🏗️ **Multi-Instance Support**: Group usage by project with `--instances` flag and filter by specific projects
 - 🌍 **Timezone Support**: Configure timezone for date grouping with `--timezone` option
-- 🌐 **Locale Support**: Customize date/time formatting with `--locale` option (e.g., en-US, ja-JP, de-DE)
 - ⚙️ **Configuration Files**: Set defaults with JSON configuration files, complete with IDE autocomplete and validation
 - 🚀 **Ultra-Small Bundle**: Unlike other CLI tools, we pay extreme attention to bundle size - incredibly small even without minification!
 

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -81,12 +81,6 @@
 							"description": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone",
 							"markdownDescription": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone"
 						},
-						"locale": {
-							"type": "string",
-							"description": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-							"markdownDescription": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-							"default": "en-CA"
-						},
 						"jq": {
 							"type": "string",
 							"description": "Process JSON output with jq command (requires jq binary, implies --json)",
@@ -177,12 +171,6 @@
 									"type": "string",
 									"description": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone",
 									"markdownDescription": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone"
-								},
-								"locale": {
-									"type": "string",
-									"description": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-									"markdownDescription": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-									"default": "en-CA"
 								},
 								"jq": {
 									"type": "string",
@@ -286,12 +274,6 @@
 									"description": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone",
 									"markdownDescription": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone"
 								},
-								"locale": {
-									"type": "string",
-									"description": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-									"markdownDescription": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-									"default": "en-CA"
-								},
 								"jq": {
 									"type": "string",
 									"description": "Process JSON output with jq command (requires jq binary, implies --json)",
@@ -377,12 +359,6 @@
 									"type": "string",
 									"description": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone",
 									"markdownDescription": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone"
-								},
-								"locale": {
-									"type": "string",
-									"description": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-									"markdownDescription": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-									"default": "en-CA"
 								},
 								"jq": {
 									"type": "string",
@@ -478,12 +454,6 @@
 									"description": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone",
 									"markdownDescription": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone"
 								},
-								"locale": {
-									"type": "string",
-									"description": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-									"markdownDescription": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-									"default": "en-CA"
-								},
 								"jq": {
 									"type": "string",
 									"description": "Process JSON output with jq command (requires jq binary, implies --json)",
@@ -574,12 +544,6 @@
 									"type": "string",
 									"description": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone",
 									"markdownDescription": "Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone"
-								},
-								"locale": {
-									"type": "string",
-									"description": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-									"markdownDescription": "Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)",
-									"default": "en-CA"
 								},
 								"jq": {
 									"type": "string",
@@ -692,8 +656,7 @@
 			"defaults": {
 				"json": false,
 				"mode": "auto",
-				"timezone": "Asia/Tokyo",
-				"locale": "ja-JP"
+				"timezone": "Asia/Tokyo"
 			},
 			"commands": {
 				"daily": {

--- a/apps/ccusage/scripts/generate-json-schema.ts
+++ b/apps/ccusage/scripts/generate-json-schema.ts
@@ -170,7 +170,6 @@ function createConfigSchemaJson() {
 					json: false,
 					mode: 'auto',
 					timezone: 'Asia/Tokyo',
-					locale: 'ja-JP',
 				},
 				commands: {
 					daily: {

--- a/apps/ccusage/src/_date-utils.ts
+++ b/apps/ccusage/src/_date-utils.ts
@@ -18,14 +18,8 @@ export { formatDateCompact } from '@ccusage/terminal/table';
  */
 export type SortOrder = 'asc' | 'desc';
 
-/**
- * Creates a date formatter with the specified timezone and locale
- * @param timezone - Timezone to use (e.g., 'UTC', 'America/New_York')
- * @param locale - Locale to use for formatting (e.g., 'en-US', 'ja-JP')
- * @returns Intl.DateTimeFormat instance
- */
-function createDateFormatter(timezone: string | undefined, locale: string): Intl.DateTimeFormat {
-	return new Intl.DateTimeFormat(locale, {
+function createDateFormatter(timezone: string | undefined): Intl.DateTimeFormat {
+	return new Intl.DateTimeFormat(DEFAULT_LOCALE, {
 		year: 'numeric',
 		month: '2-digit',
 		day: '2-digit',
@@ -37,13 +31,11 @@ function createDateFormatter(timezone: string | undefined, locale: string): Intl
  * Formats a date string to YYYY-MM-DD format
  * @param dateStr - Input date string
  * @param timezone - Optional timezone to use for formatting
- * @param locale - Optional locale to use for formatting (defaults to DEFAULT_LOCALE for YYYY-MM-DD format)
  * @returns Formatted date string in YYYY-MM-DD format
  */
-export function formatDate(dateStr: string, timezone?: string, locale?: string): string {
+export function formatDate(dateStr: string, timezone?: string): string {
 	const date = new Date(dateStr);
-	// Use DEFAULT_LOCALE as default for consistent YYYY-MM-DD format
-	const formatter = createDateFormatter(timezone, locale ?? DEFAULT_LOCALE);
+	const formatter = createDateFormatter(timezone);
 	return formatter.format(date);
 }
 
@@ -145,14 +137,9 @@ if (import.meta.vitest != null) {
 			expect(result).toBe('2024-08-04');
 		});
 
-		it('should use default locale when locale is not provided', () => {
+		it('uses the default YYYY-MM-DD locale', () => {
 			const result = formatDate('2024-08-04T12:00:00Z');
 			expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-		});
-
-		it('should handle custom locale', () => {
-			const result = formatDate('2024-08-04T12:00:00Z', 'UTC', 'en-US');
-			expect(result).toBe('08/04/2024');
 		});
 	});
 

--- a/apps/ccusage/src/_shared-args.ts
+++ b/apps/ccusage/src/_shared-args.ts
@@ -1,7 +1,6 @@
 import type { Args } from 'gunshi';
 import type { CostMode, SortOrder } from './_types.ts';
 import * as v from 'valibot';
-import { DEFAULT_LOCALE } from './_consts.ts';
 import { CostModes, filterDateSchema, SortOrders } from './_types.ts';
 
 /**
@@ -89,12 +88,6 @@ export const sharedArgs = {
 		short: 'z',
 		description:
 			'Timezone for date grouping (e.g., UTC, America/New_York, Asia/Tokyo). Default: system timezone',
-	},
-	locale: {
-		type: 'string',
-		short: 'l',
-		description: 'Locale for date/time formatting (e.g., en-US, ja-JP, de-DE)',
-		default: DEFAULT_LOCALE,
 	},
 	jq: {
 		type: 'string',

--- a/apps/ccusage/src/commands/_session_id.ts
+++ b/apps/ccusage/src/commands/_session_id.ts
@@ -15,7 +15,6 @@ export type SessionIdContext = {
 		offline: boolean;
 		jq?: string;
 		timezone?: string;
-		locale: string; // normalized to non-optional to avoid touching data-loader
 	};
 };
 
@@ -85,7 +84,7 @@ export async function handleSessionIdLookup(
 
 			for (const entry of sessionUsage.entries) {
 				table.push([
-					formatDateCompact(entry.timestamp, ctx.values.timezone, ctx.values.locale),
+					formatDateCompact(entry.timestamp, ctx.values.timezone),
 					entry.message.model ?? 'unknown',
 					formatNumber(entry.message.usage.input_tokens),
 					formatNumber(entry.message.usage.output_tokens),

--- a/apps/ccusage/src/commands/blocks.ts
+++ b/apps/ccusage/src/commands/blocks.ts
@@ -32,26 +32,25 @@ import { log, logger } from '../logger.ts';
  * Formats the time display for a session block
  * @param block - Session block to format
  * @param compact - Whether to use compact formatting for narrow terminals
- * @param locale - Locale for date/time formatting
  * @returns Formatted time string with duration and status information
  */
-function formatBlockTime(block: SessionBlock, compact = false, locale?: string): string {
+function formatBlockTime(block: SessionBlock, compact = false): string {
 	const start = compact
-		? block.startTime.toLocaleString(locale, {
+		? block.startTime.toLocaleString(undefined, {
 				month: '2-digit',
 				day: '2-digit',
 				hour: '2-digit',
 				minute: '2-digit',
 			})
-		: block.startTime.toLocaleString(locale);
+		: block.startTime.toLocaleString();
 
 	if (block.isGap ?? false) {
 		const end = compact
-			? block.endTime.toLocaleString(locale, {
+			? block.endTime.toLocaleString(undefined, {
 					hour: '2-digit',
 					minute: '2-digit',
 				})
-			: block.endTime.toLocaleString(locale);
+			: block.endTime.toLocaleString();
 		const duration = Math.round(
 			(block.endTime.getTime() - block.startTime.getTime()) / (1000 * 60 * 60),
 		);
@@ -172,7 +171,6 @@ export const blocksCommand = define({
 			offline: ctx.values.offline,
 			sessionDurationHours: ctx.values.sessionLength,
 			timezone: ctx.values.timezone,
-			locale: ctx.values.locale,
 		});
 
 		if (blocks.length === 0) {
@@ -377,7 +375,7 @@ export const blocksCommand = define({
 					if (block.isGap ?? false) {
 						// Gap row
 						const gapRow = [
-							pc.gray(formatBlockTime(block, useCompactFormat, ctx.values.locale)),
+							pc.gray(formatBlockTime(block, useCompactFormat)),
 							pc.gray('(inactive)'),
 							pc.gray('-'),
 							pc.gray('-'),
@@ -392,7 +390,7 @@ export const blocksCommand = define({
 						const status = block.isActive ? pc.green('ACTIVE') : '';
 
 						const row = [
-							formatBlockTime(block, useCompactFormat, ctx.values.locale),
+							formatBlockTime(block, useCompactFormat),
 							status,
 							formatModels(block.models),
 							formatNumber(totalTokens),

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -140,8 +140,7 @@ export const dailyCommand = define({
 			// Create table with compact mode support
 			const tableConfig: UsageReportConfig = {
 				firstColumnName: 'Date',
-				dateFormatter: (dateStr: string) =>
-					formatDateCompact(dateStr, mergedOptions.timezone, mergedOptions.locale ?? undefined),
+				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, mergedOptions.timezone),
 				forceCompact: ctx.values.compact,
 			};
 			const table = createUsageReportTable(tableConfig);

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -10,7 +10,6 @@ import {
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
-import { DEFAULT_LOCALE } from '../_consts.ts';
 import { formatDateCompact } from '../_date-utils.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
@@ -100,12 +99,7 @@ export const monthlyCommand = define({
 			// Create table with compact mode support
 			const tableConfig: UsageReportConfig = {
 				firstColumnName: 'Month',
-				dateFormatter: (dateStr: string) =>
-					formatDateCompact(
-						dateStr,
-						mergedOptions.timezone,
-						mergedOptions.locale ?? DEFAULT_LOCALE,
-					),
+				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, mergedOptions.timezone),
 				forceCompact: ctx.values.compact,
 			};
 			const table = createUsageReportTable(tableConfig);

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -10,7 +10,6 @@ import {
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
-import { DEFAULT_LOCALE } from '../_consts.ts';
 import { formatDateCompact } from '../_date-utils.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
@@ -57,7 +56,6 @@ export const sessionCommand = define({
 						offline: mergedOptions.offline,
 						jq: mergedOptions.jq,
 						timezone: mergedOptions.timezone,
-						locale: mergedOptions.locale ?? DEFAULT_LOCALE,
 					},
 				},
 				useJson,
@@ -71,7 +69,6 @@ export const sessionCommand = define({
 			mode: ctx.values.mode,
 			offline: ctx.values.offline,
 			timezone: ctx.values.timezone,
-			locale: ctx.values.locale,
 		});
 
 		if (sessionData.length === 0) {
@@ -130,8 +127,7 @@ export const sessionCommand = define({
 			const tableConfig: UsageReportConfig = {
 				firstColumnName: 'Session',
 				includeLastActivity: true,
-				dateFormatter: (dateStr: string) =>
-					formatDateCompact(dateStr, ctx.values.timezone, ctx.values.locale),
+				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, ctx.values.timezone),
 				forceCompact: ctx.values.compact,
 			};
 			const table = createUsageReportTable(tableConfig);

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -110,8 +110,7 @@ export const weeklyCommand = define({
 			// Create table with compact mode support
 			const tableConfig: UsageReportConfig = {
 				firstColumnName: 'Week',
-				dateFormatter: (dateStr: string) =>
-					formatDateCompact(dateStr, mergedOptions.timezone, mergedOptions.locale ?? undefined),
+				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, mergedOptions.timezone),
 				forceCompact: ctx.values.compact,
 			};
 			const table = createUsageReportTable(tableConfig);

--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -29,7 +29,6 @@ import {
 	CLAUDE_PROJECTS_DIR_NAME,
 	DEFAULT_CLAUDE_CODE_PATH,
 	DEFAULT_CLAUDE_CONFIG_PATH,
-	DEFAULT_LOCALE,
 	USAGE_DATA_GLOB_PATTERN,
 	USER_HOME_DIR,
 } from './_consts.ts';
@@ -748,7 +747,6 @@ export type LoadOptions = {
 	project?: string; // Filter to specific project name
 	startOfWeek?: WeekDay; // Start of week for weekly aggregation
 	timezone?: string; // Timezone for date grouping (e.g., 'UTC', 'America/New_York'). Defaults to system timezone
-	locale?: string; // Locale for date/time formatting (e.g., 'en-US', 'ja-JP'). Defaults to 'en-US'
 } & DateFilter;
 
 /**
@@ -820,8 +818,7 @@ export async function loadDailyUsageData(options?: LoadOptions): Promise<DailyUs
 				// Mark this combination as processed
 				markAsProcessed(uniqueHash, processedHashes);
 
-				// Always use DEFAULT_LOCALE for date grouping to ensure YYYY-MM-DD format
-				const date = formatDate(data.timestamp, options?.timezone, DEFAULT_LOCALE);
+				const date = formatDate(data.timestamp, options?.timezone);
 				// If fetcher is available, calculate cost based on mode and tokens
 				// If fetcher is null, use pre-calculated costUSD or default to 0
 				const cost =
@@ -1052,12 +1049,7 @@ export async function loadSessionData(options?: LoadOptions): Promise<SessionUsa
 				sessionId: createSessionId(latestEntry.sessionId),
 				projectPath: createProjectPath(latestEntry.projectPath),
 				...totals,
-				// Always use DEFAULT_LOCALE for date storage to ensure YYYY-MM-DD format
-				lastActivity: formatDate(
-					latestEntry.timestamp,
-					options?.timezone,
-					DEFAULT_LOCALE,
-				) as ActivityDate,
+				lastActivity: formatDate(latestEntry.timestamp, options?.timezone) as ActivityDate,
 				versions: uniq(versions).sort() as Version[],
 				modelsUsed: modelsUsed as ModelName[],
 				modelBreakdowns,
@@ -1449,12 +1441,10 @@ export async function loadSessionBlockData(options?: LoadOptions): Promise<Sessi
 		(options?.since != null && options.since !== '') ||
 		(options?.until != null && options.until !== '')
 			? blocks.filter((block) => {
-					// Always use DEFAULT_LOCALE for date comparison to ensure YYYY-MM-DD format
-					const blockDateStr = formatDate(
-						block.startTime.toISOString(),
-						options?.timezone,
-						DEFAULT_LOCALE,
-					).replace(/-/g, '');
+					const blockDateStr = formatDate(block.startTime.toISOString(), options?.timezone).replace(
+						/-/g,
+						'',
+					);
 					if (options.since != null && options.since !== '' && blockDateStr < options.since) {
 						return false;
 					}
@@ -1523,16 +1513,6 @@ if (import.meta.vitest != null) {
 			// Use UTC noon to avoid timezone issues
 			expect(formatDate('2024-01-05T12:00:00Z')).toBe('2024-01-05');
 			expect(formatDate('2024-10-01T12:00:00Z')).toBe('2024-10-01');
-		});
-
-		it('respects locale parameter', () => {
-			const testDate = '2024-08-04T12:00:00Z';
-
-			// Different locales format dates differently
-			expect(formatDate(testDate, 'UTC', 'en-US')).toBe('08/04/2024');
-			expect(formatDate(testDate, 'UTC', 'en-CA')).toBe('2024-08-04');
-			expect(formatDate(testDate, 'UTC', 'ja-JP')).toBe('2024/08/04');
-			expect(formatDate(testDate, 'UTC', 'de-DE')).toBe('04.08.2024');
 		});
 	});
 
@@ -4418,7 +4398,7 @@ invalid json line
 				});
 
 				expect(processedCount).toBe(lineCount);
-			});
+			}, 30000);
 		});
 	});
 }

--- a/apps/codex/src/_consts.ts
+++ b/apps/codex/src/_consts.ts
@@ -6,7 +6,6 @@ export const DEFAULT_CODEX_DIR = path.join(os.homedir(), '.codex');
 export const DEFAULT_SESSION_SUBDIR = 'sessions';
 export const SESSION_GLOB = '**/*.jsonl';
 export const DEFAULT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC';
-export const DEFAULT_LOCALE = 'en-CA';
 export const DEFAULT_PRECISION = 2;
 
 export const MILLION = 1_000_000;

--- a/apps/codex/src/_shared-args.ts
+++ b/apps/codex/src/_shared-args.ts
@@ -1,5 +1,5 @@
 import type { Args } from 'gunshi';
-import { DEFAULT_LOCALE, DEFAULT_TIMEZONE } from './_consts.ts';
+import { DEFAULT_TIMEZONE } from './_consts.ts';
 
 export const sharedArgs = {
 	json: {
@@ -23,12 +23,6 @@ export const sharedArgs = {
 		short: 'z',
 		description: 'Timezone for date grouping (IANA)',
 		default: DEFAULT_TIMEZONE,
-	},
-	locale: {
-		type: 'string',
-		short: 'l',
-		description: 'Locale for formatting',
-		default: DEFAULT_LOCALE,
 	},
 	offline: {
 		type: 'boolean',

--- a/apps/codex/src/commands/daily.ts
+++ b/apps/codex/src/commands/daily.ts
@@ -59,7 +59,6 @@ export const dailyCommand = define({
 			const rows = await buildDailyReport(events, {
 				pricingSource,
 				timezone: ctx.values.timezone,
-				locale: ctx.values.locale,
 				since,
 				until,
 			});

--- a/apps/codex/src/commands/monthly.ts
+++ b/apps/codex/src/commands/monthly.ts
@@ -61,7 +61,6 @@ export const monthlyCommand = define({
 			const rows = await buildMonthlyReport(events, {
 				pricingSource,
 				timezone: ctx.values.timezone,
-				locale: ctx.values.locale,
 				since,
 				until,
 			});

--- a/apps/codex/src/commands/session.ts
+++ b/apps/codex/src/commands/session.ts
@@ -66,7 +66,6 @@ export const sessionCommand = define({
 			const rows = await buildSessionReport(events, {
 				pricingSource,
 				timezone: ctx.values.timezone,
-				locale: ctx.values.locale,
 				since,
 				until,
 			});
@@ -172,7 +171,7 @@ export const sessionCommand = define({
 				totalsForDisplay.costUSD += row.costUSD;
 
 				const dateKey = toDateKey(row.lastActivity, ctx.values.timezone);
-				const displayDate = formatDisplayDate(dateKey, ctx.values.locale, ctx.values.timezone);
+				const displayDate = formatDisplayDate(dateKey);
 				const directoryDisplay = row.directory === '' ? '-' : row.directory;
 				const sessionFile = row.sessionFile;
 				const shortSession = sessionFile.length > 8 ? `…${sessionFile.slice(-8)}` : sessionFile;
@@ -188,7 +187,7 @@ export const sessionCommand = define({
 					formatNumber(split.cacheReadTokens),
 					formatNumber(row.totalTokens),
 					formatCurrency(row.costUSD),
-					formatDisplayDateTime(row.lastActivity, ctx.values.locale, ctx.values.timezone),
+					formatDisplayDateTime(row.lastActivity, ctx.values.timezone),
 				]);
 			}
 

--- a/apps/codex/src/daily-report.ts
+++ b/apps/codex/src/daily-report.ts
@@ -11,7 +11,6 @@ import { addUsage, calculateCostUSD, createEmptyUsage } from './token-utils.ts';
 
 export type DailyReportOptions = {
 	timezone?: string;
-	locale?: string;
 	since?: string;
 	until?: string;
 	pricingSource: PricingSource;
@@ -36,7 +35,6 @@ export async function buildDailyReport(
 	options: DailyReportOptions,
 ): Promise<DailyReportRow[]> {
 	const timezone = options.timezone;
-	const locale = options.locale;
 	const since = options.since;
 	const until = options.until;
 	const pricingSource = options.pricingSource;
@@ -107,7 +105,7 @@ export async function buildDailyReport(
 		}
 
 		rows.push({
-			date: formatDisplayDate(summary.date, locale, timezone),
+			date: formatDisplayDate(summary.date),
 			inputTokens: summary.inputTokens,
 			cachedInputTokens: summary.cachedInputTokens,
 			outputTokens: summary.outputTokens,

--- a/apps/codex/src/date-utils.ts
+++ b/apps/codex/src/date-utils.ts
@@ -53,7 +53,7 @@ export function isWithinRange(dateKey: string, since?: string, until?: string): 
 	return true;
 }
 
-export function formatDisplayDate(dateKey: string, locale?: string, _timezone?: string): string {
+export function formatDisplayDate(dateKey: string): string {
 	// dateKey is already computed for the target timezone via toDateKey().
 	// Treat it as a plain calendar date and avoid shifting it by applying a timezone.
 	const [yearStr = '0', monthStr = '1', dayStr = '1'] = dateKey.split('-');
@@ -61,7 +61,7 @@ export function formatDisplayDate(dateKey: string, locale?: string, _timezone?: 
 	const month = Number.parseInt(monthStr, 10);
 	const day = Number.parseInt(dayStr, 10);
 	const date = new Date(Date.UTC(year, month - 1, day));
-	const formatter = new Intl.DateTimeFormat(locale ?? 'en-US', {
+	const formatter = new Intl.DateTimeFormat('en-US', {
 		year: 'numeric',
 		month: 'short',
 		day: '2-digit',
@@ -82,14 +82,14 @@ export function toMonthKey(timestamp: string, timezone?: string): string {
 	return `${year}-${month}`;
 }
 
-export function formatDisplayMonth(monthKey: string, locale?: string, _timezone?: string): string {
+export function formatDisplayMonth(monthKey: string): string {
 	// monthKey is already derived in the target timezone via toMonthKey().
 	// Render it as a calendar month without shifting by timezone.
 	const [yearStr = '0', monthStr = '1'] = monthKey.split('-');
 	const year = Number.parseInt(yearStr, 10);
 	const month = Number.parseInt(monthStr, 10);
 	const date = new Date(Date.UTC(year, month - 1, 1));
-	const formatter = new Intl.DateTimeFormat(locale ?? 'en-US', {
+	const formatter = new Intl.DateTimeFormat('en-US', {
 		year: 'numeric',
 		month: 'short',
 		timeZone: 'UTC',
@@ -97,14 +97,10 @@ export function formatDisplayMonth(monthKey: string, locale?: string, _timezone?
 	return formatter.format(date);
 }
 
-export function formatDisplayDateTime(
-	timestamp: string,
-	locale?: string,
-	timezone?: string,
-): string {
+export function formatDisplayDateTime(timestamp: string, timezone?: string): string {
 	const tz = safeTimeZone(timezone);
 	const date = new Date(timestamp);
-	const formatter = new Intl.DateTimeFormat(locale ?? 'en-US', {
+	const formatter = new Intl.DateTimeFormat('en-US', {
 		dateStyle: 'short',
 		timeStyle: 'short',
 		timeZone: tz,

--- a/apps/codex/src/monthly-report.ts
+++ b/apps/codex/src/monthly-report.ts
@@ -11,7 +11,6 @@ import { addUsage, calculateCostUSD, createEmptyUsage } from './token-utils.ts';
 
 export type MonthlyReportOptions = {
 	timezone?: string;
-	locale?: string;
 	since?: string;
 	until?: string;
 	pricingSource: PricingSource;
@@ -36,7 +35,6 @@ export async function buildMonthlyReport(
 	options: MonthlyReportOptions,
 ): Promise<MonthlyReportRow[]> {
 	const timezone = options.timezone;
-	const locale = options.locale;
 	const since = options.since;
 	const until = options.until;
 	const pricingSource = options.pricingSource;
@@ -108,7 +106,7 @@ export async function buildMonthlyReport(
 		}
 
 		rows.push({
-			month: formatDisplayMonth(summary.month, locale, timezone),
+			month: formatDisplayMonth(summary.month),
 			inputTokens: summary.inputTokens,
 			cachedInputTokens: summary.cachedInputTokens,
 			outputTokens: summary.outputTokens,

--- a/apps/codex/src/session-report.ts
+++ b/apps/codex/src/session-report.ts
@@ -11,7 +11,6 @@ import { addUsage, calculateCostUSD, createEmptyUsage } from './token-utils.ts';
 
 export type SessionReportOptions = {
 	timezone?: string;
-	locale?: string;
 	since?: string;
 	until?: string;
 	pricingSource: PricingSource;

--- a/apps/mcp/src/ccusage.ts
+++ b/apps/mcp/src/ccusage.ts
@@ -12,7 +12,6 @@ export const ccusageParametersShape = {
 	until: filterDateSchema.optional(),
 	mode: z.enum(['auto', 'calculate', 'display']).default('auto').optional(),
 	timezone: z.string().optional(),
-	locale: z.string().optional(),
 } as const satisfies Record<string, z.ZodTypeAny>;
 
 export const ccusageParametersSchema = z.object(ccusageParametersShape);
@@ -52,10 +51,6 @@ async function runCcusageCliJson(
 	const timezone = parameters.timezone;
 	if (timezone != null && timezone !== '') {
 		cliArgs.push('--timezone', timezone);
-	}
-	const locale = parameters.locale;
-	if (locale != null && locale !== '') {
-		cliArgs.push('--locale', locale);
 	}
 
 	return executeCliCommand(executable, cliArgs, {

--- a/apps/mcp/src/codex.ts
+++ b/apps/mcp/src/codex.ts
@@ -57,7 +57,6 @@ export const codexParametersShape = {
 	since: z.string().optional(),
 	until: z.string().optional(),
 	timezone: z.string().optional(),
-	locale: z.string().optional(),
 	offline: z.boolean().optional(),
 } as const satisfies Record<string, z.ZodTypeAny>;
 
@@ -93,10 +92,6 @@ async function runCodexCliJson(
 	const timezone = parameters.timezone;
 	if (timezone != null && timezone !== '') {
 		cliArgs.push('--timezone', timezone);
-	}
-	const locale = parameters.locale;
-	if (locale != null && locale !== '') {
-		cliArgs.push('--locale', locale);
 	}
 	if (parameters.offline === true) {
 		cliArgs.push('--offline');

--- a/apps/mcp/src/consts.ts
+++ b/apps/mcp/src/consts.ts
@@ -1,2 +1,1 @@
-export const DEFAULT_LOCALE = 'en-CA';
 export const DATE_FILTER_REGEX = /^\d{8}$/;

--- a/ccusage.example.json
+++ b/ccusage.example.json
@@ -4,7 +4,6 @@
 		"json": true,
 		"mode": "auto",
 		"timezone": "Asia/Tokyo",
-		"locale": "ja-JP",
 		"offline": false,
 		"breakdown": false
 	},

--- a/docs/guide/cli-options.md
+++ b/docs/guide/cli-options.md
@@ -99,40 +99,6 @@ The timezone affects how usage is grouped by date. For example, usage at 11 PM U
 - **January 1st** when `--timezone America/New_York` (6 PM EST)
 - **January 2nd** when `--timezone Asia/Tokyo` (8 AM JST next day)
 
-### Locale
-
-Control date and time formatting:
-
-```bash
-# US English (12-hour time format)
-ccusage daily --locale en-US
-
-# Japanese (24-hour time format)
-ccusage blocks --locale ja-JP
-
-# German (24-hour time format)
-ccusage session -l de-DE
-
-# Short alias
-ccusage daily -l fr-FR
-```
-
-#### Locale Effects
-
-The locale affects display formatting:
-
-**Date Format:**
-
-- `en-US`: 08/04/2025
-- `en-CA`: 2025-08-04 (ISO format, default)
-- `ja-JP`: 2025/08/04
-- `de-DE`: 04.08.2025
-
-**Time Format:**
-
-- `en-US`: 3:30:00 PM (12-hour)
-- Others: 15:30:00 (24-hour)
-
 ### Debug Options
 
 Get detailed debugging information:
@@ -289,7 +255,7 @@ ccusage monthly --json > monthly-report.json
 ccusage daily --config ./team-config.json
 
 # Consistent timezone for remote team
-ccusage daily --timezone UTC --locale en-CA
+ccusage daily --timezone UTC
 
 # Generate shareable report
 ccusage weekly --json --jq ".summary"
@@ -331,7 +297,6 @@ Many options have short aliases for convenience:
 | `--breakdown` | `-b`  | Per-model breakdown |
 | `--offline`   | `-O`  | Offline mode        |
 | `--timezone`  | `-z`  | Set timezone        |
-| `--locale`    | `-l`  | Set locale          |
 | `--instances` | `-i`  | Group by project    |
 | `--project`   | `-p`  | Filter project      |
 | `--active`    | `-a`  | Active block only   |

--- a/docs/guide/codex/daily.md
+++ b/docs/guide/codex/daily.md
@@ -16,7 +16,6 @@ npx @ccusage/codex@latest daily
 | ---------------------------- | -------------------------------------------------------------- |
 | `--since` / `--until`        | Filter to a specific date range (YYYYMMDD or YYYY-MM-DD)       |
 | `--timezone`                 | Override timezone used for grouping (defaults to system)       |
-| `--locale`                   | Adjust date formatting locale                                  |
 | `--json`                     | Emit structured JSON instead of a table                        |
 | `--offline` / `--no-offline` | Force cached LiteLLM pricing or enable live fetching           |
 | `--compact`                  | Force compact table layout (same columns as a narrow terminal) |

--- a/docs/guide/codex/monthly.md
+++ b/docs/guide/codex/monthly.md
@@ -18,7 +18,6 @@ npx @ccusage/codex@latest monthly
 | ---------------------------- | --------------------------------------------------------------------------- |
 | `--since` / `--until`        | Filter to a specific date range (YYYYMMDD or YYYY-MM-DD) before aggregating |
 | `--timezone`                 | Override the timezone used to bucket usage into months                      |
-| `--locale`                   | Adjust month label formatting                                               |
 | `--json`                     | Emit structured JSON instead of a table                                     |
 | `--offline` / `--no-offline` | Force cached LiteLLM pricing or enable live fetching                        |
 | `--compact`                  | Force compact table layout (same columns as a narrow terminal)              |

--- a/docs/guide/codex/session.md
+++ b/docs/guide/codex/session.md
@@ -18,7 +18,6 @@ npx @ccusage/codex@latest session
 | ---------------------------- | ------------------------------------------------------------------------ |
 | `--since` / `--until`        | Filter sessions by their activity date (YYYYMMDD or YYYY-MM-DD)          |
 | `--timezone`                 | Override the timezone used for date grouping and last-activity display   |
-| `--locale`                   | Adjust locale for table and timestamp formatting                         |
 | `--json`                     | Emit structured JSON (`{ sessions: [], totals: {} }`) instead of a table |
 | `--offline` / `--no-offline` | Force cached LiteLLM pricing or enable live fetching                     |
 | `--compact`                  | Force compact table layout (same columns as a narrow terminal)           |

--- a/docs/guide/config-files.md
+++ b/docs/guide/config-files.md
@@ -23,7 +23,6 @@ Put frequently used options in `defaults`:
 	"$schema": "https://ccusage.com/config-schema.json",
 	"defaults": {
 		"timezone": "UTC",
-		"locale": "en-CA",
 		"breakdown": true
 	}
 }
@@ -104,7 +103,6 @@ Create a `ccusage.json` file with your preferred defaults:
 		"mode": "auto",
 		"offline": false,
 		"timezone": "Asia/Tokyo",
-		"locale": "ja-JP",
 		"breakdown": true
 	}
 }
@@ -148,7 +146,6 @@ The `defaults` section sets default values for all commands:
 		"breakdown": false,
 		"offline": false,
 		"timezone": "UTC",
-		"locale": "en-CA",
 		"jq": ".data[]"
 	}
 }
@@ -217,8 +214,7 @@ Override defaults for specific commands using the `commands` section:
 	"commands": {
 		"monthly": {
 			"breakdown": true,
-			"mode": "calculate",
-			"locale": "en-US"
+			"mode": "calculate"
 		}
 	}
 }

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -59,7 +59,6 @@ export CLAUDE_CONFIG_DIR="$HOME/.config/claude"
 	"$schema": "https://ccusage.com/config-schema.json",
 	"defaults": {
 		"timezone": "America/New_York",
-		"locale": "en-US",
 		"breakdown": true
 	}
 }
@@ -103,7 +102,6 @@ For teams sharing configuration:
 	"$schema": "https://ccusage.com/config-schema.json",
 	"defaults": {
 		"timezone": "UTC",
-		"locale": "en-CA",
 		"mode": "auto"
 	}
 }
@@ -151,11 +149,10 @@ ccusage daily --mode calculate --breakdown --offline
 Customize date/time handling:
 
 - **Timezone**: Any valid timezone (e.g., `UTC`, `America/New_York`)
-- **Locale**: Format preferences (e.g., `en-US`, `ja-JP`)
 - **Date Range**: Filter with `--since` and `--until`
 
 ```bash
-ccusage daily --timezone UTC --locale en-CA --since 20250101
+ccusage daily --timezone UTC --since 20250101
 ```
 
 ### Output Format
@@ -224,7 +221,7 @@ Debug mode shows:
 Use different configuration methods for different scopes:
 
 - **Environment variables**: Machine-specific settings (paths)
-- **User config**: Personal preferences (timezone, locale)
+- **User config**: Personal preferences (timezone)
 - **Project config**: Team standards (mode, formatting)
 - **CLI arguments**: One-off overrides
 

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -60,7 +60,7 @@ The server still provides four tools with the same schemas as before:
 - **session** – grouped by Claude session ID / project directory
 - **blocks** – 5-hour billing block summaries
 
-Each tool accepts `since`, `until`, and `mode` parameters, plus timezone/locale overrides identical to the ccusage library.
+Each tool accepts `since`, `until`, and `mode` parameters, plus a timezone override identical to the ccusage library.
 
 ## Testing the MCP Server
 

--- a/packages/internal/CLAUDE.md
+++ b/packages/internal/CLAUDE.md
@@ -24,7 +24,7 @@ This package contains shared internal utilities for the ccusage monorepo.
 - `./pricing-fetch-utils` - Pricing fetch helper functions
 - `./logger` - Logger factory using consola with LOG_LEVEL support
 - `./format` - Number formatting utilities (formatTokens, formatCurrency)
-- `./constants` - Shared constants (DEFAULT_LOCALE, MILLION)
+- `./constants` - Shared constants (MILLION)
 
 ## Development Commands
 

--- a/packages/internal/src/constants.ts
+++ b/packages/internal/src/constants.ts
@@ -1,10 +1,4 @@
 /**
- * Default locale for date formatting (en-CA provides YYYY-MM-DD ISO format)
- * @constant
- */
-export const DEFAULT_LOCALE = 'en-CA';
-
-/**
  * Common million constant for token calculations
  * @constant
  */


### PR DESCRIPTION
Summary:
Remove the public locale option from ccusage, Codex, and the MCP tools. The option only affected display formatting and is not worth keeping as supported CLI/API surface.

What Changed:
- Removed --locale / -l from ccusage and Codex shared CLI args.
- Removed locale parameters from MCP tool schemas and CLI forwarding.
- Simplified date display helpers to use fixed internal formatting where stable output is required.
- Regenerated the ccusage config schema and removed locale examples from docs and sample config.
- Dropped the now-unused internal DEFAULT_LOCALE export.

Testing:
- pnpm run format
- pnpm typecheck
- pnpm run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Locale customization for date formatting has been removed. The `--locale` command-line option and configuration file locale settings are no longer available or supported by the application.
  * All date and time formatting across reports, summaries, session data, and output tables now uses a unified standardized format consistent across all commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/978)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->