### PR TITLE
chore: sync .claude/skills into .agents/skills via symlinks

### DIFF
--- a/.agents/skills/byethrow
+++ b/.agents/skills/byethrow
@@ -1,0 +1,1 @@
+../../.claude/skills/byethrow

--- a/.agents/skills/use-gunshi-cli
+++ b/.agents/skills/use-gunshi-cli
@@ -1,0 +1,1 @@
+../../.claude/skills/use-gunshi-cli

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,4 @@
 #!/bin/sh
 
-# Sync .claude/skills -> .agents/skills symlinks
-bun scripts/sync-skills.ts
-git add .agents/skills
-
 # Run lint-staged
 npx --no-install lint-staged

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,8 @@
 #!/bin/sh
 
+# Sync .claude/skills -> .agents/skills symlinks
+bun scripts/sync-skills.ts
+git add .agents/skills
+
 # Run lint-staged
 npx --no-install lint-staged

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"*": [
 			"pnpm run format",
 			"pnpm vitest run --changed"
-		]
+		],
+		".claude/skills/**": "sh -c 'pnpm run sync:skills && git add .agents/skills'"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
 		"prerelease": "pnpm run --filter '*' prerelease",
 		"release": "pnpm bumpp -r",
 		"postrelease": "git checkout ./**/package.json package.json",
+		"sync:skills": "bun scripts/sync-skills.ts",
+		"sync:skills:check": "bun scripts/sync-skills.ts --check",
 		"test": "TZ=UTC vitest run",
 		"typecheck": "pnpm run --filter '*' typecheck"
 	},

--- a/scripts/sync-skills.ts
+++ b/scripts/sync-skills.ts
@@ -1,0 +1,103 @@
+import { lstat, mkdir, readdir, readlink, rm, symlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import process from 'node:process';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const checkMode = process.argv.includes('--check');
+
+let hasErrors = false;
+
+const CLAUDE_SKILLS = join(ROOT, '.claude', 'skills');
+const SKILL_TARGETS = [{ dir: join(ROOT, '.agents', 'skills'), label: '.agents/skills' }];
+
+const claudeSkillDirs = await readdir(CLAUDE_SKILLS);
+
+const expectedTarget = (name: string) => `../../.claude/skills/${name}`;
+
+for (const { dir, label } of SKILL_TARGETS) {
+	if (!checkMode) {
+		await mkdir(dir, { recursive: true });
+	}
+	const entries = await readdir(dir).catch(() => [] as string[]);
+
+	const linkedSkills = await Promise.all(
+		claudeSkillDirs.map(async (name) => {
+			const s = await lstat(join(CLAUDE_SKILLS, name));
+			if (!s.isDirectory()) {
+				return null;
+			}
+
+			const dst = join(dir, name);
+
+			if (checkMode) {
+				try {
+					const existing = await lstat(dst);
+					if (!existing.isSymbolicLink()) {
+						console.error(`❌ Skill not a symlink: ${label}/${name}`);
+						hasErrors = true;
+						return null;
+					}
+					const target = await readlink(dst);
+					if (target !== expectedTarget(name)) {
+						console.error(`❌ Skill symlink incorrect: ${label}/${name}`);
+						hasErrors = true;
+						return null;
+					}
+					return name;
+				} catch {
+					console.error(`❌ Skill missing: ${label}/${name}`);
+					hasErrors = true;
+					return null;
+				}
+			} else {
+				try {
+					const existing = await lstat(dst);
+					if (existing.isSymbolicLink()) {
+						const target = await readlink(dst);
+						if (target === expectedTarget(name)) {
+							return name;
+						}
+					}
+					await rm(dst, { recursive: true, force: true });
+				} catch {
+					// doesn't exist
+				}
+
+				await symlink(expectedTarget(name), dst);
+				return name;
+			}
+		}),
+	);
+
+	const validSkills = linkedSkills.filter((n): n is string => n !== null);
+	const expectedSkillNames = new Set(validSkills);
+	const skillOrphans = entries.filter((name) => !expectedSkillNames.has(name));
+
+	if (!checkMode) {
+		await Promise.all(
+			skillOrphans.map(async (name) => {
+				await rm(join(dir, name), { recursive: true, force: true });
+				console.log(`Removed orphan skill: ${label}/${name}`);
+			}),
+		);
+	}
+
+	if (skillOrphans.length > 0 && checkMode) {
+		skillOrphans.forEach((name) => {
+			console.error(`❌ Orphan skill: ${label}/${name}`);
+		});
+		hasErrors = true;
+	}
+
+	if (!checkMode) {
+		console.log(`Synced ${validSkills.length} skills: .claude/skills/ -> ${label}/ (symlinks)`);
+	}
+}
+
+if (checkMode && hasErrors) {
+	console.error('\n❌ Skills are not in sync!');
+	console.error('Run: bun scripts/sync-skills.ts');
+	process.exit(1);
+} else if (checkMode) {
+	console.log('✅ Skills are in sync!');
+}


### PR DESCRIPTION
## Summary

Mirror each subdirectory under `.claude/skills/` into `.agents/skills/` as a symlink so other agent tools (codex, cursor, etc.) can consume the same skill definitions without duplicating content. Adapted from the [rorkai `sync-rules` script](https://github.com/rorkai/rorkai/blob/main/scripts/sync-rules.ts).

## What changed

- Add `scripts/sync-skills.ts` (sync + `--check` mode + orphan cleanup)
- Add `sync:skills` and `sync:skills:check` scripts to root `package.json`
- Wire `bun scripts/sync-skills.ts` into `.githooks/pre-commit` so the symlinks stay in sync automatically
- `.claude/skills/` remains the source of truth; `.agents/skills/{byethrow,use-gunshi-cli}` are now symlinks pointing back to `../../.claude/skills/*`

## Test plan

- [x] `bun scripts/sync-skills.ts` creates expected symlinks
- [x] `bun scripts/sync-skills.ts --check` reports `✅ Skills are in sync!`
- [x] pre-commit hook runs sync and `lint-staged` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new skills (`byethrow` and `use-gunshi-cli`) expanding platform capabilities

* **Chores**
  * Implemented skill synchronization infrastructure with built-in validation
  * Added npm scripts (`sync:skills`, `sync:skills:check`) for automated skill management and integrity verification
  * Integrated automated skill syncing into the development workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/998)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->