### PR TITLE
test(ccusage): inline one-off test values

### DIFF
--- a/.agents/skills/ccusage-testing/SKILL.md
+++ b/.agents/skills/ccusage-testing/SKILL.md
@@ -27,8 +27,8 @@ Utility functions should include concise JSDoc describing their purpose and focu
 
 - Avoid `try`/`catch` in tests for expected failures. Use `expect(...).toThrow()`, `await expect(...).rejects`, or explicit Result failure assertions.
 - Avoid `if` branches inside test bodies. Split behaviors into separate tests or use `it.each` for table-driven cases.
-- Tests do not need to be DRY. Prefer repeated, explicit setup in each test when it makes the behaviour easier to read.
-- Do not hoist one-off values out of tests. Write literals and direct setup values inline in the test body when sharing them would make the behaviour harder to read.
+- Tests do not need to be DRY. Prefer repeated, explicit setup in each test when it makes the behavior easier to read.
+- Do not hoist one-off values out of tests. Write literals and direct setup values inline in the test body when sharing them would make the behavior harder to read.
 
 For concrete good and bad examples, read `../tdd/references/vitest-examples.md`.
 

--- a/.agents/skills/ccusage-testing/SKILL.md
+++ b/.agents/skills/ccusage-testing/SKILL.md
@@ -27,7 +27,8 @@ Utility functions should include concise JSDoc describing their purpose and focu
 
 - Avoid `try`/`catch` in tests for expected failures. Use `expect(...).toThrow()`, `await expect(...).rejects`, or explicit Result failure assertions.
 - Avoid `if` branches inside test bodies. Split behaviors into separate tests or use `it.each` for table-driven cases.
-- Do not over-DRY tests. Keep repeated setup inline when it makes the behavior easier to read.
+- Tests do not need to be DRY. Prefer repeated, explicit setup in each test when it makes the behaviour easier to read.
+- Do not hoist one-off values out of tests. Write literals and direct setup values inline in the test body when sharing them would make the behaviour harder to read.
 
 For concrete good and bad examples, read `../tdd/references/vitest-examples.md`.
 

--- a/.agents/skills/tdd/references/vitest-examples.md
+++ b/.agents/skills/tdd/references/vitest-examples.md
@@ -153,7 +153,28 @@ it('renders daily totals', () => {
 });
 ```
 
-Helpers are fine when they create noisy data or fixtures. Keep the assertion in the test unless the helper's name is more explicit than the assertion it hides.
+Tests do not need to be DRY. Prefer repeated, explicit setup over shared variables or helpers when duplication makes each test easier to read. Helpers are fine when they create noisy data or fixtures. Keep the assertion in the test unless the helper's name is more explicit than the assertion it hides.
+
+Avoid hoisting one-off values out of tests. Keep literals and setup values close to the behaviour they exercise.
+
+Bad:
+
+```typescript
+const defaultTimezone = 'UTC';
+const reportDate = '2026-05-16';
+
+it('formats the daily heading', () => {
+	expect(formatDailyHeading(reportDate, defaultTimezone)).toBe('2026-05-16');
+});
+```
+
+Good:
+
+```typescript
+it('formats the daily heading', () => {
+	expect(formatDailyHeading('2026-05-16', 'UTC')).toBe('2026-05-16');
+});
+```
 
 Use `assert` to make test preconditions explicit and to narrow nullable values. Do not use non-null assertions (`!`) to silence TypeScript when the test can fail with a useful message.
 

--- a/.agents/skills/tdd/references/vitest-examples.md
+++ b/.agents/skills/tdd/references/vitest-examples.md
@@ -155,7 +155,7 @@ it('renders daily totals', () => {
 
 Tests do not need to be DRY. Prefer repeated, explicit setup over shared variables or helpers when duplication makes each test easier to read. Helpers are fine when they create noisy data or fixtures. Keep the assertion in the test unless the helper's name is more explicit than the assertion it hides.
 
-Avoid hoisting one-off values out of tests. Keep literals and setup values close to the behaviour they exercise.
+Avoid hoisting one-off values out of tests. Keep literals and setup values close to the behavior they exercise.
 
 Bad:
 

--- a/apps/ccusage/test/cli-output.test.ts
+++ b/apps/ccusage/test/cli-output.test.ts
@@ -6,13 +6,6 @@ import { fileURLToPath } from 'node:url';
 import { regex } from 'arkregex';
 import { createFixture } from 'fs-fixture';
 
-const appRoot = fileURLToPath(new URL('../', import.meta.url));
-const fixtureTemplatePath = fileURLToPath(new URL('./fixtures/claude', import.meta.url));
-const snapshotRoot = fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url));
-const trailingNewlineRegex = regex('\n$');
-const trailingUnicodeNewlineRegex = regex('\n$', 'u');
-const fixtureDateRegex = regex('2026-01-02', 'gu');
-
 type DailyJsonOutput = {
 	daily: Array<{
 		agent: string;
@@ -214,7 +207,7 @@ function createAgentCliEnv(fixturePath: string): NodeJS.ProcessEnv {
 
 function runCcusage(args: string[], env: NodeJS.ProcessEnv): ReturnType<typeof spawnSync> {
 	return spawnSync('bun', ['./src/index.ts', ...args], {
-		cwd: appRoot,
+		cwd: fileURLToPath(new URL('../', import.meta.url)),
 		encoding: 'utf8',
 		env,
 	});
@@ -228,152 +221,232 @@ describe('ccusage output snapshots', () => {
 	it('matches daily JSON output', async () => {
 		const tempDir = path.join(tmpdir(), 'ccusage-cli-output-fixtures');
 		await mkdir(tempDir, { recursive: true });
-		await using fixture = await createFixture(fixtureTemplatePath, { tempDir });
+		await using fixture = await createFixture(
+			fileURLToPath(new URL('./fixtures/claude', import.meta.url)),
+			{
+				tempDir,
+			},
+		);
 
 		const result = spawnSync('bun', ['./src/index.ts', 'daily', '--offline', '--json'], {
-			cwd: appRoot,
+			cwd: fileURLToPath(new URL('../', import.meta.url)),
 			encoding: 'utf8',
 			env: await createCliEnv(fixture.path, tempDir),
 		});
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'daily-json.txt'),
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(result.stdout.replace(regex('\n$'), '')).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'daily-json.txt',
+			),
 		);
 	});
 
 	it('matches session JSON output', async () => {
 		const tempDir = path.join(tmpdir(), 'ccusage-cli-output-fixtures');
 		await mkdir(tempDir, { recursive: true });
-		await using fixture = await createFixture(fixtureTemplatePath, { tempDir });
+		await using fixture = await createFixture(
+			fileURLToPath(new URL('./fixtures/claude', import.meta.url)),
+			{
+				tempDir,
+			},
+		);
 
 		const result = spawnSync('bun', ['./src/index.ts', 'session', '--offline', '--json'], {
-			cwd: appRoot,
+			cwd: fileURLToPath(new URL('../', import.meta.url)),
 			encoding: 'utf8',
 			env: await createCliEnv(fixture.path, tempDir),
 		});
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'session-json.txt'),
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(result.stdout.replace(regex('\n$'), '')).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'session-json.txt',
+			),
 		);
 	});
 
 	it('matches blocks JSON output', async () => {
 		const tempDir = path.join(tmpdir(), 'ccusage-cli-output-fixtures');
 		await mkdir(tempDir, { recursive: true });
-		await using fixture = await createFixture(fixtureTemplatePath, { tempDir });
+		await using fixture = await createFixture(
+			fileURLToPath(new URL('./fixtures/claude', import.meta.url)),
+			{
+				tempDir,
+			},
+		);
 
 		const result = spawnSync('bun', ['./src/index.ts', 'blocks', '--offline', '--json'], {
-			cwd: appRoot,
+			cwd: fileURLToPath(new URL('../', import.meta.url)),
 			encoding: 'utf8',
 			env: await createCliEnv(fixture.path, tempDir),
 		});
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'blocks-json.txt'),
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(result.stdout.replace(regex('\n$'), '')).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'blocks-json.txt',
+			),
 		);
 	});
 
 	it('matches monthly JSON output', async () => {
 		const tempDir = path.join(tmpdir(), 'ccusage-cli-output-fixtures');
 		await mkdir(tempDir, { recursive: true });
-		await using fixture = await createFixture(fixtureTemplatePath, { tempDir });
+		await using fixture = await createFixture(
+			fileURLToPath(new URL('./fixtures/claude', import.meta.url)),
+			{
+				tempDir,
+			},
+		);
 
 		const result = spawnSync('bun', ['./src/index.ts', 'monthly', '--offline', '--json'], {
-			cwd: appRoot,
+			cwd: fileURLToPath(new URL('../', import.meta.url)),
 			encoding: 'utf8',
 			env: await createCliEnv(fixture.path, tempDir),
 		});
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'monthly-json.txt'),
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(result.stdout.replace(regex('\n$'), '')).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'monthly-json.txt',
+			),
 		);
 	});
 
 	it('matches weekly JSON output', async () => {
 		const tempDir = path.join(tmpdir(), 'ccusage-cli-output-fixtures');
 		await mkdir(tempDir, { recursive: true });
-		await using fixture = await createFixture(fixtureTemplatePath, { tempDir });
+		await using fixture = await createFixture(
+			fileURLToPath(new URL('./fixtures/claude', import.meta.url)),
+			{
+				tempDir,
+			},
+		);
 
 		const result = spawnSync('bun', ['./src/index.ts', 'weekly', '--offline', '--json'], {
-			cwd: appRoot,
+			cwd: fileURLToPath(new URL('../', import.meta.url)),
 			encoding: 'utf8',
 			env: await createCliEnv(fixture.path, tempDir),
 		});
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'weekly-json.txt'),
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(result.stdout.replace(regex('\n$'), '')).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'weekly-json.txt',
+			),
 		);
 	});
 
 	it('matches daily table output', async () => {
 		const tempDir = path.join(tmpdir(), 'ccusage-cli-output-fixtures');
 		await mkdir(tempDir, { recursive: true });
-		await using fixture = await createFixture(fixtureTemplatePath, { tempDir });
+		await using fixture = await createFixture(
+			fileURLToPath(new URL('./fixtures/claude', import.meta.url)),
+			{
+				tempDir,
+			},
+		);
 
 		const result = spawnSync('bun', ['./src/index.ts', 'daily', '--offline'], {
-			cwd: appRoot,
+			cwd: fileURLToPath(new URL('../', import.meta.url)),
 			encoding: 'utf8',
 			env: await createCliEnv(fixture.path, tempDir),
 		});
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'daily-table.txt'),
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(result.stdout.replace(regex('\n$'), '')).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'daily-table.txt',
+			),
 		);
 	});
 
 	it('matches session table output', async () => {
 		const tempDir = path.join(tmpdir(), 'ccusage-cli-output-fixtures');
 		await mkdir(tempDir, { recursive: true });
-		await using fixture = await createFixture(fixtureTemplatePath, { tempDir });
+		await using fixture = await createFixture(
+			fileURLToPath(new URL('./fixtures/claude', import.meta.url)),
+			{
+				tempDir,
+			},
+		);
 
 		const result = spawnSync('bun', ['./src/index.ts', 'session', '--offline'], {
-			cwd: appRoot,
+			cwd: fileURLToPath(new URL('../', import.meta.url)),
 			encoding: 'utf8',
 			env: await createCliEnv(fixture.path, tempDir),
 		});
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'session-table.txt'),
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(result.stdout.replace(regex('\n$'), '')).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'session-table.txt',
+			),
 		);
 	});
 
 	it('matches blocks table output', async () => {
 		const tempDir = path.join(tmpdir(), 'ccusage-cli-output-fixtures');
 		await mkdir(tempDir, { recursive: true });
-		await using fixture = await createFixture(fixtureTemplatePath, { tempDir });
+		await using fixture = await createFixture(
+			fileURLToPath(new URL('./fixtures/claude', import.meta.url)),
+			{
+				tempDir,
+			},
+		);
 
 		const result = spawnSync('bun', ['./src/index.ts', 'blocks', '--offline'], {
-			cwd: appRoot,
+			cwd: fileURLToPath(new URL('../', import.meta.url)),
 			encoding: 'utf8',
 			env: await createCliEnv(fixture.path, tempDir),
 		});
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(result.stdout.replace(trailingNewlineRegex, '')).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'blocks-table.txt'),
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(result.stdout.replace(regex('\n$'), '')).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'blocks-table.txt',
+			),
 		);
 	});
 });
@@ -390,9 +463,16 @@ describe('ccusage all-agent CLI', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 
-		const stdout = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(stdout).toMatchFileSnapshot(path.join(snapshotRoot, 'all-agent-daily-json.txt'));
+		const stdout = getStdout(result).replace(regex('\n$', 'u'), '');
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(stdout).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'all-agent-daily-json.txt',
+			),
+		);
 
 		const output = JSON.parse(stdout) as DailyJsonOutput;
 		expect(output.daily).toHaveLength(1);
@@ -463,10 +543,15 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const stdout = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
-		await mkdir(snapshotRoot, { recursive: true });
+		const stdout = getStdout(result).replace(regex('\n$', 'u'), '');
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
 		await expect(stdout).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'codex-direct-daily-json.txt'),
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'codex-direct-daily-json.txt',
+			),
 		);
 
 		const output = JSON.parse(stdout) as {
@@ -491,10 +576,15 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const stdout = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
-		await mkdir(snapshotRoot, { recursive: true });
+		const stdout = getStdout(result).replace(regex('\n$', 'u'), '');
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
 		await expect(stdout).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'claude-direct-daily-json.txt'),
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'claude-direct-daily-json.txt',
+			),
 		);
 	});
 
@@ -508,9 +598,16 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const stdout = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(stdout).toMatchFileSnapshot(path.join(snapshotRoot, 'pi-direct-daily-json.txt'));
+		const stdout = getStdout(result).replace(regex('\n$', 'u'), '');
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(stdout).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'pi-direct-daily-json.txt',
+			),
+		);
 	});
 
 	it('passes offline mode through OpenCode namespaces without fetching pricing from the network', async () => {
@@ -520,9 +617,14 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(getStdout(result).replace(trailingUnicodeNewlineRegex, '')).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'opencode-direct-daily-json.txt'),
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(getStdout(result).replace(regex('\n$', 'u'), '')).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'opencode-direct-daily-json.txt',
+			),
 		);
 	});
 
@@ -573,9 +675,16 @@ describe('ccusage all-agent CLI', () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
 
-		const stdout = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(stdout).toMatchFileSnapshot(path.join(snapshotRoot, 'amp-direct-daily-json.txt'));
+		const stdout = getStdout(result).replace(regex('\n$', 'u'), '');
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(stdout).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'amp-direct-daily-json.txt',
+			),
+		);
 
 		const output = JSON.parse(stdout) as {
 			daily: Array<{ totalTokens: number }>;
@@ -595,9 +704,16 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const output = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(output).toMatchFileSnapshot(path.join(snapshotRoot, 'amp-direct-full-table.txt'));
+		const output = getStdout(result).replace(regex('\n$', 'u'), '');
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(output).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'amp-direct-full-table.txt',
+			),
+		);
 		expect(output).not.toContain('Running in Compact Mode');
 		expect(output).toContain('Cache Create');
 		expect(output).toContain('Cache Read');
@@ -614,10 +730,15 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const output = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
-		await mkdir(snapshotRoot, { recursive: true });
+		const output = getStdout(result).replace(regex('\n$', 'u'), '');
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
 		await expect(output).toMatchFileSnapshot(
-			path.join(snapshotRoot, 'amp-direct-compact-table.txt'),
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'amp-direct-compact-table.txt',
+			),
 		);
 		expect(output).toContain('Running in Compact Mode');
 		expect(output).toContain('Credits');
@@ -638,12 +759,19 @@ describe('ccusage all-agent CLI', () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe('');
-		const output = getStdout(result).replace(trailingUnicodeNewlineRegex, '');
-		await mkdir(snapshotRoot, { recursive: true });
-		await expect(output).toMatchFileSnapshot(path.join(snapshotRoot, 'all-agent-daily-table.txt'));
+		const output = getStdout(result).replace(regex('\n$', 'u'), '');
+		await mkdir(fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)), {
+			recursive: true,
+		});
+		await expect(output).toMatchFileSnapshot(
+			path.join(
+				fileURLToPath(new URL('./snapshots/cli-output/', import.meta.url)),
+				'all-agent-daily-table.txt',
+			),
+		);
 		expect(output).toContain('Coding (Agent) CLI Usage Report - Daily');
 		expect(output).toContain('Detected: Amp, Claude, Codex, OpenCode, pi-agent');
-		expect(output.match(fixtureDateRegex)).toHaveLength(1);
+		expect(output.match(regex('2026-01-02', 'gu'))).toHaveLength(1);
 		expect(output).toContain('Amp');
 		expect(output).toContain('Codex');
 		expect(output).toContain('OpenCode');


### PR DESCRIPTION
Summary:
- Removes hoisted one-off constants from CLI output snapshot tests.
- Updates repo-local testing guidance and Vitest examples to emphasise that tests do not need to be DRY when explicit duplication improves readability.

Testing:
- pnpm run format
- pnpm typecheck
- pnpm run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inlined one-off values in ccusage CLI snapshot tests and updated testing guidance to prefer explicit, local setup over DRY helpers. Also aligned testing docs to use "behavior" per repo typos config. No runtime code changes.

- **Refactors**
  - Inlined paths, regexes, and fixture values in `apps/ccusage/test/cli-output.test.ts`; computed `cwd`, snapshot paths, and newline/date regexes inline next to assertions.
  - Kept snapshot dir creation and replacements local to each test for clarity.
  - Updated `.agents/skills/ccusage-testing/SKILL.md` and Vitest examples to say tests do not need to be DRY and to avoid hoisting one-off values; switched wording to "behavior" to match CI.

<sup>Written for commit 66da5b6395afa03163b087db4d359fc2d7c60ea5. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1055?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined testing guidance to prioritize test readability: reworded the “avoid over-DRYing” note and added explicit advice to avoid hoisting one‑off values outside test bodies.
  * Added readability examples illustrating clearer inline setup versus hoisted values.

* **Tests**
  * Improved CLI output tests for more consistent snapshot handling and stable newline/date matching to reduce flakiness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->