### PR TITLE
docs(ai): require README audits for adapter updates

### DIFF
--- a/.agents/skills/ccusage-agent-sources/SKILL.md
+++ b/.agents/skills/ccusage-agent-sources/SKILL.md
@@ -82,6 +82,7 @@ For each migrated or new agent:
 - Add fixture-backed tests for path discovery, parser behavior, aggregation totals, and important legacy compatibility.
 - Add skipped local-data smoke tests when real user log directories are useful for catching schema drift.
 - Add or update CLI JSON assertions and table snapshots for affected report modes.
-- Add or update user-facing docs under `docs/guide/`, including VitePress navigation when a new agent guide is introduced. Use the `ccusage-docs` skill for docs conventions.
+- Audit every user-facing entrypoint that lists supported agents, commands, options, or examples. Update the root `README.md`, `apps/ccusage/README.md`, `docs/guide/`, and VitePress navigation when the adapter changes what users can run or discover. Use the `ccusage-docs` skill for docs conventions.
+- When adding a new agent guide, include README usage examples, docs guide content, related guide links, and VitePress navigation in the same change unless the user explicitly scopes documentation out.
 - Validate terminal output with `cmux-debug` when changing table layout, progress, spinners, or responsive behavior.
 - Benchmark affected agents against main or the previous tag, and record whether JSON output still matches for the comparison window.

--- a/.agents/skills/ccusage-docs/SKILL.md
+++ b/.agents/skills/ccusage-docs/SKILL.md
@@ -21,12 +21,14 @@ The docs build copies `apps/ccusage/config-schema.json` to `docs/public/config-s
 
 ## Structure
 
+- `README.md` and `apps/ccusage/README.md` - package entrypoints for supported sources, common commands, features, and installation examples
 - `docs/guide/` - user guides and tutorials
 - `docs/public/` - screenshots, static assets, and generated config schema
 - `docs/.vitepress/` - VitePress configuration and theme customization
 
 ## Content Rules
 
+- When adding or changing a user-facing agent, command, option, or report mode, audit both READMEs, relevant `docs/guide/` pages, related cross-links, and VitePress navigation before finishing.
 - Prefer the unified command form in new or edited docs: `ccusage codex ...`, `ccusage opencode ...`, `ccusage amp ...`, and `ccusage pi ...`.
 - Standalone wrapper commands such as `ccusage-codex`, `ccusage-opencode`, `ccusage-amp`, and `ccusage-pi` have been removed. Do not promote or reintroduce them in docs.
 - Place screenshots immediately after the page H1 when a guide has a primary screenshot.


### PR DESCRIPTION
Expands the agent-source adapter checklist so adapter changes audit every user-facing documentation entrypoint, including the root README, package README, docs guides, and VitePress navigation. Also updates the docs skill to treat both README files as documentation surfaces for supported sources, commands, options, and examples.\n\nValidation run:\n- pnpm run format\n- pnpm typecheck\n- pnpm run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require adapter updates to audit all user-facing docs when agents, commands, options, or examples change. Adds explicit checks for the root `README.md`, `apps/ccusage/README.md`, `docs/guide/`, cross-links, and VitePress navigation, and updates the `ccusage-docs` skill to treat both READMEs as doc entrypoints.

<sup>Written for commit 49c9f752e6f3a26c814008f40ba117d771041644. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1024?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal skill documentation guidelines to improve clarity on documentation maintenance workflows and ensure consistent updates across user-facing materials when making changes to supported features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->