### PR TITLE
refactor: use arkregex for regexes

### DIFF
--- a/.agents/skills/ast-grep/SKILL.md
+++ b/.agents/skills/ast-grep/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: ast-grep
+description: Guides ccusage structural code searches with ast-grep. Use when finding syntax patterns, validating migrations, or writing AST-based search commands.
+---
+
+# ast-grep
+
+Use ast-grep when a search needs syntax structure rather than plain text. Prefer `rg` for simple text search.
+
+## Tooling
+
+This repo provides `ast-grep` through `flake.nix`. Run commands from the Nix dev shell, or use `direnv exec .` when the shell is not already active:
+
+```sh
+direnv exec . ast-grep run --lang ts --pattern '/$P/' --json=stream apps packages
+```
+
+If `direnv` is unavailable and this is a one-off search, use comma as a fallback:
+
+```sh
+, ast-grep run --lang ts --pattern '/$P/' --json=stream apps packages
+```
+
+## Workflow
+
+1. Describe the syntax shape you need to find.
+2. Start with a small pattern and test it against the repo.
+3. Use `--debug-query` when the pattern does not match the AST shape you expected.
+4. Only move to YAML rules when `run --pattern` cannot express the search.
+
+## Commands
+
+For quick pattern searches:
+
+```sh
+ast-grep run --lang ts --pattern 'console.log($ARG)' apps packages
+```
+
+For JSON output that scripts can consume:
+
+```sh
+ast-grep run --lang ts --pattern '/$P/' --json=stream apps packages
+```
+
+## Rule Tips
+
+- Use `run --pattern` for simple single-node matches.
+- Use `scan --rule` or `scan --inline-rules` for relational rules such as `inside` or `has`.
+- Add `stopBy: end` to relational rules so ast-grep searches the full direction.
+- Use `--debug-query=ast`, `--debug-query=cst`, or `--debug-query=pattern` when a rule does not match the code shape you expected.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -77,6 +77,15 @@ Use standard git history commands to understand intent before committing. Prefer
 - Potential impacts
 - Wrap at 72 characters
 
+**Subject should name the artifact or behavior changed**:
+
+- Prefer concrete subjects that make sense when read alone in a commit list.
+- Avoid vague review-process subjects such as `chore: address review feedback`,
+  `chore: apply comments`, or `fix: update per CodeRabbit`.
+- Put reviewer context in the body, not the subject. For example, use
+  `docs(skills): clarify arkregex newline guidance` with a body explaining that
+  it addresses CodeRabbit feedback.
+
 ## Quality Checks
 
 - Can this be reverted without breaking other functionality?

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -35,6 +35,23 @@ Follow Anthropic's skill authoring guidance from the Agent Skills best practices
 - Avoid vague descriptions such as "helps with docs" or "processes files".
 - Keep metadata concise because skill names and descriptions are always loaded; Anthropic's size guidance treats frontmatter as roughly 100 words.
 
+Optional file routing fields:
+
+- Use `paths` for Claude-style file matching. It may be a comma-separated glob string or a YAML list.
+- Add `globs` as a compatibility hint when a skill should trigger for file types across agent runtimes.
+- For cross-agent repo-local skills that should apply to TypeScript or JavaScript, include both:
+
+```yaml
+paths:
+  - '**/*.ts'
+  - '**/*.tsx'
+  - '**/*.js'
+  - '**/*.jsx'
+globs: '*.ts,*.tsx,*.js,*.jsx'
+```
+
+- Do not rely only on path metadata for Codex-style discovery; keep the `description` explicit about the file types and actions that should trigger the skill.
+
 For this repo, prefer one or two short sentences, usually around 20-35 words. Do not compress a description so far that it becomes only a label; the agent still needs enough trigger context to choose the skill reliably.
 
 Good pattern:

--- a/.agents/skills/typescript-style/SKILL.md
+++ b/.agents/skills/typescript-style/SKILL.md
@@ -1,9 +1,23 @@
 ---
 name: typescript-style
-description: Guides ccusage TypeScript style. Use when writing or reviewing typed objects, mocks, fixtures, table-driven cases, satisfies, or safe type suppressions.
+description: Guides ccusage TypeScript and JavaScript reading, writing, and review. Use before opening or editing .ts, .tsx, .js, or .jsx files, including regexes, Result handling, Gunshi CLI types, mocks, fixtures, satisfies, or suppressions.
+paths:
+  - '**/*.ts'
+  - '**/*.tsx'
+  - '**/*.js'
+  - '**/*.jsx'
+globs: '*.ts,*.tsx,*.js,*.jsx'
 ---
 
 # TypeScript Style
+
+## Library Conventions
+
+Use the focused references when code touches their areas:
+
+- Read `references/arkregex.md` for regular expressions, `RegExp`, `.match()`, `.test()`, `.replace()`, or `.split()` patterns.
+- Read `references/byethrow.md` for `@praha/byethrow` Result-based error handling.
+- Read `references/gunshi.md` for Gunshi command definitions, command option types, and CLI type inference.
 
 ## Prefer `satisfies` Over `as`
 

--- a/.agents/skills/typescript-style/references/arkregex.md
+++ b/.agents/skills/typescript-style/references/arkregex.md
@@ -1,0 +1,59 @@
+# ArkRegex
+
+Use `arkregex` for regular expressions in TypeScript code unless there is a concrete reason a native regex literal is better.
+
+## Source
+
+Read <https://arktype.io/docs/blog/arkregex> when unsure about API details. The repo policy follows the article's core points:
+
+- `regex(pattern, flags?)` is a typed wrapper around `new RegExp(pattern, flags)`.
+- It provides typed `.test()`, `.exec()`, captures, and named groups from native JavaScript regex syntax.
+- It is intended as a drop-in replacement for `new RegExp()`.
+- It is designed to avoid runtime bundle impact; verify dist output when changing bundled entry points.
+- If TypeScript inference is too expensive for a large pattern, use `regex.as<...>()` with explicit types.
+
+## Repo Policy
+
+- Import with `import { regex } from 'arkregex';`.
+- Prefer named constants for reused or meaningful patterns:
+
+```ts
+const isoDateRegex = regex('^\\d{4}-\\d{2}-\\d{2}$');
+```
+
+- Inline `regex(...)` is acceptable for one-off simple calls such as `value.replace(regex('-', 'g'), '')`.
+- Preserve regex flags explicitly as the second argument:
+
+```ts
+const pathRegex = regex('^[/\\\\-]+|[/\\\\-]+$', 'g');
+```
+
+- Keep pattern strings single-quoted and escape backslashes for string literals.
+- Write newline matches with a real escaped newline in the string, for example `regex('\n$')`, not `regex('\\n$')`.
+- Do not escape `/` inside `regex()` strings; use `regex('a/b')`, not `regex('a\\/b')`.
+- For broad alternations or patterns that trigger `Type instantiation is excessively deep`, use `regex.as<...>()` with explicit types.
+- Do not use regex literals such as `/.../` or `new RegExp(...)` in new TypeScript code.
+- Do not convert unrelated non-TypeScript files unless requested.
+
+## Dependencies
+
+Bundled packages keep runtime libraries in `devDependencies`. If a package starts importing `arkregex`, add:
+
+```text
+"arkregex": "catalog:runtime"
+```
+
+Use the existing `pnpm-workspace.yaml` runtime catalog entry, or add one if it is missing.
+
+## Migration Checklist
+
+1. Find regex literals with ast-grep:
+
+```sh
+, ast-grep run --lang ts --pattern '/$P/' --json=stream apps packages
+```
+
+2. Replace literals with `regex('pattern', 'flags')`.
+3. Add `arkregex` imports and package devDependencies where needed.
+4. Run focused tests for changed files, then the repo's normal validation.
+5. For bundled CLI changes, run `pnpm --filter ccusage build` and inspect the changed `dist/*.js` sizes if bundle size is a concern.

--- a/.agents/skills/typescript-style/references/arkregex.md
+++ b/.agents/skills/typescript-style/references/arkregex.md
@@ -29,7 +29,7 @@ const pathRegex = regex('^[/\\\\-]+|[/\\\\-]+$', 'g');
 ```
 
 - Keep pattern strings single-quoted and escape backslashes for string literals.
-- Write newline matches with a real escaped newline in the string, for example `regex('\n$')`, not `regex('\\n$')`.
+- Prefer escaped newline patterns such as `regex('\\n$')` because they mirror regex literal syntax. `regex('\n$')` is also valid and matches the same newline.
 - Do not escape `/` inside `regex()` strings; use `regex('a/b')`, not `regex('a\\/b')`.
 - For broad alternations or patterns that trigger `Type instantiation is excessively deep`, use `regex.as<...>()` with explicit types.
 - Do not use regex literals such as `/.../` or `new RegExp(...)` in new TypeScript code.
@@ -47,7 +47,7 @@ Use the existing `pnpm-workspace.yaml` runtime catalog entry, or add one if it i
 
 ## Migration Checklist
 
-1. Find regex literals with ast-grep:
+1. Find regex literals with ast-grep. Prefix with `,` to run ast-grep through comma when it is not already available:
 
 ```sh
 , ast-grep run --lang ts --pattern '/$P/' --json=stream apps packages

--- a/.agents/skills/typescript-style/references/byethrow.md
+++ b/.agents/skills/typescript-style/references/byethrow.md
@@ -1,10 +1,4 @@
----
-name: byethrow
-description: Guides use of @praha/byethrow Result APIs. Use when adding or reviewing Result-based TypeScript error handling, examples, or best practices.
-allowed-tools: Read, Grep, Glob
----
-
-## About byethrow
+# Byethrow
 
 `@praha/byethrow` is a lightweight, tree-shakable Result type library for handling fallible operations in JavaScript and TypeScript.
 It provides a simple, consistent API for managing errors and results without throwing exceptions.

--- a/.agents/skills/typescript-style/references/gunshi.md
+++ b/.agents/skills/typescript-style/references/gunshi.md
@@ -1,11 +1,6 @@
----
-name: use-gunshi-cli
-description: Guides Gunshi CLI definitions. Use when creating or changing JavaScript and TypeScript command-line interfaces, command options, or CLI conventions.
-globs: '*.ts, *.tsx, *.js, *.jsx, package.json'
-alwaysApply: false
----
+# Gunshi CLI
 
-use gunshi library for creating cli instead of other libraries including cac, yargs, commander, etc.
+Use Gunshi for creating CLI commands instead of other libraries including cac, yargs, commander, etc.
 Gunshi is a modern javascript command-line library
 
 For more information, read the gunshi API docs in `node_modules/@gunshi/docs/**.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,7 @@ Use these skills before working in this repository:
 - `ccusage-agent-sources` - Claude Code, Codex, OpenCode, Amp, and pi-agent log locations, token mappings, cost rules, and CLI behavior.
 - `ccusage-docs` - VitePress docs structure, screenshot placement, accessibility, and markdown linting conventions.
 - `skill-creator` - repo-local skill creation, SKILL.md frontmatter, description trigger quality, and reference layout.
-- `typescript-style` - TypeScript typing with `satisfies`, `as const satisfies`, and safer type suppressions.
-- `byethrow` - `@praha/byethrow` Result-based error handling.
-- `use-gunshi-cli` - Gunshi command definitions and CLI conventions.
+- `typescript-style` - required before reading or editing `.ts`, `.tsx`, `.js`, or `.jsx`; covers typing, `satisfies`, safe suppressions, and library-specific guidance for arkregex, byethrow, and Gunshi.
 - `bun-api-reference` - local Bun runtime API docs and type references under `node_modules/bun-types`.
 - `tdd` - Red-Green-Refactor workflow for logic changes.
 - `bun-cpu-profile` - Bun CPU profiling and branch-vs-main performance comparisons.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Use these skills before working in this repository:
 - `ccusage-docs` - VitePress docs structure, screenshot placement, accessibility, and markdown linting conventions.
 - `skill-creator` - repo-local skill creation, SKILL.md frontmatter, description trigger quality, and reference layout.
 - `typescript-style` - required before reading or editing `.ts`, `.tsx`, `.js`, or `.jsx`; covers typing, `satisfies`, safe suppressions, and library-specific guidance for arkregex, byethrow, and Gunshi.
+- `ast-grep` - structural code searches and AST-based migration verification with the dev-shell `ast-grep` CLI.
 - `bun-api-reference` - local Bun runtime API docs and type references under `node_modules/bun-types`.
 - `tdd` - Red-Green-Refactor workflow for logic changes.
 - `bun-cpu-profile` - Bun CPU profiling and branch-vs-main performance comparisons.
@@ -33,7 +34,7 @@ Check the nearest package-specific `CLAUDE.md` before editing package code:
 - The canonical user-facing CLI is `ccusage` with agent subcommands such as `ccusage amp`, `ccusage codex`, `ccusage opencode`, and `ccusage pi`.
 - Standalone agent wrapper packages have been removed. Do not add docs, tests, or features that promote `ccusage-amp`, `ccusage-codex`, `ccusage-opencode`, or `ccusage-pi`.
 - Runtime libraries for bundled packages belong in `devDependencies` unless explicitly requested otherwise.
-- Prefer tools provided by the Nix dev shell before falling back to ad hoc installs: `rg`, `fd`, `fzf`, `delta`, `dust`, `jq`, `gh`, `hyperfine`, `similarity`, `typos`, and `typos-lsp`. When a missing tool would be useful for repeated agent work in this repository, add it to `flake.nix`.
+- Prefer tools provided by the Nix dev shell before falling back to ad hoc installs: `rg`, `fd`, `fzf`, `delta`, `dust`, `jq`, `gh`, `hyperfine`, `similarity`, `ast-grep`, `typos`, and `typos-lsp`. When a missing tool would be useful for repeated agent work in this repository, add it to `flake.nix`.
 - Use `logger.ts` instead of `console.log`.
 - Use `.ts` extensions for local imports.
 - Do not use dynamic imports anywhere, especially in Vitest blocks.

--- a/apps/ccusage/CLAUDE.md
+++ b/apps/ccusage/CLAUDE.md
@@ -7,8 +7,7 @@ This is the main `ccusage` CLI package for Claude Code usage analysis.
 - Use `ccusage-development` for commands, bundled CLI dependency policy, style, exports, and validation.
 - Use `ccusage-testing` for in-source Vitest, snapshots, fixtures, Claude models, and LiteLLM pricing tests.
 - Use `ccusage-agent-sources` for Claude Code data directories, JSONL structure, session naming, cost modes, and report behavior.
-- Use `byethrow` for Result-based error handling.
-- Use `use-gunshi-cli` when changing command definitions.
+- Use `typescript-style` before reading or editing TypeScript or JavaScript package code; it also covers arkregex, byethrow, and Gunshi command typing.
 
 ## Package Notes
 

--- a/apps/ccusage/src/adapter/claude/data-loader.ts
+++ b/apps/ccusage/src/adapter/claude/data-loader.ts
@@ -1,3 +1,4 @@
+import type { LiteLLMModelPricing } from '@ccusage/internal/pricing';
 /**
  * @fileoverview Data loading utilities for Claude Code usage analysis
  *
@@ -8,7 +9,6 @@
  * @module data-loader
  */
 
-import type { LiteLLMModelPricing } from '@ccusage/internal/pricing';
 import type { IndexedWorkerItem, IndexedWorkerResultsMessage } from '@ccusage/internal/workers';
 import type { WeekDay } from '../../consts.ts';
 import type { LoadedUsageEntry, SessionBlock } from '../../session-blocks.ts';
@@ -47,6 +47,7 @@ import {
 	mapWithConcurrency,
 } from '@ccusage/internal/workers';
 import { Result } from '@praha/byethrow';
+import { regex } from 'arkregex';
 import { createFixture } from 'fs-fixture';
 import * as v from 'valibot';
 import { USER_HOME_DIR } from '../../consts.ts';
@@ -90,7 +91,7 @@ const CACHE_READ_INPUT_TOKENS_MARKER = '"cache_read_input_tokens":';
 const CONTENT_MARKER = '"content":';
 const COST_USD_MARKER = '"costUSD":';
 const INPUT_TOKENS_MARKER = '"input_tokens":';
-const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const ISO_TIMESTAMP_PATTERN = regex('^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$');
 const JSONL_WORKER_THREAD_LIMIT = 9;
 const MESSAGE_ID_MARKER = '"id":"';
 const MODEL_MARKER = '"model":"';
@@ -99,7 +100,11 @@ const REQUEST_ID_MARKER = '"requestId":"';
 const SPEED_MARKER = '"speed":"';
 const TIMESTAMP_MARKER = '"timestamp":"';
 const VERSION_MARKER = '"version":"';
-const VERSION_PATTERN = /^\d+\.\d+\.\d+/;
+const VERSION_PATTERN = regex('^\\d+\\.\\d+\\.\\d+');
+const pathSeparatorRegex = regex('[/\\\\]', 'g');
+const compactDateRegex = regex('^\\d{8}$');
+const usageLimitTimestampRegex = regex('\\|(\\d+)');
+const hyphenRegex = regex('-', 'g');
 function parseTwoDigits(value: string, offset: number): number {
 	return (value.charCodeAt(offset) - 48) * 10 + value.charCodeAt(offset + 1) - 48;
 }
@@ -342,7 +347,7 @@ export function requireClaudePaths(): string[] {
  */
 export function extractProjectFromPath(jsonlPath: string): string {
 	// Normalize path separators for cross-platform compatibility
-	const normalizedPath = jsonlPath.replace(/[/\\]/g, path.sep);
+	const normalizedPath = jsonlPath.replace(pathSeparatorRegex, path.sep);
 	const segments = normalizedPath.split(path.sep);
 	const projectsIndex = segments.findIndex((segment) => segment === CLAUDE_PROJECTS_DIR_NAME);
 
@@ -1133,7 +1138,7 @@ function filterByProject<T>(
 }
 
 function parseCompactDate(value: string | undefined): Date | null {
-	if (value == null || !/^\d{8}$/.test(value)) {
+	if (value == null || !compactDateRegex.test(value)) {
 		return null;
 	}
 
@@ -1423,7 +1428,7 @@ export function getUsageLimitResetTime(data: UsageData): Date | null {
 		const timestampMatch =
 			data.message?.content
 				?.find((c) => c.text != null && c.text.includes('Claude AI usage limit reached'))
-				?.text?.match(/\|(\d+)/) ?? null;
+				?.text?.match(usageLimitTimestampRegex) ?? null;
 
 		if (timestampMatch?.[1] != null) {
 			const resetTimestamp = Number.parseInt(timestampMatch[1]);
@@ -2953,7 +2958,10 @@ export async function loadSessionBlockData(options?: LoadOptions): Promise<Sessi
 		(options?.since != null && options.since !== '') ||
 		(options?.until != null && options.until !== '')
 			? blocks.filter((block) => {
-					const blockDateStr = formatUsageDate(block.startTime.toISOString()).replace(/-/g, '');
+					const blockDateStr = formatUsageDate(block.startTime.toISOString()).replace(
+						hyphenRegex,
+						'',
+					);
 					if (options.since != null && options.since !== '' && blockDateStr < options.since) {
 						return false;
 					}
@@ -3081,7 +3089,7 @@ if (import.meta.vitest != null) {
 			const testTimestamp = '2024-01-01T15:00:00Z'; // 3 PM UTC = midnight JST next day
 
 			// Default behavior (no timezone) uses system timezone
-			expect(formatDate(testTimestamp)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+			expect(formatDate(testTimestamp)).toMatch(regex('^\\d{4}-\\d{2}-\\d{2}$'));
 
 			// UTC timezone
 			expect(formatDate(testTimestamp, 'UTC')).toBe('2024-01-01');
@@ -5913,7 +5921,7 @@ invalid json line
 			// The filter uses formatDate which converts to YYYYMMDD format for comparison
 			expect(
 				untilResult.every((block) => {
-					const blockDateStr = block.startTime.toISOString().slice(0, 10).replace(/-/g, '');
+					const blockDateStr = block.startTime.toISOString().slice(0, 10).replace(hyphenRegex, '');
 					return blockDateStr <= '20240102';
 				}),
 			).toBe(true);

--- a/apps/ccusage/src/adapter/codex/parser.ts
+++ b/apps/ccusage/src/adapter/codex/parser.ts
@@ -18,6 +18,7 @@ import {
 	getFileWorkerThreadCount,
 } from '@ccusage/internal/workers';
 import { Result } from '@praha/byethrow';
+import { regex } from 'arkregex';
 import { createFixture } from 'fs-fixture';
 import { logger } from '../../logger.ts';
 import { getCodexSessionsPaths } from './paths.ts';
@@ -26,6 +27,7 @@ const LEGACY_FALLBACK_MODEL = 'gpt-5';
 const CODEX_JSONL_MARKERS = ['turn_context', '"type":"token_count"', '"type": "token_count"'];
 const ENCODED_CODEX_EVENT_NUMBER_STRIDE = 5;
 const TOKEN_USAGE_EVENT_KEY_SEPARATOR = '\0';
+const jsonlExtensionRegex = regex('\\.jsonl$', 'i');
 
 export function parseTokenCountLineFast(_line: string): ParsedTokenCountLine | null {
 	if (!hasTokenCountPayload(_line)) {
@@ -196,7 +198,7 @@ async function parseCodexSessionFile(
 ): Promise<TokenUsageEvent[]> {
 	const relativeSessionPath = path.relative(directoryPath, file);
 	const normalizedSessionPath = relativeSessionPath.split(path.sep).join('/');
-	const sessionId = normalizedSessionPath.replace(/\.jsonl$/i, '');
+	const sessionId = normalizedSessionPath.replace(jsonlExtensionRegex, '');
 	const events: TokenUsageEvent[] = [];
 	let previousTotals: RawUsage | null = null;
 	let currentModel: string | undefined;

--- a/apps/ccusage/src/adapter/codex/pricing.ts
+++ b/apps/ccusage/src/adapter/codex/pricing.ts
@@ -3,6 +3,7 @@ import type { CodexModelUsage, CodexSpeed } from './types.ts';
 import path from 'node:path';
 import { readTextFile } from '@ccusage/internal/fs';
 import { Result } from '@praha/byethrow';
+import { regex } from 'arkregex';
 import { getCodexHomePaths } from './paths.ts';
 import { prefetchCodexPricing } from './pricing-macro.ts' with { type: 'macro' };
 
@@ -14,6 +15,10 @@ const CODEX_MODEL_ALIASES_MAP = new Map<string, string>([
 	['gpt-5.3-codex', 'gpt-5.2-codex'],
 ]);
 const CODEX_FAST_FALLBACK_MULTIPLIER = 2;
+const codexFastServiceTierRegex = regex.as<string, { captures: [] }>(
+	'(?:^|\n)\\s*service_tier\\s*=\\s*["\']?(?:fast|priority)["\']?',
+	'iu',
+);
 
 function toPerMillion(value: number | undefined, fallback?: number): number {
 	const perToken = value ?? fallback ?? 0;
@@ -70,10 +75,7 @@ export async function resolveCodexSpeed(requested?: string): Promise<CodexSpeed>
 			try: readTextFile(configPath),
 			catch: (error) => error,
 		});
-		if (
-			!Result.isFailure(result) &&
-			/(?:^|\n)\s*service_tier\s*=\s*["']?(?:fast|priority)["']?/iu.test(result.value)
-		) {
+		if (!Result.isFailure(result) && codexFastServiceTierRegex.test(result.value)) {
 			return 'fast';
 		}
 	}

--- a/apps/ccusage/src/adapter/opencode/paths.ts
+++ b/apps/ccusage/src/adapter/opencode/paths.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { collectFilesRecursive, hasFileRecursive, isDirectorySyncSafe } from '@ccusage/internal/fs';
 import { Result } from '@praha/byethrow';
+import { regex } from 'arkregex';
 import { createFixture } from 'fs-fixture';
 import { logger } from '../../logger.ts';
 import { getExistingDirectories, normalizePathList } from '../path-list.ts';
@@ -13,7 +14,7 @@ export const OPENCODE_CONFIG_DIR_ENV = 'OPENCODE_DATA_DIR';
 export const OPENCODE_DB_FILE_NAME = 'opencode.db';
 export const OPENCODE_STORAGE_DIR_NAME = 'storage';
 export const OPENCODE_MESSAGES_DIR_NAME = 'message';
-const OPENCODE_CHANNEL_DB_PATTERN = /^opencode-[\w-]+\.db$/u;
+const OPENCODE_CHANNEL_DB_PATTERN = regex('^opencode-[\\w-]+\\.db$', 'u');
 
 export function getOpenCodePaths(): string[] {
 	return getExistingDirectories(

--- a/apps/ccusage/src/adapter/opencode/pricing.ts
+++ b/apps/ccusage/src/adapter/opencode/pricing.ts
@@ -1,6 +1,10 @@
 import type { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
 import type { OpenCodeUsageEntry } from './schema.ts';
 import { Result } from '@praha/byethrow';
+import { regex } from 'arkregex';
+
+const dottedClaudeModelRegex = regex('^(claude-(?:haiku|opus|sonnet)-\\d+)\\.(\\d+)(-.*)?$', 'u');
+const compactClaudeModelRegex = regex('^(claude-(?:haiku|opus|sonnet)-\\d)(\\d)(-.*)?$', 'u');
 
 const MODEL_ALIASES: Record<string, string> = {
 	'gemini-3-pro-high': 'gemini-3-pro-preview',
@@ -17,8 +21,8 @@ function normalizeOpenCodeProviderID(providerID: string): string {
 function normalizeOpenCodeModelName(modelName: string): string {
 	const resolved = resolveModelName(modelName);
 	return resolved
-		.replace(/^(claude-(?:haiku|opus|sonnet)-\d+)\.(\d+)(-.*)?$/u, '$1-$2$3')
-		.replace(/^(claude-(?:haiku|opus|sonnet)-\d)(\d)(-.*)?$/u, '$1-$2$3');
+		.replace(dottedClaudeModelRegex, '$1-$2$3')
+		.replace(compactClaudeModelRegex, '$1-$2$3');
 }
 
 function createModelCandidates(entry: OpenCodeUsageEntry): string[] {

--- a/apps/ccusage/src/adapter/pi/schema.ts
+++ b/apps/ccusage/src/adapter/pi/schema.ts
@@ -1,6 +1,9 @@
 import path from 'node:path';
+import { regex } from 'arkregex';
 import * as v from 'valibot';
 import { isoTimestampSchema } from '../../types.ts';
+
+const pathSeparatorRegex = regex('[/\\\\]', 'g');
 
 const piAgentUsageSchema = v.object({
 	input: v.number(),
@@ -58,7 +61,7 @@ export function extractPiAgentSessionId(filePath: string): string {
 }
 
 export function extractPiAgentProject(filePath: string): string {
-	const normalizedPath = filePath.replace(/[/\\]/g, path.sep);
+	const normalizedPath = filePath.replace(pathSeparatorRegex, path.sep);
 	const segments = normalizedPath.split(path.sep);
 	const sessionsIndex = segments.findIndex((segment) => segment === 'sessions');
 	if (sessionsIndex === -1 || sessionsIndex + 1 >= segments.length) {

--- a/apps/ccusage/src/adapter/shared.ts
+++ b/apps/ccusage/src/adapter/shared.ts
@@ -7,6 +7,7 @@ import type {
 } from './types.ts';
 import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
 import { compareStrings } from '@ccusage/internal/sort';
+import { regex } from 'arkregex';
 import { agentIds } from './types.ts';
 
 const safeTimeZoneCache = new Map<string, string>();
@@ -16,9 +17,10 @@ const dateTimeFormatterCache = new Map<string, Intl.DateTimeFormat>();
 const dateKeyCache = new Map<string, string>();
 const monthKeyCache = new Map<string, string>();
 let defaultTimeZoneCache: string | undefined;
-const isoUtcTimestampPattern = /^\d{4}-\d{2}-\d{2}T.*Z$/u;
-const dateKeyPattern = /^\d{4}-\d{2}-\d{2}$/u;
-const monthKeyPattern = /^\d{4}-\d{2}$/u;
+const isoUtcTimestampPattern = regex('^\\d{4}-\\d{2}-\\d{2}T.*Z$', 'u');
+const dateKeyPattern = regex('^\\d{4}-\\d{2}-\\d{2}$', 'u');
+const monthKeyPattern = regex('^\\d{4}-\\d{2}$', 'u');
+const compactDatePattern = regex('^\\d{8}$', 'u');
 
 function formatDateParts(year: number, month: number, day: number): string {
 	return `${year.toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
@@ -44,9 +46,9 @@ export function normalizeDateFilter(value: string | undefined): string | undefin
 	if (value == null || value === '') {
 		return undefined;
 	}
-	const normalized = /^\d{8}$/u.test(value)
+	const normalized = compactDatePattern.test(value)
 		? `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`
-		: /^\d{4}-\d{2}-\d{2}$/u.test(value)
+		: dateKeyPattern.test(value)
 			? value
 			: undefined;
 	if (normalized != null && isValidCalendarDate(normalized)) {

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -6,6 +6,7 @@ import * as pc from '@ccusage/internal/colors';
 import { createJsonFileState } from '@ccusage/internal/json-file-state';
 import { formatCurrency } from '@ccusage/terminal/table';
 import { Result } from '@praha/byethrow';
+import { regex } from 'arkregex';
 import getStdin from 'get-stdin';
 import { define } from 'gunshi';
 import * as v from 'valibot';
@@ -75,6 +76,8 @@ type SemaphoreType = {
 
 const visualBurnRateChoices = ['off', 'emoji', 'text', 'emoji-text'] as const;
 const costSourceChoices = ['auto', 'ccusage', 'cc', 'both'] as const;
+const integerStringRegex = regex('^-?\\d+$', 'u');
+const hyphenRegex = regex('-', 'g');
 
 // Valibot schema for context threshold validation
 const contextThresholdSchema = v.pipe(
@@ -83,7 +86,7 @@ const contextThresholdSchema = v.pipe(
 		v.pipe(
 			v.string(),
 			v.trim(),
-			v.check((value) => /^-?\d+$/u.test(value), 'Context threshold must be an integer'),
+			v.check((value) => integerStringRegex.test(value), 'Context threshold must be an integer'),
 			v.transform((value) => Number.parseInt(value, 10)),
 		),
 	]),
@@ -357,7 +360,7 @@ export const statuslineCommand = define({
 
 					// Load today's usage data
 					const today = new Date();
-					const todayStr = today.toISOString().split('T')[0]?.replace(/-/g, '') ?? ''; // Convert to YYYYMMDD format
+					const todayStr = today.toISOString().split('T')[0]?.replace(hyphenRegex, '') ?? ''; // Convert to YYYYMMDD format
 					const midnightToday = new Date();
 					midnightToday.setHours(0, 0, 0, 0);
 

--- a/apps/ccusage/src/date-utils.ts
+++ b/apps/ccusage/src/date-utils.ts
@@ -1,10 +1,11 @@
+import type { DayOfWeek, WeekDay } from './consts.ts';
 /**
  * Date utility functions for handling date formatting, filtering, and manipulation
  * @module date-utils
  */
 
-import type { DayOfWeek, WeekDay } from './consts.ts';
 import type { WeeklyDate } from './types.ts';
+import { regex } from 'arkregex';
 import { DEFAULT_LOCALE } from './consts.ts';
 import { createWeeklyDate } from './types.ts';
 
@@ -13,6 +14,7 @@ export { sortByDate } from '@ccusage/internal/sort';
 export { formatDateCompact } from '@ccusage/terminal/table';
 
 const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
+const hyphenRegex = regex('-', 'g');
 
 function formatDateParts(year: number, month: number, day: number): string {
 	return `${year.toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
@@ -123,7 +125,7 @@ export function filterByDateRange<T>(
 	}
 
 	return items.filter((item) => {
-		const dateStr = getDate(item).substring(0, 10).replace(/-/g, ''); // Convert to YYYYMMDD
+		const dateStr = getDate(item).substring(0, 10).replace(hyphenRegex, ''); // Convert to YYYYMMDD
 		if (since != null && dateStr < since) {
 			return false;
 		}
@@ -186,7 +188,7 @@ if (import.meta.vitest != null) {
 	describe('formatDate', () => {
 		it('should format date string to YYYY-MM-DD format', () => {
 			const result = formatDate('2024-08-04T12:00:00Z');
-			expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+			expect(result).toMatch(regex('^\\d{4}-\\d{2}-\\d{2}$'));
 		});
 
 		it('should handle timezone parameter', () => {
@@ -196,7 +198,7 @@ if (import.meta.vitest != null) {
 
 		it('uses the default YYYY-MM-DD locale', () => {
 			const result = formatDate('2024-08-04T12:00:00Z');
-			expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+			expect(result).toMatch(regex('^\\d{4}-\\d{2}-\\d{2}$'));
 		});
 	});
 

--- a/apps/ccusage/src/project-names.ts
+++ b/apps/ccusage/src/project-names.ts
@@ -1,3 +1,4 @@
+import { regex } from 'arkregex';
 /**
  * @fileoverview Project name formatting and alias utilities
  *
@@ -6,6 +7,13 @@
  *
  * @module project-names
  */
+const ignoredProjectSegmentRegex = regex.as<string, { captures: [] }>(
+	'^(?:dev|development|feat|feature|fix|bug|test|staging|prod|production|main|master|branch)$',
+	'i',
+);
+const windowsUsersPathRegex = regex('^[A-Z]:\\\\Users\\\\|^\\\\Users\\\\');
+const trimPathSegmentRegex = regex('^[/\\\\-]+|[/\\\\-]+$', 'g');
+const uuidPrefixRegex = regex('^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}', 'i');
 
 /**
  * Extract meaningful project name from directory-style project paths
@@ -38,7 +46,7 @@ function parseProjectName(projectName: string): string {
 	let cleaned = projectName;
 
 	// Handle Windows-style paths: C:\Users\... or \Users\...
-	if (cleaned.match(/^[A-Z]:\\Users\\|^\\Users\\/) != null) {
+	if (cleaned.match(windowsUsersPathRegex) != null) {
 		const segments = cleaned.split('\\');
 		const userIndex = segments.findIndex((seg) => seg === 'Users');
 		if (userIndex !== -1 && userIndex + 3 < segments.length) {
@@ -62,11 +70,11 @@ function parseProjectName(projectName: string): string {
 	// If no path cleanup occurred, use original name
 	if (cleaned === projectName) {
 		// Just basic cleanup for non-path names
-		cleaned = projectName.replace(/^[/\\-]+|[/\\-]+$/g, '');
+		cleaned = projectName.replace(trimPathSegmentRegex, '');
 	}
 
 	// Handle UUID-like patterns
-	if (cleaned.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i) != null) {
+	if (cleaned.match(uuidPrefixRegex) != null) {
 		// Extract last two segments of UUID for brevity
 		const parts = cleaned.split('-');
 		if (parts.length >= 5) {
@@ -91,11 +99,7 @@ function parseProjectName(projectName: string): string {
 
 		// Look for common meaningful patterns
 		const meaningfulSegments = segments.filter(
-			(seg) =>
-				seg.length > 2 &&
-				seg.match(
-					/^(?:dev|development|feat|feature|fix|bug|test|staging|prod|production|main|master|branch)$/i,
-				) == null,
+			(seg) => seg.length > 2 && seg.match(ignoredProjectSegmentRegex) == null,
 		);
 
 		// If we have compound project names like "adminifi-edugakko-api"
@@ -112,7 +116,7 @@ function parseProjectName(projectName: string): string {
 	}
 
 	// Final cleanup
-	cleaned = cleaned.replace(/^[/\\-]+|[/\\-]+$/g, '');
+	cleaned = cleaned.replace(trimPathSegmentRegex, '');
 
 	return cleaned !== '' ? cleaned : projectName !== '' ? projectName : 'Unknown Project';
 }

--- a/apps/ccusage/src/project-names.ts
+++ b/apps/ccusage/src/project-names.ts
@@ -7,7 +7,7 @@ import { regex } from 'arkregex';
  *
  * @module project-names
  */
-const ignoredProjectSegmentRegex = regex.as<string, { captures: [] }>(
+const ignoredProjectSegmentRegex = regex.as<`${string}`, { captures: [] }>(
 	'^(?:dev|development|feat|feature|fix|bug|test|staging|prod|production|main|master|branch)$',
 	'i',
 );

--- a/apps/ccusage/src/runtime-macro.ts
+++ b/apps/ccusage/src/runtime-macro.ts
@@ -1,10 +1,13 @@
+import { regex } from 'arkregex';
 import packageJson from '../package.json' with { type: 'json' };
 
 type NodeVersion = readonly [number, number, number];
 
+const nodeEngineRangeRegex = regex('^>=(\\d+)\\.(\\d+)\\.(\\d+)$');
+
 export function getSupportedNodeRuntime(): { minimum: NodeVersion; range: string } {
 	const range = packageJson.engines.node;
-	const match = /^>=(\d+)\.(\d+)\.(\d+)$/.exec(range);
+	const match = nodeEngineRangeRegex.exec(range);
 	if (match == null) {
 		throw new Error(`Unsupported Node.js engine range: ${range}`);
 	}

--- a/apps/ccusage/src/types.ts
+++ b/apps/ccusage/src/types.ts
@@ -1,4 +1,5 @@
 import type { TupleToUnion } from 'type-fest';
+import { regex } from 'arkregex';
 import * as v from 'valibot';
 
 /**
@@ -31,14 +32,14 @@ export const messageIdSchema = v.pipe(
 );
 
 // Date and timestamp schemas
-const isoTimestampRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const isoTimestampRegex = regex('^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$');
 export const isoTimestampSchema = v.pipe(
 	v.string(),
 	v.regex(isoTimestampRegex, 'Invalid ISO timestamp'),
 	v.brand('ISOTimestamp'),
 );
 
-const yyyymmddRegex = /^\d{4}-\d{2}-\d{2}$/;
+const yyyymmddRegex = regex('^\\d{4}-\\d{2}-\\d{2}$');
 export const dailyDateSchema = v.pipe(
 	v.string(),
 	v.regex(yyyymmddRegex, 'Date must be in YYYY-MM-DD format'),
@@ -51,7 +52,7 @@ export const activityDateSchema = v.pipe(
 	v.brand('ActivityDate'),
 );
 
-const yyyymmRegex = /^\d{4}-\d{2}$/;
+const yyyymmRegex = regex('^\\d{4}-\\d{2}$');
 export const monthlyDateSchema = v.pipe(
 	v.string(),
 	v.regex(yyyymmRegex, 'Date must be in YYYY-MM format'),
@@ -64,7 +65,7 @@ export const weeklyDateSchema = v.pipe(
 	v.brand('WeeklyDate'),
 );
 
-const filterDateRegex = /^\d{8}$/;
+const filterDateRegex = regex('^\\d{8}$');
 export const filterDateSchema = v.pipe(
 	v.string(),
 	v.regex(filterDateRegex, 'Date must be in YYYYMMDD format'),
@@ -78,7 +79,7 @@ export const projectPathSchema = v.pipe(
 	v.brand('ProjectPath'),
 );
 
-const versionRegex = /^\d+\.\d+\.\d+/;
+const versionRegex = regex('^\\d+\\.\\d+\\.\\d+');
 export const versionSchema = v.pipe(
 	v.string(),
 	v.regex(versionRegex, 'Invalid version format'),

--- a/apps/ccusage/test/cli-output.test.ts
+++ b/apps/ccusage/test/cli-output.test.ts
@@ -3,11 +3,15 @@ import { mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { regex } from 'arkregex';
 import { createFixture } from 'fs-fixture';
 
 const appRoot = fileURLToPath(new URL('../', import.meta.url));
 const fixtureTemplatePath = fileURLToPath(new URL('./fixtures/claude', import.meta.url));
 const snapshotRoot = fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url));
+const trailingNewlineRegex = regex('\n$');
+const trailingUnicodeNewlineRegex = regex('\n$', 'u');
+const fixtureDateRegex = regex('2026-01-02', 'gu');
 
 type DailyJsonOutput = {
 	daily: Array<{
@@ -235,7 +239,7 @@ describe('ccusage output snapshots', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(/\n$/, '')).toMatchFileSnapshot(
+		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'daily-json.txt'),
 		);
 	});
@@ -254,7 +258,7 @@ describe('ccusage output snapshots', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(/\n$/, '')).toMatchFileSnapshot(
+		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'session-json.txt'),
 		);
 	});
@@ -273,7 +277,7 @@ describe('ccusage output snapshots', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(/\n$/, '')).toMatchFileSnapshot(
+		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'blocks-json.txt'),
 		);
 	});
@@ -292,7 +296,7 @@ describe('ccusage output snapshots', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(/\n$/, '')).toMatchFileSnapshot(
+		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'monthly-json.txt'),
 		);
 	});
@@ -311,7 +315,7 @@ describe('ccusage output snapshots', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(/\n$/, '')).toMatchFileSnapshot(
+		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'weekly-json.txt'),
 		);
 	});
@@ -330,7 +334,7 @@ describe('ccusage output snapshots', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(/\n$/, '')).toMatchFileSnapshot(
+		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'daily-table.txt'),
 		);
 	});
@@ -349,7 +353,7 @@ describe('ccusage output snapshots', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(/\n$/, '')).toMatchFileSnapshot(
+		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'session-table.txt'),
 		);
 	});
@@ -368,7 +372,7 @@ describe('ccusage output snapshots', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(/\n$/, '')).toMatchFileSnapshot(
+		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'blocks-table.txt'),
 		);
 	});
@@ -386,7 +390,7 @@ describe('ccusage all-agent CLI', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 
-		const stdout = getStdout(result).replace(/\n$/u, '');
+		const stdout = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
 		await mkdir(snapshotRoot, { recursive: true });
 		await expect(stdout).toMatchFileSnapshot(path.join(snapshotRoot, 'all-agent-daily-json.txt'));
 
@@ -459,7 +463,7 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const stdout = getStdout(result).replace(/\n$/u, '');
+		const stdout = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
 		await mkdir(snapshotRoot, { recursive: true });
 		await expect(stdout).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'codex-direct-daily-json.txt'),
@@ -487,7 +491,7 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const stdout = getStdout(result).replace(/\n$/u, '');
+		const stdout = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
 		await mkdir(snapshotRoot, { recursive: true });
 		await expect(stdout).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'claude-direct-daily-json.txt'),
@@ -504,7 +508,7 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const stdout = getStdout(result).replace(/\n$/u, '');
+		const stdout = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
 		await mkdir(snapshotRoot, { recursive: true });
 		await expect(stdout).toMatchFileSnapshot(path.join(snapshotRoot, 'pi-direct-daily-json.txt'));
 	});
@@ -517,7 +521,7 @@ describe('ccusage all-agent CLI', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 		await mkdir(snapshotRoot, { recursive: true });
-		await expect(getStdout(result).replace(/\n$/u, '')).toMatchFileSnapshot(
+		await expect(getStdout(result).replace(trailingUnicodeNewlineRegex, '')).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'opencode-direct-daily-json.txt'),
 		);
 	});
@@ -569,7 +573,7 @@ describe('ccusage all-agent CLI', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 
-		const stdout = getStdout(result).replace(/\n$/u, '');
+		const stdout = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
 		await mkdir(snapshotRoot, { recursive: true });
 		await expect(stdout).toMatchFileSnapshot(path.join(snapshotRoot, 'amp-direct-daily-json.txt'));
 
@@ -591,7 +595,7 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const output = getStdout(result).replace(/\n$/u, '');
+		const output = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
 		await mkdir(snapshotRoot, { recursive: true });
 		await expect(output).toMatchFileSnapshot(path.join(snapshotRoot, 'amp-direct-full-table.txt'));
 		expect(output).not.toContain('Running in Compact Mode');
@@ -610,7 +614,7 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const output = getStdout(result).replace(/\n$/u, '');
+		const output = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
 		await mkdir(snapshotRoot, { recursive: true });
 		await expect(output).toMatchFileSnapshot(
 			path.join(snapshotRoot, 'amp-direct-compact-table.txt'),
@@ -634,12 +638,12 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const output = getStdout(result).replace(/\n$/u, '');
+		const output = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
 		await mkdir(snapshotRoot, { recursive: true });
 		await expect(output).toMatchFileSnapshot(path.join(snapshotRoot, 'all-agent-daily-table.txt'));
 		expect(output).toContain('Coding (Agent) CLI Usage Report - Daily');
 		expect(output).toContain('Detected: Amp, Claude, Codex, OpenCode, pi-agent');
-		expect(output.match(/2026-01-02/gu)).toHaveLength(1);
+		expect(output.match(fixtureDateRegex)).toHaveLength(1);
 		expect(output).toContain('Amp');
 		expect(output).toContain('Codex');
 		expect(output).toContain('OpenCode');

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
             gh
             hyperfine
             similarity
+            ast-grep
             ripgrep
             fd
             fzf

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -21,6 +21,7 @@
 	"devDependencies": {
 		"@ccusage/internal": "workspace:*",
 		"@ryoppippi/eslint-config": "catalog:lint",
+		"arkregex": "catalog:runtime",
 		"eslint": "catalog:lint",
 		"eslint-plugin-format": "catalog:lint",
 		"vitest": "catalog:testing"

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -1,5 +1,6 @@
 import process from 'node:process';
 import * as pc from '@ccusage/internal/colors';
+import { regex } from 'arkregex';
 import { getStringWidth } from './text-width.ts';
 
 /**
@@ -11,6 +12,15 @@ let numberFormatter: Intl.NumberFormat | undefined;
 const formattedNumberCache = new Map<number, string>();
 const formattedModelNameCache = new Map<string, string>();
 const COLOR_RESET = '\x1B[39m';
+const simpleDateRegex = regex('^\\d{4}-\\d{2}-\\d{2}$');
+const separatorRowRegex = regex('^─+$');
+const piModelPrefixRegex = regex('^\\[pi\\] (.+)$');
+const anthropicProviderRegex = regex('^(?:anthropic/|anthropic\\.)(claude-.+)$');
+const legacyDatedClaudeRegex = regex('^claude-(\\d+)-(\\d+)-(\\w+)-(\\d{8})$');
+const datedFastClaudeRegex = regex('^claude-(\\w+)-([\\d-]+)-(\\d{8})-fast$');
+const datedClaudeRegex = regex('^claude-(\\w+)-([\\d-]+)-(\\d{8})$');
+const fastClaudeRegex = regex('^claude-(\\w+)-([\\d.-]+)-fast$');
+const undatedClaudeRegex = regex('^claude-(\\w+)-([\\d.-]+)$');
 
 function getNumberFormatter(): Intl.NumberFormat {
 	numberFormatter ??= new Intl.NumberFormat('en-US');
@@ -188,7 +198,7 @@ function createDatePartsFormatter(timezone: string | undefined): Intl.DateTimeFo
  * @returns Formatted date string with newline separator (YYYY\nMM-DD)
  */
 export function formatDateCompact(dateStr: string, timezone?: string): string {
-	const isSimpleDateFormat = /^\d{4}-\d{2}-\d{2}$/.test(dateStr);
+	const isSimpleDateFormat = simpleDateRegex.test(dateStr);
 	if (isSimpleDateFormat && (timezone == null || timezone === 'UTC')) {
 		return `${dateStr.slice(0, 4)}\n${dateStr.slice(5)}`;
 	}
@@ -524,9 +534,9 @@ export class ResponsiveTable {
 		// Check for both old-style separator rows (─) and new-style empty rows
 		return row.every((cell) => {
 			if (typeof cell === 'object' && cell != null && 'content' in cell) {
-				return cell.content === '' || /^─+$/.test(cell.content);
+				return cell.content === '' || separatorRowRegex.test(cell.content);
 			}
-			return typeof cell === 'string' && (cell === '' || /^─+$/.test(cell));
+			return typeof cell === 'string' && (cell === '' || separatorRowRegex.test(cell));
 		});
 	}
 
@@ -537,7 +547,7 @@ export class ResponsiveTable {
 	 */
 	private isDateString(text: string): boolean {
 		// Check if string matches date format YYYY-MM-DD
-		return /^\d{4}-\d{2}-\d{2}$/.test(text);
+		return simpleDateRegex.test(text);
 	}
 
 	private renderFastTable(
@@ -645,28 +655,28 @@ function formatModelName(modelName: string): string {
 
 	let formatted = modelName;
 	// Handle [pi] prefix - preserve prefix, format the rest
-	const piMatch = modelName.match(/^\[pi\] (.+)$/);
+	const piMatch = modelName.match(piModelPrefixRegex);
 	if (piMatch?.[1] != null) {
 		formatted = `[pi] ${formatModelName(piMatch[1])}`;
 		formattedModelNameCache.set(modelName, formatted);
 		return formatted;
 	}
 
-	const providerMatch = modelName.match(/^(?:anthropic\/|anthropic\.)(claude-.+)$/);
+	const providerMatch = modelName.match(anthropicProviderRegex);
 	if (providerMatch?.[1] != null) {
 		formatted = formatModelName(providerMatch[1]);
 		formattedModelNameCache.set(modelName, formatted);
 		return formatted;
 	}
 
-	const legacyDatedMatch = modelName.match(/^claude-(\d+)-(\d+)-(\w+)-(\d{8})$/);
+	const legacyDatedMatch = modelName.match(legacyDatedClaudeRegex);
 	if (legacyDatedMatch != null) {
 		formatted = `${legacyDatedMatch[3]}-${legacyDatedMatch[1]}-${legacyDatedMatch[2]}`;
 		formattedModelNameCache.set(modelName, formatted);
 		return formatted;
 	}
 
-	const datedFastMatch = modelName.match(/^claude-(\w+)-([\d-]+)-(\d{8})-fast$/);
+	const datedFastMatch = modelName.match(datedFastClaudeRegex);
 	if (datedFastMatch != null) {
 		formatted = `${datedFastMatch[1]}-${datedFastMatch[2]}-fast`;
 		formattedModelNameCache.set(modelName, formatted);
@@ -677,14 +687,14 @@ function formatModelName(modelName: string): string {
 	// e.g., "claude-sonnet-4-20250514" -> "sonnet-4"
 	// e.g., "claude-opus-4-20250514" -> "opus-4"
 	// e.g., "claude-sonnet-4-5-20250929" -> "sonnet-4-5"
-	const match = modelName.match(/^claude-(\w+)-([\d-]+)-(\d{8})$/);
+	const match = modelName.match(datedClaudeRegex);
 	if (match != null) {
 		formatted = `${match[1]}-${match[2]}`;
 		formattedModelNameCache.set(modelName, formatted);
 		return formatted;
 	}
 
-	const fastMatch = modelName.match(/^claude-(\w+)-([\d.-]+)-fast$/);
+	const fastMatch = modelName.match(fastClaudeRegex);
 	if (fastMatch != null) {
 		formatted = `${fastMatch[1]}-${fastMatch[2]}-fast`;
 		formattedModelNameCache.set(modelName, formatted);
@@ -692,7 +702,7 @@ function formatModelName(modelName: string): string {
 	}
 
 	// Handle claude- without date suffix (e.g., "claude-opus-4-5" -> "opus-4-5")
-	const noDateMatch = modelName.match(/^claude-(\w+)-([\d.-]+)$/);
+	const noDateMatch = modelName.match(undatedClaudeRegex);
 	if (noDateMatch != null) {
 		formatted = `${noDateMatch[1]}-${noDateMatch[2]}`;
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.30)(eslint-plugin-format@2.0.1(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.1.2(@types/node@24.5.1)(vite@8.0.11(@types/node@24.5.1)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.1)))
+      arkregex:
+        specifier: catalog:runtime
+        version: 0.0.5
       eslint:
         specifier: catalog:lint
         version: 9.35.0(jiti@2.6.1)


### PR DESCRIPTION
## Summary
- add ArkRegex guidance to the repo-local TypeScript skill and route TS/JS files to it
- consolidate Gunshi and byethrow guidance as TypeScript skill references
- replace implementation regex literals with arkregex and keep reused patterns at module scope
- add arkregex to the terminal package devDependencies

## Notes
- left CLI output snapshot tests untouched; implementation and in-source tests now follow arkregex where touched
- built dist locally; cli.js is 2122 bytes and arkregex emits a 115 byte shared runtime chunk
- bundle-size comparison can run in CI

## Testing
- pnpm run format
- pnpm typecheck
- pnpm run test
- pnpm --filter ccusage build
- , ast-grep run --lang ts --pattern '/$P/' --json=stream apps packages | jq -r 'select(.file | test("test/") | not) | [.file, (.range.start.line+1|tostring), .text] | @tsv'

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor all regexes to `arkregex`, hoisting shared patterns and keeping behavior identical. Added an `ast-grep` skill, Nix dev-shell support, and commit subject guidance; clarified newline usage.

- **Refactors**
  - Replaced regex literals and `new RegExp(...)` with `arkregex` across app code, terminal table formatting, and tests; hoisted reused patterns and tightened `regex.as` generics where needed.
  - Updated skills and docs: added `typescript-style/references/arkregex.md`, consolidated byethrow/Gunshi references, documented file-routing metadata, added `.agents/skills/ast-grep`, linked it in `CLAUDE.md`, and required concrete commit subjects in `commit/SKILL.md`.
  - Moved remaining CLI snapshot test regexes to module-level `arkregex` constants; snapshots unchanged.

- **Dependencies**
  - Added `arkregex` to `packages/terminal` devDependencies; updated lockfile.
  - Added `ast-grep` to the Nix dev shell (`flake.nix`).

<sup>Written for commit d7b6f0b98e8bd1990791e448fdfa8881b5b25825. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1038?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/expanded guidance: skill routing, optional file-routing fields, TypeScript conventions and library references, CLI/Gunshi guidance, regex policy, ast-grep usage/examples, commit-message format, and updated CLAUDE package guidance.

* **Refactor**
  * Standardized regex handling across the codebase by adopting a compiled-regex helper for consistent parsing and normalization (multiple modules updated).

* **Tests**
  * Updated tests to use shared regex helpers and normalize outputs (dates, trailing newlines).

* **Chores**
  * Added the compiled-regex helper as a runtime dependency and included ast-grep in the dev shell.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->