### PR TITLE
fix(data-loader): dedup by messageId alone when requestId is absent

### DIFF
--- a/apps/ccusage/src/adapter/claude/data-loader.ts
+++ b/apps/ccusage/src/adapter/claude/data-loader.ts
@@ -1173,18 +1173,16 @@ async function filterFilesByMtime<T>(
 }
 
 /**
- * Create a unique identifier for deduplication using message ID and request ID
+ * Create a unique identifier for deduplication using message ID and request ID.
  */
 export function createUniqueHash(data: UsageData): string | null {
 	const messageId = data.message.id;
-	const requestId = data.requestId;
-
-	if (messageId == null || requestId == null) {
+	if (messageId == null) {
 		return null;
 	}
 
-	// Create a hash using simple concatenation
-	return `${messageId}:${requestId}`;
+	const requestId = data.requestId;
+	return requestId == null ? messageId : `${messageId}:${requestId}`;
 }
 
 async function processJSONLUsageFileByLine(
@@ -6204,7 +6202,7 @@ if (import.meta.vitest != null) {
 				expect(hash).toBeNull();
 			});
 
-			it('should return null when request id is missing', () => {
+			it('should fall back to message id when request id is missing', () => {
 				const data = {
 					timestamp: createISOTimestamp('2025-01-10T10:00:00Z'),
 					message: {
@@ -6217,7 +6215,7 @@ if (import.meta.vitest != null) {
 				};
 
 				const hash = createUniqueHash(data);
-				expect(hash).toBeNull();
+				expect(hash).toBe('msg_123');
 			});
 		});
 
@@ -6518,6 +6516,53 @@ if (import.meta.vitest != null) {
 				expect(data[0]?.inputTokens).toBe(100);
 				expect(data[0]?.outputTokens).toBe(250);
 				expect(data[0]?.totalCost).toBe(0.01);
+			});
+
+			it('deduplicates entries with the same message id when request id is missing', async () => {
+				await using fixture = await createFixture({
+					projects: {
+						project1: {
+							session1: {
+								'chat.jsonl': [
+									JSON.stringify({
+										timestamp: '2025-01-10T10:00:00.000Z',
+										message: {
+											id: 'msg_123',
+											model: 'claude-opus-4-6',
+											usage: {
+												input_tokens: 100,
+												output_tokens: 50,
+											},
+										},
+										costUSD: 0.001,
+									}),
+									JSON.stringify({
+										timestamp: '2025-01-10T10:00:01.000Z',
+										message: {
+											id: 'msg_123',
+											model: 'claude-opus-4-6',
+											usage: {
+												input_tokens: 200,
+												output_tokens: 100,
+											},
+										},
+										costUSD: 0.002,
+									}),
+								].join('\n'),
+							},
+						},
+					},
+				});
+
+				const data = await loadDailyUsageData({
+					claudePath: fixture.path,
+					mode: 'display',
+				});
+
+				expect(data).toHaveLength(1);
+				expect(data[0]?.inputTokens).toBe(200);
+				expect(data[0]?.outputTokens).toBe(100);
+				expect(data[0]?.totalCost).toBe(0.002);
 			});
 		});
 


### PR DESCRIPTION
Fixes #797.
Addresses #976.
Refs #705, #888.

## Summary

- Uses message.id as the fallback dedupe key when a Claude usage entry has no requestId.
- Keeps the existing messageId:requestId key when requestId is present.
- Adds regression coverage for the hash fallback and daily aggregation of duplicated requestId-less entries.

## Scope

This fixes the requestId-absent dedupe short-circuit only. It does not fix the separate first-wins streaming snapshot issue discussed in #705 and #888, where duplicated entries with the same key may need the final or largest usage record.

## Validation

- Real local Claude data scan: 3,144 JSONL files / 155,417 usage rows; 263 requestId-absent rows; no local token delta because the duplicated requestId-absent rows in this dataset have zero token totals.
- pnpm vitest run apps/ccusage/src/adapter/claude/data-loader.ts -t "request id is missing|same message id when request id is missing"
- pnpm run format
- pnpm typecheck
- pnpm run test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deduplication for Claude usage records: entries that share a message identifier but lack a request identifier are now treated as duplicates, reducing duplicate daily usage entries.

* **Tests**
  * Expanded test coverage to validate the new deduplication fallback and daily-usage deduplication behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->