### PR TITLE
fix(ccusage): preserve subagent cost in daily summaries

### DIFF
--- a/rust/crates/ccusage/src/claude_loader.rs
+++ b/rust/crates/ccusage/src/claude_loader.rs
@@ -575,6 +575,8 @@ fn push_deduped_daily_entry(
         let existing_total = daily_usage_token_total(&deduped[index]);
         let should_replace = if candidate_total != existing_total {
             candidate_total > existing_total
+        } else if entry.cost != deduped[index].cost {
+            entry.cost > deduped[index].cost
         } else {
             entry.usage.speed.is_some() && deduped[index].usage.speed.is_none()
         };

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -525,7 +525,53 @@ mod tests {
                 "claude-opus-4-6",
             ]
         );
-        assert_eq!(daily[0].total_cost, 0.12);
+        assert_eq!(daily[0].total_cost, 0.18);
+    }
+
+    #[test]
+    fn uses_direct_subagent_cost_for_duplicate_daily_agent_progress() {
+        let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
+        let claude_dir = temp_claude_dir("daily-agent-progress-cost");
+        let session_dir = claude_dir.join("projects/project-a/session-a");
+        let subagent_dir = session_dir.join("subagents");
+        fs::create_dir_all(&subagent_dir).unwrap();
+        fs::write(
+            claude_dir.join("projects/project-a/session-a.jsonl"),
+            r#"{"sessionId":"session-a","version":"1.2.3","type":"progress","data":{"message":{"type":"assistant","timestamp":"2026-03-10T06:00:01.000Z","message":{"model":"claude-haiku-4-5-20251001","id":"msg_haiku","type":"message","role":"assistant","content":[],"usage":{"input_tokens":20,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},"requestId":"req_haiku","uuid":"nested"}},"timestamp":"2026-03-10T06:00:01.001Z"}"#,
+        )
+        .unwrap();
+        fs::write(
+            subagent_dir.join("agent-a.jsonl"),
+            r#"{"timestamp":"2026-03-10T06:00:01.000Z","version":"1.2.3","sessionId":"session-a","message":{"id":"msg_haiku","model":"claude-haiku-4-5-20251001","role":"assistant","usage":{"input_tokens":20,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},"requestId":"req_haiku","costUSD":0.06}"#,
+        )
+        .unwrap();
+
+        let previous = env::var("CLAUDE_CONFIG_DIR").ok();
+        env::set_var("CLAUDE_CONFIG_DIR", &claude_dir);
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, None).unwrap();
+        let daily = load_daily_summaries(&shared, None, false).unwrap();
+        if let Some(previous) = previous {
+            env::set_var("CLAUDE_CONFIG_DIR", previous);
+        } else {
+            env::remove_var("CLAUDE_CONFIG_DIR");
+        }
+        fs::remove_dir_all(&claude_dir).unwrap();
+
+        let expected_daily = summarize_by_key(
+            &entries,
+            |entry| entry.date.clone(),
+            |key| (key.to_string(), None),
+        )
+        .unwrap();
+        assert_eq!(
+            daily.iter().map(summary_json).collect::<Vec<_>>(),
+            expected_daily.iter().map(summary_json).collect::<Vec<_>>()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a Claude daily-summary dedupe case where nested agent progress could win over the matching direct subagent JSONL record even though the direct record carries cost data.

This keeps daily cost totals aligned with the loaded-entry aggregation used by monthly reports when the same message/request appears in both parent progress and subagent logs.

## Verification

- Confirmed released ccusage@19.0.3 daily/monthly totals match on local real data for root/all, Claude, and Codex reports.
- Confirmed local build daily/monthly totals match after the fix for Claude reports.
- pnpm run format
- pnpm typecheck
- direnv exec . pnpm run test


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix daily dedupe in `ccusage` for Claude to preserve direct subagent cost when the same message appears in both parent progress and subagent logs. Prefer the entry with the higher cost when token totals are equal, keeping daily totals aligned with monthly reports.

- **Bug Fixes**
  - Dedupe now compares `cost` when token totals match; keeps the higher-cost record, while still preferring fuller token totals and speed metadata otherwise.
  - Added a test to ensure duplicate daily agent progress uses the direct subagent cost; updated expected daily total to 0.18.

<sup>Written for commit bd663af4baf7117cb836e25c7f1bdd37e116b5fe. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1064?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deduplication logic for daily entries with matching identifiers by adding cost as a tie-breaker criterion when token totals are equal.

* **Tests**
  * Updated existing tests and added new test coverage for cost-based deduplication behavior in daily summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->