### PR TITLE
fix(pricing): pick closest-length fuzzy match in LiteLLM pricing lookup

### DIFF
--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -270,12 +270,21 @@ export class LiteLLMPricingFetcher implements Disposable {
 				}
 
 				const lower = modelName.toLowerCase();
+				let bestMatch: { value: LiteLLMModelPricing; lengthDiff: number } | null = null;
 				for (const [key, value] of pricing) {
 					const comparison = key.toLowerCase();
-					if (comparison.includes(lower) || lower.includes(comparison)) {
-						this.modelPricingCache.set(modelName, value);
-						return value;
+					if (!comparison.includes(lower) && !lower.includes(comparison)) {
+						continue;
 					}
+					const lengthDiff = Math.abs(comparison.length - lower.length);
+					if (bestMatch == null || lengthDiff < bestMatch.lengthDiff) {
+						bestMatch = { value, lengthDiff };
+					}
+				}
+
+				if (bestMatch != null) {
+					this.modelPricingCache.set(modelName, bestMatch.value);
+					return bestMatch.value;
 				}
 
 				this.modelPricingCache.set(modelName, null);
@@ -695,6 +704,49 @@ if (import.meta.vitest != null) {
 			);
 
 			expect(standardCost).toBeCloseTo(noSpeedCost);
+		});
+
+		it('picks the closest-length fuzzy match instead of the first iteration match', async () => {
+			using fetcher = new LiteLLMPricingFetcher({
+				offline: true,
+				offlineLoader: async () => ({
+					'gpt-5': {
+						input_cost_per_token: 1.25e-6,
+						output_cost_per_token: 1e-5,
+					},
+					'gpt-5.4': {
+						input_cost_per_token: 2.5e-6,
+						output_cost_per_token: 1.5e-5,
+					},
+				}),
+			});
+
+			const pricing = await Result.unwrap(fetcher.getModelPricing('gpt-5.4-mini'));
+
+			expect(pricing).not.toBeNull();
+			expect(pricing?.input_cost_per_token).toBe(2.5e-6);
+			expect(pricing?.output_cost_per_token).toBe(1.5e-5);
+		});
+
+		it('prefers the closest-length key when the input is shorter than candidates', async () => {
+			using fetcher = new LiteLLMPricingFetcher({
+				offline: true,
+				offlineLoader: async () => ({
+					'gpt-5.4-mini-2026-03-05': {
+						input_cost_per_token: 1e-7,
+						output_cost_per_token: 1e-6,
+					},
+					'gpt-5.4-mini': {
+						input_cost_per_token: 2.5e-7,
+						output_cost_per_token: 2e-6,
+					},
+				}),
+			});
+
+			const pricing = await Result.unwrap(fetcher.getModelPricing('gpt-5.4'));
+
+			expect(pricing).not.toBeNull();
+			expect(pricing?.input_cost_per_token).toBe(2.5e-7);
 		});
 	});
 }


### PR DESCRIPTION
## Summary

Fixes #934.

When a model has no direct entry in the LiteLLM pricing map, `getModelPricing()` falls back to a substring-based fuzzy match. The old loop returned the **first** key whose name was a substring of (or contained) the input, in `Map` insertion order. For `gpt-5.4-mini` this matched `gpt-5` instead of `gpt-5.4`, producing a ~5x cost overcharge in the Codex adapter.

This change collects **all** substring matches and picks the candidate whose name length is closest to the input length. So `gpt-5.4-mini` now resolves to `gpt-5.4` (length diff 5) over `gpt-5` (length diff 7). The heuristic also handles the reverse direction: when the input is shorter than candidates, the closest-length key still wins.

This is the algorithmic fix suggested as option 2 in the issue. It does not require adding new prefetched entries and does not introduce a strict-mode flag.

## Changes

- `packages/internal/src/pricing.ts` — replace first-match fuzzy loop in `LiteLLMPricingFetcher.getModelPricing()` with a closest-length-difference scan.
- Two new in-source Vitest cases covering both directions of the fuzzy match.

## Test plan

- [x] `pnpm --filter @ccusage/internal test` — 58 passing
- [x] `pnpm run test` — 497 passing, 3 skipped
- [x] `pnpm typecheck` — clean
- [x] `pnpm run format` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbhLzSvvQtZVmKoWxbfGL5)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pricing lookup when a model has no direct entry by choosing the closest-length fuzzy match. This prevents cases like `gpt-5.4-mini` mapping to `gpt-5` and overcharging.

- **Bug Fixes**
  - Update `LiteLLMPricingFetcher.getModelPricing()` to scan all substring matches and select the key with the smallest length difference to the input.
  - Add two Vitest tests to cover longer-input and longer-key scenarios.

<sup>Written for commit b22019d4c5d7035c9cd4be09ec43efada3850a27. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1018?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model pricing lookup accuracy by implementing fuzzy matching for model names, which now selects the best match by similarity rather than the first partial match.

* **Tests**
  * Added test cases validating the new fuzzy matching behavior in pricing lookups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->