### PR TITLE
chore: upgrade pnpm to 11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1778672786,
+        "narHash": "sha256-Blg88K1jwG+P0Mr27+rKMFCufdrWkV3wWh9AdYtz0FQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "eef00dfd8a712b34af845f9350bac681b1228bd1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         default = pkgs.mkShellNoCC {
           buildInputs = with pkgs; [
             # Package manager
-            pnpm_10
+            pnpm_11
 
             # Development tools
             typos

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"apps/*",
 		"docs"
 	],
-	"packageManager": "pnpm@10.30.1",
+	"packageManager": "pnpm@11.1.2",
 	"engines": {
 		"runtime": [
 			{


### PR DESCRIPTION
Bumps the pnpm package manager from 10 to 11 across the repo, now that [NixOS/nixpkgs#505103](https://github.com/NixOS/nixpkgs/pull/505103) (init `pnpm_11`) has been merged.

- `flake.nix`: switch dev shell from `pnpm_10` to `pnpm_11`.
- `flake.lock`: bump nixpkgs to a revision containing `pnpm_11` (11.1.1).
- `package.json`: set `packageManager` to `pnpm@11.1.2` (latest).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/995)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->