### PR TITLE
docs(ai): shorten repo skill descriptions

### DIFF
--- a/.agents/skills/bun-api-reference/SKILL.md
+++ b/.agents/skills/bun-api-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-api-reference
-description: Use local bun-types docs for Bun runtime APIs.
+description: Checks local bun-types documentation before using or changing Bun runtime APIs such as Bun.$, files, spawning, argv, stdout, stderr, and string width.
 ---
 
 # Bun API Reference

--- a/.agents/skills/bun-api-reference/SKILL.md
+++ b/.agents/skills/bun-api-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-api-reference
-description: Check local Bun runtime API documentation and types from node_modules/bun-types before using or changing Bun APIs such as Bun.$, Bun.file(), Bun.write(), Bun.spawn(), Bun.argv, Bun.deepEquals(), Bun.stdout, Bun.stderr, and Bun.stringWidth().
+description: Use local bun-types docs for Bun runtime APIs.
 ---
 
 # Bun API Reference

--- a/.agents/skills/bun-cpu-profile/SKILL.md
+++ b/.agents/skills/bun-cpu-profile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-cpu-profile
-description: Debug Bun CPU performance for TypeScript/JavaScript CLIs and scripts with Bun CPU profiles, markdown profiles, hyperfine comparisons, and git worktree A/B runs. Use when investigating slow Bun execution, validating performance optimizations, comparing a branch against main, or interpreting .cpuprofile / --cpu-prof-md output.
+description: Profile Bun CLI CPU performance and compare branch speed.
 ---
 
 # Bun CPU Profile

--- a/.agents/skills/bun-cpu-profile/SKILL.md
+++ b/.agents/skills/bun-cpu-profile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-cpu-profile
-description: Profile Bun CLI CPU performance and compare branch speed.
+description: Profiles Bun TypeScript and JavaScript CLI CPU performance. Use when debugging slow execution, reading CPU profiles, or comparing branch speed with hyperfine.
 ---
 
 # Bun CPU Profile

--- a/.agents/skills/byethrow/SKILL.md
+++ b/.agents/skills/byethrow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: byethrow
-description: Reference the byethrow documentation to understand and use the Result type library for error handling in JavaScript/TypeScript. Access detailed API references, practical usage examples, and best practice guides.
+description: Use byethrow Result APIs for TypeScript error handling.
 allowed-tools: Read, Grep, Glob
 ---
 

--- a/.agents/skills/byethrow/SKILL.md
+++ b/.agents/skills/byethrow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: byethrow
-description: Use byethrow Result APIs for TypeScript error handling.
+description: Guides use of @praha/byethrow Result APIs. Use when adding or reviewing Result-based TypeScript error handling, examples, or best practices.
 allowed-tools: Read, Grep, Glob
 ---
 

--- a/.agents/skills/ccusage-agent-sources/SKILL.md
+++ b/.agents/skills/ccusage-agent-sources/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccusage-agent-sources
-description: Implement or debug ccusage parsers and reports for Claude Code, Codex, OpenCode, Amp, and pi-agent usage data, including log locations, token field mappings, pricing rules, CLI flags, and package-specific behavior.
+description: Use for ccusage agent parsers, log paths, tokens, costs, and reports.
 ---
 
 # ccusage Agent Sources

--- a/.agents/skills/ccusage-agent-sources/SKILL.md
+++ b/.agents/skills/ccusage-agent-sources/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccusage-agent-sources
-description: Use for ccusage agent parsers, log paths, tokens, costs, and reports.
+description: Guides ccusage agent source work for Claude Code, Codex, OpenCode, Amp, and pi-agent parsers, log paths, token mappings, costs, and reports.
 ---
 
 # ccusage Agent Sources

--- a/.agents/skills/ccusage-development/SKILL.md
+++ b/.agents/skills/ccusage-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccusage-development
-description: Work in the ccusage monorepo with its unified ccusage command surface, bundled CLI packaging, pnpm commands, TypeScript style, exports, dependencies, and post-change validation workflow. Use when editing packages under apps/, packages/, docs/, or shared repository configuration.
+description: Use for ccusage monorepo commands, packaging, style, and validation.
 ---
 
 # ccusage Development

--- a/.agents/skills/ccusage-development/SKILL.md
+++ b/.agents/skills/ccusage-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccusage-development
-description: Use for ccusage monorepo commands, packaging, style, and validation.
+description: Guides ccusage monorepo development. Use when editing packages, docs, shared configuration, bundled CLI packaging, dependencies, exports, or validation commands.
 ---
 
 # ccusage Development

--- a/.agents/skills/ccusage-docs/SKILL.md
+++ b/.agents/skills/ccusage-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccusage-docs
-description: Use for ccusage VitePress docs, screenshots, accessibility, and linting.
+description: Guides ccusage VitePress documentation work. Use when editing docs, screenshots, accessibility, schema-copy behavior, markdown linting, or user-facing guides.
 ---
 
 # ccusage Docs

--- a/.agents/skills/ccusage-docs/SKILL.md
+++ b/.agents/skills/ccusage-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccusage-docs
-description: Edit the ccusage VitePress documentation with screenshot placement, accessibility, schema-copy build behavior, markdown linting, and guide organization conventions. Use when working under docs/ or adding user-facing documentation.
+description: Use for ccusage VitePress docs, screenshots, accessibility, and linting.
 ---
 
 # ccusage Docs

--- a/.agents/skills/ccusage-testing/SKILL.md
+++ b/.agents/skills/ccusage-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccusage-testing
-description: Write or update ccusage tests using in-source Vitest blocks, fs-fixture data, snapshots for CLI table output, Claude model pricing expectations, and LiteLLM compatibility. Use when adding tests, fixing test failures, or changing usage aggregation and cost behavior.
+description: Use for ccusage Vitest, fixtures, snapshots, and pricing tests.
 ---
 
 # ccusage Testing

--- a/.agents/skills/ccusage-testing/SKILL.md
+++ b/.agents/skills/ccusage-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccusage-testing
-description: Use for ccusage Vitest, fixtures, snapshots, and pricing tests.
+description: Guides ccusage tests. Use when adding or fixing in-source Vitest, fs-fixture data, CLI snapshots, Claude model pricing, or LiteLLM compatibility.
 ---
 
 # ccusage Testing

--- a/.agents/skills/cmux-debug/SKILL.md
+++ b/.agents/skills/cmux-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cmux-debug
-description: Use cmux for terminal UI output and responsive table debugging.
+description: Guides cmux terminal debugging. Use when validating CLI visual output, responsive tables, terminal geometry, long-running commands, or pane captures.
 ---
 
 # cmux Debug

--- a/.agents/skills/cmux-debug/SKILL.md
+++ b/.agents/skills/cmux-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cmux-debug
-description: Use cmux to run commands in an existing terminal surface, capture rendered output, inspect terminal geometry, and debug CLI visual regressions. Use when validating terminal UIs, responsive tables, long-running CLI commands, or pane output in cmux.
+description: Use cmux for terminal UI output and responsive table debugging.
 ---
 
 # cmux Debug

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: Create atomic Conventional Commits with clear explanatory messages.
+description: Creates atomic Conventional Commits. Use when committing code changes, splitting hunks into revertable units, or writing detailed commit messages.
 ---
 
 <!--

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: Creates atomic git commits following Conventional Commits specification with detailed, well-structured messages. Analyzes changes and splits them into logical units. Use when committing code changes that need proper structure and comprehensive documentation (e.g., "commit my authentication changes" or "finished implementing search, time to commit").
+description: Create atomic Conventional Commits with clear explanatory messages.
 ---
 
 <!--

--- a/.agents/skills/fix-ci/SKILL.md
+++ b/.agents/skills/fix-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-ci
-description: Diagnose and fix failing GitHub Actions checks with gh.
+description: Diagnoses and fixes failing GitHub Actions checks with gh. Use when CI fails on a pull request and needs logs, focused fixes, and validation.
 ---
 
 # Fix CI

--- a/.agents/skills/fix-ci/SKILL.md
+++ b/.agents/skills/fix-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-ci
-description: Diagnose and fix failing GitHub Actions CI checks for the current pull request using gh, including check inspection, failed log retrieval, focused fixes, validation, and small follow-up commits.
+description: Diagnose and fix failing GitHub Actions checks with gh.
 ---
 
 # Fix CI

--- a/.agents/skills/fs-fixture/SKILL.md
+++ b/.agents/skills/fs-fixture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fs-fixture
-description: Use fs-fixture for disposable test files and directories.
+description: Guides fs-fixture test setup. Use when tests need disposable files, directories, copied templates, symlinks, or automatic cleanup with createFixture().
 ---
 
 # fs-fixture

--- a/.agents/skills/fs-fixture/SKILL.md
+++ b/.agents/skills/fs-fixture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fs-fixture
-description: Use fs-fixture to create disposable filesystem trees for tests. Use when writing or reviewing tests that need temporary files, directories, template fixture copies, symlinks, or automatic cleanup with createFixture().
+description: Use fs-fixture for disposable test files and directories.
 ---
 
 # fs-fixture

--- a/.agents/skills/pr-ai-review-workflow/SKILL.md
+++ b/.agents/skills/pr-ai-review-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-ai-review-workflow
-description: Manage PR AI review loops and follow-up commits with gh.
+description: Manages PR AI review loops with gh. Use after opening or updating a PR to request review, inspect comments, reply, fix, and re-request review.
 ---
 
 # PR AI Review Workflow

--- a/.agents/skills/pr-ai-review-workflow/SKILL.md
+++ b/.agents/skills/pr-ai-review-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-ai-review-workflow
-description: 'Manage pull request AI review loops with GitHub CLI: request generic AI/code reviewers, wait for bot or human review, inspect comments, reply to inline review comments, apply fixes, push follow-up commits, and request re-review.'
+description: Manage PR AI review loops and follow-up commits with gh.
 ---
 
 # PR AI Review Workflow

--- a/.agents/skills/pr-ai-review-workflow/SKILL.md
+++ b/.agents/skills/pr-ai-review-workflow/SKILL.md
@@ -19,6 +19,29 @@ After creating a PR or pushing a meaningful follow-up commit, check whether revi
 
 Prefer repository-local conventions when they exist. If the repo has changed reviewers, use the current reviewer mentions from recent PRs or project docs instead of the examples above.
 
+## PR Bodies and Comments
+
+When creating or editing multi-line PR bodies, use `--body-file -` and pass the Markdown through stdin. Do not embed `\n` escape sequences inside a quoted `--body` argument; fish and shell quoting can preserve them literally and break the rendered PR body.
+
+Good:
+
+```sh
+printf "%s\n" \
+	"Summary paragraph." \
+	"" \
+	"Testing:" \
+	"- pnpm run format" \
+	"- pnpm typecheck" \
+	"- pnpm run test" \
+	| gh pr edit <pr-number> --body-file -
+```
+
+Bad:
+
+```sh
+gh pr edit <pr-number> --body "Summary\n\nTesting:\n- pnpm run test"
+```
+
 ## Wait and Inspect
 
 Poll for reviews and comments before declaring the PR ready. Use flat REST comment lists for ordinary replies, and GraphQL review threads only when thread resolution state matters.

--- a/.agents/skills/reduce-similarities/SKILL.md
+++ b/.agents/skills/reduce-similarities/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reduce-similarities
-description: Detect duplicate TypeScript/JavaScript code with similarity-ts AST analysis. Use when working with .ts/.tsx/.js/.jsx files and looking for code duplication or refactoring opportunities.
+description: Detect duplicate JS and TS code with similarity-ts.
 argument-hint: '[path] [--threshold 0.85] [--print]'
 allowed-tools: Bash(similarity-ts *) Read Grep Glob
 paths: '**/*.ts,**/*.tsx,**/*.js,**/*.jsx'

--- a/.agents/skills/reduce-similarities/SKILL.md
+++ b/.agents/skills/reduce-similarities/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reduce-similarities
-description: Detect duplicate JS and TS code with similarity-ts.
+description: Detects duplicate JavaScript and TypeScript code with similarity-ts. Use when checking .js, .jsx, .ts, or .tsx files for refactoring opportunities.
 argument-hint: '[path] [--threshold 0.85] [--print]'
 allowed-tools: Bash(similarity-ts *) Read Grep Glob
 paths: '**/*.ts,**/*.tsx,**/*.js,**/*.jsx'

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: skill-creator
+description: Guides repo-local skill creation and updates. Use when adding or editing .agents/skills, SKILL.md frontmatter, references, scripts, or skill routing.
+---
+
+# Skill Creator
+
+Use this skill when creating or updating repo-local skills under `.agents/skills/`.
+
+## Workflow
+
+1. Decide whether a skill is needed. Add one only when repeated repo work needs specialized workflow, local references, command sequences, or policy that should trigger on demand.
+2. Create or update `.agents/skills/<skill-name>/SKILL.md` with YAML frontmatter and concise Markdown instructions.
+3. Keep `SKILL.md` focused on core workflow and navigation. Move detailed examples, APIs, or long checklists into `references/` files linked directly from `SKILL.md`.
+4. Add scripts under `scripts/` only for deterministic or repeated operations that are better executed than rewritten.
+5. Update the root `CLAUDE.md` Skill Routing list when adding a repo-local skill that agents should discover before work.
+6. Run `pnpm run format` after edits and use the normal repo validation level for the change.
+
+## Frontmatter
+
+Required fields:
+
+```yaml
+---
+name: skill-name
+description: Describes what the skill does and when to use it.
+---
+```
+
+Follow Anthropic's skill authoring guidance from the Agent Skills best practices and skill structure docs:
+
+- The `description` field is the primary discovery mechanism.
+- Write descriptions in third person.
+- Include both what the skill does and concrete contexts, trigger phrases, file types, commands, or task classes for when to use it.
+- Avoid vague descriptions such as "helps with docs" or "processes files".
+- Keep metadata concise because skill names and descriptions are always loaded; Anthropic's size guidance treats frontmatter as roughly 100 words.
+
+For this repo, prefer one or two short sentences, usually around 20-35 words. Do not compress a description so far that it becomes only a label; the agent still needs enough trigger context to choose the skill reliably.
+
+Good pattern:
+
+```yaml
+description: Guides ccusage tests. Use when adding or fixing in-source Vitest, fs-fixture data, CLI snapshots, Claude model pricing, or LiteLLM compatibility.
+```
+
+Weak pattern:
+
+```yaml
+description: Use for tests.
+```
+
+## Body
+
+Keep the body procedural and repo-specific:
+
+- Commands to run.
+- Files or references to read.
+- Local conventions that are easy to miss.
+- Validation expected after changes.
+- Small examples that prevent common mistakes.
+
+Avoid explaining generic concepts the model already knows. The skill body is loaded only after the skill triggers, but it still competes with task context once loaded.
+
+## References
+
+Use reference files when details are conditional:
+
+```text
+.agents/skills/example-skill/
+├── SKILL.md
+└── references/
+    ├── api.md
+    └── examples.md
+```
+
+Link reference files directly from `SKILL.md` and say when to read each one. Avoid nested reference chains because agents may only preview intermediate files.

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: t-wada style TDD workflow — Red-Green-Refactor cycle for all logic changes. Use when implementing features, fixing bugs, or refactoring code with strict test-driven development (e.g., "implement with TDD", "fix this bug TDD style", "/tdd").
+description: Use t-wada Red-Green-Refactor TDD for logic changes.
 ---
 
 <!--

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: Use t-wada Red-Green-Refactor TDD for logic changes.
+description: Guides t-wada Red-Green-Refactor TDD. Use when implementing features, fixing bugs, or refactoring logic with strict test-first development.
 ---
 
 <!--

--- a/.agents/skills/typescript-style/SKILL.md
+++ b/.agents/skills/typescript-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typescript-style
-description: Apply ccusage TypeScript style for satisfies and safe typing.
+description: Guides ccusage TypeScript style. Use when writing or reviewing typed objects, mocks, fixtures, table-driven cases, satisfies, or safe type suppressions.
 ---
 
 # TypeScript Style

--- a/.agents/skills/typescript-style/SKILL.md
+++ b/.agents/skills/typescript-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typescript-style
-description: Apply ccusage TypeScript style rules, especially preferring satisfies and as const satisfies over unsafe as assertions. Use when writing or reviewing TypeScript or TSX code, test fixtures, typed object literals, mocks, config objects, or table-driven cases.
+description: Apply ccusage TypeScript style for satisfies and safe typing.
 ---
 
 # TypeScript Style

--- a/.agents/skills/use-gunshi-cli/SKILL.md
+++ b/.agents/skills/use-gunshi-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-gunshi-cli
-description: Use the Gunshi library to create command-line interfaces in JavaScript/TypeScript.
+description: Use Gunshi for JavaScript and TypeScript CLIs.
 globs: '*.ts, *.tsx, *.js, *.jsx, package.json'
 alwaysApply: false
 ---

--- a/.agents/skills/use-gunshi-cli/SKILL.md
+++ b/.agents/skills/use-gunshi-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-gunshi-cli
-description: Use Gunshi for JavaScript and TypeScript CLIs.
+description: Guides Gunshi CLI definitions. Use when creating or changing JavaScript and TypeScript command-line interfaces, command options, or CLI conventions.
 globs: '*.ts, *.tsx, *.js, *.jsx, package.json'
 alwaysApply: false
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Use these skills before working in this repository:
 - `fs-fixture` - disposable filesystem trees for tests with `createFixture()` and local README lookup.
 - `ccusage-agent-sources` - Claude Code, Codex, OpenCode, Amp, and pi-agent log locations, token mappings, cost rules, and CLI behavior.
 - `ccusage-docs` - VitePress docs structure, screenshot placement, accessibility, and markdown linting conventions.
+- `skill-creator` - repo-local skill creation, SKILL.md frontmatter, description trigger quality, and reference layout.
 - `typescript-style` - TypeScript typing with `satisfies`, `as const satisfies`, and safer type suppressions.
 - `byethrow` - `@praha/byethrow` Result-based error handling.
 - `use-gunshi-cli` - Gunshi command definitions and CLI conventions.


### PR DESCRIPTION
Condenses repo-local Codex skill descriptions without reducing them to labels. The descriptions now follow Anthropic guidance by keeping both the capability and trigger context in frontmatter, while reducing always-loaded description text from the original 3469 characters across 16 skills to 2367 characters across those same skills.

Also adds a repo-local skill-creator skill and routes it from CLAUDE.md so future .agents/skills changes have local guidance for SKILL.md frontmatter, description quality, and reference layout. With the new skill included, total repo-local skill description text is 2516 characters across 17 skills.

Reference guidance:
- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
- https://www.mintlify.com/anthropics/skills/creating-skills/skill-structure

Testing:
- pnpm run format
- pnpm typecheck
- pnpm run test
