### PR TITLE
feat!: drop Node 20 support, require Node >=22.11.0

### DIFF
--- a/apps/amp/package.json
+++ b/apps/amp/package.json
@@ -29,7 +29,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=22.11.0"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/apps/amp/tsdown.config.ts
+++ b/apps/amp/tsdown.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
 	dts: false,
 	shims: true,
 	platform: 'node',
-	target: 'node20',
+	target: 'node22',
 	fixedExtension: false,
 });

--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -47,7 +47,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=22.11.0"
 	},
 	"scripts": {
 		"build": "pnpm run generate:schema && tsdown",

--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -19,7 +19,7 @@ import process from 'node:process';
 import { createInterface } from 'node:readline';
 import { toArray } from '@antfu/utils';
 import { Result } from '@praha/byethrow';
-import { groupBy, uniq } from 'es-toolkit'; // TODO: after node20 is deprecated, switch to native Object.groupBy
+import { uniq } from 'es-toolkit';
 import { createFixture } from 'fs-fixture';
 import { isDirectorySync } from 'path-type';
 import { glob } from 'tinyglobby';
@@ -841,7 +841,7 @@ export async function loadDailyUsageData(options?: LoadOptions): Promise<DailyUs
 		? (entry: (typeof allEntries)[0]) => `${entry.date}\x00${entry.project}`
 		: (entry: (typeof allEntries)[0]) => entry.date;
 
-	const groupedData = groupBy(allEntries, groupingKey);
+	const groupedData = Object.groupBy(allEntries, groupingKey);
 
 	// Aggregate each group
 	const results = Object.entries(groupedData)
@@ -1006,7 +1006,7 @@ export async function loadSessionData(options?: LoadOptions): Promise<SessionUsa
 	}
 
 	// Group by session using Object.groupBy
-	const groupedBySessions = groupBy(allEntries, (entry) => entry.sessionKey);
+	const groupedBySessions = Object.groupBy(allEntries, (entry) => entry.sessionKey);
 
 	// Aggregate each session group
 	const results = Object.entries(groupedBySessions)
@@ -1193,7 +1193,7 @@ export async function loadBucketUsageData(
 			}
 		: (data: DailyUsage) => `${groupingFn(data)}`;
 
-	const grouped = groupBy(dailyData, groupingKey);
+	const grouped = Object.groupBy(dailyData, groupingKey);
 
 	const buckets: BucketUsage[] = [];
 	for (const [groupKey, dailyEntries] of Object.entries(grouped)) {

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -29,7 +29,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=22.11.0"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -39,7 +39,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=22.11.0"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -32,7 +32,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=22.11.0"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/apps/opencode/tsdown.config.ts
+++ b/apps/opencode/tsdown.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
 	dts: false,
 	shims: true,
 	platform: 'node',
-	target: 'node20',
+	target: 'node22',
 	fixedExtension: false,
 });

--- a/apps/pi/package.json
+++ b/apps/pi/package.json
@@ -42,7 +42,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=22.11.0"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"description": "Documentation for ccusage",
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=22.11.0"
 	},
 	"scripts": {
 		"build": "pnpm run docs:api && cp ../apps/ccusage/config-schema.json public/config-schema.json && vitepress build",


### PR DESCRIPTION
## Summary

- Bump the `engines.node` floor from `>=20.19.4` to `>=22.11.0` across every app (`ccusage`, `mcp`, `codex`, `opencode`, `amp`, `pi`) and the docs package, since Node 20 has reached end-of-life.
- Bump the tsdown build target from `node20` to `node22` for the apps that pin it (`amp`, `opencode`).
- Replace `es-toolkit`'s `groupBy` with the native `Object.groupBy` in `apps/ccusage/src/data-loader.ts` and drop the stale `TODO: after node20 is deprecated` comment. `uniq` stays put since it has no native equivalent.

## Test plan

- [x] `pnpm typecheck` (ccusage)
- [x] `pnpm vitest run src/data-loader.ts` — all 127 tests pass
- [ ] CI runs lint/typecheck/test across the monorepo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum required Node.js version from 20.19.4 to 22.11.0 across all applications and services.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/979)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->