### PR TITLE
chore(github): approve yasunogithub contributor

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -16,4 +16,5 @@ constantins2001 pr
 lapfelix pr
 nicobailon pr
 nyatinte pr
+yasunogithub pr
 yukukotani pr


### PR DESCRIPTION
## Summary
- Add yasunogithub to the approved contributor allowlist with PR capability.

## Validation
- git diff --check
- duplicate contributor check
- pre-commit hook
- pre-push hook

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `yasunogithub` to the approved contributor allowlist in `.github/APPROVED_CONTRIBUTORS`. This lets PRs from this account stay open and bypass the contribution gate.

<sup>Written for commit 532f79d09a019674d1b7ea5cb12c40b10ed5d706. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1020?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor authorization configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1020?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->