### PR TITLE
chore: remove unused runtime catalog entries

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,28 +35,14 @@ catalogs:
   runtime:
     '@antfu/utils': ^9.2.1
     '@praha/byethrow': ^0.6.3
-    '@ryoppippi/limo': jsr:^0.2.2
-    '@std/async': jsr:^1.0.14
     ansi-escapes: ^7.0.0
     arkregex: ^0.0.5
-    cli-table3: ^0.6.5
-    consola: ^3.4.2
-    es-toolkit: ^1.39.10
-    fast-sort: ^3.4.1
     get-stdin: ^9.0.0
     gunshi: ^0.26.3
-    nano-spawn: ^1.0.3
-    p-limit: ^7.1.0
-    path-type: ^6.0.0
-    picocolors: ^1.1.1
     picospinner: ^3.0.0
-    pretty-ms: ^9.2.0
-    string-width: ^7.2.0
-    tinyglobby: ^0.2.14
     type-fest: ^4.41.0
     valibot: ^1.1.0
     xdg-basedir: ^5.1.0
-    zod: ^4.1.13
   testing:
     fs-fixture: ^2.8.1
     mitata: ^1.0.34


### PR DESCRIPTION
Removes stale runtime catalog entries from pnpm-workspace.yaml that are no longer referenced by any package manifest. The lockfile was already aligned with the active catalog entries, so no lockfile update was needed.

Validation:
- pnpm install --lockfile-only
- pnpm run format
- pnpm typecheck
- pnpm run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused runtime catalog entries from pnpm-workspace.yaml to match actual dependency usage and reduce noise. No lockfile changes needed.

<sup>Written for commit 8d896f41ee08fdc994f4d60ca68c6cc7b8c94b5f. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1039?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace build catalog configuration, consolidating and reorganizing dependency versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->