### PR TITLE
feat: add Nix flake default package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # nix
 .direnv
 !.envrc
+result

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -66,6 +66,39 @@ deno run -E -R=$HOME/.claude/projects/ -S=homedir -N='raw.githubusercontent.com:
 
 > 💡 **Important**: We strongly recommend using `@latest` suffix with npx (e.g., `npx ccusage@latest`) to ensure you're running the most recent version with the latest features and bug fixes.
 
+### NixOS / Nix flakes
+
+The repository's `flake.nix` exposes `packages.<system>.default`, so you can run it directly:
+
+```bash
+nix run github:ryoppippi/ccusage -- daily
+```
+
+To install it system-wide on NixOS, add the flake as an input and reference its package from `environment.systemPackages`:
+
+```nix
+# flake.nix
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.ccusage.url = "github:ryoppippi/ccusage";
+
+  outputs = { self, nixpkgs, ccusage, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            ccusage.packages.${pkgs.system}.default
+          ];
+        })
+      ];
+    };
+  };
+}
+```
+
+For home-manager, drop the same package reference into `home.packages` instead.
+
 ### Related Tools
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,75 @@
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
     in {
+      packages = forAllSystems (pkgs: rec {
+        default = ccusage;
+
+        ccusage = pkgs.stdenv.mkDerivation (finalAttrs: {
+          pname = "ccusage";
+          version = (builtins.fromJSON (builtins.readFile ./apps/ccusage/package.json)).version;
+
+          src = ./.;
+
+          pnpmDeps = pkgs.fetchPnpmDeps {
+            inherit (finalAttrs) pname version src;
+            fetcherVersion = 2;
+            hash = "sha256-iGdAo6e9zbuJg7Wlyh/zmAXEH/Uod9EaUzDTDygBc0I=";
+          };
+
+          nativeBuildInputs = [
+            pkgs.nodejs_24
+            pkgs.pnpm_10
+            pkgs.pnpmConfigHook
+            pkgs.bun
+            pkgs.git
+            pkgs.makeWrapper
+          ];
+
+          buildPhase = ''
+            runHook preBuild
+
+            # The npm `bun` and `node` packages ship prebuilt binaries that
+            # can't run under Nix. Drop their shims so PATH falls through to
+            # the runtimes from nativeBuildInputs.
+            rm -f node_modules/.bin/bun node_modules/.bin/node
+
+            # generate-json-schema.ts calls `git rev-parse --show-toplevel`
+            # to copy the schema into docs/public. Nix strips .git from src,
+            # so seed an empty repo here to satisfy the lookup.
+            git init -q
+            git -c user.email=nix@build -c user.name=nix commit --allow-empty -q -m init
+
+            pnpm --filter ccusage build
+
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/lib/ccusage $out/bin
+            cp -r apps/ccusage/dist $out/lib/ccusage/
+            cp apps/ccusage/package.json $out/lib/ccusage/
+            if [ -f apps/ccusage/config-schema.json ]; then
+              cp apps/ccusage/config-schema.json $out/lib/ccusage/
+            fi
+
+            makeWrapper ${pkgs.nodejs_24}/bin/node $out/bin/ccusage \
+              --add-flags $out/lib/ccusage/dist/index.js
+
+            runHook postInstall
+          '';
+
+          meta = {
+            description = "Usage analysis tool for Claude Code";
+            homepage = "https://github.com/ryoppippi/ccusage";
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "ccusage";
+            platforms = systems;
+          };
+        });
+      });
+
       devShells = forAllSystems (pkgs: {
         default = pkgs.mkShellNoCC {
           buildInputs = with pkgs; [


### PR DESCRIPTION
## Summary

- Adds `packages.<system>.default` to `flake.nix` so the repo can be consumed via `nix run github:ryoppippi/ccusage` and dropped into `environment.systemPackages` on NixOS.
- The derivation builds with `pnpm.fetchPnpmDeps` + `pnpmConfigHook`, then runs `pnpm --filter ccusage build`. Two sandbox workarounds:
  - Remove the npm-installed `bun` and `node` shims from `node_modules/.bin/` so PATH resolves to the runtimes from `nativeBuildInputs` (the npm packages ship prebuilt binaries that can't execute under Nix).
  - Seed an empty git repo in the build dir so `apps/ccusage/scripts/generate-json-schema.ts`'s `git rev-parse --show-toplevel` succeeds (Nix strips `.git` from `src`).
- Adds `result` to `.gitignore` and documents `nix run` / `environment.systemPackages` usage in `apps/ccusage/README.md`.

The dev shell is left untouched.

## Test plan

- [x] `nix build .#default` produces a working store path
- [x] `nix run .#default -- --version` prints `18.0.11`
- [x] `nix run .#default -- --help` prints the full CLI
- [ ] CI builds on all four declared platforms (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`) — only x86_64-linux was verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `ccusage` is now available as a Nix package, supporting both system-wide installation on NixOS and user-level setup through home-manager.

* **Documentation**
  * Added guide for running and installing `ccusage` via Nix flakes, with configuration examples for both system and user-level setups.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/991)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->