### PR TITLE
docs(readme): improve supported sources readability

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -68,7 +68,7 @@ npx ccusage@latest
 bunx -p https://pkg.pr.new/ryoppippi/ccusage@<pr-number> ccusage --offline
 ```
 
-> `bunx` caches the downloaded package, so repeated runs are faster after the first launch.
+> [bunx](https://bun.com/docs/pm/bunx) caches the downloaded package, so repeated runs are faster after the first launch.
 
 ## Usage
 

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -24,7 +24,27 @@
 
 ## Supported Sources
 
-The main CLI tool for analyzing Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI usage from local data. Track daily, weekly, monthly, and session-based usage with beautiful tables.
+ccusage reads local usage data from coding agent CLIs and turns it into daily, weekly, monthly, and session reports.
+
+| Source             | Focused command example  |
+| ------------------ | ------------------------ |
+| Claude Code        | `ccusage claude daily`   |
+| Codex              | `ccusage codex daily`    |
+| OpenCode           | `ccusage opencode daily` |
+| Amp                | `ccusage amp daily`      |
+| Droid              | `ccusage droid daily`    |
+| Codebuff           | `ccusage codebuff daily` |
+| Hermes Agent       | `ccusage hermes daily`   |
+| pi-agent           | `ccusage pi daily`       |
+| Goose              | `ccusage goose daily`    |
+| OpenClaw           | `ccusage openclaw daily` |
+| Kilo               | `ccusage kilo daily`     |
+| Kimi               | `ccusage kimi daily`     |
+| Qwen               | `ccusage qwen daily`     |
+| GitHub Copilot CLI | `ccusage copilot daily`  |
+| Gemini CLI         | `ccusage gemini daily`   |
+
+Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
 
 ## Installation
 

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -68,8 +68,7 @@ npx ccusage@latest
 bunx -p https://pkg.pr.new/ryoppippi/ccusage@<pr-number> ccusage --offline
 ```
 
-> 💡 **Runtime**: `bunx ccusage` is recommended for everyday use. If you use `npx`, include `@latest` and use Node.js 22.11+.
-> The npm package installs a small JavaScript launcher and the matching native binary package for your platform. Package runners such as `bunx` cache the downloaded package, so repeated runs reuse the cached native binary; the first run can still include network fetch time.
+> `bunx` caches the downloaded package, so repeated runs are faster after the first launch.
 
 ## Usage
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -5,7 +5,7 @@ Welcome to ccusage! This guide will help you get up and running with analyzing y
 ## Prerequisites
 
 - At least one supported coding CLI installed and used
-- Bun 1.3+ recommended, or Node.js 22.11+
+- Bun 1.3+ recommended for direct execution
 
 ## Quick Start
 
@@ -38,7 +38,7 @@ bunx -p https://pkg.pr.new/ryoppippi/ccusage@<pr-number> ccusage --offline
 This will show your daily usage report for all detected supported coding CLIs by default.
 
 ::: tip Runtime
-`bunx ccusage` is recommended for everyday use. The npm package installs a small JavaScript launcher and the matching native binary package for your platform. Package runners such as `bunx` cache the downloaded package, so repeated runs reuse the cached native binary; the first run can still include network fetch time.
+[bunx](https://bun.com/docs/pm/bunx) caches the downloaded package, so repeated runs are faster after the first launch.
 :::
 
 Use a data source namespace when you want the same report focused on one source:

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -35,20 +35,18 @@ bunx -p https://pkg.pr.new/ryoppippi/ccusage@<pr-number> ccusage --offline
 :::
 
 ::: tip Speed Recommendation
-We recommend `bunx` for everyday use. ccusage can run on Node.js 22.11+, but Bun generally starts faster and avoids the slower cold-start path common with `npx`.
-
-The npm package installs a small JavaScript launcher and the matching native binary package for your platform. Package runners such as `bunx` cache the downloaded package, so repeated runs reuse the cached native binary; the first run can still include network fetch time.
+We recommend [bunx](https://bun.com/docs/pm/bunx) for everyday use. It caches the downloaded package, so repeated runs are faster after the first launch.
 :::
 
 ### Performance Comparison
 
 Here's why runtime choice matters:
 
-| Runtime  | First Run | Subsequent Runs | Notes                            |
-| -------- | --------- | --------------- | -------------------------------- |
-| bunx     | Fast      | **Instant**     | Recommended for everyday use     |
-| pnpm dlx | Fast      | Fast            | Good alternative                 |
-| npx      | Slow      | Moderate        | Widely available, Node.js 22.11+ |
+| Runtime  | First Run | Subsequent Runs | Notes                        |
+| -------- | --------- | --------------- | ---------------------------- |
+| bunx     | Fast      | **Instant**     | Recommended for everyday use |
+| pnpm dlx | Fast      | Fast            | Good alternative             |
+| npx      | Slow      | Moderate        | Widely available             |
 
 ## Global Installation (Optional)
 
@@ -119,9 +117,8 @@ pnpm run format
 
 ### Node.js
 
-- **Minimum**: Node.js 22.11 for the published package
-- **Recommended**: Use Bun for command execution when available
-- `npx`, npm global installs, pnpm, and yarn all use the Node.js runtime unless ccusage re-runs through Bun
+- Needed when using Node-based package runners or npm-style global installs
+- Use Bun for direct execution when available
 
 ### Bun
 


### PR DESCRIPTION
Improves the README Supported Sources section by replacing the dense source list sentence with a compact table of supported sources and focused command examples.

This keeps the section easier to scan while preserving the unified report guidance for daily, weekly, monthly, and session views.

Testing:
- pnpm run format
- git push pre-push checks: oxfmt and docs ESLint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the README Supported Sources into a compact table with per-source `ccusage` examples and a short intro. Simplified runtime notes across README and guides by linking `bunx` cache docs and removing stale Node.js 22.11 guidance, while keeping the daily/weekly/monthly/session report commands.

<sup>Written for commit df7b6872ab84ab5223a4279a44f2de91c7832089. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1072?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded "Supported Sources" with an explicit guide and a source→command table showing example report commands.
  * Clarified unified reporting commands: ccusage daily, weekly, monthly, and session.
  * Updated Getting Started to recommend Bun 1.3+ for direct execution and removed the prior Node.js alternative.
  * Revised installation/runtime guidance and performance notes to emphasize using bunx (caches downloads for faster repeated runs) and adjusted runtime/Node.js guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->