### PR TITLE
docs: add Community Projects section (cc-usage-board, ai-heatmap)

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -49,6 +49,18 @@ Companion tool for analyzing [Amp](https://ampcode.com/) session usage. Track to
 
 Model Context Protocol server that exposes ccusage data to Claude Desktop and other MCP-compatible tools. Enable real-time usage tracking directly in your AI workflows.
 
+## Community Projects
+
+Community-built tools that consume ccusage data. Please open a PR to add yours.
+
+### 🇰🇷🇺🇸 [cc-usage-board](https://github.com/huhjayeon/cc-usage-board) - Local Bilingual Dashboard
+
+A local HTML dashboard that visualizes ccusage `--json` output. Bilingual UI
+(English / Korean) with locale-aware number units (`K/M/B` vs `만/억`), five
+charts (monthly trend, cumulative usage, weekday pattern, model donut, monthly
+model-share stacked bar), a 90-day activity heatmap, and an optional SwiftBar
+plugin for the macOS menu bar. All data stays on your machine.
+
 ## Installation
 
 ### Quick Start (Recommended)

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -51,15 +51,15 @@ Model Context Protocol server that exposes ccusage data to Claude Desktop and ot
 
 ## Community Projects
 
-Community-built tools that consume ccusage data. Please open a PR to add yours.
+Third-party tools built on ccusage data. Open a PR to add yours.
 
-### 🇰🇷🇺🇸 [cc-usage-board](https://github.com/huhjayeon/cc-usage-board) - Local Bilingual Dashboard
+### 📈 [cc-usage-board](https://github.com/huhjayeon/cc-usage-board) - Local Dashboard
 
-A local HTML dashboard that visualizes ccusage `--json` output. Bilingual UI
-(English / Korean) with locale-aware number units (`K/M/B` vs `만/억`), five
-charts (monthly trend, cumulative usage, weekday pattern, model donut, monthly
-model-share stacked bar), a 90-day activity heatmap, and an optional SwiftBar
-plugin for the macOS menu bar. All data stays on your machine.
+Renders ccusage's JSON output as a local HTML dashboard with monthly trends, a 90-day activity heatmap, model breakdown charts, and a SwiftBar plugin for the macOS menu bar. UI available in Korean, Japanese, and English.
+
+### 🟩 [ai-heatmap](https://github.com/seunggabi/ai-heatmap) - Cost Heatmap
+
+Generates a GitHub-style contribution heatmap of AI usage costs from ccusage data, available as a GitHub Pages site or a dynamic SVG via Vercel. Setup with `npx ai-heatmap@latest init`.
 
 ## Installation
 


### PR DESCRIPTION
Adds a Community Projects section to the README with two third-party tools that build on ccusage:

- [cc-usage-board](https://github.com/huhjayeon/cc-usage-board) — local HTML dashboard with charts, a 90-day heatmap, and a SwiftBar menu bar plugin. Korean / Japanese / English UI.
- [ai-heatmap](https://github.com/seunggabi/ai-heatmap) — GitHub-style contribution heatmap of AI costs (Pages site + dynamic SVG via Vercel). Requested in #852.

Happy to revise wording, drop either entry, or move the section elsewhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Community Projects" section highlighting two community tools:
    * cc-usage-board — local bilingual dashboard with multiple charts, activity heatmap, and SwiftBar plugin.
    * ai-heatmap — GitHub-style cost heatmap usable as static pages or dynamic SVG for hosted deployments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/987)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->