### PR TITLE
refactor(ccusage): replace uniq with native Set

### DIFF
--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -80,7 +80,6 @@
 		"ansi-escapes": "catalog:runtime",
 		"bumpp": "catalog:release",
 		"clean-pkg-json": "catalog:release",
-		"es-toolkit": "catalog:runtime",
 		"eslint": "catalog:lint",
 		"eslint-plugin-format": "catalog:lint",
 		"fast-sort": "catalog:runtime",

--- a/apps/ccusage/src/_session-blocks.ts
+++ b/apps/ccusage/src/_session-blocks.ts
@@ -1,4 +1,3 @@
-import { uniq } from 'es-toolkit';
 import { DEFAULT_RECENT_DAYS } from './_consts.ts';
 import { getTotalTokens } from './_token-utils.ts';
 
@@ -201,7 +200,7 @@ function createBlock(
 		entries,
 		tokenCounts,
 		costUSD,
-		models: uniq(models),
+		models: Array.from(new Set(models)),
 		usageLimitResetTime,
 	};
 }

--- a/apps/ccusage/src/data-loader.ts
+++ b/apps/ccusage/src/data-loader.ts
@@ -19,7 +19,6 @@ import process from 'node:process';
 import { createInterface } from 'node:readline';
 import { toArray } from '@antfu/utils';
 import { Result } from '@praha/byethrow';
-import { uniq } from 'es-toolkit';
 import { sort } from 'fast-sort';
 import { createFixture } from 'fs-fixture';
 import { isDirectorySync } from 'path-type';
@@ -521,7 +520,9 @@ function extractUniqueModels<T>(
 	entries: T[],
 	getModel: (entry: T) => string | undefined,
 ): string[] {
-	return uniq(entries.map(getModel).filter((m): m is string => m != null && m !== '<synthetic>'));
+	return Array.from(
+		new Set(entries.map(getModel).filter((m): m is string => m != null && m !== '<synthetic>')),
+	);
 }
 
 /**
@@ -1051,7 +1052,7 @@ export async function loadSessionData(options?: LoadOptions): Promise<SessionUsa
 				projectPath: createProjectPath(latestEntry.projectPath),
 				...totals,
 				lastActivity: formatDate(latestEntry.timestamp, options?.timezone) as ActivityDate,
-				versions: uniq(versions).sort() as Version[],
+				versions: Array.from(new Set(versions)).sort() as Version[],
 				modelsUsed: modelsUsed as ModelName[],
 				modelBreakdowns,
 			};
@@ -1248,7 +1249,7 @@ export async function loadBucketUsageData(
 			cacheCreationTokens: totalCacheCreationTokens,
 			cacheReadTokens: totalCacheReadTokens,
 			totalCost,
-			modelsUsed: uniq(models) as ModelName[],
+			modelsUsed: Array.from(new Set(models)) as ModelName[],
 			modelBreakdowns,
 			...(project != null && { project }),
 		};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,9 +322,6 @@ importers:
       clean-pkg-json:
         specifier: catalog:release
         version: 1.3.0
-      es-toolkit:
-        specifier: catalog:runtime
-        version: 1.39.10
       eslint:
         specifier: catalog:lint
         version: 9.35.0(jiti@2.6.1)


### PR DESCRIPTION
Replaces the remaining ccusage app usages of es-toolkit uniq with native Set-based deduplication.

This keeps insertion-order semantics for model and version arrays while removing the es-toolkit dependency from the ccusage package.

Testing:
- pnpm run format
- pnpm typecheck
- pnpm run test
- pnpm install --frozen-lockfile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to optimize the codebase footprint.
  * Removed external library dependency in favor of native JavaScript features for data deduplication across multiple modules, reducing overall dependency overhead.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/981)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->