### PR TITLE
fix(codex): show non-cached input tokens

### DIFF
--- a/rust/crates/ccusage/src/adapter/all.rs
+++ b/rust/crates/ccusage/src/adapter/all.rs
@@ -485,7 +485,7 @@ fn codex_group_row(
         period: period.to_string(),
         agent: "codex",
         models_used: group.models.keys().cloned().collect(),
-        input_tokens: group.input_tokens,
+        input_tokens: codex::non_cached_input_tokens(group.input_tokens, group.cached_input_tokens),
         output_tokens: group.output_tokens,
         cache_creation_tokens: 0,
         cache_read_tokens: group.cached_input_tokens,
@@ -907,6 +907,7 @@ fn agent_label(agent: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CodexModelUsage;
 
     #[test]
     fn aggregates_daily_agent_rows_by_period() {
@@ -986,6 +987,37 @@ mod tests {
         assert_eq!(report["daily"][0]["agent"], "all");
         assert_eq!(report["daily"][0]["metadata"]["agents"], json!(["codex"]));
         assert_eq!(report["totals"]["totalTokens"], 130);
+    }
+
+    #[test]
+    fn uses_non_cached_codex_input_tokens_in_all_rows() {
+        let mut group = CodexGroup {
+            input_tokens: 100,
+            cached_input_tokens: 90,
+            output_tokens: 5,
+            total_tokens: 105,
+            ..CodexGroup::default()
+        };
+        group.models.insert(
+            "gpt-5".to_string(),
+            CodexModelUsage {
+                input_tokens: 100,
+                cached_input_tokens: 90,
+                output_tokens: 5,
+                total_tokens: 105,
+                ..CodexModelUsage::default()
+            },
+        );
+        let row = codex_group_row(
+            "2026-01-02",
+            &group,
+            &PricingMap::default(),
+            CodexSpeed::Standard,
+        );
+
+        assert_eq!(row.input_tokens, 10);
+        assert_eq!(row.cache_read_tokens, 90);
+        assert_eq!(row.total_tokens, 105);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/codex.rs
+++ b/rust/crates/ccusage/src/adapter/codex.rs
@@ -435,15 +435,21 @@ fn group_json(
     speed: CodexSpeed,
 ) -> Value {
     let cost = calculate_group_cost(group, pricing, speed);
+    let input_tokens = non_cached_input_tokens(group.input_tokens, group.cached_input_tokens);
+    let models = group
+        .models
+        .iter()
+        .map(|(model, usage)| (model.clone(), model_usage_json(usage)))
+        .collect::<BTreeMap<_, _>>();
     let mut row = json!({
         period_key(kind): period,
-        "inputTokens": group.input_tokens,
+        "inputTokens": input_tokens,
         "cachedInputTokens": group.cached_input_tokens,
         "outputTokens": group.output_tokens,
         "reasoningOutputTokens": group.reasoning_output_tokens,
         "totalTokens": group.total_tokens,
         "costUSD": json_float(cost),
-        "models": group.models,
+        "models": models,
     });
     if kind == AgentReportKind::Session {
         row["lastActivity"] = json!(group.last_activity);
@@ -452,6 +458,21 @@ fn group_json(
         row["directory"] = json!(separator.map_or("", |index| &period[..index]));
     }
     row
+}
+
+pub(crate) fn non_cached_input_tokens(input_tokens: u64, cached_input_tokens: u64) -> u64 {
+    input_tokens.saturating_sub(cached_input_tokens.min(input_tokens))
+}
+
+fn model_usage_json(usage: &CodexModelUsage) -> Value {
+    json!({
+        "inputTokens": non_cached_input_tokens(usage.input_tokens, usage.cached_input_tokens),
+        "cachedInputTokens": usage.cached_input_tokens,
+        "outputTokens": usage.output_tokens,
+        "reasoningOutputTokens": usage.reasoning_output_tokens,
+        "totalTokens": usage.total_tokens,
+        "isFallback": usage.is_fallback,
+    })
 }
 
 fn totals_json<'a>(
@@ -466,7 +487,7 @@ fn totals_json<'a>(
     let mut total = 0;
     let mut cost = 0.0;
     for group in groups {
-        input += group.input_tokens;
+        input += non_cached_input_tokens(group.input_tokens, group.cached_input_tokens);
         cached += group.cached_input_tokens;
         output += group.output_tokens;
         reasoning += group.reasoning_output_tokens;
@@ -669,6 +690,38 @@ mod tests {
         assert_eq!(group.output_tokens, 75);
         assert_eq!(group.reasoning_output_tokens, 5);
         assert_eq!(group.total_tokens, 280);
+    }
+
+    #[test]
+    fn reports_non_cached_codex_input_separately_from_cached_input() {
+        let pricing = PricingMap::default();
+        let report = report_json(
+            &[CodexTokenUsageEvent {
+                session_id: "session-1".to_string(),
+                timestamp: "2026-01-02T00:00:00.000Z".to_string(),
+                model: Some("gpt-5".to_string()),
+                input_tokens: 100,
+                cached_input_tokens: 90,
+                output_tokens: 5,
+                reasoning_output_tokens: 0,
+                total_tokens: 105,
+                is_fallback_model: false,
+            }],
+            AgentReportKind::Daily,
+            Some("UTC"),
+            &pricing,
+            CodexSpeed::Standard,
+        )
+        .unwrap();
+
+        assert_eq!(report["daily"][0]["inputTokens"], 10);
+        assert_eq!(report["daily"][0]["cachedInputTokens"], 90);
+        assert_eq!(report["daily"][0]["totalTokens"], 105);
+        assert_eq!(report["daily"][0]["models"]["gpt-5"]["inputTokens"], 10);
+        assert_eq!(
+            report["daily"][0]["models"]["gpt-5"]["cachedInputTokens"],
+            90
+        );
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/codex.rs
+++ b/rust/crates/ccusage/src/adapter/codex.rs
@@ -461,7 +461,7 @@ fn group_json(
 }
 
 pub(crate) fn non_cached_input_tokens(input_tokens: u64, cached_input_tokens: u64) -> u64 {
-    input_tokens.saturating_sub(cached_input_tokens.min(input_tokens))
+    input_tokens.saturating_sub(cached_input_tokens)
 }
 
 fn model_usage_json(usage: &CodexModelUsage) -> Value {
@@ -717,6 +717,9 @@ mod tests {
         assert_eq!(report["daily"][0]["inputTokens"], 10);
         assert_eq!(report["daily"][0]["cachedInputTokens"], 90);
         assert_eq!(report["daily"][0]["totalTokens"], 105);
+        assert_eq!(report["totals"]["inputTokens"], 10);
+        assert_eq!(report["totals"]["cachedInputTokens"], 90);
+        assert_eq!(report["totals"]["totalTokens"], 105);
         assert_eq!(report["daily"][0]["models"]["gpt-5"]["inputTokens"], 10);
         assert_eq!(
             report["daily"][0]["models"]["gpt-5"]["cachedInputTokens"],

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -665,11 +665,16 @@ mod tests {
         .unwrap();
 
         assert_eq!(report["daily"][0]["date"], "2026-01-02");
-        assert_eq!(report["daily"][0]["inputTokens"], 100);
+        assert_eq!(report["daily"][0]["inputTokens"], 90);
         assert_eq!(report["daily"][0]["cachedInputTokens"], 10);
         assert_eq!(report["daily"][0]["outputTokens"], 50);
         assert_eq!(report["daily"][0]["reasoningOutputTokens"], 0);
         assert_eq!(report["daily"][0]["totalTokens"], 150);
+        assert_eq!(report["daily"][0]["models"]["gpt-5"]["inputTokens"], 90);
+        assert_eq!(
+            report["daily"][0]["models"]["gpt-5"]["cachedInputTokens"],
+            10
+        );
         assert_eq!(report["daily"][0]["costUSD"], json!(0.00061375));
         assert_eq!(report["totals"]["costUSD"], json!(0.00061375));
     }

--- a/rust/crates/ccusage/src/types.rs
+++ b/rust/crates/ccusage/src/types.rs
@@ -126,8 +126,7 @@ pub(crate) struct CodexTokenUsageEvent {
     pub(crate) is_fallback_model: bool,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct CodexModelUsage {
     pub(crate) input_tokens: u64,
     pub(crate) cached_input_tokens: u64,


### PR DESCRIPTION
## Summary

- normalise Codex report \`inputTokens\` to exclude cached input tokens
- apply the same normalisation when Codex usage is shown in the all-agent report
- keep \`cachedInputTokens\`, \`totalTokens\`, and pricing calculation semantics intact
- add regression coverage for Codex report JSON and all-agent Codex rows

## Root Cause

Codex usage events use OpenAI-style input token counts where cached prompt tokens are included in \`input_tokens\`. The native reports forwarded that inclusive value to the user-facing Input column while also showing cached tokens separately, which made heavy cache-read days look like far more paid input than the reported cost supported.

## Validation

- \`direnv exec . pnpm run format\`
- \`direnv exec . pnpm typecheck\`
- \`direnv exec . pnpm run test\`
- pre-push hook: clippy + oxfmt

Fixes #1056

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show non-cached Codex input tokens in Codex and all-agent reports so the Input column reflects paid input and matches cost. Cached reads stay visible, pricing is unchanged, and per-model rows and totals are normalized. Fixes #1056.

- **Bug Fixes**
  - Subtract `cachedInputTokens` from Codex `inputTokens` in group rows, per-model entries, and totals (including all-agent Codex rows).
  - Keep `cachedInputTokens`, `totalTokens`, and `costUSD` semantics.
  - Add regression tests for Codex report JSON, per-model JSON, totals, and all-agent Codex rows.

- **Refactors**
  - Remove direct `Serialize` from `CodexModelUsage` and serialize via a normalizing helper so all user-facing JSON shows non-cached input.

<sup>Written for commit 665500d25cefb0db6bf6d53ced0d770fd6eace52. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1067?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Codex usage reporting now separates non-cached input tokens from cached input tokens. "Input" metrics (row, per-model, and totals) report non-cached counts while cached tokens are reported separately for clearer token consumption.

* **Tests**
  * Updated tests to validate the new token reporting and per-model JSON output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->