### PR TITLE
docs: add scx to related projects

### DIFF
--- a/docs/guide/related-projects.md
+++ b/docs/guide/related-projects.md
@@ -14,6 +14,10 @@ Projects that use ccusage internally or extend its functionality:
 - [ccusage Raycast Extension](https://www.raycast.com/nyatinte/ccusage) - Raycast integration for quick usage checks
 - [ccusage.nvim](https://github.com/S1M0N38/ccusage.nvim) - Track Claude Code usage in Neovim
 
+## CLI Utilities
+
+- [scx](https://github.com/yamamuteki/scx) - Convert ccusage USD output from stdin into a local currency
+
 ## Web Applications
 
 - [viberank](https://viberank.app) - A community-driven leaderboard for Claude Code usage. ([GitHub](https://github.com/sculptdotfun/viberank))


### PR DESCRIPTION
Adds scx to the related projects guide as a CLI utility. scx wraps ccusage output from stdin and converts USD amounts into a local currency, so it fits the community projects list.

Testing:
- pnpm --filter docs format
- pnpm typecheck
- pnpm run test


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `scx` to the Related Projects guide as a CLI utility. It wraps `ccusage` output from stdin and converts USD amounts into a local currency.

<sup>Written for commit 5f36f8eea3bd0ef2b527fb0a21d99565206df341. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1052?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated related projects guide with new CLI utilities section, including reference to `scx` for currency conversion functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->