### PR TITLE
fix(ccusage): stabilize loading progress

### DIFF
--- a/apps/ccusage/src/commands/all.ts
+++ b/apps/ccusage/src/commands/all.ts
@@ -380,6 +380,8 @@ type AllLoadProgress = {
 	stop: () => void;
 };
 
+type AllLoadProgressState = 'loading' | 'succeeded' | 'failed';
+
 type CodexModelUsage = {
 	inputTokens: number;
 	cachedInputTokens: number;
@@ -781,38 +783,54 @@ function shouldShowAllLoadProgress(options: AllOptions): boolean {
 	return options.json !== true && process.stdout.isTTY === true;
 }
 
-function formatRowCount(rows: number): string {
-	return `${rows} ${rows === 1 ? 'row' : 'rows'}`;
+function formatAllLoadProgressText(states: ReadonlyMap<AgentId, AllLoadProgressState>): string {
+	if (states.size === 0) {
+		return 'Loading usage logs';
+	}
+	const completed = Array.from(states.values()).filter((state) => state !== 'loading').length;
+	const loadingAgents = Array.from(states.entries())
+		.filter(([, state]) => state === 'loading')
+		.map(([agent]) => agentLabels[agent])
+		.join(', ');
+	const suffix = loadingAgents === '' ? '' : ` :: ${loadingAgents}`;
+	return `Loading usage logs (${completed}/${states.size})${suffix}`;
 }
 
 function createAllLoadProgress(enabled: boolean): AllLoadProgress | undefined {
 	if (!enabled) {
 		return undefined;
 	}
-	const spinners = new Map<AgentId, Spinner>();
+	let spinner: Spinner | undefined;
+	const states = new Map<AgentId, AllLoadProgressState>();
+
+	function refresh(): void {
+		spinner?.setText(formatAllLoadProgressText(states));
+	}
+
 	return {
 		start(agent) {
-			const spinner = new Spinner(`${agentLabels[agent]} :: loading usage logs`);
-			spinners.set(agent, spinner);
-			spinner.start();
+			states.set(agent, 'loading');
+			if (spinner == null) {
+				spinner = new Spinner(formatAllLoadProgressText(states));
+				spinner.start();
+				return;
+			}
+			refresh();
 		},
-		succeed(agent, rows) {
-			const spinner = spinners.get(agent);
-			spinner?.succeed(`${agentLabels[agent]} :: ${formatRowCount(rows)}`);
+		succeed(agent) {
+			states.set(agent, 'succeeded');
+			refresh();
 		},
-		fail(agent, error) {
-			const spinner = spinners.get(agent);
-			spinner?.fail(
-				`${agentLabels[agent]} :: ${error instanceof Error ? error.message : String(error)}`,
-			);
+		fail(agent) {
+			states.set(agent, 'failed');
+			refresh();
 		},
 		stop() {
-			for (const spinner of spinners.values()) {
-				if (spinner.running) {
-					spinner.stop();
-				}
+			if (spinner?.running === true) {
+				spinner.stop();
 			}
-			spinners.clear();
+			spinner = undefined;
+			states.clear();
 		},
 	};
 }
@@ -835,13 +853,20 @@ async function runAllReport(kind: ReportKind, options: AllOptions): Promise<void
 
 	let rows: AllRow[];
 	const progress = createAllLoadProgress(shouldShowAllLoadProgress(options));
+	const originalLoggerLevel = logger.level;
 	try {
+		if (progress != null) {
+			logger.level = 0;
+		}
 		rows = await loadAllRows(kind, options, detectedAgents, progress);
 	} catch (error) {
 		progress?.stop();
+		logger.level = originalLoggerLevel;
 		logger.error(String(error));
 		process.exitCode = 1;
 		return;
+	} finally {
+		logger.level = originalLoggerLevel;
 	}
 	progress?.stop();
 
@@ -1040,6 +1065,31 @@ if (import.meta.vitest != null) {
 			Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: false });
 
 			expect(shouldShowAllLoadProgress({ json: false })).toBe(false);
+		});
+	});
+
+	describe('formatAllLoadProgressText', () => {
+		it('renders a single-line progress message for active agent loads', () => {
+			expect(
+				formatAllLoadProgressText(
+					new Map<AgentId, AllLoadProgressState>([
+						['claude', 'succeeded'],
+						['codex', 'loading'],
+						['opencode', 'loading'],
+					]),
+				),
+			).toBe('Loading usage logs (1/3) :: Codex, OpenCode');
+		});
+
+		it('omits active labels once every load has completed', () => {
+			expect(
+				formatAllLoadProgressText(
+					new Map<AgentId, AllLoadProgressState>([
+						['claude', 'succeeded'],
+						['codex', 'failed'],
+					]),
+				),
+			).toBe('Loading usage logs (2/2)');
 		});
 	});
 }

--- a/apps/ccusage/src/commands/all.ts
+++ b/apps/ccusage/src/commands/all.ts
@@ -836,6 +836,7 @@ function createAllLoadProgress(enabled: boolean): AllLoadProgress | undefined {
 }
 
 async function runAllReport(kind: ReportKind, options: AllOptions): Promise<void> {
+	const originalLoggerLevel = logger.level;
 	if (options.json === true) {
 		logger.level = 0;
 	}
@@ -853,7 +854,6 @@ async function runAllReport(kind: ReportKind, options: AllOptions): Promise<void
 
 	let rows: AllRow[];
 	const progress = createAllLoadProgress(shouldShowAllLoadProgress(options));
-	const originalLoggerLevel = logger.level;
 	try {
 		if (progress != null) {
 			logger.level = 0;


### PR DESCRIPTION
## Summary

- Replace per-agent loading spinners in the all-agent report with one shared progress spinner.
- Suppress ccusage logger output while the TTY loading spinner is active so pricing fetch logs do not corrupt the loading display.
- Keep JSON and non-TTY output behavior unchanged.

## Validation

- \`pnpm run format\`
- \`pnpm typecheck\`
- \`pnpm run test\`
- \`pnpm --filter ccusage build\`
- cmux verification on \`workspace:3\` / \`surface:31\`: ran \`node apps/ccusage/dist/index.js\`; loading rendered as a single progress line and completed into the report without persisted loading/pricing-log artifacts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the `ccusage` all-agent loading display by replacing per-agent spinners with a single progress line and silencing logs while it runs. Prevents duplicated or corrupted lines in TTY (e.g., cmux); JSON and non‑TTY behavior is unchanged.

- **Bug Fixes**
  - Use one shared spinner that shows overall progress (X/Y) and currently loading agents.
  - Temporarily mute the `ccusage` logger while the spinner is active; always restore the original level after the run, including when JSON mode silences output.

<sup>Written for commit 302ccbbf10fa7e206175899a0d215a6c24def849. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1002?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified progress display to a single consolidated spinner showing aggregate load progress.

* **Bug Fixes**
  * Improved error handling during agent loading with proper exit code setting and ensured logger level is restored after operations.
  * Progress stops correctly on failure.

* **Tests**
  * Added unit tests covering aggregated progress text and completion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1002?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->