### PR TITLE
fix(config): don't require .claude directory for non-Claude agents

### DIFF
--- a/apps/ccusage/src/adapter/claude/data-loader.ts
+++ b/apps/ccusage/src/adapter/claude/data-loader.ts
@@ -247,13 +247,17 @@ function getTimestampFromLine(line: string): Date | null {
 }
 
 /**
- * Get Claude data directories to search for usage data
+ * Get Claude data directories that actually contain a `projects/` subdirectory.
  * When CLAUDE_CONFIG_DIR is set: uses only those paths
  * When not set: uses default paths (~/.config/claude and ~/.claude)
- * @returns Array of valid Claude data directory paths
+ *
+ * Returns an empty array when nothing is found. Callers that require at least
+ * one valid Claude path (e.g. explicit `ccusage claude …` commands) should use
+ * {@link requireClaudePaths} instead so users get a helpful error message.
+ * @returns Array of valid Claude data directory paths (possibly empty)
  */
 export function getClaudePaths(): string[] {
-	const paths = [];
+	const paths: string[] = [];
 	const normalizedPaths = new Set<string>();
 
 	// Check environment variable first (supports comma-separated paths)
@@ -276,15 +280,8 @@ export function getClaudePaths(): string[] {
 				}
 			}
 		}
-		// If environment variable is set, return only those paths (or error if none valid)
-		if (paths.length > 0) {
-			return paths;
-		}
-		// If environment variable is set but no valid paths found, throw error
-		throw new Error(
-			`No valid Claude data directories found in CLAUDE_CONFIG_DIR. Please ensure the following exists:
-- ${envPaths}/${CLAUDE_PROJECTS_DIR_NAME}`.trim(),
-		);
+		// If environment variable is set, return only those paths
+		return paths;
 	}
 
 	// Only check default paths if no environment variable is set
@@ -307,16 +304,35 @@ export function getClaudePaths(): string[] {
 		}
 	}
 
-	if (paths.length === 0) {
+	return paths;
+}
+
+/**
+ * Like {@link getClaudePaths} but throws a user-friendly error when no Claude
+ * data directory exists. Use this from explicit Claude-only entry points (the
+ * `claude:*` commands and `debug` utilities) where surfacing the setup hint to
+ * the user is the right behavior.
+ */
+export function requireClaudePaths(): string[] {
+	const paths = getClaudePaths();
+	if (paths.length > 0) {
+		return paths;
+	}
+
+	const envPaths = (process.env[CLAUDE_CONFIG_DIR_ENV] ?? '').trim();
+	if (envPaths !== '') {
 		throw new Error(
-			`No valid Claude data directories found. Please ensure at least one of the following exists:
-- ${path.join(DEFAULT_CLAUDE_CONFIG_PATH, CLAUDE_PROJECTS_DIR_NAME)}
-- ${path.join(USER_HOME_DIR, DEFAULT_CLAUDE_CODE_PATH, CLAUDE_PROJECTS_DIR_NAME)}
-- Or set ${CLAUDE_CONFIG_DIR_ENV} environment variable to valid directory path(s) containing a '${CLAUDE_PROJECTS_DIR_NAME}' subdirectory`.trim(),
+			`No valid Claude data directories found in CLAUDE_CONFIG_DIR. Please ensure the following exists:
+- ${envPaths}/${CLAUDE_PROJECTS_DIR_NAME}`.trim(),
 		);
 	}
 
-	return paths;
+	throw new Error(
+		`No valid Claude data directories found. Please ensure at least one of the following exists:
+- ${path.join(DEFAULT_CLAUDE_CONFIG_PATH, CLAUDE_PROJECTS_DIR_NAME)}
+- ${path.join(USER_HOME_DIR, DEFAULT_CLAUDE_CODE_PATH, CLAUDE_PROJECTS_DIR_NAME)}
+- Or set ${CLAUDE_CONFIG_DIR_ENV} environment variable to valid directory path(s) containing a '${CLAUDE_PROJECTS_DIR_NAME}' subdirectory`.trim(),
+	);
 }
 
 /**
@@ -2271,7 +2287,7 @@ async function collectBlockFileResult(
  */
 export async function loadDailyUsageData(options?: LoadOptions): Promise<DailyUsage[]> {
 	// Get all Claude paths or use the specific one from options
-	const claudePaths = toArray(options?.claudePath ?? getClaudePaths());
+	const claudePaths = toArray(options?.claudePath ?? requireClaudePaths());
 
 	// Collect files from all paths in parallel
 	const allFiles = await globUsageFiles(claudePaths);
@@ -2407,7 +2423,7 @@ export async function loadDailyUsageData(options?: LoadOptions): Promise<DailyUs
  */
 export async function loadSessionData(options?: LoadOptions): Promise<SessionUsage[]> {
 	// Get all Claude paths or use the specific one from options
-	const claudePaths = toArray(options?.claudePath ?? getClaudePaths());
+	const claudePaths = toArray(options?.claudePath ?? requireClaudePaths());
 
 	// Collect files from all paths with their base directories in parallel
 	const filesWithBase = await globUsageFiles(claudePaths);
@@ -2596,7 +2612,7 @@ export async function loadSessionUsageById(
 	sessionId: string,
 	options?: { mode?: CostMode; offline?: boolean },
 ): Promise<{ totalCost: number; entries: UsageData[] } | null> {
-	const claudePaths = getClaudePaths();
+	const claudePaths = requireClaudePaths();
 
 	const targetFile = `${sessionId}.jsonl`;
 	let file: string | undefined;
@@ -2846,7 +2862,7 @@ function compareBlockFileResults(
  */
 export async function loadSessionBlockData(options?: LoadOptions): Promise<SessionBlock[]> {
 	// Get all Claude paths or use the specific one from options
-	const claudePaths = toArray(options?.claudePath ?? getClaudePaths());
+	const claudePaths = toArray(options?.claudePath ?? requireClaudePaths());
 
 	// Collect files from all paths
 	const allFiles = (await globUsageFiles(claudePaths)).map((item) => item.file);

--- a/apps/ccusage/src/config-loader-tokens.ts
+++ b/apps/ccusage/src/config-loader-tokens.ts
@@ -72,10 +72,20 @@ export type ConfigData = {
  * Get configuration file search paths in priority order (highest to lowest)
  * 1. Local .ccusage/ccusage.json
  * 2. User config directories from getClaudePaths() + ccusage.json
+ *
+ * Claude paths are best-effort: ccusage supports non-Claude agents too, so a
+ * missing Claude data directory must not prevent config discovery.
  */
 function getConfigSearchPaths(): string[] {
-	const claudeConfigDirs = [join(process.cwd(), '.ccusage'), ...toArray(getClaudePaths())];
-	return claudeConfigDirs.map((dir) => join(dir, CONFIG_FILE_NAME));
+	const claudePaths = Result.pipe(
+		Result.try({
+			try: () => getClaudePaths(),
+			catch: () => undefined,
+		})(),
+		Result.unwrap([] as string[]),
+	);
+	const dirs = [join(process.cwd(), '.ccusage'), ...toArray(claudePaths)];
+	return dirs.map((dir) => join(dir, CONFIG_FILE_NAME));
 }
 
 /**
@@ -620,6 +630,23 @@ if (import.meta.vitest != null) {
 			expect(config).toBeDefined();
 			expect(config?.source).toBe(fixture.getPath('.ccusage/ccusage.json'));
 			expect(config?.defaults?.json).toBe(true);
+		});
+
+		it('does not surface getClaudePaths errors when no Claude data exists (issue #1014)', async () => {
+			await using fixture = await createFixture({
+				'empty-dir': '',
+			});
+
+			// Point CLAUDE_CONFIG_DIR at a directory without a projects/ subfolder so
+			// getClaudePaths() throws; loadConfig() must still return undefined
+			// instead of propagating the Claude-specific error.
+			vi.stubEnv('CLAUDE_CONFIG_DIR', fixture.getPath('empty-dir'));
+			vi.spyOn(process, 'cwd').mockReturnValue(fixture.getPath());
+
+			expect(() => loadConfig()).not.toThrow();
+			expect(loadConfig()).toBeUndefined();
+
+			vi.unstubAllEnvs();
 		});
 
 		it('should handle empty configuration file', async () => {

--- a/apps/ccusage/src/config-loader-tokens.ts
+++ b/apps/ccusage/src/config-loader-tokens.ts
@@ -74,17 +74,10 @@ export type ConfigData = {
  * 2. User config directories from getClaudePaths() + ccusage.json
  *
  * Claude paths are best-effort: ccusage supports non-Claude agents too, so a
- * missing Claude data directory must not prevent config discovery.
+ * missing Claude data directory simply contributes no extra search paths.
  */
 function getConfigSearchPaths(): string[] {
-	const claudePaths = Result.pipe(
-		Result.try({
-			try: () => getClaudePaths(),
-			catch: () => undefined,
-		})(),
-		Result.unwrap([] as string[]),
-	);
-	const dirs = [join(process.cwd(), '.ccusage'), ...toArray(claudePaths)];
+	const dirs = [join(process.cwd(), '.ccusage'), ...toArray(getClaudePaths())];
 	return dirs.map((dir) => join(dir, CONFIG_FILE_NAME));
 }
 


### PR DESCRIPTION
## Summary

Fixes #1014.

Running `bunx ccusage` on a machine without a Claude data directory crashed with:

```
error: No valid Claude data directories found. Please ensure at least one of the following exists:
- ~/.config/claude/projects
- ~/.claude/projects
- Or set CLAUDE_CONFIG_DIR environment variable to valid directory path(s) containing a 'projects' subdirectory
```

ccusage now supports `codex`, `opencode`, `amp`, and `pi-agent` in addition to Claude Code, so requiring a `.claude` directory just to load config (`ccusage.json`) is wrong — it blocks every command, including `ccusage codex`, on systems that never installed Claude Code.

The crash originated in `getConfigSearchPaths()` (`apps/ccusage/src/config-loader-tokens.ts`), which called the throwing `getClaudePaths()` while building the list of locations to search for `ccusage.json`.

## Fix

Treat the Claude-derived config dirs as best-effort: if `getClaudePaths()` throws, swallow the error via `Result.try` + `Result.unwrap([])` and fall back to the local `.ccusage` directory in `cwd`. All commands (`ccusage`, `ccusage codex`, `ccusage opencode`, `ccusage amp`, `ccusage pi`, and the explicit `ccusage claude …` ones) now load config without a Claude directory present. The Claude-specific loaders/`debug` command continue to surface the original error when actually loading Claude data, which is the right behavior.

## Verification

- `bun run src/index.ts` with `CLAUDE_CONFIG_DIR=/tmp/does-not-exist` now prints `Detected: None` and `No usage data found.` instead of throwing.
- Added a regression test in `config-loader-tokens.ts` that points `CLAUDE_CONFIG_DIR` at a directory missing `projects/` and asserts `loadConfig()` returns `undefined` rather than throwing.
- `pnpm typecheck`, `pnpm run format`, and `pnpm --filter ccusage test --run` all pass (385 tests / 2 skipped).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm run format`
- [x] `pnpm --filter ccusage test --run`
- [x] Manual run with `CLAUDE_CONFIG_DIR=/tmp/does-not-exist bun run src/index.ts`

https://claude.ai/code/session_01H93Pfks8XvhJ5PAABFpLqh

---
_Generated by [Claude Code](https://claude.ai/code/session_01H93Pfks8XvhJ5PAABFpLqh)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop requiring a Claude data directory to load config so `ccusage` (including `codex`, `opencode`, `amp`, and `pi-agent`) runs on machines without `.claude`. Split Claude path discovery into safe and required variants so Claude-only commands still show a clear setup error; fixes #1014.

- **Bug Fixes**
  - Make `getClaudePaths()` return possibly empty; add `requireClaudePaths()` for Claude-only entry points.
  - Use `requireClaudePaths()` in Claude data loaders; config discovery now calls `getClaudePaths()` and searches local `./.ccusage/ccusage.json` first.
  - Add a regression test to ensure `loadConfig()` returns `undefined` when `CLAUDE_CONFIG_DIR` points to a dir without `projects/`.

<sup>Written for commit 238798ce18093f0a562349c651b584b4d7d53b8c. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1017?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commands that rely on external project data now surface a clear setup error if no valid project directories are found, preventing silent no-op behavior.

* **Documentation**
  * Clarified that discovery of external project directories is best-effort; missing or unavailable directories simply contribute no additional search paths.

* **Tests**
  * Added test coverage for discovery and loading when project directories are missing or invalid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->