### PR TITLE
ci: tolerate perf comment write failures

### DIFF
--- a/.github/scripts/upsert-pr-comment.ts
+++ b/.github/scripts/upsert-pr-comment.ts
@@ -8,6 +8,16 @@ type GitHubComment = {
 	};
 };
 
+class GitHubRequestError extends Error {
+	constructor(
+		message: string,
+		readonly status: number,
+	) {
+		super(message);
+		this.name = 'GitHubRequestError';
+	}
+}
+
 function requiredEnv(name: string): string {
 	const value = Bun.env[name];
 	if (value == null || value.length === 0) {
@@ -29,8 +39,9 @@ async function githubRequest<T>(path: string, options: RequestInit = {}): Promis
 	});
 
 	if (!response.ok) {
-		throw new Error(
+		throw new GitHubRequestError(
 			`${options.method ?? 'GET'} ${path} failed: ${response.status} ${await response.text()}`,
+			response.status,
 		);
 	}
 
@@ -46,6 +57,27 @@ const prNumber = requiredEnv('PR_NUMBER');
 const marker = requiredEnv('COMMENT_MARKER');
 const body = await Bun.file(requiredEnv('COMMENT_FILE')).text();
 
+async function createComment(): Promise<void> {
+	await githubRequest(`/repos/${repository}/issues/${prNumber}/comments`, {
+		method: 'POST',
+		body: JSON.stringify({ body }),
+	});
+}
+
+async function tryCreateComment(): Promise<void> {
+	try {
+		await createComment();
+	} catch (error) {
+		if (error instanceof GitHubRequestError && error.status === 403) {
+			console.warn(
+				`Skipping PR comment because GitHub token cannot write comments: ${error.message}`,
+			);
+			return;
+		}
+		throw error;
+	}
+}
+
 const comments = await githubRequest<GitHubComment[]>(
 	`/repos/${repository}/issues/${prNumber}/comments?per_page=100`,
 );
@@ -54,13 +86,16 @@ const existing = comments.find(
 );
 
 if (existing == null) {
-	await githubRequest(`/repos/${repository}/issues/${prNumber}/comments`, {
-		method: 'POST',
-		body: JSON.stringify({ body }),
-	});
+	await tryCreateComment();
 } else {
-	await githubRequest(`/repos/${repository}/issues/comments/${existing.id}`, {
-		method: 'PATCH',
-		body: JSON.stringify({ body }),
-	});
+	try {
+		await githubRequest(`/repos/${repository}/issues/comments/${existing.id}`, {
+			method: 'PATCH',
+			body: JSON.stringify({ body }),
+		});
+	} catch (error) {
+		console.warn(`Failed to update existing PR comment; creating a new comment instead.`);
+		console.warn(error);
+		await tryCreateComment();
+	}
 }

--- a/.github/workflows/ccusage-perf.yaml
+++ b/.github/workflows/ccusage-perf.yaml
@@ -59,6 +59,9 @@ jobs:
             --large-runs 1 \
             --output "$RUNNER_TEMP/ccusage-perf-comment.md"
 
+      - name: Write job summary
+        run: cat "$RUNNER_TEMP/ccusage-perf-comment.md" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upsert PR comment
         env:
           COMMENT_FILE: ${{ runner.temp }}/ccusage-perf-comment.md


### PR DESCRIPTION
## Summary

- always write ccusage perf results to the GitHub Actions job summary
- keep PR comment publishing for normal same-repo PRs
- fall back to a fresh comment when updating the marker comment fails
- warn instead of failing when fork PR tokens cannot write comments

## Why

Fork PRs can complete the perf comparison, but their pull_request GITHUB_TOKEN may not be allowed to write issue comments. The previous workflow failed after successful measurement because comment creation returned 403.

## Validation

- pnpm run format
- pnpm typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling for GitHub API interactions with better permission failure detection
  * Enhanced PR comment creation and update flow with graceful fallback mechanisms
  * Added performance metrics visibility in GitHub Actions job summaries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->