### PR TITLE
fix(agents): fall back to total token counts

### DIFF
--- a/rust/crates/ccusage/src/adapter/amp.rs
+++ b/rust/crates/ccusage/src/adapter/amp.rs
@@ -9,12 +9,13 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{json, Value};
 
 use crate::{
-    adapter::opencode, calculate_cost, cli::AgentCommandArgs, cli::AgentReportKind, cli::CostMode,
-    cli::WeekDay, collect_files_with_extension, filter_loaded_entries_by_date, format_currency,
-    format_date_tz, format_models_multiline, format_number, json_value_u64, non_empty_json_string,
-    parse_tz, print_box_title, print_json_or_jq, sort_summaries, summarize_by_key,
-    summarize_summaries_by_bucket, totals_json, wants_json, Align, BucketKind, Color, LoadedEntry,
-    PricingMap, Result, SimpleTable, TokenUsageRaw, UsageEntry, UsageMessage,
+    adapter::opencode, apply_total_token_fallback, calculate_cost, cli::AgentCommandArgs,
+    cli::AgentReportKind, cli::CostMode, cli::WeekDay, collect_files_with_extension,
+    filter_loaded_entries_by_date, format_currency, format_date_tz, format_models_multiline,
+    format_number, json_value_u64, non_empty_json_string, parse_tz, print_box_title,
+    print_json_or_jq, sort_summaries, summarize_by_key, summarize_summaries_by_bucket, totals_json,
+    wants_json, Align, BucketKind, Color, LoadedEntry, PricingMap, Result, SimpleTable,
+    TokenUsageRaw, UsageEntry, UsageMessage,
 };
 
 pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
@@ -196,10 +197,13 @@ pub(crate) fn read_thread_file(
             cache_read_input_tokens: cache.1,
             speed: None,
         };
+        let total_tokens = json_value_u64(tokens.get("total"));
+        let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, total_tokens);
         if usage.input_tokens == 0
             && usage.output_tokens == 0
             && usage.cache_creation_input_tokens == 0
             && usage.cache_read_input_tokens == 0
+            && extra_total_tokens == 0
         {
             continue;
         }
@@ -216,7 +220,21 @@ pub(crate) fn read_thread_file(
             request_id: None,
             is_api_error_message: None,
         };
-        let cost = calculate_cost(&data, mode, pricing);
+        let cost_data = UsageEntry {
+            message: UsageMessage {
+                usage: TokenUsageRaw {
+                    output_tokens: data
+                        .message
+                        .usage
+                        .output_tokens
+                        .saturating_add(extra_total_tokens),
+                    ..data.message.usage
+                },
+                ..data.message.clone()
+            },
+            ..data.clone()
+        };
+        let cost = calculate_cost(&cost_data, mode, pricing);
         entries.push(LoadedEntry {
             date: format_date_tz(timestamp, tz),
             timestamp,
@@ -224,7 +242,7 @@ pub(crate) fn read_thread_file(
             session_id: Arc::from(thread_id.as_str()),
             project_path: Arc::from("Amp"),
             cost,
-            extra_total_tokens: 0,
+            extra_total_tokens,
             credits: json_value_f64(event.get("credits")),
             message_count: None,
             model: Some(model),
@@ -449,5 +467,35 @@ fn agent_report_label(kind: AgentReportKind) -> &'static str {
         AgentReportKind::Weekly => "Weekly",
         AgentReportKind::Monthly => "Monthly",
         AgentReportKind::Session => "Session",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, fs, time::SystemTime};
+
+    use super::*;
+
+    #[test]
+    fn falls_back_to_total_tokens_when_amp_parts_are_missing() {
+        let nanos = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = env::temp_dir().join(format!("ccusage-amp-total-{nanos}"));
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("thread.json");
+        fs::write(
+            &file,
+            r#"{"id":"thread-a","usageLedger":{"events":[{"id":"event-a","timestamp":"2026-01-02T00:00:00.000Z","model":"gpt-5","tokens":{"total":345}}]}}"#,
+        )
+        .unwrap();
+
+        let entries = read_thread_file(&file, None, CostMode::Auto, None).unwrap();
+        fs::remove_dir_all(&dir).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 345);
+        assert_eq!(entries[0].extra_total_tokens, 0);
     }
 }

--- a/rust/crates/ccusage/src/adapter/codebuff.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff.rs
@@ -9,7 +9,7 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
 use crate::{
-    calculate_cost_for_usage,
+    apply_total_token_fallback, calculate_cost_for_usage,
     cli::{AgentCommandArgs, AgentReportKind, CostMode, SharedArgs, WeekDay},
     collect_files_with_extension, filter_loaded_entries_by_date, format_date_tz,
     format_rfc3339_millis, parse_ts_timestamp, parse_tz, print_json_or_jq, sort_summaries,
@@ -29,6 +29,7 @@ struct AssistantUsage {
     output_tokens: u64,
     cache_creation_input_tokens: u64,
     cache_read_input_tokens: u64,
+    extra_total_tokens: u64,
 }
 
 struct CodebuffEntry {
@@ -39,6 +40,7 @@ struct CodebuffEntry {
     provider: String,
     credits: f64,
     usage: TokenUsageRaw,
+    extra_total_tokens: u64,
     dedup_key: String,
 }
 
@@ -245,6 +247,7 @@ fn load_chat_file(path: &Path) -> Result<Vec<CodebuffEntry>> {
                 cache_read_input_tokens: usage.cache_read_input_tokens,
                 speed: None,
             },
+            extra_total_tokens: usage.extra_total_tokens,
             dedup_key,
         });
     }
@@ -277,7 +280,7 @@ fn to_loaded_entry(
         session_id: Arc::from(entry.session_id.as_str()),
         project_path: Arc::from("Codebuff"),
         cost,
-        extra_total_tokens: 0,
+        extra_total_tokens: entry.extra_total_tokens,
         credits: (entry.credits > 0.0).then_some(entry.credits),
         model: Some(entry.model),
         usage_limit_reset_time: None,
@@ -434,6 +437,21 @@ fn parse_usage_object(value: Option<&Value>) -> AssistantUsage {
             "cached_tokens_created",
         ],
     );
+    let total_tokens = pick_u64(record, &["totalTokens", "total_tokens", "total"]);
+    let raw_usage = TokenUsageRaw {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_creation_input_tokens: usage.cache_creation_input_tokens,
+        cache_read_input_tokens: usage.cache_read_input_tokens,
+        speed: None,
+    };
+    let (raw_usage, extra_total_tokens) =
+        apply_total_token_fallback(raw_usage, usage.extra_total_tokens, total_tokens);
+    usage.input_tokens = raw_usage.input_tokens;
+    usage.output_tokens = raw_usage.output_tokens;
+    usage.cache_creation_input_tokens = raw_usage.cache_creation_input_tokens;
+    usage.cache_read_input_tokens = raw_usage.cache_read_input_tokens;
+    usage.extra_total_tokens = extra_total_tokens;
     usage.credits = number_field(record, "credits");
     usage.model = string_field(record, "model");
     usage
@@ -452,6 +470,9 @@ fn merge_fallback(target: &mut AssistantUsage, fallback: AssistantUsage) {
     if target.cache_read_input_tokens == 0 {
         target.cache_read_input_tokens = fallback.cache_read_input_tokens;
     }
+    if target.extra_total_tokens == 0 {
+        target.extra_total_tokens = fallback.extra_total_tokens;
+    }
     if target.credits <= 0.0 {
         target.credits = fallback.credits;
     }
@@ -465,6 +486,7 @@ fn has_signal(usage: &AssistantUsage) -> bool {
         || usage.output_tokens > 0
         || usage.cache_creation_input_tokens > 0
         || usage.cache_read_input_tokens > 0
+        || usage.extra_total_tokens > 0
         || usage.credits > 0.0
 }
 
@@ -526,12 +548,13 @@ fn dedup_key(
         return format!("codebuff:{session_id}:{id}");
     }
     format!(
-        "codebuff:{session_id}:{}:{model}:{ordinal}:{}:{}:{}:{}",
+        "codebuff:{session_id}:{}:{model}:{ordinal}:{}:{}:{}:{}:{}",
         format_rfc3339_millis(timestamp),
         usage.input_tokens,
         usage.output_tokens,
         usage.cache_read_input_tokens,
-        usage.cache_creation_input_tokens
+        usage.cache_creation_input_tokens,
+        usage.extra_total_tokens
     )
 }
 
@@ -561,9 +584,16 @@ fn infer_provider(model: &str) -> &'static str {
 }
 
 fn calculate_codebuff_cost(entry: &CodebuffEntry, pricing: &PricingMap) -> f64 {
+    let usage = TokenUsageRaw {
+        output_tokens: entry
+            .usage
+            .output_tokens
+            .saturating_add(entry.extra_total_tokens),
+        ..entry.usage
+    };
     let raw = calculate_cost_for_usage(
         Some(&entry.model),
-        entry.usage,
+        usage,
         None,
         CostMode::Calculate,
         Some(pricing),
@@ -576,7 +606,7 @@ fn calculate_codebuff_cost(entry: &CodebuffEntry, pricing: &PricingMap) -> f64 {
     }
     calculate_cost_for_usage(
         Some(&format!("{}/{}", entry.provider, entry.model)),
-        entry.usage,
+        usage,
         None,
         CostMode::Calculate,
         Some(pricing),
@@ -703,6 +733,16 @@ mod tests {
         assert_eq!(entries[0].data.message.usage.input_tokens, 100);
         assert_eq!(entries[0].data.message.usage.output_tokens, 50);
         assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 10);
+    }
+
+    #[test]
+    fn falls_back_to_total_tokens_when_codebuff_parts_are_missing() {
+        let usage = parse_usage_object(Some(&serde_json::json!({
+            "totalTokens": 789
+        })));
+
+        assert_eq!(usage.output_tokens, 789);
+        assert_eq!(usage.extra_total_tokens, 0);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/copilot.rs
+++ b/rust/crates/ccusage/src/adapter/copilot.rs
@@ -9,7 +9,7 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{Map, Value};
 
 use crate::{
-    calculate_cost_for_usage,
+    apply_total_token_fallback, calculate_cost_for_usage,
     cli::{AgentCommandArgs, AgentReportKind, CostMode, WeekDay},
     collect_files_with_extension, filter_loaded_entries_by_date, format_date_tz, parse_tz,
     print_usage_table, summarize_by_key, summarize_summaries_by_bucket, LoadedEntry, Result,
@@ -344,7 +344,22 @@ fn to_candidate(
             "gen_ai.usage.reasoning_tokens",
         ],
     );
-    if input + output + cache_read + cache_creation + reasoning == 0 {
+    let total = attr_number_first(
+        attributes,
+        &[
+            "gen_ai.usage.total_tokens",
+            "gen_ai.usage.total.token_count",
+        ],
+    );
+    let usage = TokenUsageRaw {
+        input_tokens: input.saturating_sub(input.min(cache_read)),
+        output_tokens: output,
+        cache_creation_input_tokens: cache_creation,
+        cache_read_input_tokens: cache_read,
+        speed: None,
+    };
+    let (usage, reasoning) = apply_total_token_fallback(usage, reasoning, total);
+    if crate::total_usage_tokens(usage) + reasoning == 0 {
         return None;
     }
     let trace_id = trace_id_from_record(record);
@@ -359,7 +374,6 @@ fn to_candidate(
         .or_else(|| trace_id.clone())
         .unwrap_or_else(|| "unknown-session".to_string());
     let timestamp = timestamp_from_record(record).unwrap_or(fallback_timestamp);
-    let input_tokens = input.saturating_sub(input.min(cache_read));
     let dedup_key = dedup_key_for_record(
         source,
         record,
@@ -376,10 +390,10 @@ fn to_candidate(
         model,
         session_id,
         timestamp,
-        input_tokens,
-        output_tokens: output,
-        cache_creation_tokens: cache_creation,
-        cache_read_tokens: cache_read,
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_creation_tokens: usage.cache_creation_input_tokens,
+        cache_read_tokens: usage.cache_read_input_tokens,
         reasoning_output_tokens: reasoning,
         dedup_key,
     })
@@ -847,5 +861,38 @@ mod tests {
         assert_eq!(report["daily"][0]["totalCost"], 300.0);
 
         fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn falls_back_to_total_tokens_when_copilot_parts_are_missing() {
+        let dir = temp_dir("total");
+        let file = dir.join("copilot.jsonl");
+        fs::write(
+            &file,
+            format!(
+                "{}\n",
+                json!({
+                    "type": "span",
+                    "traceId": "trace-1",
+                    "spanId": "span-1",
+                    "name": "chat test-model",
+                    "endTime": [1_775_934_264_u64, 0_u64],
+                    "attributes": {
+                        "gen_ai.operation.name": "chat",
+                        "gen_ai.response.model": "test-model",
+                        "gen_ai.conversation.id": "conv-1",
+                        "gen_ai.usage.total_tokens": 567,
+                    },
+                })
+            ),
+        )
+        .unwrap();
+
+        let entries = parse_otel_file(&file).unwrap();
+        fs::remove_dir_all(dir).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].output_tokens, 567);
+        assert_eq!(entries[0].reasoning_output_tokens, 0);
     }
 }

--- a/rust/crates/ccusage/src/adapter/droid.rs
+++ b/rust/crates/ccusage/src/adapter/droid.rs
@@ -9,7 +9,7 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{json, Value};
 
 use crate::{
-    calculate_cost_for_usage,
+    apply_total_token_fallback, calculate_cost_for_usage,
     cli::{AgentCommandArgs, AgentReportKind, CostMode, SharedArgs, WeekDay},
     collect_files_with_extension, filter_loaded_entries_by_date, format_date_tz,
     format_rfc3339_millis, json_value_u64, parse_ts_timestamp, parse_tz, print_json_or_jq,
@@ -240,12 +240,23 @@ fn load_settings_file(path: &Path) -> Result<Option<DroidEntry>> {
 
 fn parse_token_usage(value: Option<&Value>) -> Option<DroidTokenUsage> {
     let usage = value?.as_object()?;
-    let tokens = DroidTokenUsage {
+    let raw_usage = TokenUsageRaw {
         input_tokens: json_value_u64(usage.get("inputTokens")),
         output_tokens: json_value_u64(usage.get("outputTokens")),
-        cache_creation_tokens: json_value_u64(usage.get("cacheCreationTokens")),
-        cache_read_tokens: json_value_u64(usage.get("cacheReadTokens")),
-        thinking_tokens: json_value_u64(usage.get("thinkingTokens")),
+        cache_creation_input_tokens: json_value_u64(usage.get("cacheCreationTokens")),
+        cache_read_input_tokens: json_value_u64(usage.get("cacheReadTokens")),
+        speed: None,
+    };
+    let thinking_tokens = json_value_u64(usage.get("thinkingTokens"));
+    let total_tokens = json_value_u64(usage.get("totalTokens"));
+    let (raw_usage, thinking_tokens) =
+        apply_total_token_fallback(raw_usage, thinking_tokens, total_tokens);
+    let tokens = DroidTokenUsage {
+        input_tokens: raw_usage.input_tokens,
+        output_tokens: raw_usage.output_tokens,
+        cache_creation_tokens: raw_usage.cache_creation_input_tokens,
+        cache_read_tokens: raw_usage.cache_read_input_tokens,
+        thinking_tokens,
     };
     (tokens.input_tokens
         + tokens.output_tokens
@@ -513,6 +524,17 @@ mod tests {
             normalize_droid_model_name("gemini-2.5-pro"),
             "gemini-2-5-pro"
         );
+    }
+
+    #[test]
+    fn falls_back_to_total_tokens_when_droid_parts_are_missing() {
+        let usage = parse_token_usage(Some(&serde_json::json!({
+            "totalTokens": 456
+        })))
+        .unwrap();
+
+        assert_eq!(usage.output_tokens, 456);
+        assert_eq!(usage.thinking_tokens, 0);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/gemini.rs
+++ b/rust/crates/ccusage/src/adapter/gemini.rs
@@ -10,7 +10,7 @@ use serde_json::{json, Map, Value};
 
 use crate::{
     adapter::opencode,
-    calculate_cost_for_usage,
+    apply_total_token_fallback, calculate_cost_for_usage,
     cli::{AgentCommandArgs, AgentReportKind, CostMode, WeekDay},
     collect_files_with_extension, filter_loaded_entries_by_date, format_date_tz,
     non_empty_json_string, parse_tz, print_json_or_jq, print_usage_table, sort_summaries,
@@ -373,7 +373,20 @@ fn build_event(
     let total_tokens = tokens
         .total
         .unwrap_or(input_tokens + tokens.output + cache_read_tokens + tokens.thoughts);
-    if input_tokens == 0 && tokens.output == 0 && cache_read_tokens == 0 && tokens.thoughts == 0 {
+    let display_usage = TokenUsageRaw {
+        input_tokens,
+        output_tokens: tokens.output,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: cache_read_tokens,
+        speed: None,
+    };
+    let (display_usage, extra_total_tokens) =
+        apply_total_token_fallback(display_usage, tokens.thoughts, total_tokens);
+    if display_usage.input_tokens == 0
+        && display_usage.output_tokens == 0
+        && display_usage.cache_read_input_tokens == 0
+        && extra_total_tokens == 0
+    {
         return None;
     }
     Some(GeminiUsageEvent {
@@ -381,10 +394,10 @@ fn build_event(
         timestamp_text: crate::format_rfc3339_millis(timestamp),
         session_id: session_id.to_string(),
         model: model.to_string(),
-        input_tokens,
-        output_tokens: tokens.output,
-        cache_read_tokens,
-        reasoning_tokens: tokens.thoughts,
+        input_tokens: display_usage.input_tokens,
+        output_tokens: display_usage.output_tokens,
+        cache_read_tokens: display_usage.cache_read_input_tokens,
+        reasoning_tokens: extra_total_tokens,
         total_tokens,
         message_id,
     })
@@ -412,7 +425,7 @@ fn parse_tokens(value: Option<&Value>) -> Option<GeminiTokens> {
             ],
         ),
         tool: token_number(record, &["tool", "tool_tokens"]),
-        total: value_u64(record.get("total")),
+        total: value_u64(record.get("total").or_else(|| record.get("total_tokens"))),
     })
 }
 
@@ -632,5 +645,24 @@ mod tests {
             11_526
         );
         assert_eq!(entries[0].extra_total_tokens, 919);
+    }
+
+    #[test]
+    fn falls_back_to_total_tokens_when_gemini_parts_are_missing() {
+        let event = build_event(
+            Some("gemini-test"),
+            "session-a",
+            TimestampMs::UNIX_EPOCH,
+            GeminiTokens {
+                total: Some(654),
+                ..GeminiTokens::default()
+            },
+            normalize_session_input,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(event.output_tokens, 654);
+        assert_eq!(event.reasoning_tokens, 0);
     }
 }

--- a/rust/crates/ccusage/src/adapter/kilo.rs
+++ b/rust/crates/ccusage/src/adapter/kilo.rs
@@ -10,7 +10,7 @@ use serde_json::{json, Value};
 
 use crate::{
     adapter::opencode,
-    calculate_cost_for_usage,
+    apply_total_token_fallback, calculate_cost_for_usage,
     cli::{AgentCommandArgs, AgentReportKind, CostMode, WeekDay},
     debug_log, filter_loaded_entries_by_date, format_date_tz, json_value_u64,
     non_empty_json_string, parse_tz, print_json_or_jq, print_usage_table, sort_summaries,
@@ -249,11 +249,14 @@ fn message_value_to_entry(
         speed: None,
     };
     let reasoning_tokens = json_value_u64(tokens.get("reasoning"));
+    let total_tokens = json_value_u64(tokens.get("total"));
+    let (usage, extra_total_tokens) =
+        apply_total_token_fallback(usage, reasoning_tokens, total_tokens);
     if usage.input_tokens == 0
         && usage.output_tokens == 0
         && usage.cache_creation_input_tokens == 0
         && usage.cache_read_input_tokens == 0
-        && reasoning_tokens == 0
+        && extra_total_tokens == 0
     {
         return None;
     }
@@ -283,7 +286,21 @@ fn message_value_to_entry(
         is_api_error_message: None,
     };
     let provider = non_empty_json_string(value.get("providerID"));
-    let cost = calculate_kilo_cost(&data, provider.as_deref(), mode, pricing);
+    let cost_data = UsageEntry {
+        message: UsageMessage {
+            usage: TokenUsageRaw {
+                output_tokens: data
+                    .message
+                    .usage
+                    .output_tokens
+                    .saturating_add(extra_total_tokens),
+                ..data.message.usage
+            },
+            ..data.message.clone()
+        },
+        ..data.clone()
+    };
+    let cost = calculate_kilo_cost(&cost_data, provider.as_deref(), mode, pricing);
     Some(LoadedEntry {
         date: format_date_tz(timestamp, tz),
         timestamp,
@@ -291,7 +308,7 @@ fn message_value_to_entry(
         session_id: Arc::from(session_id),
         project_path: Arc::from("Kilo"),
         cost,
-        extra_total_tokens: reasoning_tokens,
+        extra_total_tokens,
         credits: None,
         model: Some(model),
         usage_limit_reset_time: None,
@@ -458,6 +475,31 @@ mod tests {
         fs::remove_dir_all(&kilo_dir).unwrap();
 
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn falls_back_to_total_tokens_when_kilo_parts_are_missing() {
+        let value = serde_json::json!({
+            "id": "msg-1",
+            "role": "assistant",
+            "providerID": "openai",
+            "modelID": "gpt-5",
+            "time": { "created": 1767312000000_i64 },
+            "tokens": { "total": 234 }
+        });
+        let entry = message_value_to_entry(
+            &value,
+            "row-1",
+            "session-a",
+            Path::new("/tmp/kilo.db"),
+            None,
+            CostMode::Auto,
+            &PricingMap::load_embedded(),
+        )
+        .unwrap();
+
+        assert_eq!(entry.data.message.usage.output_tokens, 234);
+        assert_eq!(entry.extra_total_tokens, 0);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/kimi.rs
+++ b/rust/crates/ccusage/src/adapter/kimi.rs
@@ -10,7 +10,7 @@ use serde_json::{json, Value};
 
 use crate::{
     adapter::opencode,
-    calculate_cost_for_usage,
+    apply_total_token_fallback, calculate_cost_for_usage,
     cli::{AgentCommandArgs, AgentReportKind, CostMode, WeekDay},
     collect_files_with_extension, filter_loaded_entries_by_date, format_date_tz, json_value_u64,
     non_empty_json_string, parse_tz, print_json_or_jq, print_usage_table, sort_summaries,
@@ -35,6 +35,7 @@ struct KimiUsageEntry {
     output_tokens: u64,
     cache_creation_tokens: u64,
     cache_read_tokens: u64,
+    extra_total_tokens: u64,
 }
 
 pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
@@ -266,7 +267,16 @@ fn wire_line_to_entry(
     let output_tokens = json_value_u64(token_usage.get("output"));
     let cache_creation_tokens = json_value_u64(token_usage.get("input_cache_creation"));
     let cache_read_tokens = json_value_u64(token_usage.get("input_cache_read"));
-    if input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens == 0 {
+    let total_tokens = json_value_u64(token_usage.get("total"));
+    let usage = TokenUsageRaw {
+        input_tokens,
+        output_tokens,
+        cache_creation_input_tokens: cache_creation_tokens,
+        cache_read_input_tokens: cache_read_tokens,
+        speed: None,
+    };
+    let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, total_tokens);
+    if crate::total_usage_tokens(usage) + extra_total_tokens == 0 {
         return None;
     }
     let timestamp = value
@@ -280,10 +290,11 @@ fn wire_line_to_entry(
         session_id: extract_session_id(file_path),
         model: model.to_string(),
         message_id: non_empty_json_string(payload.get("message_id")),
-        input_tokens,
-        output_tokens,
-        cache_creation_tokens,
-        cache_read_tokens,
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_creation_tokens: usage.cache_creation_input_tokens,
+        cache_read_tokens: usage.cache_read_input_tokens,
+        extra_total_tokens,
     })
 }
 
@@ -310,7 +321,7 @@ fn extract_session_id(file_path: &Path) -> String {
 
 fn kimi_entry_key(entry: &KimiUsageEntry) -> String {
     format!(
-        "{}:{}:{}:{}:{}:{}:{}:{}",
+        "{}:{}:{}:{}:{}:{}:{}:{}:{}",
         entry.session_id,
         entry.message_id.as_deref().unwrap_or_default(),
         entry.timestamp_text,
@@ -318,7 +329,8 @@ fn kimi_entry_key(entry: &KimiUsageEntry) -> String {
         entry.input_tokens,
         entry.output_tokens,
         entry.cache_creation_tokens,
-        entry.cache_read_tokens
+        entry.cache_read_tokens,
+        entry.extra_total_tokens
     )
 }
 
@@ -356,7 +368,7 @@ fn kimi_entry_to_loaded(
         session_id: Arc::from(entry.session_id),
         project_path: Arc::from("Kimi"),
         cost,
-        extra_total_tokens: 0,
+        extra_total_tokens: entry.extra_total_tokens,
         credits: None,
         message_count: None,
         model: Some(entry.model),
@@ -479,6 +491,31 @@ mod tests {
             20
         );
         assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 10);
+    }
+
+    #[test]
+    fn falls_back_to_total_tokens_when_kimi_parts_are_missing() {
+        let kimi_dir = temp_kimi_dir("total");
+        fs::create_dir_all(kimi_dir.join("sessions/group/session-a")).unwrap();
+        fs::write(kimi_dir.join("config.json"), r#"{"model":"kimi-k2"}"#).unwrap();
+        let file = kimi_dir.join("sessions/group/session-a/wire.jsonl");
+        let value = serde_json::json!({
+            "timestamp": 1770983427.123,
+            "message": {
+                "type": "StatusUpdate",
+                "payload": {
+                    "token_usage": {
+                        "total": 432
+                    }
+                }
+            }
+        });
+
+        let entry = wire_line_to_entry(&value, &file, "kimi-k2", TimestampMs::UNIX_EPOCH).unwrap();
+        fs::remove_dir_all(&kimi_dir).unwrap();
+
+        assert_eq!(entry.output_tokens, 432);
+        assert_eq!(entry.extra_total_tokens, 0);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/openclaw.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw.rs
@@ -10,6 +10,7 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{json, Map, Value};
 
 use crate::{
+    apply_total_token_fallback,
     cli::{AgentCommandArgs, AgentReportKind, WeekDay},
     filter_loaded_entries_by_date, format_date_tz, json_value_u64, non_empty_json_string, parse_tz,
     print_json_or_jq, print_usage_table, sort_summaries, summarize_by_key,
@@ -289,19 +290,19 @@ fn parse_message_entry(
     let output_tokens = json_value_u64(usage.get("output"));
     let cache_read_tokens = json_value_u64(usage.get("cacheRead"));
     let cache_creation_tokens = json_value_u64(usage.get("cacheWrite"));
-    if input_tokens == 0
-        && output_tokens == 0
-        && cache_read_tokens == 0
-        && cache_creation_tokens == 0
-    {
+    let total_tokens = json_value_u64(usage.get("totalTokens"));
+    let raw_usage = TokenUsageRaw {
+        input_tokens,
+        output_tokens,
+        cache_creation_input_tokens: cache_creation_tokens,
+        cache_read_input_tokens: cache_read_tokens,
+        speed: None,
+    };
+    let (raw_usage, extra_total_tokens) = apply_total_token_fallback(raw_usage, 0, total_tokens);
+    if crate::total_usage_tokens(raw_usage) + extra_total_tokens == 0 {
         return None;
     }
-    let total_tokens = json_value_u64(usage.get("totalTokens"));
-    let total_tokens = if total_tokens == 0 {
-        input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens
-    } else {
-        total_tokens
-    };
+    let total_tokens = total_tokens.max(crate::total_usage_tokens(raw_usage) + extra_total_tokens);
     let timestamp =
         timestamp_from_value(message.get("timestamp").or_else(|| record.get("timestamp")))
             .unwrap_or(fallback_timestamp);
@@ -317,10 +318,10 @@ fn parse_message_entry(
         session_id: session_id.to_string(),
         model: format!("[openclaw] {model}"),
         provider,
-        input_tokens,
-        output_tokens,
-        cache_creation_tokens,
-        cache_read_tokens,
+        input_tokens: raw_usage.input_tokens,
+        output_tokens: raw_usage.output_tokens,
+        cache_creation_tokens: raw_usage.cache_creation_input_tokens,
+        cache_read_tokens: raw_usage.cache_read_input_tokens,
         total_tokens,
         cost: usage
             .get("cost")
@@ -505,5 +506,30 @@ mod tests {
         fs::remove_dir_all(&dir).unwrap();
 
         assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn falls_back_to_total_tokens_when_openclaw_parts_are_missing() {
+        let record = serde_json::json!({
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.2",
+                "usage": {
+                    "totalTokens": 222
+                }
+            }
+        });
+        let entry = parse_message_entry(
+            record.as_object().unwrap(),
+            "session-a",
+            None,
+            None,
+            TimestampMs::UNIX_EPOCH,
+        )
+        .unwrap();
+
+        assert_eq!(entry.output_tokens, 222);
+        assert_eq!(entry.total_tokens, 222);
     }
 }

--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -4,8 +4,9 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
 use crate::{
-    calculate_cost_for_usage, cli::CostMode, format_date_tz, json_value_u64, non_empty_json_string,
-    LoadedEntry, PricingMap, TokenUsageRaw, UsageEntry, UsageMessage,
+    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
+    json_value_u64, non_empty_json_string, LoadedEntry, PricingMap, TokenUsageRaw, UsageEntry,
+    UsageMessage,
 };
 
 pub(crate) fn message_value_to_entry(
@@ -28,10 +29,13 @@ pub(crate) fn message_value_to_entry(
             .map_or(0, |cache| json_value_u64(cache.get("read"))),
         speed: None,
     };
+    let total_tokens = json_value_u64(tokens.get("total"));
+    let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, total_tokens);
     if usage.input_tokens == 0
         && usage.output_tokens == 0
         && usage.cache_creation_input_tokens == 0
         && usage.cache_read_input_tokens == 0
+        && extra_total_tokens == 0
     {
         return None;
     }
@@ -59,7 +63,12 @@ pub(crate) fn message_value_to_entry(
         request_id: None,
         is_api_error_message: None,
     };
-    let cost = calculate_open_code_cost(&model, &provider, usage, data.cost_usd, mode, pricing);
+    let cost_usage = TokenUsageRaw {
+        output_tokens: usage.output_tokens.saturating_add(extra_total_tokens),
+        ..usage
+    };
+    let cost =
+        calculate_open_code_cost(&model, &provider, cost_usage, data.cost_usd, mode, pricing);
     let loaded_session_id = data
         .session_id
         .clone()
@@ -71,7 +80,7 @@ pub(crate) fn message_value_to_entry(
         session_id: Arc::from(loaded_session_id),
         project_path: Arc::from("OpenCode"),
         cost,
-        extra_total_tokens: 0,
+        extra_total_tokens,
         credits: None,
         message_count: None,
         model: Some(model),
@@ -215,6 +224,31 @@ mod tests {
         .unwrap();
 
         assert_eq!(entry.cost, 0.02);
+    }
+
+    #[test]
+    fn falls_back_to_total_tokens_when_opencode_token_parts_are_missing() {
+        let entry = message_value_to_entry(
+            &json!({
+                "id": "message-a",
+                "sessionID": "session-a",
+                "providerID": "openai",
+                "modelID": "gpt-test",
+                "time": { "created": 0 },
+                "tokens": {
+                    "total": 123
+                }
+            }),
+            None,
+            None,
+            None,
+            CostMode::Auto,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(entry.data.message.usage.output_tokens, 123);
+        assert_eq!(entry.extra_total_tokens, 0);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/pi.rs
+++ b/rust/crates/ccusage/src/adapter/pi.rs
@@ -9,11 +9,11 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{json, Value};
 
 use crate::{
-    cli::AgentCommandArgs, cli::AgentReportKind, cli::SharedArgs, cli::WeekDay,
-    collect_files_with_extension, filter_loaded_entries_by_date, format_date_tz, json_value_u64,
-    non_empty_json_string, parse_tz, print_json_or_jq, print_usage_table, sort_summaries,
-    summarize_by_key, summarize_summaries_by_bucket, totals_json, wants_json, BucketKind,
-    LoadedEntry, Result, SessionAccumulator, TokenUsageRaw, UsageEntry, UsageMessage,
+    apply_total_token_fallback, cli::AgentCommandArgs, cli::AgentReportKind, cli::SharedArgs,
+    cli::WeekDay, collect_files_with_extension, filter_loaded_entries_by_date, format_date_tz,
+    json_value_u64, non_empty_json_string, parse_tz, print_json_or_jq, print_usage_table,
+    sort_summaries, summarize_by_key, summarize_summaries_by_bucket, totals_json, wants_json,
+    BucketKind, LoadedEntry, Result, SessionAccumulator, TokenUsageRaw, UsageEntry, UsageMessage,
 };
 
 pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
@@ -189,7 +189,16 @@ pub(crate) fn read_session_file(
         let output = json_value_u64(usage_value.get("output"));
         let cache_read = json_value_u64(usage_value.get("cacheRead"));
         let cache_create = json_value_u64(usage_value.get("cacheWrite"));
-        if input == 0 && output == 0 && cache_read == 0 && cache_create == 0 {
+        let total = json_value_u64(usage_value.get("totalTokens"));
+        let usage = TokenUsageRaw {
+            input_tokens: input,
+            output_tokens: output,
+            cache_creation_input_tokens: cache_create,
+            cache_read_input_tokens: cache_read,
+            speed: None,
+        };
+        let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, total);
+        if crate::total_usage_tokens(usage) + extra_total_tokens == 0 {
             continue;
         }
         let model =
@@ -204,13 +213,7 @@ pub(crate) fn read_session_file(
             timestamp: timestamp_text,
             version: None,
             message: UsageMessage {
-                usage: TokenUsageRaw {
-                    input_tokens: input,
-                    output_tokens: output,
-                    cache_creation_input_tokens: cache_create,
-                    cache_read_input_tokens: cache_read,
-                    speed: None,
-                },
+                usage,
                 model: model.clone(),
                 id: None,
             },
@@ -225,7 +228,7 @@ pub(crate) fn read_session_file(
             session_id: Arc::from(session_id.as_str()),
             project_path: Arc::from(project.as_str()),
             cost,
-            extra_total_tokens: 0,
+            extra_total_tokens,
             credits: None,
             message_count: None,
             model,
@@ -287,7 +290,38 @@ fn entry_id(entry: &LoadedEntry) -> String {
             .cache_creation_input_tokens
             .to_string(),
         &entry.data.message.usage.cache_read_input_tokens.to_string(),
+        &entry.extra_total_tokens.to_string(),
         &entry.cost.to_string(),
     ]
     .join(":")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, fs, time::SystemTime};
+
+    use super::*;
+
+    #[test]
+    fn falls_back_to_total_tokens_when_pi_parts_are_missing() {
+        let nanos = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = env::temp_dir().join(format!("ccusage-pi-total-{nanos}"));
+        fs::create_dir_all(dir.join("sessions/project-a")).unwrap();
+        let file = dir.join("sessions/project-a/agent_session-a.jsonl");
+        fs::write(
+            &file,
+            r#"{"type":"message","timestamp":"2026-01-02T00:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"totalTokens":333}}}"#,
+        )
+        .unwrap();
+
+        let entries = read_session_file(&file, None).unwrap();
+        fs::remove_dir_all(&dir).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 333);
+        assert_eq!(entries[0].extra_total_tokens, 0);
+    }
 }

--- a/rust/crates/ccusage/src/adapter/qwen/parser.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/parser.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use super::paths;
 use crate::{
-    calculate_cost_for_usage,
+    apply_total_token_fallback, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
     format_date_tz, format_rfc3339_millis, json_value_u64, non_empty_json_string,
     parse_ts_timestamp, parse_tz, LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw,
@@ -86,7 +86,21 @@ fn parse_line(
     let output_tokens = json_value_u64(usage.get("candidatesTokenCount"));
     let reasoning_tokens = json_value_u64(usage.get("thoughtsTokenCount"));
     let cache_read_tokens = json_value_u64(usage.get("cachedContentTokenCount"));
-    if input_tokens == 0 && output_tokens == 0 && reasoning_tokens == 0 && cache_read_tokens == 0 {
+    let total_tokens = json_value_u64(usage.get("totalTokenCount"));
+    let display_usage = TokenUsageRaw {
+        input_tokens,
+        output_tokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: cache_read_tokens,
+        speed: None,
+    };
+    let (display_usage, extra_total_tokens) =
+        apply_total_token_fallback(display_usage, reasoning_tokens, total_tokens);
+    if display_usage.input_tokens == 0
+        && display_usage.output_tokens == 0
+        && display_usage.cache_read_input_tokens == 0
+        && extra_total_tokens == 0
+    {
         return None;
     }
 
@@ -104,15 +118,10 @@ fn parse_line(
     });
     let model = non_empty_json_string(record.get("model"))
         .unwrap_or_else(|| DEFAULT_QWEN_MODEL.to_string());
-    let display_usage = TokenUsageRaw {
-        input_tokens,
-        output_tokens,
-        cache_creation_input_tokens: 0,
-        cache_read_input_tokens: cache_read_tokens,
-        speed: None,
-    };
     let billable_usage = TokenUsageRaw {
-        output_tokens: output_tokens.saturating_add(reasoning_tokens),
+        output_tokens: display_usage
+            .output_tokens
+            .saturating_add(extra_total_tokens),
         ..display_usage
     };
     let cost = calculate_qwen_cost(&model, billable_usage, mode, pricing);
@@ -141,7 +150,7 @@ fn parse_line(
         model: Some(model),
         message_count: None,
         usage_limit_reset_time: None,
-        extra_total_tokens: reasoning_tokens,
+        extra_total_tokens,
     })
 }
 
@@ -244,6 +253,30 @@ mod tests {
         );
 
         assert_eq!(cost, 0.0);
+    }
+
+    #[test]
+    fn falls_back_to_total_token_count_when_qwen_parts_are_missing() {
+        let entry = parse_line(
+            Path::new("/tmp/project/chat.jsonl"),
+            TimestampMs::UNIX_EPOCH,
+            &serde_json::json!({
+                "type": "assistant",
+                "timestamp": "2026-01-02T00:00:00.000Z",
+                "sessionId": "session-a",
+                "model": "qwen3-coder",
+                "usageMetadata": {
+                    "totalTokenCount": 321
+                }
+            }),
+            None,
+            CostMode::Auto,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(entry.data.message.usage.output_tokens, 321);
+        assert_eq!(entry.extra_total_tokens, 0);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -43,7 +43,9 @@ pub(crate) use summary::{
     week_start, BucketKind, SessionAccumulator,
 };
 pub(crate) use types::*;
-pub(crate) use utils::{json_value_u64, non_empty_json_string, total_usage_tokens};
+pub(crate) use utils::{
+    apply_total_token_fallback, json_value_u64, non_empty_json_string, total_usage_tokens,
+};
 
 use ccusage_terminal::{terminal_width, TerminalStyle};
 pub(crate) use ccusage_terminal::{Align, Color, SimpleTable};

--- a/rust/crates/ccusage/src/utils.rs
+++ b/rust/crates/ccusage/src/utils.rs
@@ -17,3 +17,64 @@ pub(crate) fn total_usage_tokens(usage: TokenUsageRaw) -> u64 {
         + usage.cache_creation_input_tokens
         + usage.cache_read_input_tokens
 }
+
+pub(crate) fn apply_total_token_fallback(
+    mut usage: TokenUsageRaw,
+    mut extra_total_tokens: u64,
+    total_tokens: u64,
+) -> (TokenUsageRaw, u64) {
+    let known_tokens = total_usage_tokens(usage).saturating_add(extra_total_tokens);
+    let missing_tokens = total_tokens.saturating_sub(known_tokens);
+    if missing_tokens == 0 {
+        return (usage, extra_total_tokens);
+    }
+    if usage.output_tokens == 0 {
+        usage.output_tokens = missing_tokens;
+    } else {
+        extra_total_tokens = extra_total_tokens.saturating_add(missing_tokens);
+    }
+    (usage, extra_total_tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applies_total_token_fallback_to_missing_output_tokens() {
+        let (usage, extra_total_tokens) = apply_total_token_fallback(
+            TokenUsageRaw {
+                input_tokens: 100,
+                output_tokens: 0,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 25,
+                speed: None,
+            },
+            0,
+            175,
+        );
+
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.cache_read_input_tokens, 25);
+        assert_eq!(extra_total_tokens, 0);
+    }
+
+    #[test]
+    fn keeps_total_fallback_as_extra_when_output_is_known() {
+        let (usage, extra_total_tokens) = apply_total_token_fallback(
+            TokenUsageRaw {
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 25,
+                speed: None,
+            },
+            0,
+            200,
+        );
+
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(extra_total_tokens, 25);
+    }
+}


### PR DESCRIPTION
## Summary

- add a shared total-token fallback for agent adapters when only aggregate totals are present
- apply it across Amp, OpenCode, Droid, Codebuff, Copilot, Gemini, Kilo, Kimi, OpenClaw, pi-agent, and Qwen
- include targeted regression tests for each adapter fallback path

## Testing

- pnpm run format
- cargo test --manifest-path rust/Cargo.toml -p ccusage total_tokens -- --nocapture
- cargo clippy --manifest-path rust/Cargo.toml -p ccusage --all-targets -- -D warnings
- pnpm typecheck
- pnpm run test


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shared fallback to use aggregate total token counts when input/output/cache fields are missing, so usage rows aren’t dropped and costs are accurate.

- **Bug Fixes**
  - Introduced `apply_total_token_fallback`: if output tokens are missing, assign the remainder from `total`; otherwise store it as `extra_total_tokens`.
  - Applied across adapters: Amp, OpenCode, Droid, Codebuff, Copilot, Gemini, Kilo, Kimi, OpenClaw, pi-agent, Qwen.
  - Cost calculations now include `extra_total_tokens` (added to output at billing time) while keeping the displayed split unchanged.
  - Added targeted regression tests for each adapter and the shared helper.

<sup>Written for commit 1e7f1038163a501fcde8159380f2d15f7d1071ec. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1071?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback token counting when detailed token breakdowns are unavailable from AI providers, improving accuracy and completeness of token usage tracking.
  * Enhanced token usage parsing across multiple AI provider integrations (AMP, Copilot, Gemini, Kilo, Kimi, and others) to handle missing or incomplete token data.

* **Bug Fixes**
  * Fixed cost calculations to accurately reflect total token usage when detailed component data is absent from provider responses.

* **Tests**
  * Added unit tests verifying fallback behavior for all updated provider adapters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->