### PR TITLE
fix(codex): deduplicate copied branch history

### DIFF
--- a/apps/ccusage/src/adapter/codex/parser.ts
+++ b/apps/ccusage/src/adapter/codex/parser.ts
@@ -25,6 +25,7 @@ import { getCodexSessionsPaths } from './paths.ts';
 const LEGACY_FALLBACK_MODEL = 'gpt-5';
 const CODEX_JSONL_MARKERS = ['turn_context', '"type":"token_count"', '"type": "token_count"'];
 const ENCODED_CODEX_EVENT_NUMBER_STRIDE = 5;
+const TOKEN_USAGE_EVENT_KEY_SEPARATOR = '\0';
 
 export function parseTokenCountLineFast(_line: string): ParsedTokenCountLine | null {
 	if (!hasTokenCountPayload(_line)) {
@@ -120,6 +121,25 @@ function convertToEventUsage(
 						raw.reasoning_output_tokens,
 					),
 	};
+}
+
+function createTokenUsageEventKey(event: TokenUsageEvent): string {
+	const separator = TOKEN_USAGE_EVENT_KEY_SEPARATOR;
+	return `${event.timestamp}${separator}${event.model ?? ''}${separator}${event.inputTokens}${separator}${event.cachedInputTokens}${separator}${event.outputTokens}${separator}${event.reasoningOutputTokens}${separator}${event.totalTokens}`;
+}
+
+function deduplicateTokenUsageEvents(events: TokenUsageEvent[]): TokenUsageEvent[] {
+	const seen = new Set<string>();
+	const deduplicated: TokenUsageEvent[] = [];
+	for (const event of events) {
+		const key = createTokenUsageEventKey(event);
+		if (seen.has(key)) {
+			continue;
+		}
+		seen.add(key);
+		deduplicated.push(event);
+	}
+	return deduplicated;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -411,7 +431,9 @@ export async function loadTokenUsageEvents(): Promise<TokenUsageEvent[]> {
 	const directoryEvents = await Promise.all(
 		getCodexSessionsPaths().map(loadTokenUsageEventsFromDirectory),
 	);
-	return directoryEvents.flat().sort((a, b) => compareStrings(a.timestamp, b.timestamp));
+	return deduplicateTokenUsageEvents(directoryEvents.flat()).sort((a, b) =>
+		compareStrings(a.timestamp, b.timestamp),
+	);
 }
 
 async function runCodexWorker(data: CodexWorkerData): Promise<void> {
@@ -733,6 +755,78 @@ if (import.meta.vitest != null) {
 				{ sessionId: 'a', model: 'gpt-5.1', inputTokens: 10 },
 				{ sessionId: 'b', model: 'gpt-5.2', inputTokens: 20 },
 			]);
+		});
+
+		it('deduplicates copied branch history across session files', async () => {
+			const copiedHistory = [
+				JSON.stringify({
+					timestamp: '2026-05-12T08:00:00.000Z',
+					type: 'turn_context',
+					payload: {
+						model: 'gpt-5.2',
+					},
+				}),
+				JSON.stringify({
+					timestamp: '2026-05-12T08:01:00.000Z',
+					type: 'event_msg',
+					payload: {
+						type: 'token_count',
+						info: {
+							total_token_usage: {
+								input_tokens: 1_000,
+								cached_input_tokens: 100,
+								output_tokens: 200,
+								reasoning_output_tokens: 20,
+								total_tokens: 1_200,
+							},
+						},
+					},
+				}),
+			].join('\n');
+
+			await using fixture = await createFixture({
+				sessions: {
+					'project-parent.jsonl': copiedHistory,
+					'project-branch.jsonl': [
+						copiedHistory,
+						JSON.stringify({
+							timestamp: '2026-05-12T08:02:00.000Z',
+							type: 'event_msg',
+							payload: {
+								type: 'token_count',
+								info: {
+									total_token_usage: {
+										input_tokens: 1_600,
+										cached_input_tokens: 300,
+										output_tokens: 450,
+										reasoning_output_tokens: 40,
+										total_tokens: 2_050,
+									},
+								},
+							},
+						}),
+					].join('\n'),
+				},
+			});
+			vi.stubEnv('CODEX_HOME', fixture.path);
+
+			const events = await loadTokenUsageEvents();
+			expect(events).toMatchObject([
+				{
+					inputTokens: 1_000,
+					cachedInputTokens: 100,
+					outputTokens: 200,
+					totalTokens: 1_200,
+				},
+				{
+					sessionId: 'project-branch',
+					inputTokens: 600,
+					cachedInputTokens: 200,
+					outputTokens: 250,
+					totalTokens: 850,
+				},
+			]);
+			expect(events).toHaveLength(2);
 		});
 	});
 


### PR DESCRIPTION
Fixes duplicated Codex Desktop usage when a branch/forked conversation copies historical JSONL token events into another session file.

What changed:
- Adds a path-independent token event fingerprint in `@ccusage/codex` so copied historical `token_count` events are counted once across session files.
- Keeps each file’s cumulative total tracking intact before dedupe, so new events in the branched session still produce the correct delta.
- Adds a regression test that loads parent + branch session files with copied history and verifies only the new branch delta is counted.

Verification:
- `npx -y pnpm@10.30.1 --filter @ccusage/codex test src/data-loader.ts`
- `npx -y pnpm@10.30.1 --filter @ccusage/codex typecheck`
- `npx -y pnpm@10.30.1 run lint --fix` from `apps/codex`
- `git diff --check`

Closes #988.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token usage events are now deterministically deduplicated so duplicate entries from copied or branched session histories are removed, yielding more accurate usage reports.

* **Tests**
  * Test suite extended with scenarios simulating multi-session/branched histories to validate deduplication and ensure only unique events are returned.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->