### PR TITLE
fix(ccusage): align native usage parity

### DIFF
--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -4,8 +4,8 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
 use crate::{
-    calculate_cost, cli::CostMode, format_date_tz, json_value_u64, non_empty_json_string,
-    LoadedEntry, PricingMap, TokenUsageRaw, UsageEntry, UsageMessage,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz, json_value_u64,
+    non_empty_json_string, LoadedEntry, PricingMap, TokenUsageRaw, UsageEntry, UsageMessage,
 };
 
 pub(crate) fn message_value_to_entry(
@@ -36,7 +36,7 @@ pub(crate) fn message_value_to_entry(
         return None;
     }
     let model = non_empty_json_string(value.get("modelID"))?;
-    let _provider = non_empty_json_string(value.get("providerID"))?;
+    let provider = non_empty_json_string(value.get("providerID"))?;
     let millis = value
         .get("time")
         .and_then(|time| time.get("created"))
@@ -59,7 +59,14 @@ pub(crate) fn message_value_to_entry(
         request_id: None,
         is_api_error_message: None,
     };
-    let cost = calculate_cost(&data, mode, pricing);
+    let cost = calculate_open_code_cost(
+        &model,
+        &provider,
+        usage,
+        data.cost_usd,
+        mode,
+        pricing,
+    );
     let loaded_session_id = data
         .session_id
         .clone()
@@ -77,4 +84,160 @@ pub(crate) fn message_value_to_entry(
         usage_limit_reset_time: None,
         data,
     })
+}
+
+fn calculate_open_code_cost(
+    model: &str,
+    provider: &str,
+    usage: TokenUsageRaw,
+    cost_usd: Option<f64>,
+    _mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> f64 {
+    if let Some(cost) = cost_usd.filter(|cost| *cost > 0.0) {
+        return cost;
+    }
+    for candidate in open_code_model_candidates(model, provider) {
+        let cost = calculate_cost_for_usage(
+            Some(&candidate),
+            usage,
+            None,
+            CostMode::Calculate,
+            pricing,
+        );
+        if cost > 0.0 {
+            return cost;
+        }
+    }
+    0.0
+}
+
+fn open_code_model_candidates(model: &str, provider: &str) -> Vec<String> {
+    let resolved = resolve_open_code_model_name(model);
+    let normalized = normalize_open_code_model_name(&resolved);
+    let mut base = vec![resolved];
+    if normalized != base[0] {
+        base.push(normalized);
+    }
+    let mut candidates = base.clone();
+    if provider != "unknown" {
+        let provider = provider.replace('-', "_");
+        candidates.extend(base.into_iter().map(|model| format!("{provider}/{model}")));
+    }
+    candidates.dedup();
+    candidates
+}
+
+fn resolve_open_code_model_name(model: &str) -> String {
+    match model {
+        "gemini-3-pro-high" => "gemini-3-pro-preview".to_string(),
+        _ => model.to_string(),
+    }
+}
+
+fn normalize_open_code_model_name(model: &str) -> String {
+    for family in ["claude-haiku-", "claude-opus-", "claude-sonnet-"] {
+        if let Some(rest) = model.strip_prefix(family) {
+            if let Some((major, minor_and_suffix)) = rest.split_once('.') {
+                if major.chars().all(|ch| ch.is_ascii_digit())
+                    && minor_and_suffix
+                        .chars()
+                        .next()
+                        .is_some_and(|ch| ch.is_ascii_digit())
+                {
+                    return format!("{family}{major}-{minor_and_suffix}");
+                }
+            }
+            let mut chars = rest.chars();
+            if let (Some(major), Some(minor)) = (chars.next(), chars.next()) {
+                if major.is_ascii_digit() && minor.is_ascii_digit() {
+                    return format!("{family}{major}-{minor}{}", chars.collect::<String>());
+                }
+            }
+        }
+    }
+    model.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{message_value_to_entry, open_code_model_candidates};
+    use crate::{cli::CostMode, PricingMap};
+
+    #[test]
+    fn calculates_cost_when_opencode_stores_zero_cost() {
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{
+                "gpt-test": {
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000010,
+                    "cache_read_input_token_cost": 0.0000001
+                }
+            }"#,
+        );
+        let entry = message_value_to_entry(
+            &json!({
+                "id": "message-a",
+                "sessionID": "session-a",
+                "providerID": "openai",
+                "modelID": "gpt-test",
+                "time": { "created": 0 },
+                "tokens": {
+                    "input": 100,
+                    "output": 10,
+                    "cache": { "read": 50 }
+                },
+                "cost": 0
+            }),
+            None,
+            None,
+            None,
+            CostMode::Auto,
+            Some(&pricing),
+        )
+        .unwrap();
+
+        assert_eq!(entry.cost, 0.000205);
+    }
+
+    #[test]
+    fn keeps_positive_opencode_cost() {
+        let entry = message_value_to_entry(
+            &json!({
+                "id": "message-a",
+                "sessionID": "session-a",
+                "providerID": "openai",
+                "modelID": "gpt-test",
+                "time": { "created": 0 },
+                "tokens": {
+                    "input": 100
+                },
+                "cost": 0.02
+            }),
+            None,
+            None,
+            None,
+            CostMode::Auto,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(entry.cost, 0.02);
+    }
+
+    #[test]
+    fn creates_open_code_provider_and_normalized_model_candidates() {
+        assert_eq!(
+            open_code_model_candidates("claude-sonnet-4.5", "github-copilot"),
+            vec![
+                "claude-sonnet-4.5",
+                "claude-sonnet-4-5",
+                "github_copilot/claude-sonnet-4.5",
+                "github_copilot/claude-sonnet-4-5",
+            ]
+        );
+    }
 }

--- a/rust/crates/ccusage/src/claude_loader.rs
+++ b/rust/crates/ccusage/src/claude_loader.rs
@@ -933,7 +933,11 @@ pub(crate) fn usage_files(paths: &[PathBuf], project_filter: Option<&str>) -> Ve
 }
 
 fn is_project_path_segment(value: &str) -> bool {
-    !value.is_empty() && !value.contains('/') && !value.contains('\\')
+    !value.is_empty()
+        && value != "."
+        && value != ".."
+        && !value.contains('/')
+        && !value.contains('\\')
 }
 
 pub(crate) fn collect_usage_files(dir: &Path, files: &mut Vec<PathBuf>) {
@@ -1040,7 +1044,9 @@ pub(crate) fn extract_session_parts(path: &Path) -> (String, String) {
 mod tests {
     use std::{fs, path::Path};
 
-    use super::{extract_session_parts, has_unsupported_null_field, usage_files};
+    use super::{
+        extract_session_parts, has_unsupported_null_field, is_project_path_segment, usage_files,
+    };
 
     fn temp_claude_dir(name: &str) -> std::path::PathBuf {
         let nanos = std::time::SystemTime::now()
@@ -1083,6 +1089,16 @@ mod tests {
         fs::remove_dir_all(&dir).unwrap();
 
         assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn rejects_dot_segments_as_project_path_segments() {
+        assert!(!is_project_path_segment(""));
+        assert!(!is_project_path_segment("."));
+        assert!(!is_project_path_segment(".."));
+        assert!(!is_project_path_segment("project-a/session-a"));
+        assert!(!is_project_path_segment("project-a\\session-a"));
+        assert!(is_project_path_segment("project-a"));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/claude_loader.rs
+++ b/rust/crates/ccusage/src/claude_loader.rs
@@ -46,7 +46,7 @@ fn load_daily_summaries_inner(
     group_by_project: bool,
 ) -> Result<Vec<UsageSummary>> {
     let paths = claude_paths()?;
-    let files = usage_files(&paths);
+    let files = usage_files(&paths, project_filter);
     if files.is_empty() {
         return Ok(Vec::new());
     }
@@ -118,7 +118,7 @@ fn load_entries_inner(
                 .join(", ")
         ),
     );
-    let files = usage_files(&paths);
+    let files = usage_files(&paths, project_filter);
     debug_log(shared, format!("Found {} JSONL usage files", files.len()));
     if files.is_empty() {
         return Ok(Vec::new());
@@ -916,13 +916,24 @@ fn expand_home_path(raw: &str) -> PathBuf {
     PathBuf::from(raw)
 }
 
-pub(crate) fn usage_files(paths: &[PathBuf]) -> Vec<PathBuf> {
+pub(crate) fn usage_files(paths: &[PathBuf], project_filter: Option<&str>) -> Vec<PathBuf> {
     let mut files = Vec::new();
     for path in paths {
-        collect_usage_files(&path.join("projects"), &mut files);
+        let projects_dir = path.join("projects");
+        if let Some(project_filter) =
+            project_filter.filter(|filter| is_project_path_segment(filter))
+        {
+            collect_usage_files(&projects_dir.join(project_filter), &mut files);
+        } else {
+            collect_usage_files(&projects_dir, &mut files);
+        }
     }
     files.sort_by_cached_key(|path| path.to_string_lossy().into_owned());
     files
+}
+
+fn is_project_path_segment(value: &str) -> bool {
+    !value.is_empty() && !value.contains('/') && !value.contains('\\')
 }
 
 pub(crate) fn collect_usage_files(dir: &Path, files: &mut Vec<PathBuf>) {
@@ -1027,9 +1038,52 @@ pub(crate) fn extract_session_parts(path: &Path) -> (String, String) {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{fs, path::Path};
 
-    use super::{extract_session_parts, has_unsupported_null_field};
+    use super::{extract_session_parts, has_unsupported_null_field, usage_files};
+
+    fn temp_claude_dir(name: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("ccusage-claude-loader-{name}-{nanos}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn limits_usage_file_discovery_to_requested_project() {
+        let dir = temp_claude_dir("project-filter");
+        let project_a = dir.join("projects/project-a/session-a");
+        let project_b = dir.join("projects/project-b/session-b");
+        fs::create_dir_all(&project_a).unwrap();
+        fs::create_dir_all(&project_b).unwrap();
+        fs::write(project_a.join("a.jsonl"), "{}").unwrap();
+        fs::write(project_b.join("b.jsonl"), "{}").unwrap();
+
+        let files = usage_files(std::slice::from_ref(&dir), Some("project-a"));
+        fs::remove_dir_all(&dir).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert!(files[0].to_string_lossy().contains("project-a"));
+    }
+
+    #[test]
+    fn falls_back_to_full_discovery_for_non_segment_project_filter() {
+        let dir = temp_claude_dir("project-filter-fallback");
+        let project_a = dir.join("projects/project-a/session-a");
+        let project_b = dir.join("projects/project-b/session-b");
+        fs::create_dir_all(&project_a).unwrap();
+        fs::create_dir_all(&project_b).unwrap();
+        fs::write(project_a.join("a.jsonl"), "{}").unwrap();
+        fs::write(project_b.join("b.jsonl"), "{}").unwrap();
+
+        let files = usage_files(std::slice::from_ref(&dir), Some("project-a/session-a"));
+        fs::remove_dir_all(&dir).unwrap();
+
+        assert_eq!(files.len(), 2);
+    }
 
     #[test]
     fn extracts_file_session_from_modern_claude_project_path() {

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -261,7 +261,7 @@ mod tests {
         fs::write(&subagent_file, "").unwrap();
         fs::write(&parent_file, "").unwrap();
 
-        let files = claude_loader::usage_files(&[dir.clone()]);
+        let files = claude_loader::usage_files(&[dir.clone()], None);
         fs::remove_dir_all(dir).unwrap();
 
         assert_eq!(files, vec![parent_file, subagent_file]);

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -86,11 +86,14 @@ impl PricingMap {
     }
 
     pub(crate) fn load_json(&mut self, json: &str) -> usize {
-        let Ok(raw) = serde_json::from_str::<HashMap<String, LiteLlmPricing>>(json) else {
+        let Ok(raw) = serde_json::from_str::<HashMap<String, serde_json::Value>>(json) else {
             return 0;
         };
-        let loaded_count = raw.len();
-        for (model, pricing) in raw {
+        let mut loaded_count = 0;
+        for (model, value) in raw {
+            let Ok(pricing) = serde_json::from_value::<LiteLlmPricing>(value) else {
+                continue;
+            };
             let Some(input) = pricing.input_cost_per_token else {
                 continue;
             };
@@ -123,6 +126,7 @@ impl PricingMap {
             if let Some(context_limit) = context_limit {
                 self.context_limits.insert(model, context_limit);
             }
+            loaded_count += 1;
         }
         loaded_count
     }
@@ -523,6 +527,27 @@ mod tests {
                 .unwrap()
                 .cache_read_explicit
         );
+    }
+
+    #[test]
+    fn skips_invalid_litellm_entries_without_discarding_valid_pricing() {
+        let mut pricing = PricingMap::default();
+        let loaded = pricing.load_json(
+            r#"{
+                "sample_spec": {
+                    "max_input_tokens": "max input tokens, if the provider specifies it"
+                },
+                "gpt-valid": {
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000010,
+                    "max_input_tokens": 123
+                }
+            }"#,
+        );
+
+        assert_eq!(loaded, 1);
+        assert!(pricing.find("gpt-valid").is_some());
+        assert_eq!(pricing.context_limit("gpt-valid"), Some(123));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Matches the TypeScript v19 OpenCode cost fallback behavior for zero-cost records and live LiteLLM pricing parsing.
- Limits Claude JSONL discovery to a requested project directory when --project is a direct project segment.
- Keeps full discovery plus exact entry filtering for non-segment project filters to preserve bunx ccusage parity.

## Notes

The Claude discovery change is a targeted I/O reduction for large --project runs, not a broad CI benchmark speedup. The OpenCode and pricing changes are correctness/parity fixes discovered while comparing local bunx outputs through 2026-05-17.

## Testing

- direnv exec . pnpm run format
- direnv exec . cargo test --manifest-path rust/Cargo.toml --workspace usage_file
- direnv exec . cargo test --manifest-path rust/Cargo.toml --workspace falls_back_to_full_discovery_for_non_segment_project_filter
- direnv exec . cargo test --manifest-path rust/Cargo.toml --workspace rejects_dot_segments_as_project_path_segments
- direnv exec . cargo test --manifest-path rust/Cargo.toml --workspace opencode
- direnv exec . cargo test --manifest-path rust/Cargo.toml --workspace skips_invalid_litellm_entries_without_discarding_valid_pricing
- direnv exec . pnpm typecheck
- direnv exec . pnpm run test
- bunx ccusage --json --until 20260517 compared with rust/target/debug/ccusage --json --until 20260517
