### PR TITLE
docs(ai): align adapter docs audit wording

### DIFF
--- a/.agents/skills/ccusage-agent-sources/SKILL.md
+++ b/.agents/skills/ccusage-agent-sources/SKILL.md
@@ -82,7 +82,7 @@ For each migrated or new agent:
 - Add fixture-backed tests for path discovery, parser behavior, aggregation totals, and important legacy compatibility.
 - Add skipped local-data smoke tests when real user log directories are useful for catching schema drift.
 - Add or update CLI JSON assertions and table snapshots for affected report modes.
-- Audit every user-facing entrypoint that lists supported agents, commands, options, or examples. Update the root `README.md`, `apps/ccusage/README.md`, `docs/guide/`, and VitePress navigation when the adapter changes what users can run or discover. Use the `ccusage-docs` skill for docs conventions.
+- Audit every user-facing entrypoint that lists supported agents, commands, options, report modes, or examples. Update the root `README.md`, `apps/ccusage/README.md`, `docs/guide/`, and VitePress navigation when the adapter changes what users can run or discover. Use the `ccusage-docs` skill for docs conventions.
 - When adding a new agent guide, include README usage examples, docs guide content, related guide links, and VitePress navigation in the same change unless the user explicitly scopes documentation out.
 - Validate terminal output with `cmux-debug` when changing table layout, progress, spinners, or responsive behavior.
 - Benchmark affected agents against main or the previous tag, and record whether JSON output still matches for the comparison window.

--- a/.agents/skills/ccusage-docs/SKILL.md
+++ b/.agents/skills/ccusage-docs/SKILL.md
@@ -28,7 +28,7 @@ The docs build copies `apps/ccusage/config-schema.json` to `docs/public/config-s
 
 ## Content Rules
 
-- When adding or changing a user-facing agent, command, option, or report mode, audit both READMEs, relevant `docs/guide/` pages, related cross-links, and VitePress navigation before finishing.
+- When adding or changing a user-facing agent, command, option, report mode, or example, audit and update the root `README.md`, `apps/ccusage/README.md`, relevant `docs/guide/` pages, related cross-links, and VitePress navigation before finishing.
 - Prefer the unified command form in new or edited docs: `ccusage codex ...`, `ccusage opencode ...`, `ccusage amp ...`, and `ccusage pi ...`.
 - Standalone wrapper commands such as `ccusage-codex`, `ccusage-opencode`, `ccusage-amp`, and `ccusage-pi` have been removed. Do not promote or reintroduce them in docs.
 - Place screenshots immediately after the page H1 when a guide has a primary screenshot.


### PR DESCRIPTION
Follows up on #1024 by aligning the wording between the adapter-source and docs skills. The checklist now uses the same trigger set, includes report modes in the adapter skill, and makes the README requirement explicit as audit and update.\n\nValidation run:\n- pnpm run format\n- pnpm typecheck\n- pnpm run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the docs audit rules across `ccusage-agent-sources` and `ccusage-docs` skills. Both now share the same triggers; the adapter checklist includes report modes; and the docs skill explicitly says to audit and update the root README, app README, guides, cross-links, and VitePress navigation.

<sup>Written for commit 21d9a6e2eabe6fe5b49200a63b932e6b1f2b16d5. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1025?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation for report modes support in the ccusage agent
  * Enhanced checklist guidance for agent and command documentation including accessibility, screenshot placement, and navigation conventions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1025?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->