### PR TITLE
chore(github): approve conao3 contributor

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -10,6 +10,7 @@ a-c-m pr
 adhishthite pr
 ben-vargas pr
 cobra91 pr
+conao3 pr
 # spellchecker:off
 constantins2001 pr
 # spellchecker:on


### PR DESCRIPTION
## Summary
- Add conao3 to the approved contributor allowlist with PR capability.

## Validation
- git diff --check
- duplicate contributor check
- pre-commit hook
- pre-push hook

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `conao3` to `.github/APPROVED_CONTRIBUTORS` with PR permission. This ensures their future pull requests stay open and pass the contribution gate.

<sup>Written for commit e3ca9b1f639f40cc2f57557e820399c9f089efa5. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1022?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor approval configuration to manage pull request handling permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->