### PR TITLE
feat(codex): account for fast mode pricing

### DIFF
--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -71,12 +71,18 @@ npx @ccusage/codex@latest monthly --json
 
 # Session-level detailed report
 npx @ccusage/codex@latest session
+
+# Override Codex fast-mode pricing detection
+npx @ccusage/codex@latest daily --speed fast
+npx @ccusage/codex@latest daily --speed standard
 ```
 
 Useful environment variables:
 
 - `CODEX_HOME` – override the root directory that contains Codex session folders
 - `LOG_LEVEL` – control log verbosity (0 silent … 5 trace)
+
+Speed pricing defaults to `--speed auto`, which reads `${CODEX_HOME:-~/.codex}/config.toml` and applies fast pricing when `service_tier = "priority"` or legacy `service_tier = "fast"` is configured. Fast mode uses the model-specific LiteLLM multiplier when available and otherwise falls back to 2x pricing. Use `--speed fast` or `--speed standard` when the session logs do not reflect the speed tier you want to price.
 
 ℹ️ The CLI now relies on the model metadata recorded in each `turn_context`. Sessions emitted during early September 2025 that lack this metadata are skipped to avoid mispricing. Newer builds of the Codex CLI restore the model field, and aliases such as `gpt-5-codex` automatically resolve to the correct LiteLLM pricing entry.
 📦 For legacy JSONL files that never emitted `turn_context` metadata, the CLI falls back to treating the tokens as `gpt-5` so that usage still appears in reports (pricing is therefore approximate for those sessions). In JSON output you will also see `"isFallback": true` on those model entries.

--- a/apps/codex/src/_shared-args.ts
+++ b/apps/codex/src/_shared-args.ts
@@ -31,6 +31,12 @@ export const sharedArgs = {
 		default: false,
 		negatable: true,
 	},
+	speed: {
+		type: 'string',
+		description:
+			'Cost speed tier: auto reads Codex config.toml service_tier; use standard or fast to override',
+		default: 'auto',
+	},
 	compact: {
 		type: 'boolean',
 		description: 'Force compact table layout for narrow terminals',

--- a/apps/codex/src/codex-config.ts
+++ b/apps/codex/src/codex-config.ts
@@ -1,0 +1,175 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { Result } from '@praha/byethrow';
+import { CODEX_HOME_ENV, DEFAULT_CODEX_DIR } from './_consts.ts';
+import { logger } from './logger.ts';
+
+export type CodexSpeed = 'standard' | 'fast';
+export type CodexSpeedOption = 'auto' | CodexSpeed;
+
+type ParsedConfig = {
+	profile?: string;
+	serviceTier?: string;
+	profiles: Map<string, { serviceTier?: string }>;
+};
+
+function codexHome(): string {
+	const value = process.env[CODEX_HOME_ENV]?.trim();
+	return value == null || value === '' ? DEFAULT_CODEX_DIR : path.resolve(value);
+}
+
+export function codexConfigPath(): string {
+	return path.join(codexHome(), 'config.toml');
+}
+
+function parseStringValue(value: string): string | undefined {
+	const trimmed = value.trim();
+	const quoted = /^"([^"]*)"|'([^']*)'/.exec(trimmed);
+	if (quoted != null) {
+		return quoted[1] ?? quoted[2];
+	}
+
+	const bare = /^([^\s#]+)/.exec(trimmed);
+	return bare?.[1];
+}
+
+function profileNameFromSection(section: string): string | undefined {
+	const match = /^profiles\.(?:"([^"]+)"|'([^']+)'|([\w-]+))$/.exec(section);
+	return match?.[1] ?? match?.[2] ?? match?.[3];
+}
+
+export function parseCodexConfig(content: string): ParsedConfig {
+	const parsed: ParsedConfig = { profiles: new Map() };
+	let section = '';
+
+	for (const rawLine of content.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (line === '' || line.startsWith('#')) {
+			continue;
+		}
+
+		const sectionMatch = /^\[([^\]]+)\]$/.exec(line);
+		if (sectionMatch != null) {
+			section = sectionMatch[1]!.trim();
+			continue;
+		}
+
+		const assignmentIndex = line.indexOf('=');
+		if (assignmentIndex === -1) {
+			continue;
+		}
+
+		const key = line.slice(0, assignmentIndex).trim();
+		if (!/^[\w-]+$/.test(key)) {
+			continue;
+		}
+
+		const value = parseStringValue(line.slice(assignmentIndex + 1));
+		if (value == null) {
+			continue;
+		}
+
+		if (section === '') {
+			if (key === 'profile') {
+				parsed.profile = value;
+			} else if (key === 'service_tier') {
+				parsed.serviceTier = value;
+			}
+			continue;
+		}
+
+		if (key !== 'service_tier') {
+			continue;
+		}
+
+		const profileName = profileNameFromSection(section);
+		if (profileName == null) {
+			continue;
+		}
+
+		const profile = parsed.profiles.get(profileName) ?? {};
+		profile.serviceTier = value;
+		parsed.profiles.set(profileName, profile);
+	}
+
+	return parsed;
+}
+
+function isFastServiceTier(serviceTier: string | undefined): boolean {
+	const normalized = serviceTier?.trim().toLowerCase();
+	return normalized === 'fast' || normalized === 'priority';
+}
+
+export function speedFromCodexConfig(content: string): CodexSpeed {
+	const parsed = parseCodexConfig(content);
+	const profileServiceTier =
+		parsed.profile == null ? undefined : parsed.profiles.get(parsed.profile)?.serviceTier;
+	return isFastServiceTier(profileServiceTier ?? parsed.serviceTier) ? 'fast' : 'standard';
+}
+
+export function normalizeSpeedOption(value: unknown): CodexSpeedOption {
+	if (value == null || value === '') {
+		return 'auto';
+	}
+	if (value === 'auto' || value === 'standard' || value === 'fast') {
+		return value;
+	}
+	throw new Error('Invalid --speed value. Use auto, standard, or fast.');
+}
+
+export async function resolveCodexSpeed(option: CodexSpeedOption): Promise<CodexSpeed> {
+	if (option !== 'auto') {
+		return option;
+	}
+
+	const configPath = codexConfigPath();
+	const configResult = await Result.try({
+		try: readFile(configPath, 'utf8'),
+		catch: (error) => error,
+	});
+
+	if (Result.isFailure(configResult)) {
+		logger.debug('Codex config not found or unreadable; using standard pricing', {
+			configPath,
+			error: configResult.error,
+		});
+		return 'standard';
+	}
+
+	return speedFromCodexConfig(configResult.value);
+}
+
+if (import.meta.vitest != null) {
+	describe('Codex config speed resolution', () => {
+		it('detects top-level priority service tier as fast', () => {
+			expect(speedFromCodexConfig('service_tier = "priority"')).toBe('fast');
+		});
+
+		it('detects legacy top-level fast service tier as fast', () => {
+			expect(speedFromCodexConfig('service_tier = "fast"')).toBe('fast');
+		});
+
+		it('uses the active profile service tier over the top-level service tier', () => {
+			const content = [
+				'profile = "work"',
+				'service_tier = "priority"',
+				'',
+				'[profiles.work]',
+				'service_tier = "flex"',
+			].join('\n');
+
+			expect(speedFromCodexConfig(content)).toBe('standard');
+		});
+
+		it('defaults to standard when no fast tier is configured', () => {
+			expect(speedFromCodexConfig('model = "gpt-5.3-codex"')).toBe('standard');
+		});
+
+		it('validates CLI speed options', () => {
+			expect(normalizeSpeedOption(undefined)).toBe('auto');
+			expect(normalizeSpeedOption('fast')).toBe('fast');
+			expect(() => normalizeSpeedOption('slow')).toThrow('Invalid --speed value');
+		});
+	});
+}

--- a/apps/codex/src/commands/daily.ts
+++ b/apps/codex/src/commands/daily.ts
@@ -7,10 +7,12 @@ import {
 	formatNumber,
 	ResponsiveTable,
 } from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { DEFAULT_TIMEZONE } from '../_consts.ts';
 import { sharedArgs } from '../_shared-args.ts';
+import { normalizeSpeedOption, resolveCodexSpeed } from '../codex-config.ts';
 import { formatModelsList, splitUsageTokens } from '../command-utils.ts';
 import { buildDailyReport } from '../daily-report.ts';
 import { loadTokenUsageEvents } from '../data-loader.ts';
@@ -41,6 +43,16 @@ export const dailyCommand = define({
 			process.exit(1);
 		}
 
+		const speedOptionResult = Result.try({
+			try: () => normalizeSpeedOption(ctx.values.speed),
+			catch: (error) => error,
+		})();
+		if (Result.isFailure(speedOptionResult)) {
+			logger.error(String(speedOptionResult.error));
+			process.exit(1);
+		}
+		const speed = await resolveCodexSpeed(speedOptionResult.value);
+
 		const { events, missingDirectories } = await loadTokenUsageEvents();
 
 		for (const missing of missingDirectories) {
@@ -54,6 +66,7 @@ export const dailyCommand = define({
 
 		const pricingSource = new CodexPricingSource({
 			offline: ctx.values.offline,
+			speed,
 		});
 		try {
 			const rows = await buildDailyReport(events, {

--- a/apps/codex/src/commands/monthly.ts
+++ b/apps/codex/src/commands/monthly.ts
@@ -7,10 +7,12 @@ import {
 	formatNumber,
 	ResponsiveTable,
 } from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { DEFAULT_TIMEZONE } from '../_consts.ts';
 import { sharedArgs } from '../_shared-args.ts';
+import { normalizeSpeedOption, resolveCodexSpeed } from '../codex-config.ts';
 import { formatModelsList, splitUsageTokens } from '../command-utils.ts';
 import { loadTokenUsageEvents } from '../data-loader.ts';
 import { normalizeFilterDate } from '../date-utils.ts';
@@ -41,6 +43,16 @@ export const monthlyCommand = define({
 			process.exit(1);
 		}
 
+		const speedOptionResult = Result.try({
+			try: () => normalizeSpeedOption(ctx.values.speed),
+			catch: (error) => error,
+		})();
+		if (Result.isFailure(speedOptionResult)) {
+			logger.error(String(speedOptionResult.error));
+			process.exit(1);
+		}
+		const speed = await resolveCodexSpeed(speedOptionResult.value);
+
 		const { events, missingDirectories } = await loadTokenUsageEvents();
 
 		for (const missing of missingDirectories) {
@@ -56,6 +68,7 @@ export const monthlyCommand = define({
 
 		const pricingSource = new CodexPricingSource({
 			offline: ctx.values.offline,
+			speed,
 		});
 		try {
 			const rows = await buildMonthlyReport(events, {

--- a/apps/codex/src/commands/session.ts
+++ b/apps/codex/src/commands/session.ts
@@ -7,10 +7,12 @@ import {
 	formatNumber,
 	ResponsiveTable,
 } from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { DEFAULT_TIMEZONE } from '../_consts.ts';
 import { sharedArgs } from '../_shared-args.ts';
+import { normalizeSpeedOption, resolveCodexSpeed } from '../codex-config.ts';
 import { formatModelsList, splitUsageTokens } from '../command-utils.ts';
 import { loadTokenUsageEvents } from '../data-loader.ts';
 import {
@@ -46,6 +48,16 @@ export const sessionCommand = define({
 			process.exit(1);
 		}
 
+		const speedOptionResult = Result.try({
+			try: () => normalizeSpeedOption(ctx.values.speed),
+			catch: (error) => error,
+		})();
+		if (Result.isFailure(speedOptionResult)) {
+			logger.error(String(speedOptionResult.error));
+			process.exit(1);
+		}
+		const speed = await resolveCodexSpeed(speedOptionResult.value);
+
 		const { events, missingDirectories } = await loadTokenUsageEvents();
 
 		for (const missing of missingDirectories) {
@@ -61,6 +73,7 @@ export const sessionCommand = define({
 
 		const pricingSource = new CodexPricingSource({
 			offline: ctx.values.offline,
+			speed,
 		});
 		try {
 			const rows = await buildSessionReport(events, {

--- a/apps/codex/src/pricing.ts
+++ b/apps/codex/src/pricing.ts
@@ -1,5 +1,6 @@
 import type { LiteLLMModelPricing } from '@ccusage/internal/pricing';
 import type { ModelPricing, PricingSource } from './_types.ts';
+import type { CodexSpeed } from './codex-config.ts';
 import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
 import { Result } from '@praha/byethrow';
 import { MILLION } from './_consts.ts';
@@ -11,6 +12,7 @@ const CODEX_MODEL_ALIASES_MAP = new Map<string, string>([
 	['gpt-5-codex', 'gpt-5'],
 	['gpt-5.3-codex', 'gpt-5.2-codex'],
 ]);
+const CODEX_FAST_FALLBACK_MULTIPLIER = 2;
 const FREE_MODEL_PRICING = {
 	inputCostPerMToken: 0,
 	cachedInputCostPerMToken: 0,
@@ -42,14 +44,17 @@ function toPerMillion(value: number | undefined, fallback?: number): number {
 export type CodexPricingSourceOptions = {
 	offline?: boolean;
 	offlineLoader?: () => Promise<Record<string, LiteLLMModelPricing>>;
+	speed?: CodexSpeed;
 };
 
 const PREFETCHED_CODEX_PRICING = prefetchCodexPricing();
 
 export class CodexPricingSource implements PricingSource, Disposable {
 	private readonly fetcher: LiteLLMPricingFetcher;
+	private readonly speed: CodexSpeed;
 
 	constructor(options: CodexPricingSourceOptions = {}) {
+		this.speed = options.speed ?? 'standard';
 		this.fetcher = new LiteLLMPricingFetcher({
 			offline: options.offline ?? false,
 			offlineLoader: options.offlineLoader ?? (async () => PREFETCHED_CODEX_PRICING),
@@ -89,13 +94,17 @@ export class CodexPricingSource implements PricingSource, Disposable {
 			return FREE_MODEL_PRICING;
 		}
 
+		const speedMultiplier =
+			this.speed === 'fast'
+				? (pricing.provider_specific_entry?.fast ?? CODEX_FAST_FALLBACK_MULTIPLIER)
+				: 1;
+
 		return {
-			inputCostPerMToken: toPerMillion(pricing.input_cost_per_token),
-			cachedInputCostPerMToken: toPerMillion(
-				pricing.cache_read_input_token_cost,
-				pricing.input_cost_per_token,
-			),
-			outputCostPerMToken: toPerMillion(pricing.output_cost_per_token),
+			inputCostPerMToken: toPerMillion(pricing.input_cost_per_token) * speedMultiplier,
+			cachedInputCostPerMToken:
+				toPerMillion(pricing.cache_read_input_token_cost, pricing.input_cost_per_token) *
+				speedMultiplier,
+			outputCostPerMToken: toPerMillion(pricing.output_cost_per_token) * speedMultiplier,
 		};
 	}
 }
@@ -187,6 +196,45 @@ if (import.meta.vitest != null) {
 			expect(pricing.inputCostPerMToken).toBeCloseTo(1.9);
 			expect(pricing.outputCostPerMToken).toBeCloseTo(15);
 			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.19);
+		});
+
+		it('applies fast speed multiplier when configured', async () => {
+			using source = new CodexPricingSource({
+				offline: true,
+				speed: 'fast',
+				offlineLoader: async () => ({
+					'gpt-5.3-codex': {
+						input_cost_per_token: 1.75e-6,
+						output_cost_per_token: 1.4e-5,
+						cache_read_input_token_cost: 1.75e-7,
+						provider_specific_entry: { fast: 2 },
+					},
+				}),
+			});
+
+			const pricing = await source.getPricing('gpt-5.3-codex');
+			expect(pricing.inputCostPerMToken).toBeCloseTo(3.5);
+			expect(pricing.outputCostPerMToken).toBeCloseTo(28);
+			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.35);
+		});
+
+		it('uses the Codex fast fallback multiplier when pricing has no provider-specific value', async () => {
+			using source = new CodexPricingSource({
+				offline: true,
+				speed: 'fast',
+				offlineLoader: async () => ({
+					'gpt-5.3-codex': {
+						input_cost_per_token: 1.75e-6,
+						output_cost_per_token: 1.4e-5,
+						cache_read_input_token_cost: 1.75e-7,
+					},
+				}),
+			});
+
+			const pricing = await source.getPricing('gpt-5.3-codex');
+			expect(pricing.inputCostPerMToken).toBeCloseTo(3.5);
+			expect(pricing.outputCostPerMToken).toBeCloseTo(28);
+			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.35);
 		});
 	});
 }

--- a/docs/guide/codex/daily.md
+++ b/docs/guide/codex/daily.md
@@ -12,13 +12,16 @@ npx @ccusage/codex@latest daily
 
 ## Options
 
-| Flag                         | Description                                                    |
-| ---------------------------- | -------------------------------------------------------------- |
-| `--since` / `--until`        | Filter to a specific date range (YYYYMMDD or YYYY-MM-DD)       |
-| `--timezone`                 | Override timezone used for grouping (defaults to system)       |
-| `--json`                     | Emit structured JSON instead of a table                        |
-| `--offline` / `--no-offline` | Force cached LiteLLM pricing or enable live fetching           |
-| `--compact`                  | Force compact table layout (same columns as a narrow terminal) |
+| Flag                           | Description                                                    |
+| ------------------------------ | -------------------------------------------------------------- |
+| `--since` / `--until`          | Filter to a specific date range (YYYYMMDD or YYYY-MM-DD)       |
+| `--timezone`                   | Override timezone used for grouping (defaults to system)       |
+| `--json`                       | Emit structured JSON instead of a table                        |
+| `--offline` / `--no-offline`   | Force cached LiteLLM pricing or enable live fetching           |
+| `--speed auto\|standard\|fast` | Cost speed tier; default `auto` reads Codex `config.toml`      |
+| `--compact`                    | Force compact table layout (same columns as a narrow terminal) |
+
+With `--speed auto`, the command reads `${CODEX_HOME:-~/.codex}/config.toml` and applies fast pricing when `service_tier = "priority"` or legacy `service_tier = "fast"` is configured. Fast mode uses the model-specific LiteLLM multiplier when available and otherwise falls back to 2x pricing. Use `--speed fast` or `--speed standard` to override that config-based default.
 
 The output uses the same responsive table component as ccusage, including compact mode support and per-model token summaries.
 

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -51,6 +51,7 @@ The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to 
 - **Token deltas** – Each `event_msg` with `payload.type === "token_count"` reports cumulative totals. The CLI subtracts the previous totals to recover per-turn token usage (input, cached input, output, reasoning, total).
 - **Per-model grouping** – The `turn_context` metadata specifies the active model. We aggregate tokens per day/month and per model. Sessions lacking model metadata (seen in early September 2025 builds) are skipped.
 - **Pricing** – Rates come from LiteLLM's pricing dataset via the shared `LiteLLMPricingFetcher`. Aliases such as `gpt-5-codex` map to canonical entries (`gpt-5`) so cost calculations remain accurate.
+- **Speed pricing** – `--speed auto` is the default. It reads `${CODEX_HOME:-~/.codex}/config.toml` and applies fast pricing when Codex has `service_tier = "priority"` or legacy `service_tier = "fast"` configured. Fast mode uses the model-specific LiteLLM multiplier when available and otherwise falls back to 2x pricing. Pass `--speed fast` or `--speed standard` to override config-based detection.
 - **Legacy fallback** – Early September 2025 logs that never recorded `turn_context` metadata are still included; the CLI assumes `gpt-5` for pricing so you can review the tokens even though the model tag is missing (the JSON output also marks these rows with `"isFallback": true`).
 - **Cost formula** – Non-cached input uses the standard input price; cached input uses the cache-read price (falling back to the input price when missing); and output tokens are billed at the output price. All prices are per million tokens. Reasoning tokens may be shown for reference, but they are part of the output charge and are not billed separately.
 - **Totals and reports** – Daily, monthly, and session commands display per-model breakdowns, overall totals, and optional JSON for automation.
@@ -63,6 +64,21 @@ The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to 
 | `LOG_LEVEL`  | Adjust log verbosity (0 silent … 5 trace)                    |
 
 When Codex emits a model alias (for example `gpt-5-codex`), the CLI automatically resolves it to the canonical LiteLLM pricing entry. No manual override is needed.
+
+## Speed Pricing
+
+Codex logs usually do not include whether a turn used fast mode. By default, `@ccusage/codex` uses `--speed auto`, reads `${CODEX_HOME:-~/.codex}/config.toml`, and treats `service_tier = "priority"` or legacy `service_tier = "fast"` as fast pricing. Fast mode uses the model-specific LiteLLM multiplier when available and otherwise falls back to 2x pricing.
+
+```bash
+# Default: read Codex config.toml
+ccusage-codex daily --speed auto
+
+# Force fast pricing
+ccusage-codex daily --speed fast
+
+# Force standard pricing
+ccusage-codex daily --speed standard
+```
 
 ## Next Steps
 

--- a/docs/guide/codex/monthly.md
+++ b/docs/guide/codex/monthly.md
@@ -14,12 +14,15 @@ npx @ccusage/codex@latest monthly
 
 ## Options
 
-| Flag                         | Description                                                                 |
-| ---------------------------- | --------------------------------------------------------------------------- |
-| `--since` / `--until`        | Filter to a specific date range (YYYYMMDD or YYYY-MM-DD) before aggregating |
-| `--timezone`                 | Override the timezone used to bucket usage into months                      |
-| `--json`                     | Emit structured JSON instead of a table                                     |
-| `--offline` / `--no-offline` | Force cached LiteLLM pricing or enable live fetching                        |
-| `--compact`                  | Force compact table layout (same columns as a narrow terminal)              |
+| Flag                           | Description                                                                 |
+| ------------------------------ | --------------------------------------------------------------------------- |
+| `--since` / `--until`          | Filter to a specific date range (YYYYMMDD or YYYY-MM-DD) before aggregating |
+| `--timezone`                   | Override the timezone used to bucket usage into months                      |
+| `--json`                       | Emit structured JSON instead of a table                                     |
+| `--offline` / `--no-offline`   | Force cached LiteLLM pricing or enable live fetching                        |
+| `--speed auto\|standard\|fast` | Cost speed tier; default `auto` reads Codex `config.toml`                   |
+| `--compact`                    | Force compact table layout (same columns as a narrow terminal)              |
+
+With `--speed auto`, the command reads `${CODEX_HOME:-~/.codex}/config.toml` and applies fast pricing when `service_tier = "priority"` or legacy `service_tier = "fast"` is configured. Fast mode uses the model-specific LiteLLM multiplier when available and otherwise falls back to 2x pricing. Use `--speed fast` or `--speed standard` to override that config-based default.
 
 The output uses the same responsive table component as ccusage, including compact mode support, per-model token summaries, and a combined totals row.

--- a/docs/guide/codex/session.md
+++ b/docs/guide/codex/session.md
@@ -14,13 +14,16 @@ npx @ccusage/codex@latest session
 
 ## Options
 
-| Flag                         | Description                                                              |
-| ---------------------------- | ------------------------------------------------------------------------ |
-| `--since` / `--until`        | Filter sessions by their activity date (YYYYMMDD or YYYY-MM-DD)          |
-| `--timezone`                 | Override the timezone used for date grouping and last-activity display   |
-| `--json`                     | Emit structured JSON (`{ sessions: [], totals: {} }`) instead of a table |
-| `--offline` / `--no-offline` | Force cached LiteLLM pricing or enable live fetching                     |
-| `--compact`                  | Force compact table layout (same columns as a narrow terminal)           |
+| Flag                           | Description                                                              |
+| ------------------------------ | ------------------------------------------------------------------------ |
+| `--since` / `--until`          | Filter sessions by their activity date (YYYYMMDD or YYYY-MM-DD)          |
+| `--timezone`                   | Override the timezone used for date grouping and last-activity display   |
+| `--json`                       | Emit structured JSON (`{ sessions: [], totals: {} }`) instead of a table |
+| `--offline` / `--no-offline`   | Force cached LiteLLM pricing or enable live fetching                     |
+| `--speed auto\|standard\|fast` | Cost speed tier; default `auto` reads Codex `config.toml`                |
+| `--compact`                    | Force compact table layout (same columns as a narrow terminal)           |
+
+With `--speed auto`, the command reads `${CODEX_HOME:-~/.codex}/config.toml` and applies fast pricing when `service_tier = "priority"` or legacy `service_tier = "fast"` is configured. Fast mode uses the model-specific LiteLLM multiplier when available and otherwise falls back to 2x pricing. Use `--speed fast` or `--speed standard` to override that config-based default.
 
 JSON output includes a `sessions` array with per-model breakdowns, cached token counts, `lastActivity`, and `isFallback` flags for any events that required the legacy `gpt-5` pricing fallback.
 


### PR DESCRIPTION
Summary:
- Adds --speed auto|standard|fast to Codex daily, monthly, and session reports.
- Defaults auto mode to reading CODEX_HOME config.toml and treating service_tier priority or legacy fast as fast pricing.
- Applies LiteLLM fast multipliers when present, with a Codex 2x fallback when pricing data lacks one.
- Documents the new speed pricing behavior in the Codex README and guide pages.

Testing:
- pnpm run format
- pnpm typecheck
- pnpm run test
- Manual fixture: CODEX_HOME config.toml service_tier=priority produced auto cost 31.5 vs standard cost 15.75


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--speed` CLI option (auto|standard|fast) to daily, monthly, and session commands for pricing tier control
  * Implemented speed pricing that automatically applies fast pricing based on configuration when `--speed auto` is used

* **Documentation**
  * Updated command documentation with new `--speed` option details and behavior
  * Added speed pricing guide explaining auto/fast/standard tier configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/996)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->