### PR TITLE
docs: document unsupported source investigations

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -82,6 +82,7 @@ export default defineConfig({
 						{ text: 'Gemini CLI', link: '/guide/gemini/' },
 						{ text: 'Kimi', link: '/guide/kimi/' },
 						{ text: 'OpenClaw', link: '/guide/openclaw/' },
+						{ text: 'Source Support Q&A', link: '/guide/source-support-qa' },
 					],
 				},
 				{

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -79,3 +79,4 @@ ccusage gemini session --json
 - [Monthly Usage](/guide/monthly-reports) - Longer-term usage trends
 - [Session Usage](/guide/session-reports) - Per-conversation usage
 - [Data Sources](/guide/#data-sources) - Supported local data formats
+- [Source Support Q&A](/guide/source-support-qa) - Why some investigated CLIs are not supported

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -92,6 +92,8 @@ ccusage reads from local coding CLI data directories:
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Each source-specific environment variable can also contain comma-separated directories, which lets unified reports combine current profiles and archives.
 
+Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI, Grok CLI, and Devin CLI.
+
 ## Report Shape
 
 Run ccusage without a source name to aggregate all detected sources:

--- a/docs/guide/source-support-qa.md
+++ b/docs/guide/source-support-qa.md
@@ -1,0 +1,53 @@
+# Source Support Q&A
+
+ccusage only supports a coding agent when it can read local usage records with enough information to produce accurate reports. At minimum, a source needs local timestamps, session identity, model identity, and token counts or recorded costs that can be mapped to token usage.
+
+If a tool stores only prompts, transcripts, quota percentages, or opaque cloud state, ccusage does not estimate token usage from text length. That would make daily, monthly, session, and cost reports look precise while being based on guesses.
+
+## What Makes a Source Supportable?
+
+A source is a good fit when its local files include most of the following:
+
+- Per-message or per-turn token counts
+- Input and output token counts, with cache and reasoning tokens when available
+- Model identifiers for pricing
+- Timestamps for date filtering and grouping
+- Session or conversation identifiers
+- Stable local file formats such as JSONL, SQLite tables, or structured telemetry exports
+
+Local transcript text alone is not enough. A transcript can be useful for debugging, but it does not reveal tokenizer behavior, hidden system context, cached input, tool-call overhead, or provider-side accounting.
+
+## Unsupported Sources Investigated
+
+::: details Why is Antigravity CLI not supported?
+Antigravity CLI is separate from Gemini CLI. The Antigravity CLI binary is exposed as `agy`, and it stores state under `~/.gemini/antigravity-cli/`.
+
+The current local data has conversation files such as `conversations/<conversation-id>.pb`, plus lightweight history and cache JSON files. The `.pb` files are opaque binary payloads and do not expose readable token usage, model usage, or per-turn accounting without Antigravity's private schema and storage semantics.
+
+The CLI log files include operational events such as conversation creation, streaming, prompt length, auth, and model configuration messages. They do not include input, output, cache, or reasoning token counts. Quota-oriented tools can inspect remaining Antigravity quota, but quota snapshots are not the same as historical per-session token usage.
+
+Because the local files do not expose the token accounting needed for ccusage reports, Antigravity CLI is not supported right now.
+:::
+
+::: details Why is Grok CLI not supported?
+Grok CLI was investigated, but its local SQLite data did not contain usable token accounting. Without token counts, model usage, or recorded costs in the local database, ccusage has nothing reliable to aggregate.
+
+Estimating tokens from message text would ignore provider-side context, hidden prompts, tool-call payloads, cached input, and tokenizer differences, so ccusage does not do that.
+:::
+
+::: details Why is Devin CLI not supported?
+Devin CLI usage information appears to live in Devin's cloud service rather than in a local usage log that ccusage can read. The locally available data did not provide direct access to historical token usage or costs.
+
+ccusage is a local, read-only analyzer. It does not scrape private cloud services or depend on undocumented authenticated APIs for user usage history. If Devin adds a local export with timestamps, sessions, models, and token counts, support can be revisited.
+:::
+
+## Can These Be Added Later?
+
+Yes. Open an issue if a tool starts writing local usage data with token counts or exposes an official export. Useful examples include:
+
+- A sample redacted log file
+- The default data directory
+- A description of which fields represent input, output, cache, reasoning, model, timestamp, and session ID
+- Notes about whether costs are recorded or should be calculated from model pricing
+
+Please do not share secrets, API keys, OAuth tokens, raw private prompts, or full conversation transcripts.


### PR DESCRIPTION
Documents source support requirements and records investigated CLIs that are not currently supportable because their local data does not expose reliable token usage.

The new Source Support Q&A covers Antigravity CLI, Grok CLI, and Devin CLI, and links it from the guide sidebar and related guide pages.

@coderabbitai please review this documentation-only change.

Testing:
- pnpm --filter docs format
- pnpm --filter docs typecheck
- pnpm --filter docs build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Source Support Q&A page that explains the local data needed for ccusage support and documents why Antigravity CLI, Grok CLI, and Devin CLI are not currently supported. Links the page from the guide sidebar, All Reports, and the Guide index.

<sup>Written for commit ab3b4d8fdabeb51b735542fbda35a443b39fc3af. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1070?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added comprehensive Source Support Q&A guide explaining which data sources are supported and the key requirements for accurate token usage tracking, including timestamps, session identifiers, model names, and cost accounting
* Clarified support status of specific coding agents and documented the limitations preventing current support
* Updated documentation navigation and references to help users find source support information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1070?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->