### PR TITLE
docs: add Bun CPU profiling skill

### DIFF
--- a/.agents/skills/bun-cpu-profile
+++ b/.agents/skills/bun-cpu-profile
@@ -1,0 +1,1 @@
+../../.claude/skills/bun-cpu-profile

--- a/.claude/skills/bun-cpu-profile/SKILL.md
+++ b/.claude/skills/bun-cpu-profile/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: bun-cpu-profile
+description: Debug Bun CPU performance for TypeScript/JavaScript CLIs and scripts with Bun CPU profiles, markdown profiles, hyperfine comparisons, and git worktree A/B runs. Use when investigating slow Bun execution, validating performance optimizations, comparing a branch against main, or interpreting .cpuprofile / --cpu-prof-md output.
+---
+
+# Bun CPU Profile
+
+## Workflow
+
+Use Bun's markdown CPU profile first because it is grep-friendly and compact enough for agent analysis. Generate `.cpuprofile` as well when a flamegraph or Chrome DevTools / VS Code inspection is useful.
+
+```sh
+bun --cpu-prof --cpu-prof-md --cpu-prof-dir ./profiles --cpu-prof-name ccusage.cpuprofile ./src/index.ts daily --offline --json
+```
+
+For package scripts, inject profiler flags without rewriting the command:
+
+```sh
+BUN_OPTIONS="--cpu-prof --cpu-prof-md --cpu-prof-dir ./profiles" pnpm --filter ccusage run start daily --offline --json
+```
+
+Keep benchmark runs quiet and deterministic:
+
+```sh
+LOG_LEVEL=0 COLUMNS=200 bun --cpu-prof-md ./src/index.ts daily --offline --json >/tmp/ccusage.json
+jq -e . /tmp/ccusage.json >/dev/null
+```
+
+## ccusage A/B Setup
+
+For branch-vs-main performance work, create a separate worktree so both versions can be built and profiled without switching the active checkout.
+
+```sh
+git fetch origin main
+git worktree add /tmp/ccusage-main origin/main
+pnpm install
+pnpm --filter ccusage build
+cd /tmp/ccusage-main
+pnpm install
+pnpm --filter ccusage build
+```
+
+Run the same command against both builds. Prefer the published Bun entry shape when profiling bundled CLI performance.
+
+```sh
+LOG_LEVEL=0 COLUMNS=200 bun -b apps/ccusage/dist/index.js daily --offline --json >/tmp/head.json
+LOG_LEVEL=0 COLUMNS=200 bun -b /tmp/ccusage-main/apps/ccusage/dist/index.js daily --offline --json >/tmp/main.json
+jq -e . /tmp/head.json >/dev/null
+jq -e . /tmp/main.json >/dev/null
+```
+
+Measure end-to-end command latency with hyperfine before trusting a CPU profile change:
+
+```sh
+hyperfine --warmup 4 --runs 10 --shell none \
+	"bun -b apps/ccusage/dist/index.js daily --offline --json" \
+	"bun -b /tmp/ccusage-main/apps/ccusage/dist/index.js daily --offline --json" \
+	--export-json /tmp/ccusage-hyperfine.json
+```
+
+If `hyperfine` is missing, use comma first:
+
+```sh
+, hyperfine --warmup 4 --runs 10 --shell none "bun -b apps/ccusage/dist/index.js daily --offline --json"
+```
+
+## Reading Profiles
+
+Read `*.cpuprofile.md` before opening the full JSON profile. Look for:
+
+- Hot self-time frames in application code, not only total-time parents.
+- Native frames such as `Map#set`, `JSON.parse`, `Intl.DateTimeFormat`, string slicing, array construction, stdout writes, and worker message serialization.
+- Whether the hot frame is in parsing, merging, aggregation, rendering, or process startup.
+- Whether worker-thread changes moved cost from parsing into post-worker merge.
+- Whether an apparent hotspot matters to end-to-end hyperfine results.
+
+Use `rg` on markdown profiles to connect frames to source:
+
+```sh
+rg -n "Map#set|JSON.parse|Intl|postMessage|write|data-loader|table" profiles/*.md
+```
+
+For `.cpuprofile`, open Chrome DevTools Performance tab or VS Code's CPU profiler and inspect both bottom-up self time and call tree context.
+
+## Bun References
+
+Use Bun's local agent-readable docs before web docs. In this repo, the useful Bun docs live in `node_modules/bun-types`.
+
+Read this first for profiling flags and benchmarking guidance:
+
+```sh
+sed -n '1,280p' node_modules/bun-types/docs/project/benchmarking.mdx
+```
+
+Use the type files for runtime APIs used in this repo, such as `Bun.$`, `Bun.file()`, `Bun.write()`, `Bun.spawn()`, `Bun.argv`, `Bun.deepEquals()`, `Bun.file().writer()`, `Bun.stdout`, `Bun.stderr`, and `Bun.stringWidth()`:
+
+```sh
+rg -n "cpu-prof|cpu-prof-md|Bun\\.\\$|function file|function write|function spawn|argv|deepEquals|stringWidth" \
+	node_modules/bun-types
+```
+
+Relevant local docs are usually under:
+
+- `node_modules/bun-types/README.md`
+- `node_modules/.pnpm/bun-types*/node_modules/bun-types/docs/project/benchmarking.mdx`
+- `node_modules/.pnpm/bun-types*/node_modules/bun-types/bun.d.ts`
+
+If local docs are unavailable, use Bun's benchmarking docs: `https://bun.com/docs/project/benchmarking`.
+
+## ccusage Lessons
+
+Past ccusage performance work found wins by profiling the real bundled CLI on real Claude logs, then validating with hyperfine and JSON parity. Useful patterns:
+
+- Replace hot exact-key `Map` indexes with null-prototype object indexes only when keys are plain strings and inherited keys are covered.
+- Avoid adopting a profile-inspired prototype unless hyperfine shows an end-to-end win.
+- Keep rejected experiments documented in commit messages when they explain why a tempting profile hotspot was not changed.
+- Always verify output parity for `daily`, `session`, `monthly`, `weekly`, and `blocks` JSON when changing aggregation order.
+- Pipe large JSON output through `jq -e .` because Bun CLIs can expose stdout flushing bugs under benchmark-style piping.
+
+## Microbenchmarks
+
+Use microbenchmarks for isolated language/runtime questions, not as proof of CLI wins. Prefer `mitata` for JavaScript microbenchmarks. Confirm any microbenchmark-driven change with the full CLI profile and hyperfine A/B run.

--- a/.claude/skills/bun-cpu-profile/agents/openai.yaml
+++ b/.claude/skills/bun-cpu-profile/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: Bun CPU Profile
+  short_description: Profile Bun CPU performance and inspect hot paths.
+  default_prompt: Use Bun CPU profiling to debug a slow command.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,12 @@ docs: comprehensive API documentation update
 - File paths always use Node.js path utilities for cross-platform compatibility
 - **Import conventions**: Use `.ts` extensions for local file imports (e.g., `import { foo } from './utils.ts'`)
 
+**Bun API References:**
+
+- Bun runtime API documentation and type references are available locally in `node_modules/bun-types/`
+- Start with `node_modules/bun-types/README.md` and the relevant docs under `node_modules/bun-types/docs/`
+- Use `rg` against `node_modules/bun-types/` when checking Bun APIs used in this repo, especially `Bun.$`, `Bun.file()`, `Bun.write()`, `Bun.spawn()`, `Bun.argv`, `Bun.deepEquals()`, `Bun.file().writer()`, `Bun.stdout`, `Bun.stderr`, and `Bun.stringWidth()`
+
 **Error Handling:**
 
 - **Prefer @praha/byethrow Result type** over traditional try-catch for functional error handling


### PR DESCRIPTION
Adds a Bun CPU profiling skill under .claude/skills and syncs the corresponding .agents symlink. The skill documents markdown CPU profiles, worktree-based comparisons against main, hyperfine validation, and ccusage-specific lessons from recent performance work.\n\nAlso records that Bun API docs and type references are available locally in node_modules/bun-types, with examples limited to Bun APIs already used in this repository.\n\nValidation: Bun.YAML.parse verified the skill frontmatter; lefthook ran during commit and push.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable Bun CPU profiling skill for `ccusage`, with clear steps for markdown CPU profiles, A/B worktrees, and `hyperfine` validation. Also notes that local Bun API/type references live under `node_modules/bun-types` and links them in `CLAUDE.md`.

- **New Features**
  - Added `.claude/skills/bun-cpu-profile` with `SKILL.md` and agent config; synced symlink in `.agents/skills/bun-cpu-profile`.
  - Documents `--cpu-prof`/`--cpu-prof-md`, reading `*.cpuprofile.md`, `git worktree` A/B against `main`, and `rg` search tips; includes `ccusage` lessons and microbenchmark guidance.
  - Updated `CLAUDE.md` to point to local Bun docs/types in `node_modules/bun-types` and list common APIs (`Bun.$`, `Bun.file()`, `Bun.write()`, `Bun.spawn()`, `Bun.argv`, `Bun.deepEquals()`, `Bun.stdout`, `Bun.stderr`, `Bun.stringWidth()`).

<sup>Written for commit d44ab046ec1b751170a23df1eda7115fb7fea902. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1001?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CPU profiling workflow documentation for Bun performance investigations, including benchmarking and comparison guidance.
  * Added Bun API reference guidance for contributors working with Bun functionality.

* **Chores**
  * Added Bun CPU profiling skill configuration for development tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1001)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->