### PR TITLE
fix(ccusage): require Node 22 for Node runtime

### DIFF
--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -38,7 +38,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=23.0.0"
+		"node": ">=22.0.0"
 	},
 	"scripts": {
 		"bench": "node scripts/bench.mjs",

--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -38,7 +38,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=22.0.0"
+		"node": ">=23.0.0"
 	},
 	"scripts": {
 		"bench": "node scripts/bench.mjs",

--- a/apps/ccusage/src/cli.ts
+++ b/apps/ccusage/src/cli.ts
@@ -88,12 +88,15 @@ function getUnsupportedNodeRuntimeMessage(nodeVersion = process.version): string
 	return `ccusage requires Bun or Node.js >=${MIN_NODE_MAJOR_VERSION}.0.0. Current Node.js: ${nodeVersion}\n`;
 }
 
+async function runBunMain(): Promise<void> {
+	await import('./main.bun.ts');
+}
+
 function resolveCliRuntime({
 	argv,
 	bunAutoRunValue = process.env[CCUSAGE_BUN_AUTO_RUN_ENV],
 	distDir,
 	findBunPath = () => findExecutableInPath('bun'),
-	isBunRuntime = isBun(),
 	nodeVersion = process.version,
 	processExecPath = process.execPath,
 }: {
@@ -101,16 +104,11 @@ function resolveCliRuntime({
 	bunAutoRunValue?: string;
 	distDir: string;
 	findBunPath?: () => string | undefined;
-	isBunRuntime?: boolean;
 	nodeVersion?: string;
 	processExecPath?: string;
 }): CliRuntime {
 	const bunPath =
-		bunAutoRunValue !== CCUSAGE_BUN_AUTO_RUN_DISABLED_VALUE
-			? isBunRuntime
-				? processExecPath
-				: findBunPath()
-			: undefined;
+		bunAutoRunValue !== CCUSAGE_BUN_AUTO_RUN_DISABLED_VALUE ? findBunPath() : undefined;
 	if (bunPath != null) {
 		return {
 			args: [join(distDir, 'main.bun.js'), ...argv],
@@ -129,7 +127,21 @@ function resolveCliRuntime({
 	};
 }
 
-async function runCli(argv: string[]): Promise<number> {
+async function runCli(
+	argv: string[],
+	{
+		isBunRuntime = isBun(),
+		runBun = runBunMain,
+	}: {
+		isBunRuntime?: boolean;
+		runBun?: () => Promise<void>;
+	} = {},
+): Promise<number> {
+	if (isBunRuntime) {
+		await runBun();
+		return 0;
+	}
+
 	const distDir = dirname(fileURLToPath(import.meta.url));
 	const runtime = resolveCliRuntime({ argv, distDir });
 	if ('errorMessage' in runtime) {
@@ -166,7 +178,6 @@ if (import.meta.vitest != null) {
 					argv: ['daily'],
 					distDir: '/app/dist',
 					findBunPath: () => '/usr/local/bin/bun',
-					isBunRuntime: false,
 					nodeVersion: 'v22.13.1',
 					processExecPath: '/usr/bin/node',
 				}),
@@ -176,37 +187,28 @@ if (import.meta.vitest != null) {
 			});
 		});
 
-		it('skips PATH lookup and Node.js checks when running under Bun', () => {
-			expect(
-				resolveCliRuntime({
-					argv: ['daily'],
-					distDir: '/app/dist',
-					findBunPath: () => {
-						throw new Error('should not scan PATH');
-					},
-					isBunRuntime: true,
-					nodeVersion: 'v21.7.3',
-					processExecPath: '/usr/local/bin/bun',
-				}),
-			).toEqual({
-				args: ['/app/dist/main.bun.js', 'daily'],
-				command: '/usr/local/bin/bun',
-			});
-		});
-
-		it('rejects Node.js 21 when Bun is unavailable', () => {
+		it('rejects Node.js 20 when Bun is unavailable', () => {
 			expect(
 				resolveCliRuntime({
 					argv: ['daily'],
 					distDir: '/app/dist',
 					findBunPath: () => undefined,
-					isBunRuntime: false,
-					nodeVersion: 'v21.7.3',
+					nodeVersion: 'v20.19.0',
 					processExecPath: '/usr/bin/node',
 				}),
 			).toEqual({
-				errorMessage: 'ccusage requires Bun or Node.js >=22.0.0. Current Node.js: v21.7.3\n',
+				errorMessage: 'ccusage requires Bun or Node.js >=22.0.0. Current Node.js: v20.19.0\n',
 			});
+		});
+	});
+
+	describe('runCli', () => {
+		it('imports the Bun entrypoint directly under Bun', async () => {
+			const runBun = vi.fn(async () => {});
+
+			await expect(runCli(['daily'], { isBunRuntime: true, runBun })).resolves.toBe(0);
+
+			expect(runBun).toHaveBeenCalledOnce();
 		});
 	});
 

--- a/apps/ccusage/src/cli.ts
+++ b/apps/ccusage/src/cli.ts
@@ -69,6 +69,10 @@ function findExecutableInPath(
 	return undefined;
 }
 
+function isBun(): boolean {
+	return (globalThis as { Bun?: unknown }).Bun != null;
+}
+
 function getNodeMajorVersion(version = process.version): number | undefined {
 	const [majorVersion] = version.replace(/^v/, '').split('.');
 	const major = Number(majorVersion);
@@ -89,7 +93,7 @@ function resolveCliRuntime({
 	bunAutoRunValue = process.env[CCUSAGE_BUN_AUTO_RUN_ENV],
 	distDir,
 	findBunPath = () => findExecutableInPath('bun'),
-	isRunningInBun = process.versions.bun != null,
+	isBunRuntime = isBun(),
 	nodeVersion = process.version,
 	processExecPath = process.execPath,
 }: {
@@ -97,13 +101,13 @@ function resolveCliRuntime({
 	bunAutoRunValue?: string;
 	distDir: string;
 	findBunPath?: () => string | undefined;
-	isRunningInBun?: boolean;
+	isBunRuntime?: boolean;
 	nodeVersion?: string;
 	processExecPath?: string;
 }): CliRuntime {
 	const bunPath =
 		bunAutoRunValue !== CCUSAGE_BUN_AUTO_RUN_DISABLED_VALUE
-			? isRunningInBun
+			? isBunRuntime
 				? processExecPath
 				: findBunPath()
 			: undefined;
@@ -162,9 +166,27 @@ if (import.meta.vitest != null) {
 					argv: ['daily'],
 					distDir: '/app/dist',
 					findBunPath: () => '/usr/local/bin/bun',
-					isRunningInBun: false,
+					isBunRuntime: false,
 					nodeVersion: 'v22.13.1',
 					processExecPath: '/usr/bin/node',
+				}),
+			).toEqual({
+				args: ['/app/dist/main.bun.js', 'daily'],
+				command: '/usr/local/bin/bun',
+			});
+		});
+
+		it('skips PATH lookup and Node.js checks when running under Bun', () => {
+			expect(
+				resolveCliRuntime({
+					argv: ['daily'],
+					distDir: '/app/dist',
+					findBunPath: () => {
+						throw new Error('should not scan PATH');
+					},
+					isBunRuntime: true,
+					nodeVersion: 'v21.7.3',
+					processExecPath: '/usr/local/bin/bun',
 				}),
 			).toEqual({
 				args: ['/app/dist/main.bun.js', 'daily'],
@@ -178,7 +200,7 @@ if (import.meta.vitest != null) {
 					argv: ['daily'],
 					distDir: '/app/dist',
 					findBunPath: () => undefined,
-					isRunningInBun: false,
+					isBunRuntime: false,
 					nodeVersion: 'v21.7.3',
 					processExecPath: '/usr/bin/node',
 				}),

--- a/apps/ccusage/src/cli.ts
+++ b/apps/ccusage/src/cli.ts
@@ -6,6 +6,17 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { CCUSAGE_BUN_AUTO_RUN_DISABLED_VALUE, CCUSAGE_BUN_AUTO_RUN_ENV } from './_env.ts';
 
+const MIN_NODE_MAJOR_VERSION = 23;
+
+type CliRuntime =
+	| {
+			args: string[];
+			command: string;
+	  }
+	| {
+			errorMessage: string;
+	  };
+
 function getExecutableNames(
 	command: string,
 	platform = process.platform,
@@ -58,20 +69,71 @@ function findExecutableInPath(
 	return undefined;
 }
 
+function getNodeMajorVersion(version = process.version): number | undefined {
+	const [majorVersion] = version.replace(/^v/, '').split('.');
+	const major = Number(majorVersion);
+	return Number.isInteger(major) ? major : undefined;
+}
+
+function getUnsupportedNodeRuntimeMessage(nodeVersion = process.version): string | undefined {
+	const nodeMajorVersion = getNodeMajorVersion(nodeVersion);
+	if (nodeMajorVersion == null || nodeMajorVersion >= MIN_NODE_MAJOR_VERSION) {
+		return undefined;
+	}
+
+	return `ccusage requires Bun or Node.js >=${MIN_NODE_MAJOR_VERSION}.0.0. Current Node.js: ${nodeVersion}\n`;
+}
+
+function resolveCliRuntime({
+	argv,
+	bunAutoRunValue = process.env[CCUSAGE_BUN_AUTO_RUN_ENV],
+	distDir,
+	findBunPath = () => findExecutableInPath('bun'),
+	isRunningInBun = process.versions.bun != null,
+	nodeVersion = process.version,
+	processExecPath = process.execPath,
+}: {
+	argv: string[];
+	bunAutoRunValue?: string;
+	distDir: string;
+	findBunPath?: () => string | undefined;
+	isRunningInBun?: boolean;
+	nodeVersion?: string;
+	processExecPath?: string;
+}): CliRuntime {
+	const bunPath =
+		bunAutoRunValue !== CCUSAGE_BUN_AUTO_RUN_DISABLED_VALUE
+			? isRunningInBun
+				? processExecPath
+				: findBunPath()
+			: undefined;
+	if (bunPath != null) {
+		return {
+			args: [join(distDir, 'main.bun.js'), ...argv],
+			command: bunPath,
+		};
+	}
+
+	const errorMessage = getUnsupportedNodeRuntimeMessage(nodeVersion);
+	if (errorMessage != null) {
+		return { errorMessage };
+	}
+
+	return {
+		args: [join(distDir, 'main.node.js'), ...argv],
+		command: processExecPath,
+	};
+}
+
 async function runCli(argv: string[]): Promise<number> {
 	const distDir = dirname(fileURLToPath(import.meta.url));
-	const bunPath =
-		process.env[CCUSAGE_BUN_AUTO_RUN_ENV] !== CCUSAGE_BUN_AUTO_RUN_DISABLED_VALUE
-			? process.versions.bun == null
-				? findExecutableInPath('bun')
-				: process.execPath
-			: undefined;
-	const entryPath = join(distDir, bunPath == null ? 'main.node.js' : 'main.bun.js');
+	const runtime = resolveCliRuntime({ argv, distDir });
+	if ('errorMessage' in runtime) {
+		process.stderr.write(runtime.errorMessage);
+		return 1;
+	}
 
-	const child =
-		bunPath == null
-			? spawn(process.execPath, [entryPath, ...argv], { stdio: 'inherit' })
-			: spawn(bunPath, [entryPath, ...argv], { stdio: 'inherit' });
+	const child = spawn(runtime.command, runtime.args, { stdio: 'inherit' });
 
 	return new Promise((resolve) => {
 		child.on('error', (error) => {
@@ -93,6 +155,39 @@ if (import.meta.vitest == null) {
 }
 
 if (import.meta.vitest != null) {
+	describe('resolveCliRuntime', () => {
+		it('keeps using Bun when Node.js is unsupported but Bun is available', () => {
+			expect(
+				resolveCliRuntime({
+					argv: ['daily'],
+					distDir: '/app/dist',
+					findBunPath: () => '/usr/local/bin/bun',
+					isRunningInBun: false,
+					nodeVersion: 'v22.13.1',
+					processExecPath: '/usr/bin/node',
+				}),
+			).toEqual({
+				args: ['/app/dist/main.bun.js', 'daily'],
+				command: '/usr/local/bin/bun',
+			});
+		});
+
+		it('rejects Node.js 22 when Bun is unavailable', () => {
+			expect(
+				resolveCliRuntime({
+					argv: ['daily'],
+					distDir: '/app/dist',
+					findBunPath: () => undefined,
+					isRunningInBun: false,
+					nodeVersion: 'v22.13.1',
+					processExecPath: '/usr/bin/node',
+				}),
+			).toEqual({
+				errorMessage: 'ccusage requires Bun or Node.js >=23.0.0. Current Node.js: v22.13.1\n',
+			});
+		});
+	});
+
 	describe('findExecutableInPath', () => {
 		it('finds an executable by scanning PATH directly', () => {
 			expect(

--- a/apps/ccusage/src/cli.ts
+++ b/apps/ccusage/src/cli.ts
@@ -6,7 +6,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { CCUSAGE_BUN_AUTO_RUN_DISABLED_VALUE, CCUSAGE_BUN_AUTO_RUN_ENV } from './_env.ts';
 
-const MIN_NODE_MAJOR_VERSION = 23;
+const MIN_NODE_MAJOR_VERSION = 22;
 
 type CliRuntime =
 	| {
@@ -172,18 +172,18 @@ if (import.meta.vitest != null) {
 			});
 		});
 
-		it('rejects Node.js 22 when Bun is unavailable', () => {
+		it('rejects Node.js 21 when Bun is unavailable', () => {
 			expect(
 				resolveCliRuntime({
 					argv: ['daily'],
 					distDir: '/app/dist',
 					findBunPath: () => undefined,
 					isRunningInBun: false,
-					nodeVersion: 'v22.13.1',
+					nodeVersion: 'v21.7.3',
 					processExecPath: '/usr/bin/node',
 				}),
 			).toEqual({
-				errorMessage: 'ccusage requires Bun or Node.js >=23.0.0. Current Node.js: v22.13.1\n',
+				errorMessage: 'ccusage requires Bun or Node.js >=22.0.0. Current Node.js: v21.7.3\n',
 			});
 		});
 	});


### PR DESCRIPTION
## Summary
- detect an already-active Bun runtime from the Bun global object
- when the wrapper is already running under Bun, import the Bun entrypoint directly and skip PATH lookup, Node version checks, and re-spawning
- when launched by Node, keep the existing PATH lookup for Bun auto-run, then fall back to the Node bundle with a Node.js >=22.0.0 guard

## Testing
- pnpm --filter ccusage exec vitest run --changed HEAD
- pnpm --filter ccusage build
- pnpm run format
- pnpm typecheck
- pnpm run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now selects the best available runtime (prefers Bun when available) and supports direct execution under Bun.

* **Refactor**
  * Improved runtime initialization and clearer error handling when Node is below required version and Bun is unavailable.

* **Tests**
  * Added tests covering runtime selection and direct Bun execution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->