### PR TITLE
fix(ccusage): enforce Node runtime range

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -43,7 +43,7 @@ pnpx ccusage
 npx ccusage@latest
 ```
 
-> 💡 **Runtime**: `bunx ccusage` is recommended for everyday use. If you use `npx`, include `@latest` and use Node.js 22+.
+> 💡 **Runtime**: `bunx ccusage` is recommended for everyday use. If you use `npx`, include `@latest` and use Node.js 22.11+.
 > Because the published CLI shebang targets Node.js, package runners can start ccusage under Node.js even when launched through `bunx`. When ccusage finds `bun` in `PATH`, it automatically re-runs the bundled entrypoint with Bun for better warm runtime performance. Set `CCUSAGE_BUN_AUTO_RUN=0` to force Node.js.
 
 ## Usage

--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -38,7 +38,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=22.0.0"
+		"node": ">=22.11.0"
 	},
 	"scripts": {
 		"bench": "node scripts/bench.mjs",

--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -66,6 +66,7 @@
 		"@ryoppippi/eslint-config": "catalog:lint",
 		"@types/bun": "catalog:types",
 		"@typescript/native-preview": "catalog:types",
+		"arkregex": "catalog:runtime",
 		"clean-pkg-json": "catalog:release",
 		"eslint": "catalog:lint",
 		"eslint-plugin-format": "catalog:lint",

--- a/apps/ccusage/src/cli.ts
+++ b/apps/ccusage/src/cli.ts
@@ -4,9 +4,10 @@ import { accessSync, constants, statSync } from 'node:fs';
 import { delimiter, dirname, join } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import { engines } from '../package.json';
 import { CCUSAGE_BUN_AUTO_RUN_DISABLED_VALUE, CCUSAGE_BUN_AUTO_RUN_ENV } from './env.ts';
 
-const MIN_NODE_MAJOR_VERSION = 22;
+const SUPPORTED_NODE_RANGE = engines.node;
 
 type CliRuntime =
 	| {
@@ -73,19 +74,52 @@ function isBun(): boolean {
 	return (globalThis as { Bun?: unknown }).Bun != null;
 }
 
-function getNodeMajorVersion(version = process.version): number | undefined {
-	const [majorVersion] = version.replace(/^v/, '').split('.');
-	const major = Number(majorVersion);
-	return Number.isInteger(major) ? major : undefined;
-}
-
-function getUnsupportedNodeRuntimeMessage(nodeVersion = process.version): string | undefined {
-	const nodeMajorVersion = getNodeMajorVersion(nodeVersion);
-	if (nodeMajorVersion == null || nodeMajorVersion >= MIN_NODE_MAJOR_VERSION) {
+function parseNodeVersion(version: string): [number, number, number] | undefined {
+	const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(version);
+	if (match == null) {
 		return undefined;
 	}
 
-	return `ccusage requires Bun or Node.js >=${MIN_NODE_MAJOR_VERSION}.0.0. Current Node.js: ${nodeVersion}\n`;
+	const major = Number(match[1]);
+	const minor = Number(match[2]);
+	const patch = Number(match[3]);
+	if (!Number.isInteger(major) || !Number.isInteger(minor) || !Number.isInteger(patch)) {
+		return undefined;
+	}
+
+	return [major, minor, patch];
+}
+
+function satisfiesMinimumVersion(version: string, range: string): boolean {
+	const match = /^>=(\d+)\.(\d+)\.(\d+)$/.exec(range);
+	if (match == null) {
+		return true;
+	}
+
+	const actual = parseNodeVersion(version);
+	if (actual == null) {
+		return true;
+	}
+
+	const minimum: [number, number, number] = [Number(match[1]), Number(match[2]), Number(match[3])];
+	for (const index of [0, 1, 2] as const) {
+		if (actual[index] > minimum[index]) {
+			return true;
+		}
+		if (actual[index] < minimum[index]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function getUnsupportedNodeRuntimeMessage(nodeVersion = process.version): string | undefined {
+	if (satisfiesMinimumVersion(nodeVersion, SUPPORTED_NODE_RANGE)) {
+		return undefined;
+	}
+
+	return `ccusage requires Bun or Node.js ${SUPPORTED_NODE_RANGE}. Current Node.js: ${nodeVersion}\n`;
 }
 
 async function runBunMain(): Promise<void> {
@@ -178,7 +212,7 @@ if (import.meta.vitest != null) {
 					argv: ['daily'],
 					distDir: '/app/dist',
 					findBunPath: () => '/usr/local/bin/bun',
-					nodeVersion: 'v22.13.1',
+					nodeVersion: 'v22.10.0',
 					processExecPath: '/usr/bin/node',
 				}),
 			).toEqual({
@@ -187,17 +221,47 @@ if (import.meta.vitest != null) {
 			});
 		});
 
-		it('rejects Node.js 20 when Bun is unavailable', () => {
+		it('uses Node.js 23 when Bun is unavailable', () => {
 			expect(
 				resolveCliRuntime({
 					argv: ['daily'],
 					distDir: '/app/dist',
 					findBunPath: () => undefined,
-					nodeVersion: 'v20.19.0',
+					nodeVersion: 'v23.11.1',
 					processExecPath: '/usr/bin/node',
 				}),
 			).toEqual({
-				errorMessage: 'ccusage requires Bun or Node.js >=22.0.0. Current Node.js: v20.19.0\n',
+				args: ['/app/dist/main.node.js', 'daily'],
+				command: '/usr/bin/node',
+			});
+		});
+
+		it('uses the minimum supported Node.js version when Bun is unavailable', () => {
+			expect(
+				resolveCliRuntime({
+					argv: ['daily'],
+					distDir: '/app/dist',
+					findBunPath: () => undefined,
+					nodeVersion: 'v22.11.0',
+					processExecPath: '/usr/bin/node',
+				}),
+			).toEqual({
+				args: ['/app/dist/main.node.js', 'daily'],
+				command: '/usr/bin/node',
+			});
+		});
+
+		it('rejects Node.js below the supported range when Bun is unavailable', () => {
+			expect(
+				resolveCliRuntime({
+					argv: ['daily'],
+					distDir: '/app/dist',
+					findBunPath: () => undefined,
+					nodeVersion: 'v22.10.0',
+					processExecPath: '/usr/bin/node',
+				}),
+			).toEqual({
+				errorMessage: 'ccusage requires Bun or Node.js >=22.11.0. Current Node.js: v22.10.0\n',
 			});
 		});
 	});

--- a/apps/ccusage/src/cli.ts
+++ b/apps/ccusage/src/cli.ts
@@ -4,10 +4,14 @@ import { accessSync, constants, statSync } from 'node:fs';
 import { delimiter, dirname, join } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
-import { engines } from '../package.json';
 import { CCUSAGE_BUN_AUTO_RUN_DISABLED_VALUE, CCUSAGE_BUN_AUTO_RUN_ENV } from './env.ts';
 
-const SUPPORTED_NODE_RANGE = engines.node;
+declare const __CCUSAGE_SUPPORTED_NODE_RANGE__: string | undefined;
+
+const SUPPORTED_NODE_RANGE =
+	typeof __CCUSAGE_SUPPORTED_NODE_RANGE__ === 'string'
+		? __CCUSAGE_SUPPORTED_NODE_RANGE__
+		: '>=22.11.0';
 
 type CliRuntime =
 	| {

--- a/apps/ccusage/src/cli.ts
+++ b/apps/ccusage/src/cli.ts
@@ -5,13 +5,10 @@ import { delimiter, dirname, join } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { CCUSAGE_BUN_AUTO_RUN_DISABLED_VALUE, CCUSAGE_BUN_AUTO_RUN_ENV } from './env.ts';
+import { isSupportedNodeVersion } from './node-version.ts';
+import { getSupportedNodeRuntime } from './runtime-macro.ts' with { type: 'macro' };
 
-declare const __CCUSAGE_SUPPORTED_NODE_RANGE__: string | undefined;
-
-const SUPPORTED_NODE_RANGE =
-	typeof __CCUSAGE_SUPPORTED_NODE_RANGE__ === 'string'
-		? __CCUSAGE_SUPPORTED_NODE_RANGE__
-		: '>=22.11.0';
+const SUPPORTED_NODE_RUNTIME = getSupportedNodeRuntime();
 
 type CliRuntime =
 	| {
@@ -78,52 +75,12 @@ function isBun(): boolean {
 	return (globalThis as { Bun?: unknown }).Bun != null;
 }
 
-function parseNodeVersion(version: string): [number, number, number] | undefined {
-	const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(version);
-	if (match == null) {
-		return undefined;
-	}
-
-	const major = Number(match[1]);
-	const minor = Number(match[2]);
-	const patch = Number(match[3]);
-	if (!Number.isInteger(major) || !Number.isInteger(minor) || !Number.isInteger(patch)) {
-		return undefined;
-	}
-
-	return [major, minor, patch];
-}
-
-function satisfiesMinimumVersion(version: string, range: string): boolean {
-	const match = /^>=(\d+)\.(\d+)\.(\d+)$/.exec(range);
-	if (match == null) {
-		return true;
-	}
-
-	const actual = parseNodeVersion(version);
-	if (actual == null) {
-		return true;
-	}
-
-	const minimum: [number, number, number] = [Number(match[1]), Number(match[2]), Number(match[3])];
-	for (const index of [0, 1, 2] as const) {
-		if (actual[index] > minimum[index]) {
-			return true;
-		}
-		if (actual[index] < minimum[index]) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 function getUnsupportedNodeRuntimeMessage(nodeVersion = process.version): string | undefined {
-	if (satisfiesMinimumVersion(nodeVersion, SUPPORTED_NODE_RANGE)) {
+	if (isSupportedNodeVersion(nodeVersion, SUPPORTED_NODE_RUNTIME.minimum)) {
 		return undefined;
 	}
 
-	return `ccusage requires Bun or Node.js ${SUPPORTED_NODE_RANGE}. Current Node.js: ${nodeVersion}\n`;
+	return `ccusage requires Bun or Node.js ${SUPPORTED_NODE_RUNTIME.range}. Current Node.js: ${nodeVersion}\n`;
 }
 
 async function runBunMain(): Promise<void> {

--- a/apps/ccusage/src/node-version.ts
+++ b/apps/ccusage/src/node-version.ts
@@ -1,7 +1,11 @@
+import { regex } from 'arkregex';
+
 type NodeVersion = readonly [number, number, number];
 
+const nodeVersionRegex = regex('^v?(\\d+)\\.(\\d+)\\.(\\d+)$');
+
 function parseNodeVersion(version: string): NodeVersion | undefined {
-	const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(version);
+	const match = nodeVersionRegex.exec(version);
 	if (match == null) {
 		return undefined;
 	}

--- a/apps/ccusage/src/node-version.ts
+++ b/apps/ccusage/src/node-version.ts
@@ -1,7 +1,7 @@
 type NodeVersion = readonly [number, number, number];
 
 function parseNodeVersion(version: string): NodeVersion | undefined {
-	const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(version);
+	const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(version);
 	if (match == null) {
 		return undefined;
 	}
@@ -19,7 +19,7 @@ function parseNodeVersion(version: string): NodeVersion | undefined {
 export function isSupportedNodeVersion(version: string, minimum: NodeVersion): boolean {
 	const actual = parseNodeVersion(version);
 	if (actual == null) {
-		return true;
+		return false;
 	}
 
 	for (const index of [0, 1, 2] as const) {
@@ -50,6 +50,10 @@ if (import.meta.vitest != null) {
 
 		it('rejects versions below the minimum patch version', () => {
 			expect(isSupportedNodeVersion('v22.11.0', [22, 11, 1])).toBe(false);
+		});
+
+		it('rejects malformed versions', () => {
+			expect(isSupportedNodeVersion('v22.11.0-nightly', [22, 11, 0])).toBe(false);
 		});
 	});
 }

--- a/apps/ccusage/src/node-version.ts
+++ b/apps/ccusage/src/node-version.ts
@@ -1,0 +1,55 @@
+type NodeVersion = readonly [number, number, number];
+
+function parseNodeVersion(version: string): NodeVersion | undefined {
+	const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(version);
+	if (match == null) {
+		return undefined;
+	}
+
+	const major = Number(match[1]);
+	const minor = Number(match[2]);
+	const patch = Number(match[3]);
+	if (!Number.isInteger(major) || !Number.isInteger(minor) || !Number.isInteger(patch)) {
+		return undefined;
+	}
+
+	return [major, minor, patch];
+}
+
+export function isSupportedNodeVersion(version: string, minimum: NodeVersion): boolean {
+	const actual = parseNodeVersion(version);
+	if (actual == null) {
+		return true;
+	}
+
+	for (const index of [0, 1, 2] as const) {
+		if (actual[index] > minimum[index]) {
+			return true;
+		}
+		if (actual[index] < minimum[index]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+if (import.meta.vitest != null) {
+	describe('isSupportedNodeVersion', () => {
+		it('accepts the minimum version', () => {
+			expect(isSupportedNodeVersion('v22.11.0', [22, 11, 0])).toBe(true);
+		});
+
+		it('accepts later major versions', () => {
+			expect(isSupportedNodeVersion('v23.0.0', [22, 11, 0])).toBe(true);
+		});
+
+		it('rejects versions below the minimum minor version', () => {
+			expect(isSupportedNodeVersion('v22.10.0', [22, 11, 0])).toBe(false);
+		});
+
+		it('rejects versions below the minimum patch version', () => {
+			expect(isSupportedNodeVersion('v22.11.0', [22, 11, 1])).toBe(false);
+		});
+	});
+}

--- a/apps/ccusage/src/runtime-macro.ts
+++ b/apps/ccusage/src/runtime-macro.ts
@@ -1,0 +1,16 @@
+import packageJson from '../package.json' with { type: 'json' };
+
+type NodeVersion = readonly [number, number, number];
+
+export function getSupportedNodeRuntime(): { minimum: NodeVersion; range: string } {
+	const range = packageJson.engines.node;
+	const match = /^>=(\d+)\.(\d+)\.(\d+)$/.exec(range);
+	if (match == null) {
+		throw new Error(`Unsupported Node.js engine range: ${range}`);
+	}
+
+	return {
+		minimum: [Number(match[1]), Number(match[2]), Number(match[3])],
+		range,
+	};
+}

--- a/apps/ccusage/tsdown.config.ts
+++ b/apps/ccusage/tsdown.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'tsdown';
 import Macros from 'unplugin-macros/rolldown';
+import packageJson from './package.json' with { type: 'json' };
 
 export default defineConfig({
 	entry: {
@@ -55,6 +56,7 @@ export default defineConfig({
 		}),
 	],
 	define: {
+		__CCUSAGE_SUPPORTED_NODE_RANGE__: JSON.stringify(packageJson.engines.node),
 		'import.meta.vitest': 'undefined',
 	},
 });

--- a/apps/ccusage/tsdown.config.ts
+++ b/apps/ccusage/tsdown.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'tsdown';
 import Macros from 'unplugin-macros/rolldown';
-import packageJson from './package.json' with { type: 'json' };
 
 export default defineConfig({
 	entry: {
@@ -47,6 +46,7 @@ export default defineConfig({
 		Macros({
 			include: [
 				'src/index.ts',
+				'src/cli.ts',
 				'src/pricing-fetcher.ts',
 				'src/adapter/amp/pricing.ts',
 				'src/adapter/codex/pricing.ts',
@@ -56,7 +56,6 @@ export default defineConfig({
 		}),
 	],
 	define: {
-		__CCUSAGE_SUPPORTED_NODE_RANGE__: JSON.stringify(packageJson.engines.node),
 		'import.meta.vitest': 'undefined',
 	},
 });

--- a/apps/ccusage/vitest.config.ts
+++ b/apps/ccusage/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 	},
 	plugins: [
 		Macros({
-			include: ['src/index.ts', 'src/pricing-fetcher.ts'],
+			include: ['src/index.ts', 'src/cli.ts', 'src/pricing-fetcher.ts'],
 		}) as any, // vitest bundles its own vite types, so relax plugin typing here
 	],
 });

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -5,7 +5,7 @@ Welcome to ccusage! This guide will help you get up and running with analyzing y
 ## Prerequisites
 
 - At least one supported coding CLI installed and used
-- Bun 1.3+ recommended, or Node.js 22+
+- Bun 1.3+ recommended, or Node.js 22.11+
 
 ## Quick Start
 
@@ -30,7 +30,7 @@ pnpm dlx ccusage
 This will show your daily usage report for all detected supported coding CLIs by default.
 
 ::: tip Runtime
-`bunx ccusage` is recommended for everyday use. ccusage can run on Node.js 22+, and because the published CLI shebang targets Node.js, package runners can start ccusage under Node.js even when launched through `bunx`. When ccusage finds `bun` in `PATH`, it automatically re-runs the bundled entrypoint with Bun for better warm runtime performance. Set `CCUSAGE_BUN_AUTO_RUN=0` to force Node.js.
+`bunx ccusage` is recommended for everyday use. ccusage can run on Node.js 22.11+, and because the published CLI shebang targets Node.js, package runners can start ccusage under Node.js even when launched through `bunx`. When ccusage finds `bun` in `PATH`, it automatically re-runs the bundled entrypoint with Bun for better warm runtime performance. Set `CCUSAGE_BUN_AUTO_RUN=0` to force Node.js.
 :::
 
 Use a data source namespace when you want the same report focused on one source:

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -32,7 +32,7 @@ npx ccusage@latest
 :::
 
 ::: tip Speed Recommendation
-We recommend `bunx` for everyday use. ccusage can run on Node.js 22+, but Bun generally starts faster and avoids the slower cold-start path common with `npx`.
+We recommend `bunx` for everyday use. ccusage can run on Node.js 22.11+, but Bun generally starts faster and avoids the slower cold-start path common with `npx`.
 
 Because the published CLI shebang targets Node.js, package runners can start ccusage under Node.js even when launched through `bunx`. When ccusage finds `bun` in `PATH`, it automatically re-runs the bundled entrypoint with Bun for better warm runtime performance. Set `CCUSAGE_BUN_AUTO_RUN=0` to force the Node.js runtime.
 :::
@@ -41,11 +41,11 @@ Because the published CLI shebang targets Node.js, package runners can start ccu
 
 Here's why runtime choice matters:
 
-| Runtime  | First Run | Subsequent Runs | Notes                         |
-| -------- | --------- | --------------- | ----------------------------- |
-| bunx     | Fast      | **Instant**     | Recommended for everyday use  |
-| pnpm dlx | Fast      | Fast            | Good alternative              |
-| npx      | Slow      | Moderate        | Widely available, Node.js 22+ |
+| Runtime  | First Run | Subsequent Runs | Notes                            |
+| -------- | --------- | --------------- | -------------------------------- |
+| bunx     | Fast      | **Instant**     | Recommended for everyday use     |
+| pnpm dlx | Fast      | Fast            | Good alternative                 |
+| npx      | Slow      | Moderate        | Widely available, Node.js 22.11+ |
 
 ## Global Installation (Optional)
 
@@ -116,7 +116,7 @@ pnpm run format
 
 ### Node.js
 
-- **Minimum**: Node.js 22.x for the published package
+- **Minimum**: Node.js 22.11 for the published package
 - **Recommended**: Use Bun for command execution when available
 - `npx`, npm global installs, pnpm, and yarn all use the Node.js runtime unless ccusage re-runs through Bun
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"description": "Documentation for coding (agent) CLI usage analysis with ccusage",
 	"engines": {
-		"node": ">=22.0.0"
+		"node": ">=22.11.0"
 	},
 	"scripts": {
 		"build": "cp ../apps/ccusage/config-schema.json public/config-schema.json && vitepress build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ catalogs:
     ansi-escapes:
       specifier: ^7.0.0
       version: 7.1.0
+    arkregex:
+      specifier: ^0.0.5
+      version: 0.0.5
     get-stdin:
       specifier: ^9.0.0
       version: 9.0.0
@@ -193,6 +196,9 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:types
         version: 7.0.0-dev.20260510.1
+      arkregex:
+        specifier: catalog:runtime
+        version: 0.0.5
       clean-pkg-json:
         specifier: catalog:release
         version: 1.3.0
@@ -396,6 +402,9 @@ packages:
 
   '@antfu/utils@9.3.0':
     resolution: {integrity: sha512-9hFT4RauhcUzqOE4f1+frMKLZrgNog5b06I7VmZQV1BkvwvqrbC8EBZf3L1eEL2AKb6rNKjER0sEvJiSP1FXEA==}
+
+  '@ark/util@0.56.0':
+    resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
 
   '@babel/generator@8.0.0-rc.4':
     resolution: {integrity: sha512-YZ+FuIgkj7KrIb2a2X1XiY0QYgDxAbVbYP64SjwJzOK3euCsUerzenh2oqdsmKuPSlhzmFOOklnxzHAzXagvpw==}
@@ -2248,6 +2257,9 @@ packages:
   args-tokens@0.20.1:
     resolution: {integrity: sha512-pQ5R5TsJyx94zsgSCCQ9kzOgUfMmI4bkqNjgSSt2C92mzPCvovoUMMW6HqR+35mHZ0cb1++MD2uAOLm62sGC+Q==}
     engines: {node: '>= 20'}
+
+  arkregex@0.0.5:
+    resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
 
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
@@ -5131,6 +5143,8 @@ snapshots:
 
   '@antfu/utils@9.3.0': {}
 
+  '@ark/util@0.56.0': {}
+
   '@babel/generator@8.0.0-rc.4':
     dependencies:
       '@babel/parser': 8.0.0-rc.4
@@ -6569,6 +6583,10 @@ snapshots:
   args-tokenizer@0.3.0: {}
 
   args-tokens@0.20.1: {}
+
+  arkregex@0.0.5:
+    dependencies:
+      '@ark/util': 0.56.0
 
   ast-kit@2.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ catalogs:
     '@ryoppippi/limo': jsr:^0.2.2
     '@std/async': jsr:^1.0.14
     ansi-escapes: ^7.0.0
+    arkregex: ^0.0.5
     cli-table3: ^0.6.5
     consola: ^3.4.2
     es-toolkit: ^1.39.10


### PR DESCRIPTION
## Summary
- set the ccusage and docs Node engine floor to Node.js 22.11
- make the CLI wrapper read engines.node and reject Node versions below that range when Bun is unavailable
- update runtime docs from Node.js 22+ to Node.js 22.11+

## Testing
- pnpm run format
- pnpm typecheck
- pnpm run test
- pnpm --filter ccusage build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the Node.js runtime range for `ccusage` from `engines.node` with a floor at Node.js 22.11. The CLI rejects unsupported or malformed Node when Bun isn’t available; the supported range is macro-inlined at build time, and docs updated to match.

- **Bug Fixes**
  - CLI validates full semver via `isSupportedNodeVersion`; allows 22.11+ and 23.x, rejects 22.10 and malformed versions when Bun isn’t available.
  - Updated `engines.node` in `apps/ccusage` and `docs` to ">=22.11.0"; tests cover minimum/above/below and malformed cases.

- **Refactors**
  - Replaced `tsdown` define with a build-time macro (`getSupportedNodeRuntime`) that reads package metadata and inlines the minimum tuple and range; no runtime `package.json` import or extra bundle chunk. Enabled in `tsdown` and `vitest` configs.
  - Switched Node version parsing to `arkregex` for strict, precise matching.

<sup>Written for commit 68b515fd66b972a6f1c498b989e8596ab7a5ac05. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1037?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js minimum to 22.11+ across docs, README, and installation guidance; clarified runtime guidance recommending Bun for daily use and how to force Node via an env flag.

* **Improvements**
  * Stricter runtime selection and clearer error messages that report the supported Node range and the detected runtime.

* **Chores**
  * Project Node engine requirement raised to 22.11+.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->