### PR TITLE
docs(ai): require US English GitHub communication

### DIFF
--- a/.agents/skills/pr-ai-review-workflow/SKILL.md
+++ b/.agents/skills/pr-ai-review-workflow/SKILL.md
@@ -21,6 +21,8 @@ Prefer repository-local conventions when they exist. If the repo has changed rev
 
 ## PR Bodies and Comments
 
+Write all repository-facing GitHub communication in US English, including PR descriptions, issue comments, triage notes, review replies, and bot-directed replies.
+
 When creating or editing multi-line PR bodies, use `--body-file -` and pass the Markdown through stdin. Do not embed `\n` escape sequences inside a quoted `--body` argument; fish and shell quoting can preserve them literally and break the rendered PR body.
 
 Good:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,4 +42,5 @@ Check the nearest package-specific `CLAUDE.md` before editing package code:
 - Vitest globals are enabled; use `describe`, `it`, `expect`, and `vi` without importing them.
 - After code changes, run `pnpm run format`, `pnpm typecheck`, and `pnpm run test`.
 - PR branches are squash-merged by default; prefer stacked, small, revertable follow-up commits over `git commit --amend` unless explicitly requested.
+- Use US English for repository-facing GitHub communication, including issue comments, PR descriptions, review replies, triage notes, and bot-directed replies.
 - Do what has been asked, nothing more. Do not proactively create documentation files unless explicitly requested.


### PR DESCRIPTION
## Summary

- Require US English for repository-facing GitHub communication in the always-visible repo instructions
- Add the same rule to the PR AI review workflow skill

## Validation

- git diff --cached --check
- pre-commit hook: oxfmt, root eslint
- pre-push hook: test skipped because there were no inspected files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes repository-facing GitHub communication to US English. Adds this rule to `CLAUDE.md` and the PR review workflow skill so PR descriptions, issue comments, review replies, triage notes, and bot-directed replies are written in US English.

<sup>Written for commit 11beeffb560e815ef7bf9cd4aa5ca2b0450223b8. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1034?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidelines to standardize on US English for repository-facing communication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->