### PR TITLE
fix(opencode): resolve provider model pricing aliases

### DIFF
--- a/apps/opencode/src/cost-utils.ts
+++ b/apps/opencode/src/cost-utils.ts
@@ -1,5 +1,5 @@
-import type { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
 import type { LoadedUsageEntry } from './data-loader.ts';
+import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
 import { Result } from '@praha/byethrow';
 
 /**
@@ -15,6 +15,32 @@ function resolveModelName(modelName: string): string {
 	return MODEL_ALIASES[modelName] ?? modelName;
 }
 
+function normalizeOpenCodeProviderID(providerID: string): string {
+	return providerID.replaceAll('-', '_');
+}
+
+function normalizeOpenCodeModelName(modelName: string): string {
+	const resolved = resolveModelName(modelName);
+
+	return resolved
+		.replace(/^(claude-(?:haiku|opus|sonnet)-\d+)\.(\d+)(-.*)?$/u, '$1-$2$3')
+		.replace(/^(claude-(?:haiku|opus|sonnet)-\d)(\d)(-.*)?$/u, '$1-$2$3');
+}
+
+function createModelCandidates(entry: LoadedUsageEntry): string[] {
+	const resolved = resolveModelName(entry.model);
+	const normalized = normalizeOpenCodeModelName(resolved);
+	const baseCandidates = normalized === resolved ? [resolved] : [normalized];
+	const candidates = [...baseCandidates];
+
+	if (entry.providerID !== 'unknown') {
+		const providerPrefix = normalizeOpenCodeProviderID(entry.providerID);
+		candidates.push(...baseCandidates.map((candidate) => `${providerPrefix}/${candidate}`));
+	}
+
+	return Array.from(new Set(candidates));
+}
+
 /**
  * Calculate cost for a single usage entry
  * Uses pre-calculated cost if available, otherwise calculates from tokens
@@ -27,16 +53,110 @@ export async function calculateCostForEntry(
 		return entry.costUSD;
 	}
 
-	const resolvedModel = resolveModelName(entry.model);
-	const result = await fetcher.calculateCostFromTokens(
-		{
-			input_tokens: entry.usage.inputTokens,
-			output_tokens: entry.usage.outputTokens,
-			cache_creation_input_tokens: entry.usage.cacheCreationInputTokens,
-			cache_read_input_tokens: entry.usage.cacheReadInputTokens,
-		},
-		resolvedModel,
-	);
+	const tokens = {
+		input_tokens: entry.usage.inputTokens,
+		output_tokens: entry.usage.outputTokens,
+		cache_creation_input_tokens: entry.usage.cacheCreationInputTokens,
+		cache_read_input_tokens: entry.usage.cacheReadInputTokens,
+	};
 
-	return Result.unwrap(result, 0);
+	for (const candidate of createModelCandidates(entry)) {
+		const result = await fetcher.calculateCostFromTokens(tokens, candidate);
+		if (Result.isSuccess(result) && result.value > 0) {
+			return result.value;
+		}
+	}
+
+	return 0;
+}
+
+if (import.meta.vitest != null) {
+	const { describe, expect, it } = import.meta.vitest;
+
+	function createEntry(model: string, providerID = 'github-copilot'): LoadedUsageEntry {
+		return {
+			timestamp: new Date('2026-01-01T00:00:00Z'),
+			sessionID: 'session',
+			usage: {
+				inputTokens: 1000,
+				outputTokens: 100,
+				cacheCreationInputTokens: 0,
+				cacheReadInputTokens: 0,
+			},
+			model,
+			providerID,
+			costUSD: null,
+		};
+	}
+
+	describe('calculateCostForEntry', () => {
+		it('normalizes OpenCode Claude dot notation without hard-coded aliases', async () => {
+			using fetcher = new LiteLLMPricingFetcher({
+				offline: true,
+				offlineLoader: async () => ({
+					'github_copilot/claude-opus-4.7': {},
+					'claude-opus-4-1': {
+						input_cost_per_token: 99,
+						output_cost_per_token: 99,
+					},
+					'claude-opus-4-7': {
+						input_cost_per_token: 1e-6,
+						output_cost_per_token: 2e-6,
+					},
+				}),
+			});
+
+			await expect(
+				calculateCostForEntry(createEntry('claude-opus-4.7'), fetcher),
+			).resolves.toBeCloseTo(0.0012);
+		});
+
+		it('normalizes compact Claude minor versions', async () => {
+			using fetcher = new LiteLLMPricingFetcher({
+				offline: true,
+				offlineLoader: async () => ({
+					'claude-opus-4-1': {
+						input_cost_per_token: 1e-6,
+						output_cost_per_token: 2e-6,
+					},
+				}),
+			});
+
+			await expect(
+				calculateCostForEntry(createEntry('claude-opus-41'), fetcher),
+			).resolves.toBeCloseTo(0.0012);
+		});
+
+		it('normalizes future Claude generations', async () => {
+			using fetcher = new LiteLLMPricingFetcher({
+				offline: true,
+				offlineLoader: async () => ({
+					'claude-opus-5-1': {
+						input_cost_per_token: 1e-6,
+						output_cost_per_token: 2e-6,
+					},
+				}),
+			});
+
+			await expect(
+				calculateCostForEntry(createEntry('claude-opus-5.1'), fetcher),
+			).resolves.toBeCloseTo(0.0012);
+		});
+
+		it('uses provider-prefixed pricing candidates after base model candidates', async () => {
+			using fetcher = new LiteLLMPricingFetcher({
+				offline: true,
+				offlineLoader: async () => ({
+					'xai/grok-code-fast-1': {
+						input_cost_per_token: 1e-6,
+						output_cost_per_token: 2e-6,
+					},
+				}),
+			});
+
+			await expect(
+				calculateCostForEntry(createEntry('grok-code-fast-1', 'xai'), fetcher),
+			).resolves.toBeCloseTo(0.0012);
+		});
+	});
 }

--- a/apps/opencode/src/data-loader.ts
+++ b/apps/opencode/src/data-loader.ts
@@ -112,6 +112,7 @@ export type LoadedUsageEntry = {
 		cacheReadInputTokens: number;
 	};
 	model: string;
+	providerID: string;
 	costUSD: number | null;
 };
 
@@ -183,6 +184,7 @@ function convertOpenCodeMessageToUsageEntry(
 			cacheReadInputTokens: message.tokens?.cache?.read ?? 0,
 		},
 		model: message.modelID ?? 'unknown',
+		providerID: message.providerID ?? 'unknown',
 		costUSD: message.cost ?? null,
 	};
 }
@@ -342,6 +344,7 @@ if (import.meta.vitest != null) {
 			expect(entry.usage.cacheReadInputTokens).toBe(50);
 			expect(entry.usage.cacheCreationInputTokens).toBe(25);
 			expect(entry.model).toBe('claude-sonnet-4-5');
+			expect(entry.providerID).toBe('anthropic');
 		});
 
 		it('should handle missing optional fields', () => {
@@ -364,6 +367,7 @@ if (import.meta.vitest != null) {
 			expect(entry.usage.outputTokens).toBe(100);
 			expect(entry.usage.cacheReadInputTokens).toBe(0);
 			expect(entry.usage.cacheCreationInputTokens).toBe(0);
+			expect(entry.providerID).toBe('openai');
 			expect(entry.costUSD).toBe(null);
 		});
 	});


### PR DESCRIPTION
Replaces one-off OpenCode model aliases with provider-aware pricing resolution.

OpenCode records providerID and modelID from its models.dev-backed model metadata. This preserves providerID in loaded entries, normalizes Claude minor-version IDs such as claude-opus-4.7 and claude-opus-41 algorithmically, and tries pricing candidates in an order that avoids zero-cost provider metadata when a canonical LiteLLM model price exists.

This supersedes #868.

Testing:
- pnpm --filter @ccusage/opencode test
- pnpm --filter @ccusage/opencode typecheck
- pnpm run format
- pnpm typecheck
- pnpm run test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cost calculation to try multiple normalized model name variants and provider-prefixed candidates, returning accurate nonzero pricing when available.

* **Data**
  * Usage entries now include a provider identifier (defaults to "unknown" when missing).

* **Tests**
  * Added tests covering model name normalization patterns, provider handling, and candidate selection ordering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/983)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->