### PR TITLE
chore(hooks): lint rust and typescript paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules
 out
 dist
 target/
+result
+result-*
 *.tgz
 packages/ccusage-*/bin/
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 # output
 out
 dist
+target/
 *.tgz
 packages/ccusage-*/bin/
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,12 +22,17 @@ pre-commit:
       run: pnpm exec oxfmt --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
 
+    - name: rustfmt
+      glob: 'rust/**/*.rs'
+      run: rustfmt {staged_files}
+      stage_fixed: true
+
     - name: eslint
       group:
         parallel: true
         jobs:
           - name: root
-            glob: '**/*'
+            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
             exclude:
               - 'apps/**'
               - 'packages/**'
@@ -36,17 +41,44 @@ pre-commit:
             stage_fixed: true
           - name: ccusage
             root: apps/ccusage/
-            glob: '**/*'
+            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
             run: pnpm exec eslint --cache --fix --no-warn-ignored {staged_files}
             stage_fixed: true
           - name: docs
             root: docs/
-            glob: '**/*'
+            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
             run: pnpm exec eslint --cache --fix --no-warn-ignored {staged_files}
             stage_fixed: true
 
 pre-push:
+  parallel: true
   jobs:
-    - name: test
+    - name: lint
+      group:
+        parallel: true
+        jobs:
+          - name: oxfmt
+            glob: '**/*'
+            run: pnpm exec oxfmt --check .
+          - name: eslint root
+            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
+            exclude:
+              - 'apps/**'
+              - 'packages/**'
+              - 'docs/**'
+            run: pnpm exec eslint --cache eslint.config.js .
+          - name: eslint ccusage
+            root: apps/ccusage/
+            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
+            run: pnpm exec eslint --cache .
+          - name: eslint docs
+            root: docs/
+            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
+            run: pnpm exec eslint --cache .
+          - name: clippy
+            glob: 'rust/**/*.rs'
+            run: cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings
+
+    - name: vitest related
       glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
       run: pnpm vitest related --run {push_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,7 +32,7 @@ pre-commit:
         parallel: true
         jobs:
           - name: root
-            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
+            glob: '**/*.{ts,tsx,js,jsx,mjs,cjs}'
             exclude:
               - 'apps/**'
               - 'packages/**'
@@ -41,12 +41,12 @@ pre-commit:
             stage_fixed: true
           - name: ccusage
             root: apps/ccusage/
-            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
+            glob: '**/*.{ts,tsx,js,jsx,mjs,cjs}'
             run: pnpm exec eslint --cache --fix --no-warn-ignored {staged_files}
             stage_fixed: true
           - name: docs
             root: docs/
-            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
+            glob: '**/*.{ts,tsx,js,jsx,mjs,cjs}'
             run: pnpm exec eslint --cache --fix --no-warn-ignored {staged_files}
             stage_fixed: true
 
@@ -61,7 +61,7 @@ pre-push:
             glob: '**/*'
             run: pnpm exec oxfmt --check .
           - name: eslint root
-            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
+            glob: '**/*.{ts,tsx,js,jsx,mjs,cjs}'
             exclude:
               - 'apps/**'
               - 'packages/**'
@@ -69,11 +69,11 @@ pre-push:
             run: pnpm exec eslint --cache eslint.config.js .
           - name: eslint ccusage
             root: apps/ccusage/
-            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
+            glob: '**/*.{ts,tsx,js,jsx,mjs,cjs}'
             run: pnpm exec eslint --cache .
           - name: eslint docs
             root: docs/
-            glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
+            glob: '**/*.{ts,tsx,js,jsx,mjs,cjs}'
             run: pnpm exec eslint --cache .
           - name: clippy
             glob: 'rust/**/*.rs'

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -5,9 +5,11 @@ export default defineConfig({
 	singleQuote: true,
 	ignorePatterns: [
 		'dist',
+		'target',
 		'node_modules',
 		'coverage',
 		'.git',
+		'**/package.json',
 		'**/pnpm-lock.yaml',
 		'rust/crates/ccusage/src/litellm-pricing-fallback.json',
 	],

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"lint": "pnpm --no-bail --aggregate-output /^lint:/",
 		"lint:oxfmt": "oxfmt --check .",
 		"lint:root": "eslint --cache eslint.config.js .",
+		"lint:rust": "cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings",
 		"lint:submodules": "pnpm --parallel -r --no-bail /^lint/",
 		"prepare": "pnpm run /^prepare:/",
 		"prepare:lefthook": "lefthook install",

--- a/rust/crates/ccusage/src/adapter/all.rs
+++ b/rust/crates/ccusage/src/adapter/all.rs
@@ -7,8 +7,8 @@ use crate::{
     cli::{AgentCommandArgs, AgentReportKind, CodexSpeed, SharedArgs, SortOrder, WeekDay},
     color, filter_loaded_entries_by_date, format_currency, format_models_multiline, format_number,
     json_float, print_box_title, print_json_or_jq, summarize_by_key, summarize_summaries_by_bucket,
-    wants_json, Align, BucketKind, CodexGroup, Color, LoadedEntry, PricingMap, Result, SimpleTable,
-    SessionAccumulator, UsageSummary,
+    wants_json, Align, BucketKind, CodexGroup, Color, LoadedEntry, PricingMap, Result,
+    SessionAccumulator, SimpleTable, UsageSummary,
 };
 
 #[derive(Debug, Clone)]
@@ -186,7 +186,7 @@ fn load_codex_rows(
     Ok(AgentRows {
         rows: groups
             .iter()
-            .map(|(period, group)| codex_group_row(period, group, &pricing, speed))
+            .map(|(period, group)| codex_group_row(period, group, pricing, speed))
             .collect(),
         detected,
     })
@@ -607,11 +607,7 @@ fn print_table(
                 format_number(crate::json_value_u64(totals.get("cacheReadTokens"))),
                 Color::Yellow,
             ),
-            color(
-                shared,
-                format_number(table_total_tokens),
-                Color::Yellow,
-            ),
+            color(shared, format_number(table_total_tokens), Color::Yellow),
             color(
                 shared,
                 format_currency(
@@ -667,7 +663,11 @@ fn detected_agent_labels(rows: &[AllRow], detected_agents: &[&'static str]) -> S
     if agents.is_empty() {
         return "None".to_string();
     }
-    agents.into_iter().map(agent_label).collect::<Vec<_>>().join(", ")
+    agents
+        .into_iter()
+        .map(agent_label)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn all_table_row(row: &AllRow, compact: bool, breakdown: bool) -> Vec<String> {
@@ -969,7 +969,11 @@ mod tests {
             vec!["2026-01-02", "All", "", "100", "20", "$0.01"]
         );
         assert_eq!(
-            all_table_row(row.agent_breakdowns.as_ref().unwrap().first().unwrap(), true, true),
+            all_table_row(
+                row.agent_breakdowns.as_ref().unwrap().first().unwrap(),
+                true,
+                true
+            ),
             vec!["", "- Codex", "- gpt-5", "100", "20", "$0.01"]
         );
     }

--- a/rust/crates/ccusage/src/adapter/codex.rs
+++ b/rust/crates/ccusage/src/adapter/codex.rs
@@ -261,7 +261,7 @@ fn add_event_to_groups(
         AgentReportKind::Monthly => date[..7].to_string(),
         AgentReportKind::Session => event.session_id.clone(),
     };
-    let group = groups.entry(period).or_insert_with(CodexGroup::default);
+    let group = groups.entry(period).or_default();
     accumulate_codex_event_into_group(group, event, model);
     Ok(())
 }
@@ -573,9 +573,7 @@ fn print_table(output: &Value, kind: AgentReportKind, shared: &SharedArgs) {
         let models = row
             .get("models")
             .and_then(Value::as_object)
-            .map(|models| {
-                format_models_multiline(&models.keys().cloned().collect::<Vec<_>>())
-            })
+            .map(|models| format_models_multiline(&models.keys().cloned().collect::<Vec<_>>()))
             .unwrap_or_default();
         table.push(vec![
             label.to_string(),

--- a/rust/crates/ccusage/src/claude_loader.rs
+++ b/rust/crates/ccusage/src/claude_loader.rs
@@ -1,6 +1,6 @@
 use std::{
-    collections::BTreeMap,
     collections::hash_map::DefaultHasher,
+    collections::BTreeMap,
     collections::{HashMap, HashSet},
     env, fs,
     hash::{Hash, Hasher},
@@ -528,21 +528,16 @@ fn push_deduped_entry(
     deduped_indexes: &mut HashMap<u64, Vec<usize>>,
     deduped: &mut Vec<LoadedEntry>,
 ) {
-    let dedupe_lookup = entry
-        .data
-        .message
-        .id
-        .as_deref()
-        .map(|message_id| {
-            let request_id = entry.data.request_id.as_deref();
-            let hash = usage_dedupe_hash(message_id, request_id);
-            let existing_index = deduped_indexes.get(&hash).and_then(|indexes| {
-                indexes.iter().copied().find(|&index| {
-                    loaded_entry_matches_dedupe_key(&deduped[index], message_id, request_id)
-                })
-            });
-            (hash, existing_index)
+    let dedupe_lookup = entry.data.message.id.as_deref().map(|message_id| {
+        let request_id = entry.data.request_id.as_deref();
+        let hash = usage_dedupe_hash(message_id, request_id);
+        let existing_index = deduped_indexes.get(&hash).and_then(|indexes| {
+            indexes.iter().copied().find(|&index| {
+                loaded_entry_matches_dedupe_key(&deduped[index], message_id, request_id)
+            })
         });
+        (hash, existing_index)
+    });
 
     if let Some((_, Some(index))) = dedupe_lookup {
         if should_replace_deduped_entry(&entry.data, &deduped[index].data) {
@@ -563,20 +558,17 @@ fn push_deduped_daily_entry(
     deduped_indexes: &mut HashMap<u64, Vec<usize>>,
     deduped: &mut Vec<DailyLoadedEntry>,
 ) {
-    let dedupe_lookup = entry
-        .message_id
-        .as_deref()
-        .map(|message_id| {
-            let request_id = entry.request_id.as_deref();
-            let hash = usage_dedupe_hash(message_id, request_id);
-            let existing_index = deduped_indexes.get(&hash).and_then(|indexes| {
-                indexes.iter().copied().find(|&index| {
-                    deduped[index].message_id.as_deref() == Some(message_id)
-                        && deduped[index].request_id.as_deref() == request_id
-                })
-            });
-            (hash, existing_index)
+    let dedupe_lookup = entry.message_id.as_deref().map(|message_id| {
+        let request_id = entry.request_id.as_deref();
+        let hash = usage_dedupe_hash(message_id, request_id);
+        let existing_index = deduped_indexes.get(&hash).and_then(|indexes| {
+            indexes.iter().copied().find(|&index| {
+                deduped[index].message_id.as_deref() == Some(message_id)
+                    && deduped[index].request_id.as_deref() == request_id
+            })
         });
+        (hash, existing_index)
+    });
 
     if let Some((_, Some(index))) = dedupe_lookup {
         let candidate_total = daily_usage_token_total(&entry);
@@ -894,10 +886,7 @@ pub(crate) fn claude_paths() -> Result<Vec<PathBuf>> {
 fn normalize_claude_config_path(raw: &str) -> PathBuf {
     let path = expand_home_path(raw);
     if path.file_name().is_some_and(|name| name == "projects") && path.is_dir() {
-        return path
-            .parent()
-            .map(Path::to_path_buf)
-            .unwrap_or(path);
+        return path.parent().map(Path::to_path_buf).unwrap_or(path);
     }
     path
 }
@@ -1026,6 +1015,41 @@ pub(crate) fn extract_session_parts(path: &Path) -> (String, String) {
 }
 
 #[cfg(test)]
+pub(crate) fn usage_limit_reset_time_from_line(
+    line: &str,
+    is_api_error_message: Option<bool>,
+) -> Option<TimestampMs> {
+    usage_limit_reset_time_from_line_bytes(line.as_bytes(), is_api_error_message)
+}
+
+fn usage_limit_reset_time_from_line_bytes(
+    line: &[u8],
+    is_api_error_message: Option<bool>,
+) -> Option<TimestampMs> {
+    if is_api_error_message != Some(true) {
+        return None;
+    }
+    let marker = b"Claude AI usage limit reached";
+    let marker_start = memmem::find(line, marker)?;
+    let timestamp_start = memchr::memchr(b'|', &line[marker_start..])? + marker_start + 1;
+    let timestamp_end = line[timestamp_start..]
+        .iter()
+        .position(|byte| !byte.is_ascii_digit())
+        .map_or(line.len(), |offset| timestamp_start + offset);
+    if timestamp_start == timestamp_end {
+        return None;
+    }
+    let timestamp = std::str::from_utf8(&line[timestamp_start..timestamp_end])
+        .ok()?
+        .parse::<i64>()
+        .ok()?;
+    if timestamp <= 0 {
+        return None;
+    }
+    TimestampMs::from_unix_seconds(timestamp)
+}
+
+#[cfg(test)]
 mod tests {
     use std::path::Path;
 
@@ -1033,8 +1057,9 @@ mod tests {
 
     #[test]
     fn extracts_file_session_from_modern_claude_project_path() {
-        let (session_id, project_path) =
-            extract_session_parts(Path::new("/home/me/.claude/projects/project-a/session-a.jsonl"));
+        let (session_id, project_path) = extract_session_parts(Path::new(
+            "/home/me/.claude/projects/project-a/session-a.jsonl",
+        ));
 
         assert_eq!(session_id, "session-a");
         assert_eq!(project_path, "project-a");
@@ -1079,39 +1104,4 @@ mod tests {
             br#"{"message":{"content":null,"usage":{"input_tokens":0}}}"#
         ));
     }
-}
-
-#[cfg(test)]
-pub(crate) fn usage_limit_reset_time_from_line(
-    line: &str,
-    is_api_error_message: Option<bool>,
-) -> Option<TimestampMs> {
-    usage_limit_reset_time_from_line_bytes(line.as_bytes(), is_api_error_message)
-}
-
-fn usage_limit_reset_time_from_line_bytes(
-    line: &[u8],
-    is_api_error_message: Option<bool>,
-) -> Option<TimestampMs> {
-    if is_api_error_message != Some(true) {
-        return None;
-    }
-    let marker = b"Claude AI usage limit reached";
-    let marker_start = memmem::find(line, marker)?;
-    let timestamp_start = memchr::memchr(b'|', &line[marker_start..])? + marker_start + 1;
-    let timestamp_end = line[timestamp_start..]
-        .iter()
-        .position(|byte| !byte.is_ascii_digit())
-        .map_or(line.len(), |offset| timestamp_start + offset);
-    if timestamp_start == timestamp_end {
-        return None;
-    }
-    let timestamp = std::str::from_utf8(&line[timestamp_start..timestamp_end])
-        .ok()?
-        .parse::<i64>()
-        .ok()?;
-    if timestamp <= 0 {
-        return None;
-    }
-    TimestampMs::from_unix_seconds(timestamp)
 }

--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -738,12 +738,11 @@ fn legacy_agent_report_supported(agent: &str, report: &str) -> bool {
 }
 
 fn report_flag_alias_error(args: &[String]) -> Option<String> {
-    let flag = args.iter().find_map(|arg| {
+    let flag = args.iter().find(|arg| {
         matches!(
             arg.as_str(),
             "--daily" | "--weekly" | "--monthly" | "--session" | "--blocks" | "--statusline"
         )
-        .then_some(arg)
     })?;
     Some(format!(
         "Report flags like {flag} are not supported. Use \"ccusage {}\" instead.",
@@ -1261,9 +1260,10 @@ mod tests {
 
     #[test]
     fn cargo_version_matches_npm_package_version() {
-        let package_json =
-            serde_json::from_str::<serde_json::Value>(include_str!("../../../../apps/ccusage/package.json"))
-                .unwrap();
+        let package_json = serde_json::from_str::<serde_json::Value>(include_str!(
+            "../../../../apps/ccusage/package.json"
+        ))
+        .unwrap();
 
         assert_eq!(
             env!("CARGO_PKG_VERSION"),

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -22,10 +22,9 @@ use crate::{
     group_project_output, identify_session_blocks, load_daily_summaries, load_entries,
     print_active_block_detail, print_blocks_table, print_json_or_jq, print_usage_table,
     session_summary_json, sort_blocks, sort_summaries, summarize_by_key,
-    summarize_summaries_by_bucket, summary_json,
-    total_usage_tokens, totals_json, utc_now, wants_json, BucketKind, Color, Context, Result,
-    SessionAccumulator, TimestampMs, DEFAULT_RECENT_DAYS, DEFAULT_SESSION_DURATION_HOURS,
-    MILLIS_PER_DAY, MILLIS_PER_MINUTE,
+    summarize_summaries_by_bucket, summary_json, total_usage_tokens, totals_json, utc_now,
+    wants_json, BucketKind, Color, Context, Result, SessionAccumulator, TimestampMs,
+    DEFAULT_RECENT_DAYS, DEFAULT_SESSION_DURATION_HOURS, MILLIS_PER_DAY, MILLIS_PER_MINUTE,
 };
 
 pub(crate) fn run_daily(args: DailyArgs) -> Result<()> {
@@ -187,11 +186,7 @@ pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
         });
     }
     rows.retain(|row| {
-        row.input_tokens
-            + row.output_tokens
-            + row.cache_creation_tokens
-            + row.cache_read_tokens
-            > 0
+        row.input_tokens + row.output_tokens + row.cache_creation_tokens + row.cache_read_tokens > 0
     });
     rows.sort_by(|a, b| match session_shared.order {
         SortOrder::Asc => a.total_cost.total_cmp(&b.total_cost),
@@ -396,17 +391,17 @@ fn render_statusline(
 ) -> Result<String> {
     let session_cost = match args.cost_source {
         CostSource::Cc => hook.cost.as_ref().map(|cost| cost.total_cost_usd),
-        CostSource::Ccusage => calculate_session_cost(&hook.session_id, &shared).ok(),
+        CostSource::Ccusage => calculate_session_cost(&hook.session_id, shared).ok(),
         CostSource::Auto => hook
             .cost
             .as_ref()
             .map(|cost| cost.total_cost_usd)
-            .or_else(|| calculate_session_cost(&hook.session_id, &shared).ok()),
+            .or_else(|| calculate_session_cost(&hook.session_id, shared).ok()),
         CostSource::Both => None,
     };
 
     let ccusage_cost = if args.cost_source == CostSource::Both {
-        calculate_session_cost(&hook.session_id, &shared).ok()
+        calculate_session_cost(&hook.session_id, shared).ok()
     } else {
         None
     };
@@ -435,7 +430,7 @@ fn render_statusline(
         })
         .unwrap_or(0.0);
 
-    let blocks = load_entries(&shared, None)
+    let blocks = load_entries(shared, None)
         .map(|entries| identify_session_blocks(entries, DEFAULT_SESSION_DURATION_HOURS))
         .unwrap_or_default();
     let active_block = blocks.iter().find(|block| block.is_active && !block.is_gap);
@@ -487,7 +482,7 @@ fn render_statusline(
                 hook.model.id.as_deref(),
                 shared.offline,
             )
-                .map(|context| (context.total_input_tokens, context.context_window_size))
+            .map(|context| (context.total_input_tokens, context.context_window_size))
         })
         .map(|(total_input_tokens, context_window_size)| {
             format_statusline_context(total_input_tokens, context_window_size, args, shared)


### PR DESCRIPTION
## Summary

Update lefthook so pre-commit keeps staged formatting focused on changed files, while pre-push runs directory-specific TypeScript lint and Rust clippy checks.

The Rust lint surfaced existing Clippy warnings, so this also applies the minimal mechanical fixes needed for the new \`lint:rust\` command to pass.

@coderabbitai please review this PR.

## Testing

- \`pnpm exec lefthook validate\`
- \`nix develop --command pnpm run format\`
- \`nix develop --command pnpm run lint\`
- \`nix develop --command pnpm typecheck\`
- \`nix develop --command pnpm run test\`
- \`nix develop --command git push -u origin codex/lefthook-rust-typescript-lint\` (pre-push hook passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `lefthook` so pre-commit formats only staged files and pre-push runs scoped TS/JS lint and Rust `cargo clippy`. Adds a root `lint:rust` script, fixes Clippy warnings, and ignores Nix result symlinks for cleaner dev output.

- **New Features**
  - Pre-commit: format staged files with `oxfmt` and `rustfmt`; lint staged TS/JS per directory.
  - Pre-push: run `oxfmt --check`, directory `eslint` jobs (parallel), and `cargo clippy` for the Rust workspace.
  - Add `lint:rust` in the root; exclude `target` and `package.json` from `oxfmt` to avoid formatting noise.

- **Bug Fixes**
  - Use recursive `eslint` globs so nested JS/TS files are linted in both pre-commit and pre-push.
  - Ignore Nix `result*` symlinks and Cargo `target/` in `.gitignore` to avoid untracked noise.

<sup>Written for commit 2130bf7784ca47bdb1643e917c8695306cbfe8f5. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1063?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced dev tooling: pre-commit/pre-push hooks now run Rust formatting and stricter lint checks (Clippy fails on warnings), ESLint scopes narrowed to JS/TS files, and lint tasks split by area.
  * Added a root script to run Rust linting.
  * Updated ignore rules to omit build artifacts (e.g., target/) and result* paths; adjusted formatter config ignores.

* **Style**
  * Minor formatting and small refactors across Rust code for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->