### PR TITLE
build: update gunshi to 0.31

### DIFF
--- a/.agents/skills/typescript-style/references/gunshi.md
+++ b/.agents/skills/typescript-style/references/gunshi.md
@@ -9,10 +9,10 @@ For more information, read the gunshi API docs in `node_modules/@gunshi/docs/**.
 
 Let Gunshi infer command argument values from the concrete `args` object passed to `define()`. Avoid widening command types to `Command<Args>` or `ReturnType<typeof define>` because that erases the specific option keys and value types.
 
-When a command factory needs an explicit return type, preserve the concrete args type:
+Prefer omitting command factory return types when the factory directly returns `define(...)`:
 
 ```ts
-function createCommand(): Command<typeof commandArgs> {
+function createCommand() {
 	return define({
 		args: commandArgs,
 		async run(ctx) {
@@ -22,4 +22,12 @@ function createCommand(): Command<typeof commandArgs> {
 }
 ```
 
-If a factory chooses between different argument sets, split it into typed helper factories or overloads so each branch keeps `Command<typeof specificArgs>`.
+For application packages, prefer the app-oriented ESLint preset when explicit return type rules would force redundant Gunshi factory annotations.
+
+Only add an explicit command type at real type adaptation boundaries, such as a wrapper that adds shared arguments or replays another command's runner. In Gunshi 0.27+, `Command` is parameterized by Gunshi params rather than the args object directly:
+
+```ts
+type GunshiCommand<TArgs extends Args> = Command<{ args: TArgs; extensions: Record<never, never> }>;
+```
+
+If a factory chooses between different argument sets, first try splitting it into typed helper factories and letting each helper infer its own `define(...)` result. Use overloads only when callers truly need literal-specific return types.

--- a/.agents/skills/typescript-style/references/gunshi.md
+++ b/.agents/skills/typescript-style/references/gunshi.md
@@ -24,10 +24,6 @@ function createCommand() {
 
 For application packages, prefer the app-oriented ESLint preset when explicit return type rules would force redundant Gunshi factory annotations.
 
-Only add an explicit command type at real type adaptation boundaries, such as a wrapper that adds shared arguments or replays another command's runner. In Gunshi 0.27+, `Command` is parameterized by Gunshi params rather than the args object directly:
-
-```ts
-type GunshiCommand<TArgs extends Args> = Command<{ args: TArgs; extensions: Record<never, never> }>;
-```
+Only add an explicit Gunshi command type at real adapter boundaries; otherwise let `define(...)` and helper returns infer.
 
 If a factory chooses between different argument sets, first try splitting it into typed helper factories and letting each helper infer its own `define(...)` result. Use overloads only when callers truly need literal-specific return types.

--- a/apps/ccusage/eslint.config.js
+++ b/apps/ccusage/eslint.config.js
@@ -3,7 +3,7 @@ import { ryoppippi } from '@ryoppippi/eslint-config';
 /** @type {import('eslint').Linter.FlatConfig[]} */
 const config = ryoppippi(
 	{
-		type: 'lib',
+		type: 'app',
 		stylistic: false,
 	},
 	{

--- a/apps/ccusage/scripts/generate-json-schema.ts
+++ b/apps/ccusage/scripts/generate-json-schema.ts
@@ -10,6 +10,7 @@
  * - Schema validation for configuration files
  */
 
+import type { SubCommandable } from 'gunshi';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { Result } from '@praha/byethrow';
@@ -55,6 +56,10 @@ type TokenDefinition = {
 	default?: unknown;
 };
 type TokenSchema = Record<string, TokenDefinition>;
+type SchemaCommand = {
+	args?: unknown;
+	subCommands?: Record<string, SubCommandable> | Map<string, SubCommandable>;
+};
 
 /**
  * Convert args-tokens schema to JSON Schema format
@@ -114,6 +119,15 @@ function splitCommandName(name: string): { agent?: AgentName; report: string } {
 		return { agent: prefix as AgentName, report };
 	}
 	return { report: name };
+}
+
+function getSubCommandEntries(command: SchemaCommand): Array<[string, SchemaCommand]> {
+	const subCommands = command.subCommands;
+	if (subCommands == null) {
+		return [];
+	}
+	const entries = subCommands instanceof Map ? subCommands.entries() : Object.entries(subCommands);
+	return Array.from(entries, ([name, subCommand]) => [name, subCommand as SchemaCommand]);
 }
 
 function filterCommandSchema(report: string, schema: TokenSchema): TokenSchema {
@@ -192,6 +206,16 @@ function createConfigSchemaJson(): JsonSchemaNode {
 	>;
 
 	for (const [commandName, command] of subCommandUnion) {
+		if (AGENT_NAMES.includes(commandName as AgentName)) {
+			for (const [report, subCommand] of getSubCommandEntries(command)) {
+				agentCommandSchemas[commandName as AgentName][report] = filterCommandSchema(
+					report,
+					(subCommand.args ?? {}) as TokenSchema,
+				);
+			}
+			continue;
+		}
+
 		const { agent, report } = splitCommandName(commandName);
 		const commandSchema = filterCommandSchema(report, command.args as TokenSchema);
 		if (agent == null) {

--- a/apps/ccusage/scripts/generate-json-schema.ts
+++ b/apps/ccusage/scripts/generate-json-schema.ts
@@ -10,7 +10,6 @@
  * - Schema validation for configuration files
  */
 
-import type { SubCommandable } from 'gunshi';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { Result } from '@praha/byethrow';
@@ -58,7 +57,7 @@ type TokenDefinition = {
 type TokenSchema = Record<string, TokenDefinition>;
 type SchemaCommand = {
 	args?: unknown;
-	subCommands?: Record<string, SubCommandable> | Map<string, SubCommandable>;
+	subCommands?: Record<string, unknown> | Map<string, unknown>;
 };
 
 /**

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -1,4 +1,4 @@
-import type { Args, Command } from 'gunshi';
+import type { Args } from 'gunshi';
 import type {
 	AdapterContext,
 	AdapterOptions,
@@ -26,8 +26,6 @@ import { agentLabels } from '../adapter/types.ts';
 import { formatDateCompact } from '../date-utils.ts';
 import { logger, writeStdoutLine } from '../logger.ts';
 import { createUsageLoadProgress, shouldShowUsageLoadProgress } from './loading-progress.ts';
-
-type GunshiCommand<TArgs extends Args> = Command<{ args: TArgs; extensions: Record<never, never> }>;
 
 type AgentTotals = {
 	inputTokens: number;
@@ -410,7 +408,7 @@ function createCommonAgentCommand(
 	agent: Exclude<AgentId, 'pi'>,
 	kind: AgentCommandKind,
 	description: string,
-): GunshiCommand<typeof commonAgentArgs> {
+) {
 	return define({
 		name: kind,
 		description,
@@ -422,10 +420,7 @@ function createCommonAgentCommand(
 	});
 }
 
-function createPiAgentCommand(
-	kind: AgentCommandKind,
-	description: string,
-): GunshiCommand<typeof piAgentArgs> {
+function createPiAgentCommand(kind: AgentCommandKind, description: string) {
 	return define({
 		name: kind,
 		description,
@@ -437,21 +432,7 @@ function createPiAgentCommand(
 	});
 }
 
-export function createAgentCommand(
-	agent: 'pi',
-	kind: AgentCommandKind,
-	description: string,
-): GunshiCommand<typeof piAgentArgs>;
-export function createAgentCommand(
-	agent: Exclude<AgentId, 'pi'>,
-	kind: AgentCommandKind,
-	description: string,
-): GunshiCommand<typeof commonAgentArgs>;
-export function createAgentCommand(
-	agent: AgentId,
-	kind: AgentCommandKind,
-	description: string,
-): GunshiCommand<typeof commonAgentArgs> | GunshiCommand<typeof piAgentArgs> {
+export function createAgentCommand(agent: AgentId, kind: AgentCommandKind, description: string) {
 	return agent === 'pi'
 		? createPiAgentCommand(kind, description)
 		: createCommonAgentCommand(agent, kind, description);

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -27,6 +27,8 @@ import { formatDateCompact } from '../date-utils.ts';
 import { logger, writeStdoutLine } from '../logger.ts';
 import { createUsageLoadProgress, shouldShowUsageLoadProgress } from './loading-progress.ts';
 
+type GunshiCommand<TArgs extends Args> = Command<{ args: TArgs; extensions: Record<never, never> }>;
+
 type AgentTotals = {
 	inputTokens: number;
 	outputTokens: number;
@@ -408,7 +410,7 @@ function createCommonAgentCommand(
 	agent: Exclude<AgentId, 'pi'>,
 	kind: AgentCommandKind,
 	description: string,
-): Command<typeof commonAgentArgs> {
+): GunshiCommand<typeof commonAgentArgs> {
 	return define({
 		name: kind,
 		description,
@@ -423,7 +425,7 @@ function createCommonAgentCommand(
 function createPiAgentCommand(
 	kind: AgentCommandKind,
 	description: string,
-): Command<typeof piAgentArgs> {
+): GunshiCommand<typeof piAgentArgs> {
 	return define({
 		name: kind,
 		description,
@@ -439,17 +441,17 @@ export function createAgentCommand(
 	agent: 'pi',
 	kind: AgentCommandKind,
 	description: string,
-): Command<typeof piAgentArgs>;
+): GunshiCommand<typeof piAgentArgs>;
 export function createAgentCommand(
 	agent: Exclude<AgentId, 'pi'>,
 	kind: AgentCommandKind,
 	description: string,
-): Command<typeof commonAgentArgs>;
+): GunshiCommand<typeof commonAgentArgs>;
 export function createAgentCommand(
 	agent: AgentId,
 	kind: AgentCommandKind,
 	description: string,
-): Command<typeof commonAgentArgs> | Command<typeof piAgentArgs> {
+): GunshiCommand<typeof commonAgentArgs> | GunshiCommand<typeof piAgentArgs> {
 	return agent === 'pi'
 		? createPiAgentCommand(kind, description)
 		: createCommonAgentCommand(agent, kind, description);

--- a/apps/ccusage/src/commands/all.ts
+++ b/apps/ccusage/src/commands/all.ts
@@ -1,4 +1,4 @@
-import type { Args, Command } from 'gunshi';
+import type { Args } from 'gunshi';
 import type {
 	AdapterContext,
 	AdapterOptions,
@@ -26,8 +26,6 @@ import { formatDateCompact, getDateStringWeek } from '../date-utils.ts';
 import { logger, writeStdoutLine } from '../logger.ts';
 import { sharedArgs } from '../shared-args.ts';
 import { createUsageLoadProgress, shouldShowUsageLoadProgress } from './loading-progress.ts';
-
-type GunshiCommand<TArgs extends Args> = Command<{ args: TArgs; extensions: Record<never, never> }>;
 
 type AllRow = AgentUsageRow;
 type AllBaseOptions = AdapterOptions & {
@@ -304,7 +302,7 @@ async function runAllReport(kind: ReportKind, options: AllOptions): Promise<void
 	}
 }
 
-function createAllCommand(kind: ReportKind, description: string): GunshiCommand<typeof allArgs> {
+function createAllCommand(kind: ReportKind, description: string) {
 	return define({
 		name: kind,
 		description,

--- a/apps/ccusage/src/commands/all.ts
+++ b/apps/ccusage/src/commands/all.ts
@@ -27,6 +27,8 @@ import { logger, writeStdoutLine } from '../logger.ts';
 import { sharedArgs } from '../shared-args.ts';
 import { createUsageLoadProgress, shouldShowUsageLoadProgress } from './loading-progress.ts';
 
+type GunshiCommand<TArgs extends Args> = Command<{ args: TArgs; extensions: Record<never, never> }>;
+
 type AllRow = AgentUsageRow;
 type AllBaseOptions = AdapterOptions & {
 	config?: string;
@@ -302,7 +304,7 @@ async function runAllReport(kind: ReportKind, options: AllOptions): Promise<void
 	}
 }
 
-function createAllCommand(kind: ReportKind, description: string): Command<typeof allArgs> {
+function createAllCommand(kind: ReportKind, description: string): GunshiCommand<typeof allArgs> {
 	return define({
 		name: kind,
 		description,

--- a/apps/ccusage/src/commands/codex.ts
+++ b/apps/ccusage/src/commands/codex.ts
@@ -14,6 +14,8 @@ import { formatDateCompact } from '../date-utils.ts';
 import { logger, writeStdoutLine } from '../logger.ts';
 import { createUsageLoadProgress, shouldShowUsageLoadProgress } from './loading-progress.ts';
 
+type GunshiCommand<TArgs extends Args> = Command<{ args: TArgs; extensions: Record<never, never> }>;
+
 const codexArgs = {
 	json: {
 		type: 'boolean',
@@ -251,7 +253,7 @@ async function runCodexReport(kind: CodexCommandKind, options: AdapterOptions): 
 function createCodexCommand(
 	kind: CodexCommandKind,
 	description: string,
-): Command<typeof codexArgs> {
+): GunshiCommand<typeof codexArgs> {
 	return define({
 		name: kind,
 		description,

--- a/apps/ccusage/src/commands/codex.ts
+++ b/apps/ccusage/src/commands/codex.ts
@@ -1,4 +1,4 @@
-import type { Args, Command } from 'gunshi';
+import type { Args } from 'gunshi';
 import type { AdapterOptions, ReportKind } from '../adapter/types.ts';
 import process from 'node:process';
 import {
@@ -13,8 +13,6 @@ import { loadCodexReportRows } from '../adapter/codex/index.ts';
 import { formatDateCompact } from '../date-utils.ts';
 import { logger, writeStdoutLine } from '../logger.ts';
 import { createUsageLoadProgress, shouldShowUsageLoadProgress } from './loading-progress.ts';
-
-type GunshiCommand<TArgs extends Args> = Command<{ args: TArgs; extensions: Record<never, never> }>;
 
 const codexArgs = {
 	json: {
@@ -250,10 +248,7 @@ async function runCodexReport(kind: CodexCommandKind, options: AdapterOptions): 
 	}
 }
 
-function createCodexCommand(
-	kind: CodexCommandKind,
-	description: string,
-): GunshiCommand<typeof codexArgs> {
+function createCodexCommand(kind: CodexCommandKind, description: string) {
 	return define({
 		name: kind,
 		description,

--- a/apps/ccusage/src/commands/index.ts
+++ b/apps/ccusage/src/commands/index.ts
@@ -251,7 +251,7 @@ const reportFlagAliases = new Set([
 ]);
 const agentFilterOptions = new Set(['--agent', '-a']);
 
-// Keep accepting the pre-nested internal command names that were directly invokable.
+// Keep accepting the pre-nested internal command names that were directly invocable.
 export function normalizeLegacyAgentCommandArgs(args: string[]): string[] {
 	const [command, ...rest] = args;
 	const [agent, report, extra] = command?.split(':') ?? [];

--- a/apps/ccusage/src/commands/index.ts
+++ b/apps/ccusage/src/commands/index.ts
@@ -251,6 +251,23 @@ const reportFlagAliases = new Set([
 ]);
 const agentFilterOptions = new Set(['--agent', '-a']);
 
+// Keep accepting the pre-nested internal command names that were directly invokable.
+export function normalizeLegacyAgentCommandArgs(args: string[]): string[] {
+	const [command, ...rest] = args;
+	const [agent, report, extra] = command?.split(':') ?? [];
+	if (
+		agent == null ||
+		report == null ||
+		extra != null ||
+		!agentCommands.has(agent) ||
+		agentReportCapabilities.get(agent)?.has(report) !== true
+	) {
+		return args;
+	}
+
+	return [agent, report, ...rest];
+}
+
 export function getReportFlagAliasError(args: string[]): string | undefined {
 	const reportFlag = args.find((arg) => reportFlagAliases.has(arg));
 	if (reportFlag != null) {
@@ -298,6 +315,7 @@ export async function run(): Promise<void> {
 	if (args[0] === 'ccusage') {
 		args = args.slice(1);
 	}
+	args = normalizeLegacyAgentCommandArgs(args);
 	const reportFlagAliasError = getReportFlagAliasError(args);
 	if (reportFlagAliasError != null) {
 		process.stderr.write(`${reportFlagAliasError}\n`);
@@ -326,6 +344,25 @@ export async function run(): Promise<void> {
 }
 
 if (import.meta.vitest != null) {
+	describe('normalizeLegacyAgentCommandArgs', () => {
+		it('maps legacy colon agent commands to nested Gunshi subcommands', () => {
+			expect(normalizeLegacyAgentCommandArgs(['codex:monthly', '--json'])).toEqual([
+				'codex',
+				'monthly',
+				'--json',
+			]);
+			expect(normalizeLegacyAgentCommandArgs(['claude:statusline'])).toEqual([
+				'claude',
+				'statusline',
+			]);
+		});
+
+		it('leaves unsupported legacy colon commands unchanged', () => {
+			expect(normalizeLegacyAgentCommandArgs(['codex:blocks'])).toEqual(['codex:blocks']);
+			expect(normalizeLegacyAgentCommandArgs(['daily'])).toEqual(['daily']);
+		});
+	});
+
 	describe('getReportFlagAliasError', () => {
 		it('rejects report mode flags', () => {
 			expect(getReportFlagAliasError(['--daily'])).toBe(

--- a/apps/ccusage/src/commands/index.ts
+++ b/apps/ccusage/src/commands/index.ts
@@ -1,6 +1,6 @@
-import type { Args, Command, SubCommandable } from 'gunshi';
+import type { Args } from 'gunshi';
 import process from 'node:process';
-import { cli } from 'gunshi';
+import { cli, define } from 'gunshi';
 import { description, name, version } from '../../package.json';
 import { loadConfig, mergeConfigWithArgs } from '../config-loader-tokens.ts';
 import { sharedArgs } from '../shared-args.ts';
@@ -14,7 +14,19 @@ import { sessionCommand } from './session.ts';
 import { statuslineCommand } from './statusline.ts';
 import { weeklyCommand } from './weekly.ts';
 
-type GunshiCommand<TArgs extends Args> = Command<{ args: TArgs; extensions: Record<never, never> }>;
+type ConfigurableCommand<TArgs extends Args> = {
+	name?: string;
+	description?: string;
+	args?: TArgs;
+	subCommands?: GunshiSubCommands;
+	toKebab?: boolean;
+	run?: unknown;
+};
+type GunshiSubCommands = NonNullable<NonNullable<Parameters<typeof cli>[2]>['subCommands']>;
+type GunshiSubCommand =
+	Extract<GunshiSubCommands, Map<string, unknown>> extends Map<string, infer TSubCommand>
+		? TSubCommand
+		: never;
 
 // Re-export all commands for easy importing
 export {
@@ -30,23 +42,23 @@ function withCommandName<T extends { name?: string }>(command: T, commandName: s
 	return { ...command, name: commandName };
 }
 
-function withSubCommands<
-	T extends { subCommands?: Record<string, SubCommandable> | Map<string, SubCommandable> },
->(command: T, subCommands: Map<string, SubCommandable>): T {
+function withSubCommands<const T, const TSubCommands extends GunshiSubCommands>(
+	command: T,
+	subCommands: TSubCommands,
+): T & { subCommands: TSubCommands } {
 	return { ...command, subCommands };
 }
 
-function withCcusageConfig<const TArgs extends Args>(
-	command: GunshiCommand<TArgs>,
-	configCommandName: string,
-	commandName = command.name,
-): GunshiCommand<Args> {
+function withCcusageConfig<
+	const TArgs extends Args,
+	const TCommand extends ConfigurableCommand<TArgs>,
+>(command: TCommand, configCommandName: string, commandName = command.name) {
 	const args = {
 		...(command.args ?? {}),
 		config: sharedArgs.config,
 	} satisfies Args;
 
-	return {
+	return define({
 		name: commandName,
 		description: command.description,
 		args,
@@ -66,12 +78,15 @@ function withCcusageConfig<const TArgs extends Args>(
 				config,
 				debug,
 			);
-			await command.run?.({
-				...ctx,
-				values: mergedValues,
-			} as Parameters<NonNullable<GunshiCommand<TArgs>['run']>>[0]);
+			if (typeof command.run === 'function') {
+				const run = command.run as (replayedContext: typeof ctx) => unknown;
+				await run({
+					...ctx,
+					values: mergedValues,
+				});
+			}
 		},
-	};
+	});
 }
 
 const opencodeDailyCommand = createAgentCommand(
@@ -117,7 +132,7 @@ const piSessionCommand = createAgentCommand(
 	'Show pi-agent usage grouped by session',
 );
 
-const claudeSubCommands = new Map<string, SubCommandable>([
+const claudeSubCommands = new Map<string, GunshiSubCommand>([
 	['daily', dailyCommand],
 	['monthly', monthlyCommand],
 	['weekly', weeklyCommand],
@@ -125,23 +140,23 @@ const claudeSubCommands = new Map<string, SubCommandable>([
 	['blocks', blocksCommand],
 	['statusline', statuslineCommand],
 ]);
-const codexSubCommands = new Map<string, SubCommandable>([
+const codexSubCommands = new Map<string, GunshiSubCommand>([
 	['daily', withCcusageConfig(codexDailyCommand, 'codex daily', 'daily')],
 	['monthly', withCcusageConfig(codexMonthlyCommand, 'codex monthly', 'monthly')],
 	['session', withCcusageConfig(codexSessionCommand, 'codex session', 'session')],
 ]);
-const opencodeSubCommands = new Map<string, SubCommandable>([
+const opencodeSubCommands = new Map<string, GunshiSubCommand>([
 	['daily', withCcusageConfig(opencodeDailyCommand, 'opencode daily', 'daily')],
 	['weekly', withCcusageConfig(opencodeWeeklyCommand, 'opencode weekly', 'weekly')],
 	['monthly', withCcusageConfig(opencodeMonthlyCommand, 'opencode monthly', 'monthly')],
 	['session', withCcusageConfig(opencodeSessionCommand, 'opencode session', 'session')],
 ]);
-const ampSubCommands = new Map<string, SubCommandable>([
+const ampSubCommands = new Map<string, GunshiSubCommand>([
 	['daily', withCcusageConfig(ampDailyCommand, 'amp daily', 'daily')],
 	['monthly', withCcusageConfig(ampMonthlyCommand, 'amp monthly', 'monthly')],
 	['session', withCcusageConfig(ampSessionCommand, 'amp session', 'session')],
 ]);
-const piSubCommands = new Map<string, SubCommandable>([
+const piSubCommands = new Map<string, GunshiSubCommand>([
 	['daily', withCcusageConfig(piDailyCommand, 'pi daily', 'daily')],
 	['monthly', withCcusageConfig(piMonthlyCommand, 'pi monthly', 'monthly')],
 	['session', withCcusageConfig(piSessionCommand, 'pi session', 'session')],

--- a/apps/ccusage/src/commands/index.ts
+++ b/apps/ccusage/src/commands/index.ts
@@ -1,4 +1,4 @@
-import type { Args, Command } from 'gunshi';
+import type { Args, Command, SubCommandable } from 'gunshi';
 import process from 'node:process';
 import { cli } from 'gunshi';
 import { description, name, version } from '../../package.json';
@@ -14,6 +14,8 @@ import { sessionCommand } from './session.ts';
 import { statuslineCommand } from './statusline.ts';
 import { weeklyCommand } from './weekly.ts';
 
+type GunshiCommand<TArgs extends Args> = Command<{ args: TArgs; extensions: Record<never, never> }>;
+
 // Re-export all commands for easy importing
 export {
 	blocksCommand,
@@ -28,10 +30,17 @@ function withCommandName<T extends { name?: string }>(command: T, commandName: s
 	return { ...command, name: commandName };
 }
 
+function withSubCommands<
+	T extends { subCommands?: Record<string, SubCommandable> | Map<string, SubCommandable> },
+>(command: T, subCommands: Map<string, SubCommandable>): T {
+	return { ...command, subCommands };
+}
+
 function withCcusageConfig<const TArgs extends Args>(
-	command: Command<TArgs>,
-	commandName: string,
-): Command<Args> {
+	command: GunshiCommand<TArgs>,
+	configCommandName: string,
+	commandName = command.name,
+): GunshiCommand<Args> {
 	const args = {
 		...(command.args ?? {}),
 		config: sharedArgs.config,
@@ -41,6 +50,7 @@ function withCcusageConfig<const TArgs extends Args>(
 		name: commandName,
 		description: command.description,
 		args,
+		subCommands: command.subCommands,
 		toKebab: command.toKebab,
 		async run(ctx) {
 			const values = ctx.values as Record<string, unknown>;
@@ -51,7 +61,7 @@ function withCcusageConfig<const TArgs extends Args>(
 				{
 					values,
 					tokens: ctx.tokens,
-					name: commandName,
+					name: configCommandName,
 				},
 				config,
 				debug,
@@ -59,7 +69,7 @@ function withCcusageConfig<const TArgs extends Args>(
 			await command.run?.({
 				...ctx,
 				values: mergedValues,
-			} as Parameters<NonNullable<Command<TArgs>['run']>>[0]);
+			} as Parameters<NonNullable<GunshiCommand<TArgs>['run']>>[0]);
 		},
 	};
 }
@@ -107,6 +117,36 @@ const piSessionCommand = createAgentCommand(
 	'Show pi-agent usage grouped by session',
 );
 
+const claudeSubCommands = new Map<string, SubCommandable>([
+	['daily', dailyCommand],
+	['monthly', monthlyCommand],
+	['weekly', weeklyCommand],
+	['session', sessionCommand],
+	['blocks', blocksCommand],
+	['statusline', statuslineCommand],
+]);
+const codexSubCommands = new Map<string, SubCommandable>([
+	['daily', withCcusageConfig(codexDailyCommand, 'codex daily', 'daily')],
+	['monthly', withCcusageConfig(codexMonthlyCommand, 'codex monthly', 'monthly')],
+	['session', withCcusageConfig(codexSessionCommand, 'codex session', 'session')],
+]);
+const opencodeSubCommands = new Map<string, SubCommandable>([
+	['daily', withCcusageConfig(opencodeDailyCommand, 'opencode daily', 'daily')],
+	['weekly', withCcusageConfig(opencodeWeeklyCommand, 'opencode weekly', 'weekly')],
+	['monthly', withCcusageConfig(opencodeMonthlyCommand, 'opencode monthly', 'monthly')],
+	['session', withCcusageConfig(opencodeSessionCommand, 'opencode session', 'session')],
+]);
+const ampSubCommands = new Map<string, SubCommandable>([
+	['daily', withCcusageConfig(ampDailyCommand, 'amp daily', 'daily')],
+	['monthly', withCcusageConfig(ampMonthlyCommand, 'amp monthly', 'monthly')],
+	['session', withCcusageConfig(ampSessionCommand, 'amp session', 'session')],
+]);
+const piSubCommands = new Map<string, SubCommandable>([
+	['daily', withCcusageConfig(piDailyCommand, 'pi daily', 'daily')],
+	['monthly', withCcusageConfig(piMonthlyCommand, 'pi monthly', 'monthly')],
+	['session', withCcusageConfig(piSessionCommand, 'pi session', 'session')],
+]);
+
 /**
  * Command entries as tuple array
  */
@@ -117,25 +157,39 @@ export const subCommandUnion = [
 	['session', allSessionCommand],
 	['blocks', blocksCommand],
 	['statusline', statuslineCommand],
-	['claude:daily', withCommandName(dailyCommand, 'claude daily')],
-	['claude:monthly', withCommandName(monthlyCommand, 'claude monthly')],
-	['claude:weekly', withCommandName(weeklyCommand, 'claude weekly')],
-	['claude:session', withCommandName(sessionCommand, 'claude session')],
-	['claude:blocks', withCommandName(blocksCommand, 'claude blocks')],
-	['claude:statusline', withCommandName(statuslineCommand, 'claude statusline')],
-	['codex:daily', withCcusageConfig(codexDailyCommand, 'codex daily')],
-	['codex:monthly', withCcusageConfig(codexMonthlyCommand, 'codex monthly')],
-	['codex:session', withCcusageConfig(codexSessionCommand, 'codex session')],
-	['opencode:daily', withCcusageConfig(opencodeDailyCommand, 'opencode daily')],
-	['opencode:weekly', withCcusageConfig(opencodeWeeklyCommand, 'opencode weekly')],
-	['opencode:monthly', withCcusageConfig(opencodeMonthlyCommand, 'opencode monthly')],
-	['opencode:session', withCcusageConfig(opencodeSessionCommand, 'opencode session')],
-	['amp:daily', withCcusageConfig(ampDailyCommand, 'amp daily')],
-	['amp:monthly', withCcusageConfig(ampMonthlyCommand, 'amp monthly')],
-	['amp:session', withCcusageConfig(ampSessionCommand, 'amp session')],
-	['pi:daily', withCcusageConfig(piDailyCommand, 'pi daily')],
-	['pi:monthly', withCcusageConfig(piMonthlyCommand, 'pi monthly')],
-	['pi:session', withCcusageConfig(piSessionCommand, 'pi session')],
+	['claude', withCommandName(withSubCommands(dailyCommand, claudeSubCommands), 'claude')],
+	[
+		'codex',
+		withCcusageConfig(
+			withCommandName(withSubCommands(codexDailyCommand, codexSubCommands), 'codex'),
+			'codex daily',
+			'codex',
+		),
+	],
+	[
+		'opencode',
+		withCcusageConfig(
+			withCommandName(withSubCommands(opencodeDailyCommand, opencodeSubCommands), 'opencode'),
+			'opencode daily',
+			'opencode',
+		),
+	],
+	[
+		'amp',
+		withCcusageConfig(
+			withCommandName(withSubCommands(ampDailyCommand, ampSubCommands), 'amp'),
+			'amp daily',
+			'amp',
+		),
+	],
+	[
+		'pi',
+		withCcusageConfig(
+			withCommandName(withSubCommands(piDailyCommand, piSubCommands), 'pi'),
+			'pi daily',
+			'pi',
+		),
+	],
 ] as const;
 
 /**
@@ -181,19 +235,6 @@ const reportFlagAliases = new Set([
 	'--statusline',
 ]);
 const agentFilterOptions = new Set(['--agent', '-a']);
-
-export function normalizeAgentCommandArgs(args: string[]): string[] {
-	const [agent, report, ...rest] = args;
-	if (agent == null || !agentCommands.has(agent)) {
-		return args;
-	}
-
-	if (report != null && agentReports.has(report)) {
-		return [`${agent}:${report}`, ...rest];
-	}
-
-	return [`${agent}:daily`, ...args.slice(1)];
-}
 
 export function getReportFlagAliasError(args: string[]): string | undefined {
 	const reportFlag = args.find((arg) => reportFlagAliases.has(arg));
@@ -260,8 +301,6 @@ export async function run(): Promise<void> {
 		process.exitCode = 1;
 		return;
 	}
-	args = normalizeAgentCommandArgs(args);
-
 	await cli(args, mainCommand, {
 		name,
 		version,
@@ -272,27 +311,6 @@ export async function run(): Promise<void> {
 }
 
 if (import.meta.vitest != null) {
-	describe('normalizeAgentCommandArgs', () => {
-		it('maps an agent report to a flat Gunshi subcommand', () => {
-			expect(normalizeAgentCommandArgs(['codex', 'monthly', '--speed', 'fast'])).toEqual([
-				'codex:monthly',
-				'--speed',
-				'fast',
-			]);
-		});
-
-		it('uses daily as the default report for an agent namespace', () => {
-			expect(normalizeAgentCommandArgs(['opencode', '--json'])).toEqual([
-				'opencode:daily',
-				'--json',
-			]);
-		});
-
-		it('leaves top-level reports unchanged', () => {
-			expect(normalizeAgentCommandArgs(['daily', '--json'])).toEqual(['daily', '--json']);
-		});
-	});
-
 	describe('getReportFlagAliasError', () => {
 		it('rejects report mode flags', () => {
 			expect(getReportFlagAliasError(['--daily'])).toBe(

--- a/apps/ccusage/test/cli-output.test.ts
+++ b/apps/ccusage/test/cli-output.test.ts
@@ -453,11 +453,11 @@ describe('ccusage all-agent CLI', () => {
 		expect(output.daily[0]?.metadata?.agents).toEqual(['amp', 'claude', 'opencode', 'pi']);
 	});
 
-	it('runs Codex daily JSON through the main ccusage namespace instead of the deprecated standalone wrapper', async () => {
+	it('runs Codex default daily JSON through the main ccusage namespace instead of the deprecated standalone wrapper', async () => {
 		await using fixture = await createFixture(createAgentFixtureTree());
 
 		const result = runCcusage(
-			['codex', 'daily', '--offline', '--json', '--since', '20260102', '--until', '20260102'],
+			['codex', '--offline', '--json', '--since', '20260102', '--until', '20260102'],
 			createAgentCliEnv(fixture.path),
 		);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ catalogs:
       version: 0.3.12
   llm-docs:
     '@gunshi/docs':
-      specifier: ^0.27.5
-      version: 0.27.6
+      specifier: ^0.31.0
+      version: 0.31.0
     '@praha/byethrow-docs':
       specifier: ^0.9.0
       version: 0.9.0
@@ -90,8 +90,8 @@ catalogs:
       specifier: ^9.0.0
       version: 9.0.0
     gunshi:
-      specifier: ^0.26.3
-      version: 0.26.3
+      specifier: ^0.31.0
+      version: 0.31.0
     picospinner:
       specifier: ^3.0.0
       version: 3.0.0
@@ -138,7 +138,7 @@ importers:
     devDependencies:
       '@gunshi/docs':
         specifier: catalog:llm-docs
-        version: 0.27.6
+        version: 0.31.0
       '@praha/byethrow-docs':
         specifier: catalog:llm-docs
         version: 0.9.0(@praha/byethrow@0.9.0(typescript@5.9.2))
@@ -216,7 +216,7 @@ importers:
         version: 9.0.0
       gunshi:
         specifier: catalog:runtime
-        version: 0.26.3
+        version: 0.31.0
       mitata:
         specifier: catalog:testing
         version: 1.0.34
@@ -911,8 +911,8 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
-  '@gunshi/docs@0.27.6':
-    resolution: {integrity: sha512-eyUmbLoSFNZbqXM8DNjUrE9NO9A+kuk78z/wSwuPEBDC2BveyO41dl6NwT5Z2b3NgSPiP4i5inG88Uw3HnUI4Q==}
+  '@gunshi/docs@0.31.0':
+    resolution: {integrity: sha512-XFRjB/wgcpTnBVfJ6FYme/ZW2tM7kHsU1T3zxvOy6rJjW2B1urN+wdjQF6P7d8B1+Ad8x76PA3zB9osKAoG5Ew==}
     hasBin: true
 
   '@humanfs/core@0.19.1':
@@ -2257,10 +2257,6 @@ packages:
   args-tokenizer@0.3.0:
     resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
 
-  args-tokens@0.20.1:
-    resolution: {integrity: sha512-pQ5R5TsJyx94zsgSCCQ9kzOgUfMmI4bkqNjgSSt2C92mzPCvovoUMMW6HqR+35mHZ0cb1++MD2uAOLm62sGC+Q==}
-    engines: {node: '>= 20'}
-
   arkregex@0.0.5:
     resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
 
@@ -3209,9 +3205,9 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
-  gunshi@0.26.3:
-    resolution: {integrity: sha512-x/CaxovzDA3KMkrjqow7M1dnsO1CxGMNabBaeGTGdVNtjOMN1G/eK7vjKeJ+zHdFIsWHmo47YQ2DQIESUut2+A==}
-    engines: {node: '>= 20'}
+  gunshi@0.31.0:
+    resolution: {integrity: sha512-D7Amp1BlSzI5cbXiL16TPQ6mp6p3Hzboc1pyc2gYu3j1rXQyG5aYfE4bZW0J3MzU7pKdTJlFytxWlCwif3CxvA==}
+    engines: {node: '>= 22'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -5494,10 +5490,10 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@gunshi/docs@0.27.6':
+  '@gunshi/docs@0.31.0':
     dependencies:
       '@antfu/install-pkg': 1.1.0
-      tinyexec: 1.0.2
+      tinyexec: 1.1.2
 
   '@humanfs/core@0.19.1': {}
 
@@ -6585,8 +6581,6 @@ snapshots:
 
   args-tokenizer@0.3.0: {}
 
-  args-tokens@0.20.1: {}
-
   arkregex@0.0.5:
     dependencies:
       '@ark/util': 0.56.0
@@ -7564,9 +7558,7 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  gunshi@0.26.3:
-    dependencies:
-      args-tokens: 0.20.1
+  gunshi@0.31.0: {}
 
   has-flag@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalogs:
     oxfmt: ^0.45.0
     publint: ^0.3.12
   llm-docs:
-    '@gunshi/docs': ^0.27.5
+    '@gunshi/docs': ^0.31.0
     '@praha/byethrow-docs': ^0.9.0
   release:
     bumpp: ^10.2.3
@@ -38,7 +38,7 @@ catalogs:
     ansi-escapes: ^7.0.0
     arkregex: ^0.0.5
     get-stdin: ^9.0.0
-    gunshi: ^0.26.3
+    gunshi: ^0.31.0
     picospinner: ^3.0.0
     type-fest: ^4.41.0
     valibot: ^1.1.0


### PR DESCRIPTION
## Summary
- update gunshi and @gunshi/docs catalog entries to 0.31.0
- adapt command typing to GunshiParams-based Command generics
- use Gunshi nested subCommands for agent report namespaces and keep config schema generation aligned with nested commands

## Version check
- current locked gunshi: 0.26.3
- current locked @gunshi/docs: 0.27.6
- latest npm dist-tag for both packages: 0.31.0
- notable upstream changes checked: v0.27 plugin system and @gunshi/docs, v0.28 nested sub-commands, v0.29 experimental parser combinators, v0.30 Node.js >=22 requirement, v0.31 lazy command argument parsing fix and gunshi/agent entry point

## Validation
- pnpm run format
- pnpm typecheck
- pnpm run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `gunshi` and `@gunshi/docs` to 0.31.0, moved agent reports to nested subCommands with a `daily` default, and kept legacy `agent:report` aliases working. This also simplifies command typing via inference and keeps config schema generation aligned.

- **Bug Fixes**
  - Normalize legacy `agent:report` invocations to nested commands (e.g., `codex:monthly` -> `codex monthly`) to avoid a CLI compatibility break.

- **Refactors**
  - Switched agent reports to nested `subCommands`; removed argument rewriting and replaced it with a small pre-dispatch normalizer only for legacy colon aliases.
  - Let command factories infer return types and removed the `GunshiCommand` alias; the config wrapper uses `define(...)` with a local cast at the boundary.
  - Updated JSON schema generation to walk nested agent `subCommands` (Map/Object) and emit per-agent report schemas.
  - Switched ESLint preset to app and refreshed local TypeScript guidance.

<sup>Written for commit efc1cf275bd9acea1221a1800fa5af7c47bd7ff4. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1040?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now exposes nested agent subcommands (e.g., `ccusage codex daily`) instead of flat `agent:report` names.

* **Behavior Changes**
  * Legacy colon-style invocations (e.g., `codex:monthly`) are accepted and normalized to the new nested form.

* **Documentation**
  * Updated guidance on type inference and command factory patterns.

* **Tests**
  * CLI integration tests adjusted to use the new nested invocation style.

* **Dependencies**
  * Bumped gunshi-related packages to v0.31.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->