### PR TITLE
docs: add Straude community project

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -92,7 +92,7 @@ export default defineConfig({
 				{
 					text: 'Community',
 					items: [
-						{ text: 'Related Projects', link: '/guide/related-projects' },
+						{ text: 'Community Projects', link: '/guide/community-projects' },
 						{ text: 'Sponsors', link: '/guide/sponsors' },
 					],
 				},
@@ -145,6 +145,7 @@ export default defineConfig({
 					{ from: '/sponsor', to: 'https://github.com/sponsors/ryoppippi', status: 302 },
 					{ from: '/guide/custom-paths', to: '/guide/claude/', status: 301 },
 					{ from: '/guide/directory-detection', to: '/guide/claude/', status: 301 },
+					{ from: '/guide/related-projects', to: '/guide/community-projects', status: 301 },
 				],
 			}) as any,
 			groupIconVitePlugin(),

--- a/docs/guide/community-projects.md
+++ b/docs/guide/community-projects.md
@@ -1,6 +1,8 @@
-# Related Projects
+# Community Projects
 
-Projects that use ccusage internally or extend its functionality:
+Community projects built around ccusage, Claude Code usage tracking, or related workflows.
+
+These projects are maintained independently and are not affiliated with the ccusage project or ryoppippi.
 
 ## Desktop Applications
 
@@ -20,6 +22,7 @@ Projects that use ccusage internally or extend its functionality:
 
 ## Web Applications
 
+- [Straude](https://straude.com) - Strava-style Claude Code telemetry for logging usage, tracking spend, and comparing pace
 - [viberank](https://viberank.app) - A community-driven leaderboard for Claude Code usage. ([GitHub](https://github.com/sculptdotfun/viberank))
 
 ## Contributing


### PR DESCRIPTION
Renames the related projects guide to Community Projects and keeps the old route redirected.

This also adds Straude as a community web application and states that listed projects are independently maintained and not affiliated with the ccusage project or ryoppippi.

Testing:
- pnpm --filter docs format
- pnpm --filter docs build
- pnpm typecheck
- pnpm run test


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the docs “Related Projects” guide to “Community Projects” and updated the sidebar, with a 301 redirect from `/guide/related-projects` to `/guide/community-projects`. Added Straude under Web Applications and clarified that listings are independently maintained and not affiliated with `ccusage` or `ryoppippi`.

<sup>Written for commit d5c90f2e47cde703cd06e0a991f16412a57f90ae. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1053?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation sidebar navigation to better showcase community-contributed projects
  * Added "Straude" web application to the community projects directory
  * Implemented automatic redirects from legacy documentation URLs to maintain backward compatibility with existing links

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->