### PR TITLE
feat(ccusage): add --prompts flag to claude daily/weekly/monthly reports (rebase of #710 onto v19)

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -94,6 +94,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which models are used across supported sources
 - 📊 **Model Breakdown**: View per-model cost breakdown with `--breakdown` flag
+- ✉️ **Prompt Count**: Add a Prompts column to Claude daily/weekly/monthly reports with `--prompts` (counts usage-bearing entries - one per API request, including each tool-call iteration)
 - 📅 **Date Filtering**: Filter reports by date range using `--since` and `--until`
 - 📁 **Custom Paths**: Support for custom local data directory locations
 - 🎨 **Beautiful Output**: Colorful table-formatted display with automatic responsive layout

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -165,6 +165,12 @@
 									"description": "Comma-separated project aliases (e.g., 'ccusage=Usage Tracker,myproject=My Project')",
 									"markdownDescription": "Comma-separated project aliases (e.g., 'ccusage=Usage Tracker,myproject=My Project')"
 								},
+								"prompts": {
+									"type": "boolean",
+									"description": "Show prompt count column (number of usage-bearing entries per bucket)",
+									"markdownDescription": "Show prompt count column (number of usage-bearing entries per bucket)",
+									"default": false
+								},
 								"all": {
 									"type": "boolean",
 									"description": "Accepted for compatibility; all detected supported agents are included by default",
@@ -256,6 +262,12 @@
 									"type": "boolean",
 									"description": "Force compact table layout for narrow terminals",
 									"markdownDescription": "Force compact table layout for narrow terminals",
+									"default": false
+								},
+								"prompts": {
+									"type": "boolean",
+									"description": "Show prompt count column (number of usage-bearing entries per bucket)",
+									"markdownDescription": "Show prompt count column (number of usage-bearing entries per bucket)",
 									"default": false
 								},
 								"all": {
@@ -365,6 +377,12 @@
 									"description": "Day to start the week on",
 									"markdownDescription": "Day to start the week on",
 									"default": "sunday"
+								},
+								"prompts": {
+									"type": "boolean",
+									"description": "Show prompt count column (number of usage-bearing entries per bucket)",
+									"markdownDescription": "Show prompt count column (number of usage-bearing entries per bucket)",
+									"default": false
 								},
 								"all": {
 									"type": "boolean",
@@ -762,6 +780,12 @@
 											"type": "string",
 											"description": "Comma-separated project aliases (e.g., 'ccusage=Usage Tracker,myproject=My Project')",
 											"markdownDescription": "Comma-separated project aliases (e.g., 'ccusage=Usage Tracker,myproject=My Project')"
+										},
+										"prompts": {
+											"type": "boolean",
+											"description": "Show prompt count column (number of usage-bearing entries per bucket)",
+											"markdownDescription": "Show prompt count column (number of usage-bearing entries per bucket)",
+											"default": false
 										}
 									},
 									"additionalProperties": false
@@ -848,6 +872,12 @@
 											"type": "boolean",
 											"description": "Force compact mode for narrow displays (better for screenshots)",
 											"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
+											"default": false
+										},
+										"prompts": {
+											"type": "boolean",
+											"description": "Show prompt count column (number of usage-bearing entries per bucket)",
+											"markdownDescription": "Show prompt count column (number of usage-bearing entries per bucket)",
 											"default": false
 										}
 									},
@@ -951,6 +981,12 @@
 											"description": "Day to start the week on",
 											"markdownDescription": "Day to start the week on",
 											"default": "sunday"
+										},
+										"prompts": {
+											"type": "boolean",
+											"description": "Show prompt count column (number of usage-bearing entries per bucket)",
+											"markdownDescription": "Show prompt count column (number of usage-bearing entries per bucket)",
+											"default": false
 										}
 									},
 									"additionalProperties": false

--- a/apps/ccusage/src/adapter/claude/data-loader.ts
+++ b/apps/ccusage/src/adapter/claude/data-loader.ts
@@ -856,6 +856,7 @@ export type DailyUsage = {
 	totalCost: number;
 	modelsUsed: ModelName[];
 	modelBreakdowns: ModelBreakdown[];
+	promptCount: number;
 	project?: string;
 };
 
@@ -888,6 +889,7 @@ export type MonthlyUsage = {
 	totalCost: number;
 	modelsUsed: ModelName[];
 	modelBreakdowns: ModelBreakdown[];
+	promptCount: number;
 	project?: string;
 };
 
@@ -903,6 +905,7 @@ export type WeeklyUsage = {
 	totalCost: number;
 	modelsUsed: ModelName[];
 	modelBreakdowns: ModelBreakdown[];
+	promptCount: number;
 	project?: string;
 };
 
@@ -918,6 +921,7 @@ export type BucketUsage = {
 	totalCost: number;
 	modelsUsed: ModelName[];
 	modelBreakdowns: ModelBreakdown[];
+	promptCount: number;
 	project?: string;
 };
 
@@ -936,13 +940,14 @@ type UsageSummary = TokenStats & {
 	totalCost: number;
 	modelsUsed: ModelName[];
 	modelBreakdowns: ModelBreakdown[];
+	promptCount: number;
 };
 
 type TokenStatsIndex = Record<string, TokenStats | undefined>;
 type ModelSeenIndex = Record<string, true | undefined>;
 
 type UsageSummaryAccumulator = {
-	totals: TokenStats & { totalCost: number };
+	totals: TokenStats & { totalCost: number; promptCount: number };
 	modelAggregates: TokenStatsIndex;
 	modelSeen: ModelSeenIndex;
 	modelsUsed: string[];
@@ -1003,6 +1008,7 @@ function createUsageSummaryAccumulator(): UsageSummaryAccumulator {
 		totals: {
 			...createEmptyTokenStats(),
 			totalCost: 0,
+			promptCount: 0,
 		},
 		modelAggregates: createTokenStatsIndex(),
 		modelSeen: Object.create(null) as ModelSeenIndex,
@@ -1019,6 +1025,7 @@ function addUsageToSummaryAccumulator(
 	const modelName = model ?? 'unknown';
 	addUsageToTokenStats(accumulator.totals, usage, cost);
 	accumulator.totals.totalCost += cost;
+	accumulator.totals.promptCount += 1;
 
 	if (modelName === '<synthetic>') {
 		return;
@@ -1054,6 +1061,7 @@ function addTokenFieldsToSummaryAccumulator(
 	accumulator.totals.cacheReadTokens += tokens.cacheReadTokens;
 	accumulator.totals.cost += cost;
 	accumulator.totals.totalCost += cost;
+	accumulator.totals.promptCount += 1;
 
 	if (modelName === '<synthetic>') {
 		return;
@@ -2697,6 +2705,7 @@ export async function loadBucketUsageData(
 		group.summary.totals.cacheReadTokens += daily.cacheReadTokens;
 		group.summary.totals.cost += daily.totalCost;
 		group.summary.totals.totalCost += daily.totalCost;
+		group.summary.totals.promptCount += daily.promptCount;
 
 		for (const model of daily.modelsUsed) {
 			if (model !== '<synthetic>') {
@@ -2732,6 +2741,7 @@ export async function loadBucketUsageData(
 			totalCost: summary.totalCost,
 			modelsUsed: summary.modelsUsed,
 			modelBreakdowns: summary.modelBreakdowns,
+			promptCount: summary.promptCount,
 			...(group.project != null && { project: group.project }),
 		};
 	});
@@ -3705,6 +3715,7 @@ invalid json line
 						cost: 0.015,
 					},
 				],
+				promptCount: 1,
 			});
 			expect(result[1]).toEqual({
 				month: '2024-01',
@@ -3724,6 +3735,7 @@ invalid json line
 						cost: 0.03,
 					},
 				],
+				promptCount: 2,
 			});
 		});
 
@@ -3781,6 +3793,7 @@ invalid json line
 						cost: 0.03,
 					},
 				],
+				promptCount: 2,
 			});
 		});
 
@@ -4057,6 +4070,7 @@ invalid json line
 						cost: 0.015,
 					},
 				],
+				promptCount: 1,
 			});
 			expect(result[1]).toEqual({
 				week: '2023-12-31',
@@ -4076,6 +4090,7 @@ invalid json line
 						cost: 0.03,
 					},
 				],
+				promptCount: 2,
 			});
 		});
 
@@ -4133,6 +4148,7 @@ invalid json line
 						cost: 0.03,
 					},
 				],
+				promptCount: 2,
 			});
 		});
 

--- a/apps/ccusage/src/calculate-cost.ts
+++ b/apps/ccusage/src/calculate-cost.ts
@@ -99,6 +99,7 @@ if (import.meta.vitest != null) {
 					totalCost: 0.01,
 					modelsUsed: [createModelName('claude-sonnet-4-20250514')],
 					modelBreakdowns: [],
+					promptCount: 1,
 				},
 				{
 					date: createDailyDate('2024-01-02'),
@@ -109,6 +110,7 @@ if (import.meta.vitest != null) {
 					totalCost: 0.02,
 					modelsUsed: [createModelName('claude-opus-4-20250514')],
 					modelBreakdowns: [],
+					promptCount: 1,
 				},
 			];
 

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -43,6 +43,11 @@ export const dailyCommand = define({
 				"Comma-separated project aliases (e.g., 'ccusage=Usage Tracker,myproject=My Project')",
 			hidden: true,
 		},
+		prompts: {
+			type: 'boolean',
+			description: 'Show prompt count column (number of usage-bearing entries per bucket)',
+			default: false,
+		},
 	},
 	async run(ctx) {
 		// Load configuration and merge with CLI arguments
@@ -107,6 +112,8 @@ export const dailyCommand = define({
 
 		// Calculate totals
 		const totals = calculateTotals(dailyData);
+		const includePrompts = Boolean(mergedOptions.prompts);
+		const totalPromptCount = dailyData.reduce((sum, day) => sum + day.promptCount, 0);
 
 		// Show debug information if requested
 		if (mergedOptions.debug && !useJson) {
@@ -115,12 +122,16 @@ export const dailyCommand = define({
 		}
 
 		if (useJson) {
+			const jsonTotals = {
+				...createTotalsObject(totals),
+				...(includePrompts && { promptCount: totalPromptCount }),
+			};
 			// Output JSON format - group by project if instances flag is used
 			const jsonOutput =
 				Boolean(mergedOptions.instances) && dailyData.some((d) => d.project != null)
 					? {
-							projects: groupByProject(dailyData),
-							totals: createTotalsObject(totals),
+							projects: groupByProject(dailyData, includePrompts),
+							totals: jsonTotals,
 						}
 					: {
 							daily: dailyData.map((data) => ({
@@ -133,9 +144,10 @@ export const dailyCommand = define({
 								totalCost: data.totalCost,
 								modelsUsed: data.modelsUsed,
 								modelBreakdowns: data.modelBreakdowns,
+								...(includePrompts && { promptCount: data.promptCount }),
 								...(data.project != null && { project: data.project }),
 							})),
-							totals: createTotalsObject(totals),
+							totals: jsonTotals,
 						};
 
 			await writeStdoutLine(JSON.stringify(jsonOutput, null, 2));
@@ -148,8 +160,10 @@ export const dailyCommand = define({
 				firstColumnName: 'Date',
 				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, mergedOptions.timezone),
 				forceCompact: ctx.values.compact,
+				includePrompts,
 			};
 			const table = createUsageReportTable(tableConfig);
+			const columnCount = 8 + (includePrompts ? 1 : 0);
 
 			// Add daily data - group by project if instances flag is used
 			if (Boolean(mergedOptions.instances) && dailyData.some((d) => d.project != null)) {
@@ -161,20 +175,17 @@ export const dailyCommand = define({
 					// Add project section header
 					if (!isFirstProject) {
 						// Add empty row for visual separation between projects
-						table.push(['', '', '', '', '', '', '', '']);
+						table.push(Array.from({ length: columnCount }, () => ''));
 					}
 
 					// Add project header row
-					table.push([
+					const projectHeaderRow: (string | number)[] = [
 						pc.cyan(`Project: ${formatProjectName(projectName, projectAliases)}`),
-						'',
-						'',
-						'',
-						'',
-						'',
-						'',
-						'',
-					]);
+					];
+					while (projectHeaderRow.length < columnCount) {
+						projectHeaderRow.push('');
+					}
+					table.push(projectHeaderRow);
 
 					// Add data rows for this project
 					for (const data of projectData) {
@@ -185,12 +196,13 @@ export const dailyCommand = define({
 							cacheReadTokens: data.cacheReadTokens,
 							totalCost: data.totalCost,
 							modelsUsed: data.modelsUsed,
+							...(includePrompts && { promptCount: data.promptCount }),
 						});
 						table.push(row);
 
 						// Add model breakdown rows if flag is set
 						if (mergedOptions.breakdown) {
-							pushBreakdownRows(table, data.modelBreakdowns);
+							pushBreakdownRows(table, data.modelBreakdowns, includePrompts ? 2 : 1);
 						}
 					}
 
@@ -207,18 +219,19 @@ export const dailyCommand = define({
 						cacheReadTokens: data.cacheReadTokens,
 						totalCost: data.totalCost,
 						modelsUsed: data.modelsUsed,
+						...(includePrompts && { promptCount: data.promptCount }),
 					});
 					table.push(row);
 
 					// Add model breakdown rows if flag is set
 					if (mergedOptions.breakdown) {
-						pushBreakdownRows(table, data.modelBreakdowns);
+						pushBreakdownRows(table, data.modelBreakdowns, includePrompts ? 2 : 1);
 					}
 				}
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, columnCount);
 
 			// Add totals
 			const totalsRow = formatTotalsRow({
@@ -227,6 +240,7 @@ export const dailyCommand = define({
 				cacheCreationTokens: totals.cacheCreationTokens,
 				cacheReadTokens: totals.cacheReadTokens,
 				totalCost: totals.totalCost,
+				...(includePrompts && { promptCount: totalPromptCount }),
 			});
 			table.push(totalsRow);
 

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -21,6 +21,14 @@ export const monthlyCommand = define({
 	name: 'monthly',
 	description: 'Show usage report grouped by month',
 	...sharedCommandConfig,
+	args: {
+		...sharedCommandConfig.args,
+		prompts: {
+			type: 'boolean',
+			description: 'Show prompt count column (number of usage-bearing entries per bucket)',
+			default: false,
+		},
+	},
 	async run(ctx) {
 		// Load configuration and merge with CLI arguments
 		const config = loadConfig(ctx.values.config, ctx.values.debug);
@@ -51,6 +59,8 @@ export const monthlyCommand = define({
 			logger.level = originalLoggerLevel;
 		}
 
+		const includePrompts = Boolean(mergedOptions.prompts);
+
 		if (monthlyData.length === 0) {
 			if (useJson) {
 				const emptyOutput = {
@@ -62,6 +72,7 @@ export const monthlyCommand = define({
 						cacheReadTokens: 0,
 						totalTokens: 0,
 						totalCost: 0,
+						...(includePrompts && { promptCount: 0 }),
 					},
 				};
 				await writeStdoutLine(JSON.stringify(emptyOutput, null, 2));
@@ -73,6 +84,7 @@ export const monthlyCommand = define({
 
 		// Calculate totals
 		const totals = calculateTotals(monthlyData);
+		const totalPromptCount = monthlyData.reduce((sum, month) => sum + month.promptCount, 0);
 
 		// Show debug information if requested
 		if (mergedOptions.debug && !useJson) {
@@ -93,8 +105,12 @@ export const monthlyCommand = define({
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
+					...(includePrompts && { promptCount: data.promptCount }),
 				})),
-				totals: createTotalsObject(totals),
+				totals: {
+					...createTotalsObject(totals),
+					...(includePrompts && { promptCount: totalPromptCount }),
+				},
 			};
 
 			await writeStdoutLine(JSON.stringify(jsonOutput, null, 2));
@@ -107,8 +123,10 @@ export const monthlyCommand = define({
 				firstColumnName: 'Month',
 				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, mergedOptions.timezone),
 				forceCompact: ctx.values.compact,
+				includePrompts,
 			};
 			const table = createUsageReportTable(tableConfig);
+			const columnCount = 8 + (includePrompts ? 1 : 0);
 
 			// Add monthly data
 			for (const data of monthlyData) {
@@ -120,17 +138,18 @@ export const monthlyCommand = define({
 					cacheReadTokens: data.cacheReadTokens,
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
+					...(includePrompts && { promptCount: data.promptCount }),
 				});
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, includePrompts ? 2 : 1);
 				}
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, columnCount);
 
 			// Add totals
 			const totalsRow = formatTotalsRow({
@@ -139,6 +158,7 @@ export const monthlyCommand = define({
 				cacheCreationTokens: totals.cacheCreationTokens,
 				cacheReadTokens: totals.cacheReadTokens,
 				totalCost: totals.totalCost,
+				...(includePrompts && { promptCount: totalPromptCount }),
 			});
 			table.push(totalsRow);
 

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -30,6 +30,11 @@ export const weeklyCommand = define({
 			default: 'sunday' as const,
 			choices: WEEK_DAYS,
 		},
+		prompts: {
+			type: 'boolean',
+			description: 'Show prompt count column (number of usage-bearing entries per bucket)',
+			default: false,
+		},
 	},
 	toKebab: true,
 	async run(ctx) {
@@ -62,6 +67,8 @@ export const weeklyCommand = define({
 			logger.level = originalLoggerLevel;
 		}
 
+		const includePrompts = Boolean(mergedOptions.prompts);
+
 		if (weeklyData.length === 0) {
 			if (useJson) {
 				const emptyOutput = {
@@ -73,6 +80,7 @@ export const weeklyCommand = define({
 						cacheReadTokens: 0,
 						totalTokens: 0,
 						totalCost: 0,
+						...(includePrompts && { promptCount: 0 }),
 					},
 				};
 				await writeStdoutLine(JSON.stringify(emptyOutput, null, 2));
@@ -84,6 +92,7 @@ export const weeklyCommand = define({
 
 		// Calculate totals
 		const totals = calculateTotals(weeklyData);
+		const totalPromptCount = weeklyData.reduce((sum, week) => sum + week.promptCount, 0);
 
 		// Show debug information if requested
 		if (mergedOptions.debug && !useJson) {
@@ -104,8 +113,12 @@ export const weeklyCommand = define({
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
 					modelBreakdowns: data.modelBreakdowns,
+					...(includePrompts && { promptCount: data.promptCount }),
 				})),
-				totals: createTotalsObject(totals),
+				totals: {
+					...createTotalsObject(totals),
+					...(includePrompts && { promptCount: totalPromptCount }),
+				},
 			};
 
 			await writeStdoutLine(JSON.stringify(jsonOutput, null, 2));
@@ -118,8 +131,10 @@ export const weeklyCommand = define({
 				firstColumnName: 'Week',
 				dateFormatter: (dateStr: string) => formatDateCompact(dateStr, mergedOptions.timezone),
 				forceCompact: ctx.values.compact,
+				includePrompts,
 			};
 			const table = createUsageReportTable(tableConfig);
+			const columnCount = 8 + (includePrompts ? 1 : 0);
 
 			// Add weekly data
 			for (const data of weeklyData) {
@@ -131,17 +146,18 @@ export const weeklyCommand = define({
 					cacheReadTokens: data.cacheReadTokens,
 					totalCost: data.totalCost,
 					modelsUsed: data.modelsUsed,
+					...(includePrompts && { promptCount: data.promptCount }),
 				});
 				table.push(row);
 
 				// Add model breakdown rows if flag is set
 				if (mergedOptions.breakdown) {
-					pushBreakdownRows(table, data.modelBreakdowns);
+					pushBreakdownRows(table, data.modelBreakdowns, includePrompts ? 2 : 1);
 				}
 			}
 
 			// Add empty row for visual separation before totals
-			addEmptySeparatorRow(table, 8);
+			addEmptySeparatorRow(table, columnCount);
 
 			// Add totals
 			const totalsRow = formatTotalsRow({
@@ -150,6 +166,7 @@ export const weeklyCommand = define({
 				cacheCreationTokens: totals.cacheCreationTokens,
 				cacheReadTokens: totals.cacheReadTokens,
 				totalCost: totals.totalCost,
+				...(includePrompts && { promptCount: totalPromptCount }),
 			});
 			table.push(totalsRow);
 

--- a/apps/ccusage/src/daily-grouping.ts
+++ b/apps/ccusage/src/daily-grouping.ts
@@ -99,6 +99,48 @@ if (import.meta.vitest != null) {
 			expect(result['project-b']![0]!.totalTokens).toBe(3500);
 		});
 
+		it('omits promptCount when includePrompts is false (default)', () => {
+			const mockData = [
+				{
+					date: createDailyDate('2024-01-01'),
+					project: 'project-a',
+					inputTokens: 1000,
+					outputTokens: 500,
+					cacheCreationTokens: 0,
+					cacheReadTokens: 0,
+					totalCost: 0.01,
+					modelsUsed: [createModelName('claude-sonnet-4-20250514')],
+					modelBreakdowns: [],
+					promptCount: 5,
+				},
+			];
+
+			const result = groupByProject(mockData);
+
+			expect(result['project-a']![0]!).not.toHaveProperty('promptCount');
+		});
+
+		it('includes promptCount when includePrompts is true', () => {
+			const mockData = [
+				{
+					date: createDailyDate('2024-01-01'),
+					project: 'project-a',
+					inputTokens: 1000,
+					outputTokens: 500,
+					cacheCreationTokens: 0,
+					cacheReadTokens: 0,
+					totalCost: 0.01,
+					modelsUsed: [createModelName('claude-sonnet-4-20250514')],
+					modelBreakdowns: [],
+					promptCount: 5,
+				},
+			];
+
+			const result = groupByProject(mockData, true);
+
+			expect(result['project-a']![0]!.promptCount).toBe(5);
+		});
+
 		it('handles unknown project names', () => {
 			const mockData = [
 				{

--- a/apps/ccusage/src/daily-grouping.ts
+++ b/apps/ccusage/src/daily-grouping.ts
@@ -11,7 +11,10 @@ type DailyData = Awaited<ReturnType<typeof loadDailyUsageData>>;
 /**
  * Group daily usage data by project for JSON output
  */
-export function groupByProject(dailyData: DailyData): Record<string, DailyProjectOutput[]> {
+export function groupByProject(
+	dailyData: DailyData,
+	includePrompts = false,
+): Record<string, DailyProjectOutput[]> {
 	const projects: Record<string, DailyProjectOutput[]> = {};
 
 	for (const data of dailyData) {
@@ -31,6 +34,7 @@ export function groupByProject(dailyData: DailyData): Record<string, DailyProjec
 			totalCost: data.totalCost,
 			modelsUsed: data.modelsUsed,
 			modelBreakdowns: data.modelBreakdowns,
+			...(includePrompts && { promptCount: data.promptCount }),
 		});
 	}
 
@@ -70,6 +74,7 @@ if (import.meta.vitest != null) {
 					totalCost: 0.01,
 					modelsUsed: [createModelName('claude-sonnet-4-20250514')],
 					modelBreakdowns: [],
+					promptCount: 0,
 				},
 				{
 					date: createDailyDate('2024-01-01'),
@@ -81,6 +86,7 @@ if (import.meta.vitest != null) {
 					totalCost: 0.02,
 					modelsUsed: [createModelName('claude-opus-4-20250514')],
 					modelBreakdowns: [],
+					promptCount: 0,
 				},
 			];
 
@@ -105,6 +111,7 @@ if (import.meta.vitest != null) {
 					totalCost: 0.01,
 					modelsUsed: [createModelName('claude-sonnet-4-20250514')],
 					modelBreakdowns: [],
+					promptCount: 0,
 				},
 			];
 
@@ -128,6 +135,7 @@ if (import.meta.vitest != null) {
 					totalCost: 0.01,
 					modelsUsed: [createModelName('claude-sonnet-4-20250514')],
 					modelBreakdowns: [],
+					promptCount: 0,
 				},
 				{
 					date: createDailyDate('2024-01-02'),
@@ -139,6 +147,7 @@ if (import.meta.vitest != null) {
 					totalCost: 0.008,
 					modelsUsed: [createModelName('claude-sonnet-4-20250514')],
 					modelBreakdowns: [],
+					promptCount: 0,
 				},
 			];
 

--- a/apps/ccusage/src/json-output-types.ts
+++ b/apps/ccusage/src/json-output-types.ts
@@ -25,4 +25,5 @@ export type DailyProjectOutput = {
 	totalCost: number;
 	modelsUsed: ModelName[];
 	modelBreakdowns: ModelBreakdown[];
+	promptCount?: number;
 };

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -792,6 +792,8 @@ export type UsageReportConfig = {
 	includeLastActivity?: boolean;
 	/** Whether to include Agent column (for all-agent reports) */
 	includeAgent?: boolean;
+	/** Whether to include Prompts column (count of usage-bearing entries per bucket) */
+	includePrompts?: boolean;
 	/** Date formatter function for responsive date formatting */
 	dateFormatter?: (dateStr: string) => string;
 	/** Force compact mode regardless of terminal width */
@@ -809,6 +811,7 @@ export type UsageData = {
 	totalCost: number;
 	modelsUsed?: string[];
 	agent?: string;
+	promptCount?: number;
 };
 
 /**
@@ -855,6 +858,22 @@ export function createUsageReportTable(config: UsageReportConfig): ResponsiveTab
 		baseHeaders.splice(1, 0, 'Agent');
 		baseAligns.splice(1, 0, 'left');
 		minColumnWidths.splice(1, 0, 10);
+	}
+
+	// Add Prompts column between Models (or Agent) and Input for time-bucketed reports
+	if (config.includePrompts ?? false) {
+		const baseInputIndex = baseHeaders.indexOf('Input');
+		if (baseInputIndex !== -1) {
+			baseHeaders.splice(baseInputIndex, 0, 'Prompts');
+			baseAligns.splice(baseInputIndex, 0, 'right');
+			minColumnWidths.splice(baseInputIndex, 0, 9);
+		}
+		const compactInputIndex = compactHeaders.indexOf('Input');
+		if (compactInputIndex !== -1) {
+			compactHeaders.splice(compactInputIndex, 0, 'Prompts');
+			compactAligns.splice(compactInputIndex, 0, 'right');
+			compactMinColumnWidths.splice(compactInputIndex, 0, 9);
+		}
 	}
 
 	// Add Last Activity column for session reports
@@ -915,6 +934,12 @@ export function formatUsageDataRow(
 		row.splice(1, 0, data.agent);
 	}
 
+	if (data.promptCount != null) {
+		// Prompts column sits just before Input; index = (agent ? 3 : 2)
+		const insertAt = data.agent != null ? 3 : 2;
+		row.splice(insertAt, 0, formatNumber(data.promptCount));
+	}
+
 	if (lastActivity !== undefined) {
 		row.push(lastActivity);
 	}
@@ -949,6 +974,12 @@ export function formatTotalsRow(
 
 	if (includeAgent) {
 		row.splice(1, 0, '');
+	}
+
+	if (totals.promptCount != null) {
+		// Prompts column sits just before Input
+		const insertAt = includeAgent ? 3 : 2;
+		row.splice(insertAt, 0, pc.yellow(formatNumber(totals.promptCount)));
 	}
 
 	if (includeLastActivity) {

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -860,7 +860,8 @@ export function createUsageReportTable(config: UsageReportConfig): ResponsiveTab
 		minColumnWidths.splice(1, 0, 10);
 	}
 
-	// Add Prompts column between Models (or Agent) and Input for time-bucketed reports
+	// Add Prompts column between Models/Agent and the first metric column
+	// (Input in default layouts, Total Tokens in the all-agent compact layout)
 	if (config.includePrompts ?? false) {
 		const baseInputIndex = baseHeaders.indexOf('Input');
 		if (baseInputIndex !== -1) {
@@ -868,11 +869,13 @@ export function createUsageReportTable(config: UsageReportConfig): ResponsiveTab
 			baseAligns.splice(baseInputIndex, 0, 'right');
 			minColumnWidths.splice(baseInputIndex, 0, 9);
 		}
-		const compactInputIndex = compactHeaders.indexOf('Input');
-		if (compactInputIndex !== -1) {
-			compactHeaders.splice(compactInputIndex, 0, 'Prompts');
-			compactAligns.splice(compactInputIndex, 0, 'right');
-			compactMinColumnWidths.splice(compactInputIndex, 0, 9);
+		const compactAnchor = compactHeaders.includes('Input')
+			? compactHeaders.indexOf('Input')
+			: compactHeaders.indexOf('Total Tokens');
+		if (compactAnchor !== -1) {
+			compactHeaders.splice(compactAnchor, 0, 'Prompts');
+			compactAligns.splice(compactAnchor, 0, 'right');
+			compactMinColumnWidths.splice(compactAnchor, 0, 9);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Reimplements @antonioribeiro's #710 (`--prompts` flag for daily/weekly/monthly reports) on top of the v19 adapter architecture. The original PR sat against pre-v19 code that has since been substantially reshaped (#1004 adapter unification, #1007 file-prefix rename, #1000 all-agent reports). A literal rebase wasn't viable, so this is a fresh implementation that preserves #710's scope and behavior while fitting the new layout.

Scope is intentionally limited to the **Claude adapter** to match #710. Generalizing `promptCount` to the shared adapter layer (so Codex/Amp/OpenCode/Pi inherit the column) is a separate change - happy to do that if you'd prefer it bundled.

## What's in here

**Adapter (`apps/ccusage/src/adapter/claude/data-loader.ts`)**
- Track `promptCount` on the shared `UsageSummaryAccumulator` and surface it from `finalizeUsageSummary`.
- Add `promptCount: number` to `DailyUsage`, `WeeklyUsage`, `MonthlyUsage`, and `BucketUsage`.
- Bucket aggregation (used by weekly/monthly) sums each daily's `promptCount` so the numbers stay consistent across reports.

**Terminal (`packages/terminal/src/table.ts`)**
- New `includePrompts?: boolean` on `UsageReportConfig`.
- New optional `promptCount?: number` on `UsageData`.
- When set, the `Prompts` column slots between Models (or Agent) and Input in both base and compact layouts.
- `formatUsageDataRow` and `formatTotalsRow` derive whether to render a Prompts cell from `data.promptCount != null` - no signature breakage for existing callers.

**Commands (`apps/ccusage/src/commands/{daily,weekly,monthly}.ts`)**
- New `prompts` boolean CLI arg (defaults to `false`).
- Thread `includePrompts` through table config, row/total formatters, separator column count, and `pushBreakdownRows` offset (2 instead of 1 when `--prompts` is on) so `--breakdown` rows stay aligned.
- JSON output gates `promptCount` on rows, totals, and `emptyOutput` totals behind `--prompts` so the payload shape is stable when the flag is off.

**Project grouping (`apps/ccusage/src/daily-grouping.ts`, `json-output-types.ts`)**
- `groupByProject` takes a new `includePrompts` argument and propagates `promptCount` into `DailyProjectOutput` (which gained an optional `promptCount` field). Keeps `daily --instances --prompts --json` consistent with the flat output.

**Misc**
- README: added a feature-list bullet describing the flag and its semantics.
- `config-schema.json` regenerated.

## Note on semantics

`promptCount` counts usage-bearing entries (one per assistant API call). A single user message that triggers N tool iterations counts as N+ entries, not 1. The companion PR #679 (blocks command) filters to user-role messages instead, so the two PRs count different things under the same flag. Worth deciding whether to unify the definition before merging both.

## Test plan

- [x] `pnpm test` - 498/498 pass (3 pre-existing skipped)
- [x] `pnpm lint` - clean
- [x] `pnpm --filter ccusage typecheck` - clean
- [x] `pnpm --filter ccusage build` - clean
- [x] Manually verified `ccusage claude daily` / `claude weekly` / `claude monthly` against real Claude Code data: Total-row input-token / cost figures match between flag states (proves no column shift).
- [x] Manually verified `ccusage claude weekly --breakdown --prompts`: breakdown rows have an empty Prompts cell so model token columns stay aligned with the data row above.
- [x] Verified `--json` gating: `promptCount` absent on rows and totals without `--prompts`, present with it.
- [x] Verified `ccusage claude daily --instances --prompts --json` propagates `promptCount` through `groupByProject` and totals.
- [x] Confirmed default `ccusage daily` (all-agent unified report) is unaffected.

Closes #710. Companion PR #679 is independent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --prompts option for daily, weekly, and monthly reports to show a Prompts column (counts of usage-bearing API requests, including tool-call iterations). Feature is disabled by default.
* **Documentation**
  * README updated with a Prompt Count feature note explaining the Prompts column and semantics.
* **Tests**
  * Updated tests/fixtures to cover prompt-count behavior in aggregation and output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->