### PR TITLE
refactor(byethrow): update result handling for 0.11

### DIFF
--- a/apps/ccusage/eslint.config.js
+++ b/apps/ccusage/eslint.config.js
@@ -3,7 +3,7 @@ import { ryoppippi } from '@ryoppippi/eslint-config';
 /** @type {import('eslint').Linter.FlatConfig[]} */
 const config = ryoppippi(
 	{
-		type: 'lib',
+		type: 'app',
 		stylistic: false,
 	},
 	{

--- a/apps/ccusage/scripts/generate-json-schema.ts
+++ b/apps/ccusage/scripts/generate-json-schema.ts
@@ -284,27 +284,26 @@ function createConfigSchemaJson(): JsonSchemaNode {
  */
 async function runFormat(files: string[]) {
 	return Result.try({
-		try: $`pnpm exec oxfmt ${files}`,
+		try: async () => $`pnpm exec oxfmt ${files}`,
 		catch: (error) => error,
 	});
 }
 
 async function writeFile(path: string, content: string) {
-	const attempt = Result.try({
+	return Result.try({
 		try: async () => Bun.write(path, content),
 		catch: (error) => error,
 	});
-	return attempt();
 }
 
-async function readFile(path: string): Promise<Result.Result<string, any>> {
+async function readFile(path: string) {
 	return Result.try({
 		try: async () => {
 			const file = Bun.file(path);
 			return file.text();
 		},
 		catch: (error) => error,
-	})();
+	});
 }
 
 async function copySchemaToDocsPublic() {
@@ -322,7 +321,7 @@ async function generateJsonSchema() {
 		Result.try({
 			try: () => createConfigSchemaJson(),
 			catch: (error) => error,
-		})(),
+		}),
 		Result.inspectError((error) => {
 			logger.error('Error creating JSON Schema:', error);
 			process.exit(1);
@@ -338,7 +337,7 @@ async function generateJsonSchema() {
 				Result.try({
 					try: () => JSON.parse(content) as unknown,
 					catch: () => '',
-				})(),
+				}),
 				Result.unwrap(''),
 			),
 		),
@@ -360,10 +359,7 @@ async function generateJsonSchema() {
 	const schemaJson = JSON.stringify(schemaObject, null, '\t');
 
 	await Result.pipe(
-		Result.try({
-			try: writeFile(SCHEMA_FILENAME, schemaJson),
-			safe: true,
-		}),
+		writeFile(SCHEMA_FILENAME, schemaJson),
 		Result.inspectError((error) => {
 			logger.error(`Failed to write ${SCHEMA_FILENAME}:`, error);
 			process.exit(1);
@@ -376,10 +372,7 @@ async function generateJsonSchema() {
 
 	// Run format on the root schema file that was changed
 	await Result.pipe(
-		Result.try({
-			try: runFormat([SCHEMA_FILENAME]),
-			safe: true,
-		}),
+		runFormat([SCHEMA_FILENAME]),
 		Result.inspectError((error) => {
 			logger.error('Failed to format generated files:', error);
 			process.exit(1);

--- a/apps/ccusage/src/adapter/amp/parser.ts
+++ b/apps/ccusage/src/adapter/amp/parser.ts
@@ -12,6 +12,7 @@ import {
 } from '@ccusage/internal/workers';
 import { Result } from '@praha/byethrow';
 import { createFixture } from 'fs-fixture';
+import * as v from 'valibot';
 import { discoverAmpThreadFiles } from './paths.ts';
 import { ampThreadSchema } from './schema.ts';
 
@@ -64,13 +65,13 @@ async function loadAmpThreadEvents(filePath: string): Promise<AmpUsageEvent[]> {
 		return [];
 	}
 
-	const threadResult = Result.parse(ampThreadSchema, parseResult.value);
-	if (Result.isFailure(threadResult)) {
+	const threadResult = v.safeParse(ampThreadSchema, parseResult.value);
+	if (!threadResult.success) {
 		return [];
 	}
 
-	return (threadResult.value.usageLedger?.events ?? []).map((event) =>
-		toAmpUsageEvent(threadResult.value, event),
+	return (threadResult.output.usageLedger?.events ?? []).map((event) =>
+		toAmpUsageEvent(threadResult.output, event),
 	);
 }
 

--- a/apps/ccusage/src/adapter/amp/parser.ts
+++ b/apps/ccusage/src/adapter/amp/parser.ts
@@ -12,13 +12,17 @@ import {
 } from '@ccusage/internal/workers';
 import { Result } from '@praha/byethrow';
 import { createFixture } from 'fs-fixture';
-import * as v from 'valibot';
 import { discoverAmpThreadFiles } from './paths.ts';
 import { ampThreadSchema } from './schema.ts';
 
 type AmpWorkerData = IndexedWorkerData<'ccusage:amp-worker', string>;
 
 type AmpWorkerResponse = IndexedWorkerResultsMessage<AmpUsageEvent[]>;
+
+const parseJson = Result.fn({
+	try: (value: string): unknown => JSON.parse(value) as unknown,
+	catch: (error) => error,
+});
 
 function getAmpCacheTokens(
 	messages: AmpMessage[] | undefined,
@@ -48,28 +52,25 @@ function toAmpUsageEvent(thread: AmpThread, event: AmpLedgerEvent): AmpUsageEven
 
 async function loadAmpThreadEvents(filePath: string): Promise<AmpUsageEvent[]> {
 	const readResult = await Result.try({
-		try: readTextFile(filePath),
+		try: async () => readTextFile(filePath),
 		catch: (error) => error,
 	});
 	if (Result.isFailure(readResult)) {
 		return [];
 	}
 
-	const parseResult = Result.try({
-		try: () => JSON.parse(readResult.value) as unknown,
-		catch: (error) => error,
-	})();
+	const parseResult = parseJson(readResult.value);
 	if (Result.isFailure(parseResult)) {
 		return [];
 	}
 
-	const threadResult = v.safeParse(ampThreadSchema, parseResult.value);
-	if (!threadResult.success) {
+	const threadResult = Result.parse(ampThreadSchema, parseResult.value);
+	if (Result.isFailure(threadResult)) {
 		return [];
 	}
 
-	return (threadResult.output.usageLedger?.events ?? []).map((event) =>
-		toAmpUsageEvent(threadResult.output, event),
+	return (threadResult.value.usageLedger?.events ?? []).map((event) =>
+		toAmpUsageEvent(threadResult.value, event),
 	);
 }
 

--- a/apps/ccusage/src/adapter/amp/pricing-macro.ts
+++ b/apps/ccusage/src/adapter/amp/pricing-macro.ts
@@ -21,7 +21,7 @@ function isAmpModel(modelName: string, _pricing: LiteLLMModelPricing): boolean {
 
 export async function prefetchAmpPricing(): Promise<Record<string, LiteLLMModelPricing>> {
 	const result = await Result.try({
-		try: fetchLiteLLMPricingDataset(),
+		try: async () => fetchLiteLLMPricingDataset(),
 		catch: (error) => error,
 	});
 	if (Result.isFailure(result)) {

--- a/apps/ccusage/src/adapter/codex/parser.ts
+++ b/apps/ccusage/src/adapter/codex/parser.ts
@@ -29,6 +29,11 @@ const ENCODED_CODEX_EVENT_NUMBER_STRIDE = 5;
 const TOKEN_USAGE_EVENT_KEY_SEPARATOR = '\0';
 const jsonlExtensionRegex = regex('\\.jsonl$', 'i');
 
+const parseJsonLine = Result.fn({
+	try: (line: string): unknown => JSON.parse(line) as unknown,
+	catch: (error) => error,
+});
+
 export function parseTokenCountLineFast(_line: string): ParsedTokenCountLine | null {
 	if (!hasTokenCountPayload(_line)) {
 		return null;
@@ -251,65 +256,70 @@ async function parseCodexSessionFile(
 		});
 	};
 
-	try {
-		await processJSONLFileByMarkers(
-			file,
-			CODEX_JSONL_MARKERS,
-			(line) => {
-				const contextModel = extractTurnContextModelFast(line);
-				if (contextModel != null) {
-					currentModel = contextModel;
-					currentModelIsFallback = false;
-					return;
-				}
-
-				const parsedFast = parseTokenCountLineFast(line);
-				if (parsedFast != null) {
-					addTokenCountEvent(parsedFast);
-					return;
-				}
-
-				try {
-					const entry = asRecord(JSON.parse(line) as unknown);
-					if (entry == null) {
-						return;
-					}
-					const entryType = typeof entry.type === 'string' ? entry.type : undefined;
-					const payload = entry.payload;
-					const timestamp = typeof entry.timestamp === 'string' ? entry.timestamp : undefined;
-					if (entryType === 'turn_context') {
-						const model = extractModel(payload);
-						if (model != null) {
-							currentModel = model;
+	await Result.pipe(
+		Result.try({
+			try: async () =>
+				processJSONLFileByMarkers(
+					file,
+					CODEX_JSONL_MARKERS,
+					(line) => {
+						const contextModel = extractTurnContextModelFast(line);
+						if (contextModel != null) {
+							currentModel = contextModel;
 							currentModelIsFallback = false;
+							return;
 						}
-						return;
-					}
-					if (entryType !== 'event_msg' || timestamp == null) {
-						return;
-					}
-					const payloadRecord = asRecord(payload);
-					if (payloadRecord?.type !== 'token_count') {
-						return;
-					}
-					const info = asRecord(payloadRecord.info);
-					addTokenCountEvent({
-						timestamp,
-						lastUsage: normalizeRawUsage(info?.last_token_usage),
-						totalUsage: normalizeRawUsage(info?.total_token_usage),
-						model: extractModel({ info, ...payloadRecord }),
-					});
-				} catch {}
-			},
-			{
-				bufferedEncoding: 'latin1',
-				callbackMode: 'sync',
-				scanMode: 'line',
-			},
-		);
-	} catch (error) {
-		logger.debug('Failed to read Codex session file', error);
-	}
+
+						const parsedFast = parseTokenCountLineFast(line);
+						if (parsedFast != null) {
+							addTokenCountEvent(parsedFast);
+							return;
+						}
+
+						const parseResult = parseJsonLine(line);
+						if (Result.isFailure(parseResult)) {
+							return;
+						}
+						const entry = asRecord(parseResult.value);
+						if (entry == null) {
+							return;
+						}
+						const entryType = typeof entry.type === 'string' ? entry.type : undefined;
+						const payload = entry.payload;
+						const timestamp = typeof entry.timestamp === 'string' ? entry.timestamp : undefined;
+						if (entryType === 'turn_context') {
+							const model = extractModel(payload);
+							if (model != null) {
+								currentModel = model;
+								currentModelIsFallback = false;
+							}
+							return;
+						}
+						if (entryType !== 'event_msg' || timestamp == null) {
+							return;
+						}
+						const payloadRecord = asRecord(payload);
+						if (payloadRecord?.type !== 'token_count') {
+							return;
+						}
+						const info = asRecord(payloadRecord.info);
+						addTokenCountEvent({
+							timestamp,
+							lastUsage: normalizeRawUsage(info?.last_token_usage),
+							totalUsage: normalizeRawUsage(info?.total_token_usage),
+							model: extractModel({ info, ...payloadRecord }),
+						});
+					},
+					{
+						bufferedEncoding: 'latin1',
+						callbackMode: 'sync',
+						scanMode: 'line',
+					},
+				),
+			catch: (error) => error,
+		}),
+		Result.inspectError((error) => logger.debug('Failed to read Codex session file', error)),
+	);
 
 	return events;
 }

--- a/apps/ccusage/src/adapter/codex/parser.ts
+++ b/apps/ccusage/src/adapter/codex/parser.ts
@@ -410,7 +410,7 @@ async function loadTokenUsageEventsFromDirectory(
 	directoryPath: string,
 ): Promise<TokenUsageEvent[]> {
 	const statResult = await Result.try({
-		try: stat(directoryPath),
+		try: async () => stat(directoryPath),
 		catch: (error) => error,
 	});
 	if (Result.isFailure(statResult) || !statResult.value.isDirectory()) {

--- a/apps/ccusage/src/adapter/codex/pricing-macro.ts
+++ b/apps/ccusage/src/adapter/codex/pricing-macro.ts
@@ -18,7 +18,7 @@ function isCodexModel(modelName: string, _pricing: LiteLLMModelPricing): boolean
 
 export async function prefetchCodexPricing(): Promise<Record<string, LiteLLMModelPricing>> {
 	const result = await Result.try({
-		try: fetchLiteLLMPricingDataset(),
+		try: async () => fetchLiteLLMPricingDataset(),
 		catch: (error) => error,
 	});
 	if (Result.isFailure(result)) {

--- a/apps/ccusage/src/adapter/codex/pricing.ts
+++ b/apps/ccusage/src/adapter/codex/pricing.ts
@@ -72,7 +72,7 @@ export async function resolveCodexSpeed(requested?: string): Promise<CodexSpeed>
 		path.join(codexHome, 'config.toml'),
 	)) {
 		const result = await Result.try({
-			try: readTextFile(configPath),
+			try: async () => readTextFile(configPath),
 			catch: (error) => error,
 		});
 		if (!Result.isFailure(result) && codexFastServiceTierRegex.test(result.value)) {

--- a/apps/ccusage/src/adapter/index.ts
+++ b/apps/ccusage/src/adapter/index.ts
@@ -120,7 +120,7 @@ export async function loadAgentRows(
 ): Promise<AgentUsageRow[]> {
 	context.progress?.start(agent);
 	const result = await Result.try({
-		try: loadAgentRowsWithoutProgress(agent, kind, options, context),
+		try: async () => loadAgentRowsWithoutProgress(agent, kind, options, context),
 		catch: (error) => error,
 	});
 	if (Result.isFailure(result)) {

--- a/apps/ccusage/src/adapter/opencode/loader.ts
+++ b/apps/ccusage/src/adapter/opencode/loader.ts
@@ -15,6 +15,7 @@ import {
 } from '@ccusage/internal/workers';
 import { Result } from '@praha/byethrow';
 import { createFixture } from 'fs-fixture';
+import * as v from 'valibot';
 import { logger } from '../../logger.ts';
 import { discoverOpenCodeMessageFiles, getOpenCodeDbPath, getOpenCodePaths } from './paths.ts';
 import { openCodeDbMessageRowSchema, openCodeMessageSchema } from './schema.ts';
@@ -75,13 +76,13 @@ function convertOpenCodeMessageToUsageEntry(message: OpenCodeMessage): OpenCodeU
 }
 
 function parseOpenCodeMessageRecord(value: unknown): OpenCodeMessageResult | null {
-	const parsed = Result.parse(openCodeMessageSchema, value);
-	if (Result.isFailure(parsed) || !shouldLoadOpenCodeMessage(parsed.value)) {
+	const parsed = v.safeParse(openCodeMessageSchema, value);
+	if (!parsed.success || !shouldLoadOpenCodeMessage(parsed.output)) {
 		return null;
 	}
 	return {
-		id: parsed.value.id,
-		entry: convertOpenCodeMessageToUsageEntry(parsed.value),
+		id: parsed.output.id,
+		entry: convertOpenCodeMessageToUsageEntry(parsed.output),
 	};
 }
 
@@ -141,20 +142,20 @@ function loadOpenCodeMessagesFromDb(openCodePath: string): OpenCodeMessageResult
 					const rows = db.prepare('SELECT id, session_id, data FROM message').all();
 					const records: OpenCodeMessageResult[] = [];
 					for (const rawRow of rows) {
-						const rowResult = Result.parse(openCodeDbMessageRowSchema, rawRow);
-						if (Result.isFailure(rowResult)) {
+						const rowResult = v.safeParse(openCodeDbMessageRowSchema, rawRow);
+						if (!rowResult.success) {
 							continue;
 						}
 
-						const data = parseJsonObject(rowResult.value.data);
+						const data = parseJsonObject(rowResult.output.data);
 						if (data == null) {
 							continue;
 						}
 
 						const result = parseOpenCodeMessageRecord({
 							...data,
-							id: rowResult.value.id,
-							sessionID: rowResult.value.session_id,
+							id: rowResult.output.id,
+							sessionID: rowResult.output.session_id,
 						});
 						if (result == null) {
 							continue;

--- a/apps/ccusage/src/adapter/opencode/loader.ts
+++ b/apps/ccusage/src/adapter/opencode/loader.ts
@@ -15,7 +15,6 @@ import {
 } from '@ccusage/internal/workers';
 import { Result } from '@praha/byethrow';
 import { createFixture } from 'fs-fixture';
-import * as v from 'valibot';
 import { logger } from '../../logger.ts';
 import { discoverOpenCodeMessageFiles, getOpenCodeDbPath, getOpenCodePaths } from './paths.ts';
 import { openCodeDbMessageRowSchema, openCodeMessageSchema } from './schema.ts';
@@ -24,11 +23,13 @@ type OpenCodeWorkerData = IndexedWorkerData<'ccusage:opencode-worker', string>;
 
 type OpenCodeWorkerResponse = IndexedWorkerResultsMessage<OpenCodeMessageResult | null>;
 
+const parseJson = Result.fn({
+	try: (value: string): unknown => JSON.parse(value) as unknown,
+	catch: (error) => error,
+});
+
 function parseJsonObject(value: string): Record<string, unknown> | null {
-	const result = Result.try({
-		try: () => JSON.parse(value) as unknown,
-		catch: (error) => error,
-	})();
+	const result = parseJson(value);
 	if (Result.isFailure(result)) {
 		return null;
 	}
@@ -74,13 +75,13 @@ function convertOpenCodeMessageToUsageEntry(message: OpenCodeMessage): OpenCodeU
 }
 
 function parseOpenCodeMessageRecord(value: unknown): OpenCodeMessageResult | null {
-	const parsed = v.safeParse(openCodeMessageSchema, value);
-	if (!parsed.success || !shouldLoadOpenCodeMessage(parsed.output)) {
+	const parsed = Result.parse(openCodeMessageSchema, value);
+	if (Result.isFailure(parsed) || !shouldLoadOpenCodeMessage(parsed.value)) {
 		return null;
 	}
 	return {
-		id: parsed.output.id,
-		entry: convertOpenCodeMessageToUsageEntry(parsed.output),
+		id: parsed.value.id,
+		entry: convertOpenCodeMessageToUsageEntry(parsed.value),
 	};
 }
 
@@ -91,7 +92,7 @@ function parseOpenCodeMessageText(value: string): OpenCodeMessageResult | null {
 
 async function loadOpenCodeMessageFile(filePath: string): Promise<OpenCodeMessageResult | null> {
 	const content = await Result.try({
-		try: readTextFile(filePath),
+		try: async () => readTextFile(filePath),
 		catch: (error) => error,
 	});
 	return Result.isFailure(content) ? null : parseOpenCodeMessageText(content.value);
@@ -140,20 +141,20 @@ function loadOpenCodeMessagesFromDb(openCodePath: string): OpenCodeMessageResult
 					const rows = db.prepare('SELECT id, session_id, data FROM message').all();
 					const records: OpenCodeMessageResult[] = [];
 					for (const rawRow of rows) {
-						const rowResult = v.safeParse(openCodeDbMessageRowSchema, rawRow);
-						if (!rowResult.success) {
+						const rowResult = Result.parse(openCodeDbMessageRowSchema, rawRow);
+						if (Result.isFailure(rowResult)) {
 							continue;
 						}
 
-						const data = parseJsonObject(rowResult.output.data);
+						const data = parseJsonObject(rowResult.value.data);
 						if (data == null) {
 							continue;
 						}
 
 						const result = parseOpenCodeMessageRecord({
 							...data,
-							id: rowResult.output.id,
-							sessionID: rowResult.output.session_id,
+							id: rowResult.value.id,
+							sessionID: rowResult.value.session_id,
 						});
 						if (result == null) {
 							continue;
@@ -166,7 +167,7 @@ function loadOpenCodeMessagesFromDb(openCodePath: string): OpenCodeMessageResult
 				logger.warn,
 			),
 		catch: (error) => error,
-	})();
+	});
 	if (Result.isFailure(result)) {
 		logger.warn('Failed to load OpenCode messages from DB:', result.error);
 		return [];

--- a/apps/ccusage/src/adapter/opencode/paths.ts
+++ b/apps/ccusage/src/adapter/opencode/paths.ts
@@ -35,7 +35,7 @@ function resolveOpenCodeDbCandidate(dbPath: string, resolvedOpenCodePath: string
 	const result = Result.try({
 		try: () => realpathSync(dbPath),
 		catch: (error) => error,
-	})();
+	});
 	if (Result.isFailure(result) || !isPathInsideDirectory(result.value, resolvedOpenCodePath)) {
 		return null;
 	}
@@ -46,7 +46,7 @@ export function getOpenCodeDbPath(openCodePath: string): string | null {
 	const resolvedPath = Result.try({
 		try: () => realpathSync(openCodePath),
 		catch: (error) => error,
-	})();
+	});
 	if (Result.isFailure(resolvedPath)) {
 		logger.warn('Failed to resolve OpenCode data directory:', resolvedPath.error);
 		return null;
@@ -63,7 +63,7 @@ export function getOpenCodeDbPath(openCodePath: string): string | null {
 	const entries = Result.try({
 		try: () => readdirSync(openCodePath),
 		catch: (error) => error,
-	})();
+	});
 	if (Result.isFailure(entries)) {
 		logger.warn('Failed to read OpenCode data directory:', entries.error);
 		return null;

--- a/apps/ccusage/src/adapter/opencode/paths.ts
+++ b/apps/ccusage/src/adapter/opencode/paths.ts
@@ -88,11 +88,14 @@ export function hasOpenCodeDatabase(openCodePath: string): boolean {
 	if (existsSync(path.join(openCodePath, OPENCODE_DB_FILE_NAME))) {
 		return true;
 	}
-	try {
-		return readdirSync(openCodePath).some((entry) => OPENCODE_CHANNEL_DB_PATTERN.test(entry));
-	} catch {
-		return false;
-	}
+	return Result.pipe(
+		Result.try({
+			try: () => readdirSync(openCodePath),
+			catch: (error) => error,
+		}),
+		Result.map((entries) => entries.some((entry) => OPENCODE_CHANNEL_DB_PATTERN.test(entry))),
+		Result.unwrap(false),
+	);
 }
 
 export async function discoverOpenCodeMessageFiles(openCodePath: string): Promise<string[]> {

--- a/apps/ccusage/src/adapter/pi/parser.ts
+++ b/apps/ccusage/src/adapter/pi/parser.ts
@@ -12,7 +12,6 @@ import {
 } from '@ccusage/internal/workers';
 import { Result } from '@praha/byethrow';
 import { createFixture } from 'fs-fixture';
-import * as v from 'valibot';
 import { getPiAgentPaths } from './paths.ts';
 import {
 	extractPiAgentProject,
@@ -26,6 +25,11 @@ const PI_AGENT_JSONL_MARKERS = ['"usage"'];
 type PiWorkerData = IndexedWorkerData<'ccusage:pi-usage-worker', string>;
 
 type PiWorkerResponse = IndexedWorkerResultsMessage<PiUsageEntry[]>;
+
+const parseJsonLine = Result.fn({
+	try: (line: string): unknown => JSON.parse(line) as unknown,
+	catch: (error) => error,
+});
 
 async function globPiAgentFiles(paths: string[]): Promise<string[]> {
 	const allFiles: string[] = [];
@@ -52,36 +56,34 @@ async function parsePiAgentFile(file: string): Promise<PiUsageEntry[]> {
 	const sessionId = extractPiAgentSessionId(file);
 	const entries: PiUsageEntry[] = [];
 	const result = await Result.try({
-		try: processJSONLFileByMarkers(file, PI_AGENT_JSONL_MARKERS, (line) => {
-			if (!line.includes('"message"')) {
-				return;
-			}
+		try: async () =>
+			processJSONLFileByMarkers(file, PI_AGENT_JSONL_MARKERS, (line) => {
+				if (!line.includes('"message"')) {
+					return;
+				}
 
-			const parseResult = Result.try({
-				try: () => JSON.parse(line) as unknown,
-				catch: (error) => error,
-			})();
-			if (Result.isFailure(parseResult)) {
-				return;
-			}
+				const parseResult = parseJsonLine(line);
+				if (Result.isFailure(parseResult)) {
+					return;
+				}
 
-			const messageResult = v.safeParse(piAgentMessageSchema, parseResult.value);
-			if (!messageResult.success) {
-				return;
-			}
+				const messageResult = Result.parse(piAgentMessageSchema, parseResult.value);
+				if (Result.isFailure(messageResult)) {
+					return;
+				}
 
-			const usage = transformPiAgentUsage(messageResult.output);
-			if (usage == null) {
-				return;
-			}
+				const usage = transformPiAgentUsage(messageResult.value);
+				if (usage == null) {
+					return;
+				}
 
-			entries.push({
-				timestamp: messageResult.output.timestamp,
-				project,
-				sessionId,
-				...usage,
-			});
-		}),
+				entries.push({
+					timestamp: messageResult.value.timestamp,
+					project,
+					sessionId,
+					...usage,
+				});
+			}),
 		catch: (error) => error,
 	});
 	return Result.isFailure(result) ? [] : entries;

--- a/apps/ccusage/src/adapter/pi/parser.ts
+++ b/apps/ccusage/src/adapter/pi/parser.ts
@@ -12,6 +12,7 @@ import {
 } from '@ccusage/internal/workers';
 import { Result } from '@praha/byethrow';
 import { createFixture } from 'fs-fixture';
+import * as v from 'valibot';
 import { getPiAgentPaths } from './paths.ts';
 import {
 	extractPiAgentProject,
@@ -67,18 +68,18 @@ async function parsePiAgentFile(file: string): Promise<PiUsageEntry[]> {
 					return;
 				}
 
-				const messageResult = Result.parse(piAgentMessageSchema, parseResult.value);
-				if (Result.isFailure(messageResult)) {
+				const messageResult = v.safeParse(piAgentMessageSchema, parseResult.value);
+				if (!messageResult.success) {
 					return;
 				}
 
-				const usage = transformPiAgentUsage(messageResult.value);
+				const usage = transformPiAgentUsage(messageResult.output);
 				if (usage == null) {
 					return;
 				}
 
 				entries.push({
-					timestamp: messageResult.value.timestamp,
+					timestamp: messageResult.output.timestamp,
 					project,
 					sessionId,
 					...usage,

--- a/apps/ccusage/src/adapter/shared.ts
+++ b/apps/ccusage/src/adapter/shared.ts
@@ -7,6 +7,7 @@ import type {
 } from './types.ts';
 import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
 import { compareStrings } from '@ccusage/internal/sort';
+import { Result } from '@praha/byethrow';
 import { regex } from 'arkregex';
 import { agentIds } from './types.ts';
 
@@ -102,14 +103,16 @@ export function safeTimeZone(timezone?: string): string {
 		return cached;
 	}
 
-	try {
-		Intl.DateTimeFormat('en-US', { timeZone: cacheKey });
-		safeTimeZoneCache.set(cacheKey, cacheKey);
-		return cacheKey;
-	} catch {
-		safeTimeZoneCache.set(cacheKey, 'UTC');
-		return 'UTC';
-	}
+	const resolved = Result.pipe(
+		Result.try({
+			try: () => Intl.DateTimeFormat('en-US', { timeZone: cacheKey }),
+			catch: (error) => error,
+		}),
+		Result.map(() => cacheKey),
+		Result.unwrap('UTC'),
+	);
+	safeTimeZoneCache.set(cacheKey, resolved);
+	return resolved;
 }
 
 function getDateFormatter(timezone: string): Intl.DateTimeFormat {

--- a/apps/ccusage/src/commands/agent.ts
+++ b/apps/ccusage/src/commands/agent.ts
@@ -20,6 +20,7 @@ import {
 	formatUsageDataRow,
 	ResponsiveTable,
 } from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadAgentRows } from '../adapter/index.ts';
 import { agentLabels } from '../adapter/types.ts';
@@ -358,23 +359,28 @@ async function runAgentReport(
 		logger.level = 0;
 	}
 
-	let rows: AgentUsageRow[];
 	const progress = createUsageLoadProgress(shouldShowUsageLoadProgress(options, process.stdout));
-	try {
-		if (progress != null) {
-			logger.level = 0;
-		}
-		rows = await loadRows(agent, kind, options, progress);
-	} catch (error) {
+	const rowsResult = await Result.pipe(
+		Result.try({
+			try: async () => {
+				if (progress != null) {
+					logger.level = 0;
+				}
+				return loadRows(agent, kind, options, progress);
+			},
+			catch: (error) => error,
+		}),
+		Result.inspectError((error) => logger.error(String(error))),
+	);
+	if (Result.isFailure(rowsResult)) {
 		progress?.stop();
 		logger.level = originalLoggerLevel;
-		logger.error(String(error));
 		process.exitCode = 1;
 		return;
-	} finally {
-		logger.level = originalLoggerLevel;
 	}
 	progress?.stop();
+	logger.level = originalLoggerLevel;
+	const rows = rowsResult.value;
 
 	if (rows.length === 0) {
 		await writeStdoutLine(

--- a/apps/ccusage/src/commands/all.ts
+++ b/apps/ccusage/src/commands/all.ts
@@ -17,6 +17,7 @@ import {
 	formatTotalsRow,
 	formatUsageDataRow,
 } from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { aggregateRowsByPeriod, detectAllAgents, loadAgentRows } from '../adapter/index.ts';
 import { createEmptyRow, getRowAgents } from '../adapter/shared.ts';
@@ -195,23 +196,28 @@ async function runAllReport(kind: ReportKind, options: AllOptions): Promise<void
 		logger.box(`${title}\nDetected: ${detectedAgentLabels === '' ? 'None' : detectedAgentLabels}`);
 	}
 
-	let rows: AllRow[];
 	const progress = createUsageLoadProgress(shouldShowUsageLoadProgress(options, process.stdout));
-	try {
-		if (progress != null) {
-			logger.level = 0;
-		}
-		rows = await loadAllRows(kind, options, detectedAgents, progress);
-	} catch (error) {
+	const rowsResult = await Result.pipe(
+		Result.try({
+			try: async () => {
+				if (progress != null) {
+					logger.level = 0;
+				}
+				return loadAllRows(kind, options, detectedAgents, progress);
+			},
+			catch: (error) => error,
+		}),
+		Result.inspectError((error) => logger.error(String(error))),
+	);
+	if (Result.isFailure(rowsResult)) {
 		progress?.stop();
 		logger.level = originalLoggerLevel;
-		logger.error(String(error));
 		process.exitCode = 1;
 		return;
-	} finally {
-		logger.level = originalLoggerLevel;
 	}
 	progress?.stop();
+	logger.level = originalLoggerLevel;
+	const rows = rowsResult.value;
 
 	const totals = calculateTotals(rows);
 	if (options.json === true) {

--- a/apps/ccusage/src/commands/codex.ts
+++ b/apps/ccusage/src/commands/codex.ts
@@ -8,6 +8,7 @@ import {
 	formatNumber,
 	ResponsiveTable,
 } from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadCodexReportRows } from '../adapter/codex/index.ts';
 import { formatDateCompact } from '../date-utils.ts';
@@ -117,25 +118,32 @@ async function runCodexReport(kind: CodexCommandKind, options: AdapterOptions): 
 	}
 
 	const progress = createUsageLoadProgress(shouldShowUsageLoadProgress(options, process.stdout));
-	let rows: Awaited<ReturnType<typeof loadCodexReportRows>>;
-	try {
-		if (progress != null) {
-			logger.level = 0;
-		}
-		progress?.start('codex');
-		rows = await loadCodexReportRows(kind, options, { progress });
-		progress?.succeed('codex', rows.length);
-	} catch (error) {
-		progress?.fail('codex', error);
+	const rowsResult = await Result.pipe(
+		Result.try({
+			try: async () => {
+				if (progress != null) {
+					logger.level = 0;
+				}
+				progress?.start('codex');
+				return loadCodexReportRows(kind, options, { progress });
+			},
+			catch: (error) => error,
+		}),
+		Result.inspect((rows) => progress?.succeed('codex', rows.length)),
+		Result.inspectError((error) => {
+			progress?.fail('codex', error);
+			logger.error(String(error));
+		}),
+	);
+	if (Result.isFailure(rowsResult)) {
 		progress?.stop();
 		logger.level = originalLoggerLevel;
-		logger.error(String(error));
 		process.exitCode = 1;
 		return;
-	} finally {
-		logger.level = originalLoggerLevel;
 	}
 	progress?.stop();
+	logger.level = originalLoggerLevel;
+	const rows = rowsResult.value;
 
 	const rowsKey = getRowsKey(kind);
 	if (rows.length === 0) {

--- a/apps/ccusage/src/commands/daily.ts
+++ b/apps/ccusage/src/commands/daily.ts
@@ -8,6 +8,7 @@ import {
 	formatUsageDataRow,
 	pushBreakdownRows,
 } from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadDailyUsageData } from '../adapter/claude/data-loader.ts';
 import { calculateTotals, createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
@@ -77,24 +78,31 @@ export const dailyCommand = define({
 		const progress = createUsageLoadProgress(
 			shouldShowUsageLoadProgress(mergedOptions, process.stdout),
 		);
-		let dailyData: Awaited<ReturnType<typeof loadDailyUsageData>>;
-		try {
-			if (progress != null) {
-				logger.level = 0;
-			}
-			progress?.start('claude');
-			dailyData = await loadDailyUsageData({
-				...mergedOptions,
-				groupByProject: mergedOptions.instances,
-			});
-			progress?.succeed('claude', dailyData.length);
-		} catch (error) {
-			progress?.fail('claude', error);
-			throw error;
-		} finally {
+		const dailyDataResult = await Result.pipe(
+			Result.try({
+				try: async () => {
+					if (progress != null) {
+						logger.level = 0;
+					}
+					progress?.start('claude');
+					return loadDailyUsageData({
+						...mergedOptions,
+						groupByProject: mergedOptions.instances,
+					});
+				},
+				catch: (error) => error,
+			}),
+			Result.inspect((dailyData) => progress?.succeed('claude', dailyData.length)),
+			Result.inspectError((error) => progress?.fail('claude', error)),
+		);
+		if (Result.isFailure(dailyDataResult)) {
 			progress?.stop();
 			logger.level = originalLoggerLevel;
+			throw dailyDataResult.error;
 		}
+		progress?.stop();
+		logger.level = originalLoggerLevel;
+		const dailyData = dailyDataResult.value;
 
 		if (dailyData.length === 0) {
 			if (useJson) {

--- a/apps/ccusage/src/commands/monthly.ts
+++ b/apps/ccusage/src/commands/monthly.ts
@@ -7,6 +7,7 @@ import {
 	formatUsageDataRow,
 	pushBreakdownRows,
 } from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadMonthlyUsageData } from '../adapter/claude/data-loader.ts';
 import { calculateTotals, createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
@@ -35,21 +36,28 @@ export const monthlyCommand = define({
 		const progress = createUsageLoadProgress(
 			shouldShowUsageLoadProgress(mergedOptions, process.stdout),
 		);
-		let monthlyData: Awaited<ReturnType<typeof loadMonthlyUsageData>>;
-		try {
-			if (progress != null) {
-				logger.level = 0;
-			}
-			progress?.start('claude');
-			monthlyData = await loadMonthlyUsageData(mergedOptions);
-			progress?.succeed('claude', monthlyData.length);
-		} catch (error) {
-			progress?.fail('claude', error);
-			throw error;
-		} finally {
+		const monthlyDataResult = await Result.pipe(
+			Result.try({
+				try: async () => {
+					if (progress != null) {
+						logger.level = 0;
+					}
+					progress?.start('claude');
+					return loadMonthlyUsageData(mergedOptions);
+				},
+				catch: (error) => error,
+			}),
+			Result.inspect((monthlyData) => progress?.succeed('claude', monthlyData.length)),
+			Result.inspectError((error) => progress?.fail('claude', error)),
+		);
+		if (Result.isFailure(monthlyDataResult)) {
 			progress?.stop();
 			logger.level = originalLoggerLevel;
+			throw monthlyDataResult.error;
 		}
+		progress?.stop();
+		logger.level = originalLoggerLevel;
+		const monthlyData = monthlyDataResult.value;
 
 		if (monthlyData.length === 0) {
 			if (useJson) {

--- a/apps/ccusage/src/commands/session.ts
+++ b/apps/ccusage/src/commands/session.ts
@@ -7,6 +7,7 @@ import {
 	formatUsageDataRow,
 	pushBreakdownRows,
 } from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadSessionData } from '../adapter/claude/data-loader.ts';
 import { calculateTotals, createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
@@ -64,28 +65,35 @@ export const sessionCommand = define({
 		const progress = createUsageLoadProgress(
 			shouldShowUsageLoadProgress(mergedOptions, process.stdout),
 		);
-		let sessionData: Awaited<ReturnType<typeof loadSessionData>>;
-		try {
-			if (progress != null) {
-				logger.level = 0;
-			}
-			progress?.start('claude');
-			sessionData = await loadSessionData({
-				since: mergedOptions.since,
-				until: mergedOptions.until,
-				mode: mergedOptions.mode,
-				offline: mergedOptions.offline,
-				singleThread: mergedOptions.singleThread,
-				timezone: mergedOptions.timezone,
-			});
-			progress?.succeed('claude', sessionData.length);
-		} catch (error) {
-			progress?.fail('claude', error);
-			throw error;
-		} finally {
+		const sessionDataResult = await Result.pipe(
+			Result.try({
+				try: async () => {
+					if (progress != null) {
+						logger.level = 0;
+					}
+					progress?.start('claude');
+					return loadSessionData({
+						since: mergedOptions.since,
+						until: mergedOptions.until,
+						mode: mergedOptions.mode,
+						offline: mergedOptions.offline,
+						singleThread: mergedOptions.singleThread,
+						timezone: mergedOptions.timezone,
+					});
+				},
+				catch: (error) => error,
+			}),
+			Result.inspect((sessionData) => progress?.succeed('claude', sessionData.length)),
+			Result.inspectError((error) => progress?.fail('claude', error)),
+		);
+		if (Result.isFailure(sessionDataResult)) {
 			progress?.stop();
 			logger.level = originalLoggerLevel;
+			throw sessionDataResult.error;
 		}
+		progress?.stop();
+		logger.level = originalLoggerLevel;
+		const sessionData = sessionDataResult.value;
 
 		if (sessionData.length === 0) {
 			if (useJson) {

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -257,13 +257,14 @@ export const statuslineCommand = define({
 				const pid = initialSemaphoreState.pid;
 				let isProcessAlive = false;
 				if (pid != null) {
-					try {
-						process.kill(pid, 0); // Signal 0 doesn't kill, just checks if process exists
-						isProcessAlive = true;
-					} catch {
-						// Process doesn't exist, likely dead
-						isProcessAlive = false;
-					}
+					isProcessAlive = Result.pipe(
+						Result.try({
+							try: () => process.kill(pid, 0),
+							catch: (error) => error,
+						}),
+						Result.map(() => true),
+						Result.unwrap(false),
+					);
 				}
 
 				if (isProcessAlive) {

--- a/apps/ccusage/src/commands/statusline.ts
+++ b/apps/ccusage/src/commands/statusline.ts
@@ -320,7 +320,7 @@ export const statuslineCommand = define({
 											offline: mergedOptions.offline,
 										}),
 									catch: (error) => error,
-								})(),
+								}),
 								Result.map((sessionCost) => sessionCost?.totalCost),
 								Result.inspectError((error) => logger.error('Failed to load session data:', error)),
 								Result.unwrap(undefined),
@@ -375,7 +375,7 @@ export const statuslineCommand = define({
 									minUpdateTime: midnightToday,
 								}),
 							catch: (error) => error,
-						})(),
+						}),
 						Result.map((dailyData) => {
 							if (dailyData.length > 0) {
 								const totals = calculateTotals(dailyData);
@@ -398,7 +398,7 @@ export const statuslineCommand = define({
 									minUpdateTime: lastBlocksTime,
 								}),
 							catch: (error) => error,
-						})(),
+						}),
 						Result.map((blocks) => {
 							// Only identify blocks if we have data
 							if (blocks.length === 0) {
@@ -504,7 +504,7 @@ export const statuslineCommand = define({
 											mergedOptions.offline,
 										),
 									catch: (error) => error,
-								})();
+								});
 
 					const contextInfo = Result.pipe(
 						contextDataResult,
@@ -546,7 +546,7 @@ export const statuslineCommand = define({
 					return statusLine;
 				},
 				catch: (error) => error,
-			})(),
+			}),
 		);
 
 		if (Result.isSuccess(mainProcessingResult)) {

--- a/apps/ccusage/src/commands/weekly.ts
+++ b/apps/ccusage/src/commands/weekly.ts
@@ -7,6 +7,7 @@ import {
 	formatUsageDataRow,
 	pushBreakdownRows,
 } from '@ccusage/terminal/table';
+import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadWeeklyUsageData } from '../adapter/claude/data-loader.ts';
 import { calculateTotals, createTotalsObject, getTotalTokens } from '../calculate-cost.ts';
@@ -46,21 +47,28 @@ export const weeklyCommand = define({
 		const progress = createUsageLoadProgress(
 			shouldShowUsageLoadProgress(mergedOptions, process.stdout),
 		);
-		let weeklyData: Awaited<ReturnType<typeof loadWeeklyUsageData>>;
-		try {
-			if (progress != null) {
-				logger.level = 0;
-			}
-			progress?.start('claude');
-			weeklyData = await loadWeeklyUsageData(mergedOptions);
-			progress?.succeed('claude', weeklyData.length);
-		} catch (error) {
-			progress?.fail('claude', error);
-			throw error;
-		} finally {
+		const weeklyDataResult = await Result.pipe(
+			Result.try({
+				try: async () => {
+					if (progress != null) {
+						logger.level = 0;
+					}
+					progress?.start('claude');
+					return loadWeeklyUsageData(mergedOptions);
+				},
+				catch: (error) => error,
+			}),
+			Result.inspect((weeklyData) => progress?.succeed('claude', weeklyData.length)),
+			Result.inspectError((error) => progress?.fail('claude', error)),
+		);
+		if (Result.isFailure(weeklyDataResult)) {
 			progress?.stop();
 			logger.level = originalLoggerLevel;
+			throw weeklyDataResult.error;
 		}
+		progress?.stop();
+		logger.level = originalLoggerLevel;
+		const weeklyData = weeklyDataResult.value;
 
 		if (weeklyData.length === 0) {
 			if (useJson) {

--- a/apps/ccusage/src/config-loader-tokens.ts
+++ b/apps/ccusage/src/config-loader-tokens.ts
@@ -206,7 +206,7 @@ function loadConfigFile(filePath: string, debug = false): ConfigData | undefined
 				return data;
 			},
 			catch: (error) => error,
-		})(),
+		}),
 		Result.inspect(() => {
 			logger.debug(`Parsed configuration file: ${filePath}`);
 			if (debug) {
@@ -426,7 +426,7 @@ export function validateConfigFile(
 		return { success: false, error: new Error(`Configuration file does not exist: ${configPath}`) };
 	}
 
-	const parseConfig = Result.try({
+	const result = Result.try({
 		try: () => {
 			const content = readFileSync(configPath, 'utf-8');
 			const data = JSON.parse(content) as unknown;
@@ -438,7 +438,6 @@ export function validateConfigFile(
 		catch: (error) => (error instanceof Error ? error : new Error(String(error))),
 	});
 
-	const result = parseConfig();
 	if (Result.isSuccess(result)) {
 		return { success: true, data: result.value };
 	} else {

--- a/apps/ccusage/src/debug.ts
+++ b/apps/ccusage/src/debug.ts
@@ -110,12 +110,10 @@ export async function detectMismatches(claudePath?: string): Promise<MismatchSta
 			.filter((line) => line.length > 0);
 
 		for (const line of lines) {
-			const parseParser = Result.try({
+			const parseResult = Result.try({
 				try: () => JSON.parse(line) as unknown,
 				catch: () => new Error('Invalid JSON'),
 			});
-
-			const parseResult = parseParser();
 			if (Result.isFailure(parseResult)) {
 				continue;
 			}

--- a/apps/ccusage/src/utils.ts
+++ b/apps/ccusage/src/utils.ts
@@ -14,7 +14,7 @@ export function unreachable(value: never): never {
 export async function getFileModifiedTime(filePath: string): Promise<number> {
 	return Result.pipe(
 		Result.try({
-			try: stat(filePath),
+			try: async () => stat(filePath),
 			catch: (error) => error,
 		}),
 		Result.map((stats) => stats.mtime.getTime()),

--- a/packages/internal/eslint.config.js
+++ b/packages/internal/eslint.config.js
@@ -3,7 +3,7 @@ import { ryoppippi } from '@ryoppippi/eslint-config';
 /** @type {import('eslint').Linter.FlatConfig[]} */
 const config = ryoppippi(
 	{
-		type: 'lib',
+		type: 'app',
 		stylistic: false,
 	},
 	{

--- a/packages/internal/src/pricing-fetch-utils.ts
+++ b/packages/internal/src/pricing-fetch-utils.ts
@@ -1,5 +1,5 @@
 import type { LiteLLMModelPricing } from './pricing.ts';
-import * as v from 'valibot';
+import { Result } from '@praha/byethrow';
 import { LITELLM_PRICING_URL, liteLLMModelPricingSchema } from './pricing.ts';
 
 export type PricingDataset = Record<string, LiteLLMModelPricing>;
@@ -22,12 +22,12 @@ export async function fetchLiteLLMPricingDataset(): Promise<PricingDataset> {
 			continue;
 		}
 
-		const parsed = v.safeParse(liteLLMModelPricingSchema, modelData);
-		if (!parsed.success) {
+		const parsed = Result.parse(liteLLMModelPricingSchema, modelData);
+		if (Result.isFailure(parsed)) {
 			continue;
 		}
 
-		dataset[modelName] = parsed.output;
+		dataset[modelName] = parsed.value;
 	}
 
 	return dataset;

--- a/packages/internal/src/pricing-fetch-utils.ts
+++ b/packages/internal/src/pricing-fetch-utils.ts
@@ -1,5 +1,5 @@
 import type { LiteLLMModelPricing } from './pricing.ts';
-import { Result } from '@praha/byethrow';
+import * as v from 'valibot';
 import { LITELLM_PRICING_URL, liteLLMModelPricingSchema } from './pricing.ts';
 
 export type PricingDataset = Record<string, LiteLLMModelPricing>;
@@ -22,12 +22,12 @@ export async function fetchLiteLLMPricingDataset(): Promise<PricingDataset> {
 			continue;
 		}
 
-		const parsed = Result.parse(liteLLMModelPricingSchema, modelData);
-		if (Result.isFailure(parsed)) {
+		const parsed = v.safeParse(liteLLMModelPricingSchema, modelData);
+		if (!parsed.success) {
 			continue;
 		}
 
-		dataset[modelName] = parsed.value;
+		dataset[modelName] = parsed.output;
 	}
 
 	return dataset;

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -118,8 +118,7 @@ function createLogger(logger?: PricingLogger): PricingLogger {
 
 export class LiteLLMPricingFetcher implements Disposable {
 	private cachedPricing: Map<string, LiteLLMModelPricing> | null = null;
-	private pricingLoadPromise: Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> | null =
-		null;
+	private pricingLoadPromise: ReturnType<LiteLLMPricingFetcher['loadPricing']> | null = null;
 	private readonly modelPricingCache = new Map<string, LiteLLMModelPricing | null>();
 	private readonly logger: PricingLogger;
 	private readonly offline: boolean;
@@ -145,7 +144,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 		this.modelPricingCache.clear();
 	}
 
-	private loadOfflinePricing = Result.try({
+	private loadOfflinePricing = Result.fn({
 		try: async () => {
 			if (this.offlineLoader == null) {
 				throw new Error('Offline loader was not provided');
@@ -158,9 +157,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 		catch: (error) => new Error('Failed to load offline pricing data', { cause: error }),
 	});
 
-	private async handleFallbackToCachedPricing(
-		originalError: unknown,
-	): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
+	private async handleFallbackToCachedPricing(originalError: unknown) {
 		this.logger.warn(
 			'Failed to fetch model pricing from LiteLLM, falling back to cached pricing data',
 		);
@@ -177,7 +174,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 		);
 	}
 
-	private async loadPricing(): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
+	private async loadPricing() {
 		if (this.offline) {
 			return this.loadOfflinePricing();
 		}
@@ -185,7 +182,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 		this.logger.warn('Fetching latest model pricing from LiteLLM...');
 		return Result.pipe(
 			Result.try({
-				try: fetch(this.url),
+				try: async () => fetch(this.url),
 				catch: (error) => new Error('Failed to fetch model pricing from LiteLLM', { cause: error }),
 			}),
 			Result.andThrough((response) => {
@@ -196,7 +193,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 			}),
 			Result.andThen(async (response) =>
 				Result.try({
-					try: response.json() as Promise<Record<string, unknown>>,
+					try: async () => response.json() as Promise<Record<string, unknown>>,
 					catch: (error) => new Error('Failed to parse pricing data', { cause: error }),
 				}),
 			),
@@ -207,12 +204,12 @@ export class LiteLLMPricingFetcher implements Disposable {
 						continue;
 					}
 
-					const parsed = v.safeParse(liteLLMModelPricingSchema, modelData);
-					if (!parsed.success) {
+					const parsed = Result.parse(liteLLMModelPricingSchema, modelData);
+					if (Result.isFailure(parsed)) {
 						continue;
 					}
 
-					pricing.set(modelName, parsed.output);
+					pricing.set(modelName, parsed.value);
 				}
 				return pricing;
 			}),
@@ -224,7 +221,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 		);
 	}
 
-	private async ensurePricingLoaded(): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
+	private async ensurePricingLoaded() {
 		if (this.cachedPricing != null) {
 			return Result.succeed(this.cachedPricing);
 		}
@@ -238,7 +235,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 		return this.pricingLoadPromise;
 	}
 
-	async fetchModelPricing(): Result.ResultAsync<Map<string, LiteLLMModelPricing>, Error> {
+	async fetchModelPricing() {
 		return this.ensurePricingLoaded();
 	}
 
@@ -253,7 +250,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 		return Array.from(candidates);
 	}
 
-	async getModelPricing(modelName: string): Result.ResultAsync<LiteLLMModelPricing | null, Error> {
+	async getModelPricing(modelName: string) {
 		if (this.modelPricingCache.has(modelName)) {
 			return Result.succeed(this.modelPricingCache.get(modelName) ?? null);
 		}
@@ -293,7 +290,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 		);
 	}
 
-	async getModelContextLimit(modelName: string): Result.ResultAsync<number | null, Error> {
+	async getModelContextLimit(modelName: string) {
 		return Result.pipe(
 			this.getModelPricing(modelName),
 			Result.map((pricing) => pricing?.max_input_tokens ?? null),
@@ -360,7 +357,7 @@ export class LiteLLMPricingFetcher implements Disposable {
 		},
 		modelName?: string,
 		options?: { speed?: 'standard' | 'fast' },
-	): Result.ResultAsync<number, Error> {
+	) {
 		if (modelName == null || modelName === '') {
 			return Result.succeed(0);
 		}

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -204,12 +204,12 @@ export class LiteLLMPricingFetcher implements Disposable {
 						continue;
 					}
 
-					const parsed = Result.parse(liteLLMModelPricingSchema, modelData);
-					if (Result.isFailure(parsed)) {
+					const parsed = v.safeParse(liteLLMModelPricingSchema, modelData);
+					if (!parsed.success) {
 						continue;
 					}
 
-					pricing.set(modelName, parsed.value);
+					pricing.set(modelName, parsed.output);
 				}
 				return pricing;
 			}),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: ^0.27.5
       version: 0.27.6
     '@praha/byethrow-docs':
-      specifier: ^0.9.0
-      version: 0.9.0
+      specifier: ^0.11.2
+      version: 0.11.2
   release:
     bumpp:
       specifier: ^10.2.3
@@ -78,8 +78,8 @@ catalogs:
       specifier: ^9.2.1
       version: 9.3.0
     '@praha/byethrow':
-      specifier: ^0.6.3
-      version: 0.6.3
+      specifier: ^0.11.2
+      version: 0.11.2
     ansi-escapes:
       specifier: ^7.0.0
       version: 7.1.0
@@ -141,7 +141,7 @@ importers:
         version: 0.27.6
       '@praha/byethrow-docs':
         specifier: catalog:llm-docs
-        version: 0.9.0(@praha/byethrow@0.9.0(typescript@5.9.2))
+        version: 0.11.2(@praha/byethrow@0.11.2(typescript@5.9.2))
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.30)(eslint-plugin-format@2.0.1(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.1.2(@types/node@24.5.1)(vite@8.0.11(@types/node@24.5.1)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.1)))
@@ -186,7 +186,7 @@ importers:
         version: 0.129.0
       '@praha/byethrow':
         specifier: catalog:runtime
-        version: 0.6.3
+        version: 0.11.2(typescript@5.9.2)
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.30)(eslint-plugin-format@2.0.1(eslint@9.35.0(jiti@2.6.1)))(eslint@9.35.0(jiti@2.6.1))(typescript@5.9.2)(vitest@4.1.2(@types/node@24.5.1)(vite@8.0.11(@types/node@24.5.1)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.1)))
@@ -288,7 +288,7 @@ importers:
     dependencies:
       '@praha/byethrow':
         specifier: catalog:runtime
-        version: 0.6.3
+        version: 0.11.2(typescript@5.9.2)
       valibot:
         specifier: catalog:runtime
         version: 1.1.0(typescript@5.9.2)
@@ -908,9 +908,6 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@gar/promisify@1.1.3':
-    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
-
   '@gunshi/docs@0.27.6':
     resolution: {integrity: sha512-eyUmbLoSFNZbqXM8DNjUrE9NO9A+kuk78z/wSwuPEBDC2BveyO41dl6NwT5Z2b3NgSPiP4i5inG88Uw3HnUI4Q==}
     hasBin: true
@@ -1099,6 +1096,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1139,14 +1140,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@npmcli/fs@1.1.1':
-    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
-
-  '@npmcli/move-file@1.1.2':
-    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
-    engines: {node: '>=10'}
-    deprecated: This functionality has been moved to @npmcli/fs
 
   '@octokit/action@6.1.0':
     resolution: {integrity: sha512-lo+nHx8kAV86bxvOVOI3vFjX3gXPd/L7guAUbvs3pUvnR2KC+R7yjBkA1uACt4gYhs4LcWP3AXSGQzsbeN2XXw==}
@@ -1471,17 +1464,14 @@ packages:
   '@poppinss/exception@1.2.2':
     resolution: {integrity: sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==}
 
-  '@praha/byethrow-docs@0.9.0':
-    resolution: {integrity: sha512-/qbTE0rcMvoEHyUG8fPtXEv8ChNDjFPKLvf5NyWD02gn9ZX8AaVw4mdYfPrS7iBfTR6Iq4RH6d+RoM8EjRMHow==}
+  '@praha/byethrow-docs@0.11.2':
+    resolution: {integrity: sha512-9hshtZpKNNTCKjjmdHUQtEMi9v9saOcAy1Ez+NA0oYtkSscEDwZi9IRDuRfPBh9BgForiMcdHXNl/6Xi5JJSAw==}
     hasBin: true
     peerDependencies:
-      '@praha/byethrow': 0.9.0
+      '@praha/byethrow': 0.11.2
 
-  '@praha/byethrow@0.6.3':
-    resolution: {integrity: sha512-WeHnDRzan8Zx4Lj3wCKy88K0zFZqnGKBho2QuTAM94yutkLDOsDSIYDbu/OXgnc+bQnnomCOteJNtE53o7l+Zw==}
-
-  '@praha/byethrow@0.9.0':
-    resolution: {integrity: sha512-D8XhQ40RsGkwcJdKYqoQ2RUfoqgzztHWXZNpMaRE5P5U+D1c1YboFPc8hysJWQhqloQ32kCXB0XPwM3dFiNyIg==}
+  '@praha/byethrow@0.11.2':
+    resolution: {integrity: sha512-DtX4J1BhuojwA88vhymyGR+AsEeJjxXP4RmR7R9gqk299fAMtqH6dI82jq+0emWmk9+HSLZ54y3VIB14WuqfwQ==}
     peerDependencies:
       typescript: '>=5.0.0'
 
@@ -1868,9 +1858,6 @@ packages:
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1879,10 +1866,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=9.0.0'
-
-  '@tootallnate/once@1.1.2':
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -2188,8 +2171,9 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2200,18 +2184,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
-
-  aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -2236,17 +2208,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  aproba@2.1.0:
-    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
-
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
-
-  are-we-there-yet@3.0.1:
-    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This package is no longer supported.
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -2485,10 +2449,6 @@ packages:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
-  cacache@15.3.0:
-    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
-    engines: {node: '>= 10'}
-
   call-me-maybe@1.0.2:
     resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
@@ -2546,12 +2506,19 @@ packages:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   ci-info@4.3.0:
     resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
     engines: {node: '>=8'}
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
   clean-pkg-json@1.3.0:
     resolution: {integrity: sha512-EsOnQbKkrmCTIHCYODpIZ4FS1kP8UqX9fEji5SAA2OhG4K+Z/xuXON53hJdSBroVIpxddrUtR/dbh+QF5Aq7Vw==}
@@ -2560,10 +2527,6 @@ packages:
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
-
-  clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2578,10 +2541,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  color-support@1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
-    hasBin: true
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -2605,9 +2564,6 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  console-control-strings@1.1.0:
-    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   convert-gitmoji@0.1.5:
     resolution: {integrity: sha512-4wqOafJdk2tqZC++cjcbGcaJ13BZ3kwldf06PTiAQRAB76Z1KJwZNL1SaRZMi2w1FM9RYTgZ6QErS8NUl/GBmQ==}
@@ -2646,8 +2602,8 @@ packages:
       supports-color:
         optional: true
 
-  decode-named-character-reference@1.2.0:
-    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   decode-uri-component@0.4.1:
     resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
@@ -2681,9 +2637,6 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
-
-  delegates@1.0.0:
-    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
@@ -2733,9 +2686,6 @@ packages:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
-  encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -2758,9 +2708,6 @@ packages:
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
-
-  err-code@2.0.3:
-    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
@@ -3026,6 +2973,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
@@ -3126,18 +3076,10 @@ packages:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  gauge@4.0.4:
-    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This package is no longer supported.
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -3180,10 +3122,6 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -3217,9 +3155,6 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  has-unicode@2.0.1:
-    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
-
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
@@ -3235,27 +3170,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  http-cache-semantics@4.2.0:
-    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
-
-  http-proxy-agent@4.0.1:
-    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
-    engines: {node: '>= 6'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
-
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
-
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3280,30 +3197,15 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  indent-string@4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
-    engines: {node: '>=8'}
-
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
-
-  infer-owner@1.0.4:
-    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
-    engines: {node: '>= 12'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -3339,9 +3241,6 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
-  is-lambda@1.0.1:
-    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
-
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -3368,6 +3267,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -3589,20 +3492,12 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
-
   magic-string-ast@1.0.3:
     resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
     engines: {node: '>=20.19.0'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  make-fetch-happen@9.1.0:
-    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
-    engines: {node: '>= 10'}
 
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
@@ -3620,9 +3515,6 @@ packages:
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
-
-  mdast-util-from-markdown@2.0.2:
-    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
 
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
@@ -3785,26 +3677,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass-collect@1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
-
-  minipass-fetch@1.4.1:
-    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
-    engines: {node: '>=8'}
-
-  minipass-flush@1.0.7:
-    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
-    engines: {node: '>= 8'}
-
-  minipass-pipeline@1.2.4:
-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
-
-  minipass-sized@1.0.3:
-    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
-    engines: {node: '>=8'}
-
   minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
@@ -3813,12 +3685,20 @@ packages:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   mitata@1.0.34:
     resolution: {integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==}
@@ -3856,23 +3736,20 @@ packages:
     resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
     engines: {node: '>=18'}
 
-  negotiator@0.6.4:
-    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
-    engines: {node: '>= 0.6'}
-
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
 
-  node-addon-api@7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+  node-addon-api@8.7.0:
+    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
-  node-gyp@8.4.1:
-    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
-    engines: {node: '>= 10.12.0'}
+  node-gyp@12.3.0:
+    resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   node-releases@2.0.21:
@@ -3968,9 +3845,9 @@ packages:
     version: 24.15.0
     hasBin: true
 
-  nopt@5.0.0:
-    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
-    engines: {node: '>=6'}
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   normalize-path@3.0.0:
@@ -3980,11 +3857,6 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
-
-  npmlog@6.0.2:
-    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This package is no longer supported.
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -4054,10 +3926,6 @@ packages:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  p-map@4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
-    engines: {node: '>=10'}
-
   package-manager-detector@1.3.0:
     resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
 
@@ -4082,10 +3950,6 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -4189,17 +4053,9 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
-  promise-inflight@1.0.1:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-
-  promise-retry@2.0.1:
-    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
-    engines: {node: '>=10'}
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -4308,18 +4164,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  retry@0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
-
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   rolldown-plugin-dts@0.25.0:
     resolution: {integrity: sha512-GE3uDZgUuA9l6g+1u928TRmadd5IVhaWiwpWast2kCyLv9tYJJCC6E5HHkV0HGmwC5ZL73xh12/PRZI+KZ2vdQ==}
@@ -4378,9 +4225,6 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
   scslre@0.3.0:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
     engines: {node: ^14.0.0 || >=16.0.0}
@@ -4402,9 +4246,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  set-blocking@2.0.0:
-    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -4423,9 +4264,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4438,18 +4276,6 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  socks-proxy-agent@6.2.1:
-    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
-    engines: {node: '>= 10'}
-
-  socks@2.8.9:
-    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4474,12 +4300,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  sqlite3@5.1.7:
-    resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
-
-  ssri@8.0.1:
-    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
-    engines: {node: '>= 8'}
+  sqlite3@6.0.1:
+    resolution: {integrity: sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==}
+    engines: {node: '>=20.17.0'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4557,6 +4380,11 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tar@7.5.15:
+    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4701,6 +4529,10 @@ packages:
     resolution: {integrity: sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==}
     engines: {node: '>=18.17'}
 
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
+
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
@@ -4714,12 +4546,6 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
-
-  unique-filename@1.1.1:
-    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
-
-  unique-slug@2.0.2:
-    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
 
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
@@ -4963,13 +4789,15 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wide-align@1.1.5:
-    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -5028,6 +4856,10 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
   yaml-eslint-parser@1.3.0:
     resolution: {integrity: sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==}
     engines: {node: ^14.17.0 || >=16.0.0}
@@ -5049,8 +4881,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  yocto-queue@1.2.1:
-    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
   yoctocolors@2.1.2:
@@ -5473,7 +5305,7 @@ snapshots:
       '@eslint/core': 0.15.2
       '@eslint/plugin-kit': 0.3.5
       github-slugger: 2.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-frontmatter: 2.0.1
       mdast-util-gfm: 3.1.0
       micromark-extension-frontmatter: 2.0.0
@@ -5490,9 +5322,6 @@ snapshots:
       levn: 0.4.1
 
   '@fastify/busboy@2.1.1': {}
-
-  '@gar/promisify@1.1.3':
-    optional: true
 
   '@gunshi/docs@0.27.6':
     dependencies:
@@ -5626,6 +5455,10 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5675,18 +5508,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
-
-  '@npmcli/fs@1.1.1':
-    dependencies:
-      '@gar/promisify': 1.1.3
-      semver: 7.7.3
-    optional: true
-
-  '@npmcli/move-file@1.1.2':
-    dependencies:
-      mkdirp: 1.0.4
-      rimraf: 3.0.2
-    optional: true
 
   '@octokit/action@6.1.0':
     dependencies:
@@ -5894,24 +5715,19 @@ snapshots:
 
   '@poppinss/exception@1.2.2': {}
 
-  '@praha/byethrow-docs@0.9.0(@praha/byethrow@0.9.0(typescript@5.9.2))':
+  '@praha/byethrow-docs@0.11.2(@praha/byethrow@0.11.2(typescript@5.9.2))':
     dependencies:
-      '@praha/byethrow': 0.9.0(typescript@5.9.2)
-      citty: 0.1.6
+      '@praha/byethrow': 0.11.2(typescript@5.9.2)
+      citty: 0.2.2
       find-up: 8.0.0
       flexsearch: 0.8.212
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-string: 4.0.0
-      sqlite3: 5.1.7
+      sqlite3: 6.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@praha/byethrow@0.6.3':
-    dependencies:
-      '@standard-schema/spec': 1.0.0
-
-  '@praha/byethrow@0.9.0(typescript@5.9.2)':
+  '@praha/byethrow@0.11.2(typescript@5.9.2)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       typescript: 5.9.2
@@ -6169,8 +5985,6 @@ snapshots:
 
   '@speed-highlight/core@1.2.7': {}
 
-  '@standard-schema/spec@1.0.0': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@stylistic/eslint-plugin@5.4.0(eslint@9.35.0(jiti@2.6.1))':
@@ -6182,9 +5996,6 @@ snapshots:
       espree: 10.4.0
       estraverse: 5.3.0
       picomatch: 4.0.3
-
-  '@tootallnate/once@1.1.2':
-    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -6515,7 +6326,7 @@ snapshots:
     dependencies:
       vue: 3.5.30(typescript@5.9.2)
 
-  abbrev@1.1.1:
+  abbrev@4.0.0:
     optional: true
 
   acorn-jsx@5.3.2(acorn@8.15.0):
@@ -6523,24 +6334,6 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
-    optional: true
-
-  aggregate-error@3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
-    optional: true
 
   ajv@6.12.6:
     dependencies:
@@ -6566,16 +6359,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  aproba@2.1.0:
-    optional: true
-
   are-docs-informative@0.0.2: {}
-
-  are-we-there-yet@3.0.1:
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.2
-    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -6726,30 +6510,6 @@ snapshots:
 
   cac@7.0.0: {}
 
-  cacache@15.3.0:
-    dependencies:
-      '@npmcli/fs': 1.1.1
-      '@npmcli/move-file': 1.1.2
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      glob: 7.2.3
-      infer-owner: 1.0.4
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      mkdirp: 1.0.4
-      p-map: 4.0.0
-      promise-inflight: 1.0.1
-      rimraf: 3.0.2
-      ssri: 8.0.1
-      tar: 6.2.1
-      unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
-    optional: true
-
   call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
@@ -6826,20 +6586,21 @@ snapshots:
 
   chownr@2.0.0: {}
 
+  chownr@3.0.0: {}
+
   ci-info@4.3.0: {}
 
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
 
+  citty@0.2.2: {}
+
   clean-pkg-json@1.3.0: {}
 
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
-
-  clean-stack@2.2.0:
-    optional: true
 
   cliui@8.0.1:
     dependencies:
@@ -6855,9 +6616,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  color-support@1.1.3:
-    optional: true
-
   colorette@2.0.20: {}
 
   comma-separated-tokens@2.0.3: {}
@@ -6871,9 +6629,6 @@ snapshots:
   confbox@0.2.2: {}
 
   consola@3.4.2: {}
-
-  console-control-strings@1.1.0:
-    optional: true
 
   convert-gitmoji@0.1.5: {}
 
@@ -6901,7 +6656,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decode-named-character-reference@1.2.0:
+  decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
 
@@ -6927,9 +6682,6 @@ snapshots:
   defu@6.1.4: {}
 
   defu@6.1.7: {}
-
-  delegates@1.0.0:
-    optional: true
 
   deprecation@2.3.1: {}
 
@@ -6957,11 +6709,6 @@ snapshots:
 
   empathic@2.0.0: {}
 
-  encoding@0.1.13:
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
-
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -6979,9 +6726,6 @@ snapshots:
     optional: true
 
   environment@1.1.0: {}
-
-  err-code@2.0.3:
-    optional: true
 
   error-stack-parser-es@1.0.5: {}
 
@@ -7056,7 +6800,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@9.35.0(jiti@2.6.1)):
     dependencies:
       eslint: 9.35.0(jiti@2.6.1)
-      semver: 7.7.3
+      semver: 7.8.0
 
   eslint-compat-utils@0.6.5(eslint@9.35.0(jiti@2.6.1)):
     dependencies:
@@ -7378,6 +7122,9 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  exponential-backoff@3.1.3:
+    optional: true
+
   exsolve@1.0.8: {}
 
   extend-shallow@2.0.1:
@@ -7469,22 +7216,7 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
-  fs.realpath@1.0.0:
-    optional: true
-
   fsevents@2.3.3:
-    optional: true
-
-  gauge@4.0.4:
-    dependencies:
-      aproba: 2.1.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
     optional: true
 
   get-caller-file@2.0.5: {}
@@ -7535,16 +7267,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    optional: true
-
   globals@14.0.0: {}
 
   globals@15.15.0: {}
@@ -7570,9 +7292,6 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  has-unicode@2.0.1:
-    optional: true
-
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -7597,37 +7316,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  http-cache-semantics@4.2.0:
-    optional: true
-
-  http-proxy-agent@4.0.1:
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   human-signals@8.0.1: {}
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
-    optional: true
-
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-    optional: true
 
   ieee754@1.2.1: {}
 
@@ -7644,26 +7333,11 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  indent-string@4.0.0:
-    optional: true
-
   indent-string@5.0.0: {}
-
-  infer-owner@1.0.4:
-    optional: true
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-    optional: true
 
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
-
-  ip-address@10.2.0:
-    optional: true
 
   is-binary-path@2.1.0:
     dependencies:
@@ -7689,9 +7363,6 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
-  is-lambda@1.0.1:
-    optional: true
-
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -7707,6 +7378,9 @@ snapshots:
   isbinaryfile@5.0.7: {}
 
   isexe@2.0.0: {}
+
+  isexe@4.0.0:
+    optional: true
 
   jiti@1.21.7: {}
 
@@ -7875,11 +7549,6 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
-    optional: true
-
   magic-string-ast@1.0.3:
     dependencies:
       magic-string: 0.30.21
@@ -7887,29 +7556,6 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  make-fetch-happen@9.1.0:
-    dependencies:
-      agentkeepalive: 4.6.0
-      cacache: 15.3.0
-      http-cache-semantics: 4.2.0
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
-      is-lambda: 1.0.1
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 1.4.1
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.4
-      promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1
-      ssri: 8.0.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    optional: true
 
   mark.js@8.11.1: {}
 
@@ -7933,28 +7579,11 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  mdast-util-from-markdown@2.0.2:
-    dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
-      decode-named-character-reference: 1.2.0
-      devlop: 1.1.0
-      mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
-      micromark-util-decode-numeric-character-reference: 2.0.2
-      micromark-util-decode-string: 2.0.1
-      micromark-util-normalize-identifier: 2.0.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-      unist-util-stringify-position: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
-      decode-named-character-reference: 1.2.0
+      decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
       micromark: 4.0.2
@@ -7972,7 +7601,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -8025,7 +7654,7 @@ snapshots:
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -8074,7 +7703,7 @@ snapshots:
 
   micromark-core-commonmark@2.0.3:
     dependencies:
-      decode-named-character-reference: 1.2.0
+      decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-factory-destination: 2.0.1
       micromark-factory-label: 2.0.1
@@ -8214,7 +7843,7 @@ snapshots:
 
   micromark-util-decode-string@2.0.1:
     dependencies:
-      decode-named-character-reference: 1.2.0
+      decode-named-character-reference: 1.3.0
       micromark-util-character: 2.1.1
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-symbol: 2.0.1
@@ -8252,7 +7881,7 @@ snapshots:
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.4.3
-      decode-named-character-reference: 1.2.0
+      decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-factory-space: 2.0.1
@@ -8307,40 +7936,13 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass-collect@1.0.2:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
-  minipass-fetch@1.4.1:
-    dependencies:
-      minipass: 3.3.6
-      minipass-sized: 1.0.3
-      minizlib: 2.1.2
-    optionalDependencies:
-      encoding: 0.1.13
-    optional: true
-
-  minipass-flush@1.0.7:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
-  minipass-pipeline@1.2.4:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
-  minipass-sized@1.0.3:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
   minipass@3.3.6:
     dependencies:
       yallist: 4.0.0
 
   minipass@5.0.0: {}
+
+  minipass@7.1.3: {}
 
   minisearch@7.2.0: {}
 
@@ -8348,6 +7950,10 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
 
   mitata@1.0.34: {}
 
@@ -8374,41 +7980,35 @@ snapshots:
 
   natural-orderby@5.0.0: {}
 
-  negotiator@0.6.4:
-    optional: true
-
   node-abi@3.92.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.0
 
-  node-addon-api@7.1.1: {}
+  node-addon-api@8.7.0: {}
 
   node-fetch-native@1.6.7: {}
 
-  node-gyp@8.4.1:
+  node-gyp@12.3.0:
     dependencies:
       env-paths: 2.2.1
-      glob: 7.2.3
+      exponential-backoff: 3.1.3
       graceful-fs: 4.2.11
-      make-fetch-happen: 9.1.0
-      nopt: 5.0.0
-      npmlog: 6.0.2
-      rimraf: 3.0.2
-      semver: 7.7.3
-      tar: 6.2.1
-      which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.8.0
+      tar: 7.5.15
+      tinyglobby: 0.2.16
+      undici: 6.25.0
+      which: 6.0.1
     optional: true
 
   node-releases@2.0.21: {}
 
   node@runtime:24.15.0: {}
 
-  nopt@5.0.0:
+  nopt@9.0.0:
     dependencies:
-      abbrev: 1.1.1
+      abbrev: 4.0.0
     optional: true
 
   normalize-path@3.0.0: {}
@@ -8417,14 +8017,6 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
-
-  npmlog@6.0.2:
-    dependencies:
-      are-we-there-yet: 3.0.1
-      console-control-strings: 1.1.0
-      gauge: 4.0.4
-      set-blocking: 2.0.0
-    optional: true
 
   nth-check@2.1.1:
     dependencies:
@@ -8541,7 +8133,7 @@ snapshots:
 
   p-limit@4.0.0:
     dependencies:
-      yocto-queue: 1.2.1
+      yocto-queue: 1.2.2
 
   p-locate@5.0.0:
     dependencies:
@@ -8550,11 +8142,6 @@ snapshots:
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
-
-  p-map@4.0.0:
-    dependencies:
-      aggregate-error: 3.1.0
-    optional: true
 
   package-manager-detector@1.3.0: {}
 
@@ -8573,9 +8160,6 @@ snapshots:
   parse-statements@1.0.11: {}
 
   path-exists@4.0.0: {}
-
-  path-is-absolute@1.0.1:
-    optional: true
 
   path-key@3.1.1: {}
 
@@ -8655,7 +8239,7 @@ snapshots:
 
   prebuild-install@7.1.3:
     dependencies:
-      detect-libc: 2.1.0
+      detect-libc: 2.1.2
       expand-template: 2.0.3
       github-from-package: 0.0.0
       minimist: 1.2.8
@@ -8682,13 +8266,7 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  promise-inflight@1.0.1:
-    optional: true
-
-  promise-retry@2.0.1:
-    dependencies:
-      err-code: 2.0.3
-      retry: 0.12.0
+  proc-log@6.1.0:
     optional: true
 
   property-information@7.1.0: {}
@@ -8820,15 +8398,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  retry@0.12.0:
-    optional: true
-
   reusify@1.1.0: {}
-
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
-    optional: true
 
   rolldown-plugin-dts@0.25.0(@typescript/native-preview@7.0.0-dev.20260510.1)(rolldown@1.0.0)(typescript@5.9.2):
     dependencies:
@@ -8934,9 +8504,6 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  safer-buffer@2.1.2:
-    optional: true
-
   scslre@0.3.0:
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -8953,9 +8520,6 @@ snapshots:
   semver@7.7.3: {}
 
   semver@7.8.0: {}
-
-  set-blocking@2.0.0:
-    optional: true
 
   sharp@0.34.5:
     dependencies:
@@ -9007,9 +8571,6 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@3.0.7:
-    optional: true
-
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -9021,24 +8582,6 @@ snapshots:
       simple-concat: 1.0.1
 
   sisteransi@1.0.5: {}
-
-  smart-buffer@4.2.0:
-    optional: true
-
-  socks-proxy-agent@6.2.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  socks@2.8.9:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-    optional: true
 
   source-map-js@1.2.1: {}
 
@@ -9057,22 +8600,14 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  sqlite3@5.1.7:
+  sqlite3@6.0.1:
     dependencies:
       bindings: 1.5.0
-      node-addon-api: 7.1.1
+      node-addon-api: 8.7.0
       prebuild-install: 7.1.3
-      tar: 6.2.1
+      tar: 7.5.15
     optionalDependencies:
-      node-gyp: 8.4.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-
-  ssri@8.0.1:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
+      node-gyp: 12.3.0
 
   stackback@0.0.2: {}
 
@@ -9148,6 +8683,14 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+
+  tar@7.5.15:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   tinybench@2.9.0: {}
 
@@ -9259,6 +8802,9 @@ snapshots:
 
   undici@6.22.0: {}
 
+  undici@6.25.0:
+    optional: true
+
   undici@7.24.8: {}
 
   unenv@2.0.0-rc.24:
@@ -9276,16 +8822,6 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
-
-  unique-filename@1.1.1:
-    dependencies:
-      unique-slug: 2.0.2
-    optional: true
-
-  unique-slug@2.0.2:
-    dependencies:
-      imurmurhash: 0.1.4
-    optional: true
 
   unist-util-is@6.0.0:
     dependencies:
@@ -9571,15 +9107,15 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+    optional: true
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wide-align@1.1.5:
-    dependencies:
-      string-width: 4.2.3
-    optional: true
 
   word-wrap@1.2.5: {}
 
@@ -9629,6 +9165,8 @@ snapshots:
 
   yallist@4.0.0: {}
 
+  yallist@5.0.0: {}
+
   yaml-eslint-parser@1.3.0:
     dependencies:
       eslint-visitor-keys: 3.4.3
@@ -9650,7 +9188,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  yocto-queue@1.2.1: {}
+  yocto-queue@1.2.2: {}
 
   yoctocolors@2.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,7 @@ catalogs:
     publint: ^0.3.12
   llm-docs:
     '@gunshi/docs': ^0.27.5
-    '@praha/byethrow-docs': ^0.9.0
+    '@praha/byethrow-docs': ^0.11.2
   release:
     bumpp: ^10.2.3
     changelogithub: ^13.16.1
@@ -34,7 +34,7 @@ catalogs:
     pkg-pr-new: ^0.0.60
   runtime:
     '@antfu/utils': ^9.2.1
-    '@praha/byethrow': ^0.6.3
+    '@praha/byethrow': ^0.11.2
     ansi-escapes: ^7.0.0
     arkregex: ^0.0.5
     get-stdin: ^9.0.0


### PR DESCRIPTION
## Summary
- update @praha/byethrow and @praha/byethrow-docs to 0.11.2
- migrate Result.try call sites to the 0.11 direct-return API
- use Result.fn, Result.parse, and Result.pipe for recoverable parsing, validation, and progress/error handling
- switch touched ESLint presets to app mode so byethrow return types can be inferred

## Testing
- pnpm run format
- pnpm typecheck
- pnpm run test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Updated internal error-handling patterns across the application for improved code consistency and maintainability.
  * Upgraded dependency versions to latest stable releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->