### PR TITLE
fix(ccusage): clarify CLI help by command context

### DIFF
--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -214,6 +214,12 @@ impl Cli {
         if let Some(message) = unsupported_agent_report_error(&parser.args) {
             return Err(message);
         }
+        if has_help_flag(&parser.args) {
+            if let Some(help) = help_for_args(&parser.args) {
+                println!("{help}");
+                process::exit(0);
+            }
+        }
         if parser.peek_help_or_version() {
             parser.print_help_or_version();
         }
@@ -1043,9 +1049,6 @@ impl ArgParser {
         let arg = self
             .next()
             .ok_or_else(|| "Expected option but reached end of arguments".to_string())?;
-        if matches!(arg.as_str(), "-h" | "--help" | "-V" | "--version") {
-            print_help_or_version_arg(&arg);
-        }
         if let Some((flag, value)) = arg.split_once('=') {
             self.pending_value = Some(value.to_string());
             return Ok(flag.to_string());
@@ -1090,8 +1093,94 @@ fn print_help_or_version_arg(arg: &str) -> ! {
     process::exit(0);
 }
 
+fn has_help_flag(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| matches!(flag_name(arg), "-h" | "--help"))
+}
+
+fn flag_name(arg: &str) -> &str {
+    arg.split_once('=').map_or(arg, |(name, _)| name)
+}
+
+fn help_for_args(args: &[String]) -> Option<&'static str> {
+    let tokens = command_tokens(args);
+    match tokens.as_slice() {
+        [] => Some(help_text()),
+        [command] => match command.as_str() {
+            "daily" | "weekly" | "monthly" | "session" => Some(unified_report_help()),
+            "blocks" => Some(claude_blocks_help()),
+            "statusline" => Some(claude_statusline_help()),
+            "claude" => Some(claude_help()),
+            "codex" => Some(codex_help()),
+            "opencode" => Some(opencode_help()),
+            "amp" => Some(amp_help()),
+            "pi" => Some(pi_help()),
+            "copilot" => Some(copilot_help()),
+            "gemini" => Some(gemini_help()),
+            _ => None,
+        },
+        [agent, report] if is_agent_command(agent) && agent_report_supported(agent, report) => {
+            match agent.as_str() {
+                "claude" => match report.as_str() {
+                    "blocks" => Some(claude_blocks_help()),
+                    "statusline" => Some(claude_statusline_help()),
+                    _ => Some(claude_help()),
+                },
+                "codex" => Some(codex_help()),
+                "opencode" => Some(opencode_help()),
+                "amp" => Some(amp_help()),
+                "pi" => Some(pi_help()),
+                "copilot" => Some(copilot_help()),
+                "gemini" => Some(gemini_help()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
 fn help_text() -> &'static str {
-    "Usage: ccusage [OPTIONS] [COMMAND]\n\nCommands:\n  daily\n  monthly\n  weekly\n  session\n  blocks\n  statusline\n  claude\n  codex\n  opencode\n  amp\n  pi\n  copilot\n  gemini\n\nOptions:\n  -s, --since <YYYYMMDD>\n  -u, --until <YYYYMMDD>\n  -j, --json\n  -m, --mode <auto|calculate|display>\n  -d, --debug\n      --debug-samples <N>\n  -o, --order <asc|desc>\n  -b, --breakdown\n  -O, --offline\n      --no-offline\n      --color\n      --no-color\n  -z, --timezone <TZ>\n  -q, --jq <QUERY>\n      --config <PATH>\n      --compact\n      --single-thread\n  -h, --help\n  -V, --version"
+    "Usage: ccusage [OPTIONS] [COMMAND]\n\nUnified reports:\n  daily       All detected sources by day\n  weekly      All detected sources by week\n  monthly     All detected sources by month\n  session     All detected sources by session\n\nClaude Code reports:\n  claude      Claude Code reports (daily, weekly, monthly, session, blocks, statusline)\n  blocks      Claude Code billing block report\n  statusline  Claude Code status line hook output\n\nSource reports:\n  codex       Codex reports (daily, monthly, session)\n  opencode    OpenCode reports (daily, weekly, monthly, session)\n  amp         Amp reports (daily, monthly, session)\n  pi          pi-agent reports (daily, monthly, session)\n  copilot     GitHub Copilot CLI reports (daily, monthly, session)\n  gemini      Gemini CLI reports (daily, monthly, session)\n\nOptions:\n  -s, --since <YYYYMMDD>\n  -u, --until <YYYYMMDD>\n  -j, --json\n  -m, --mode <auto|calculate|display>\n  -d, --debug\n      --debug-samples <N>\n  -o, --order <asc|desc>\n  -b, --breakdown\n  -O, --offline\n      --no-offline\n      --color\n      --no-color\n  -z, --timezone <TZ>\n  -q, --jq <QUERY>\n      --config <PATH>\n      --compact\n      --single-thread\n  -h, --help\n  -V, --version"
+}
+
+fn unified_report_help() -> &'static str {
+    "Usage: ccusage [OPTIONS] <daily|weekly|monthly|session>\n\nUnified reports aggregate every detected source. Use a source command such as \"ccusage codex daily\" to focus on one source."
+}
+
+fn claude_help() -> &'static str {
+    "Usage: ccusage claude [OPTIONS] [daily|weekly|monthly|session|blocks|statusline]\n\nClaude Code reports include the Claude-only blocks and statusline commands."
+}
+
+fn claude_blocks_help() -> &'static str {
+    "Usage: ccusage claude blocks [OPTIONS]\n       ccusage blocks [OPTIONS]\n\nShows Claude Code billing block usage."
+}
+
+fn claude_statusline_help() -> &'static str {
+    "Usage: ccusage claude statusline [OPTIONS]\n       ccusage statusline [OPTIONS]\n\nRenders Claude Code status line hook output."
+}
+
+fn codex_help() -> &'static str {
+    "Usage: ccusage codex [OPTIONS] [daily|monthly|session]\n\nOptions:\n      --speed <auto|standard|fast>"
+}
+
+fn opencode_help() -> &'static str {
+    "Usage: ccusage opencode [OPTIONS] [daily|weekly|monthly|session]"
+}
+
+fn amp_help() -> &'static str {
+    "Usage: ccusage amp [OPTIONS] [daily|monthly|session]"
+}
+
+fn pi_help() -> &'static str {
+    "Usage: ccusage pi [OPTIONS] [daily|monthly|session]\n\nOptions:\n      --pi-path <PATHS>"
+}
+
+fn copilot_help() -> &'static str {
+    "Usage: ccusage copilot [OPTIONS] [daily|monthly|session]"
+}
+
+fn gemini_help() -> &'static str {
+    "Usage: ccusage gemini [OPTIONS] [daily|monthly|session]"
 }
 
 #[cfg(test)]
@@ -1291,13 +1380,40 @@ mod tests {
     #[test]
     fn help_lists_agent_namespace_commands() {
         let help = help_text();
-        assert!(help.contains("\n  claude\n"));
-        assert!(help.contains("\n  codex\n"));
-        assert!(help.contains("\n  opencode\n"));
-        assert!(help.contains("\n  amp\n"));
-        assert!(help.contains("\n  pi\n"));
-        assert!(help.contains("\n  copilot\n"));
-        assert!(help.contains("\n  gemini\n"));
+        assert!(help.contains("\nClaude Code reports:\n"));
+        assert!(help.contains("\n  claude      Claude Code reports"));
+        assert!(help.contains("\n  statusline  Claude Code status line hook output"));
+        assert!(help.contains("\nSource reports:\n"));
+        assert!(help.contains("\n  codex       Codex reports"));
+        assert!(help.contains("\n  opencode    OpenCode reports"));
+        assert!(help.contains("\n  amp         Amp reports"));
+        assert!(help.contains("\n  pi          pi-agent reports"));
+        assert!(help.contains("\n  copilot     GitHub Copilot CLI reports"));
+        assert!(help.contains("\n  gemini      Gemini CLI reports"));
+    }
+
+    #[test]
+    fn help_for_valid_subcommands_is_contextual() {
+        assert_eq!(
+            help_for_args(&["codex".to_string(), "daily".to_string(), "--help".to_string()]),
+            Some(codex_help())
+        );
+        assert_eq!(
+            help_for_args(&[
+                "claude".to_string(),
+                "statusline".to_string(),
+                "--help".to_string()
+            ]),
+            Some(claude_statusline_help())
+        );
+    }
+
+    #[test]
+    fn help_for_unknown_commands_falls_back_to_parse_error() {
+        assert_eq!(
+            help_for_args(&["hermes".to_string(), "daily".to_string(), "--help".to_string()]),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- group root CLI help by unified reports, Claude Code reports, and source reports
- show contextual help for valid subcommands such as \`ccusage codex daily --help\`
- keep unknown sources such as \`hermes\` on the normal unknown-command error path and keep Claude-only guidance for unsupported reports like \`codex statusline\`

## Verification
- \`pnpm run format\`
- \`pnpm typecheck\`
- \`direnv exec . cargo test --manifest-path rust/Cargo.toml --package ccusage cli::tests::help\`
- \`direnv exec . pnpm run test\`
- \`direnv exec . pnpm --filter ccusage build\`
- manual: \`ccusage --help\`, \`ccusage codex daily --help\`, \`ccusage hermes daily --help\`, \`ccusage codex statusline --help\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies `ccusage` CLI help by command context. Valid subcommands now show focused help (e.g., `ccusage codex daily --help`), and the root help is grouped for easier scanning.

- **New Features**
  - Route `--help` through the parsed command shape to show contextual help for supported agent/report pairs.
  - Group root help into Unified reports, Claude Code reports (including `blocks` and `statusline`), and Source reports (`codex`, `opencode`, `amp`, `pi`, `copilot`, `gemini`).
  - Keep unknown sources and unsupported reports on the normal error path, preserving Claude-only guidance where relevant.

<sup>Written for commit 9943e7e55efecabcec683839d8fbacd68846637f. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1065?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

