### PR TITLE
fix(release): lint native packages before publish

### DIFF
--- a/packages/ccusage-darwin-arm64/package.json
+++ b/packages/ccusage-darwin-arm64/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@ccusage/ccusage-darwin-arm64",
+	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for macOS arm64",
 	"license": "MIT",
@@ -21,6 +22,10 @@
 		"access": "public"
 	},
 	"scripts": {
-		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs"
+		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs && clean-pkg-json && publint"
+	},
+	"devDependencies": {
+		"clean-pkg-json": "catalog:release",
+		"publint": "catalog:lint"
 	}
 }

--- a/packages/ccusage-darwin-x64/package.json
+++ b/packages/ccusage-darwin-x64/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@ccusage/ccusage-darwin-x64",
+	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for macOS x64",
 	"license": "MIT",
@@ -21,6 +22,10 @@
 		"access": "public"
 	},
 	"scripts": {
-		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs"
+		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs && clean-pkg-json && publint"
+	},
+	"devDependencies": {
+		"clean-pkg-json": "catalog:release",
+		"publint": "catalog:lint"
 	}
 }

--- a/packages/ccusage-linux-arm64/package.json
+++ b/packages/ccusage-linux-arm64/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@ccusage/ccusage-linux-arm64",
+	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Static native ccusage binary for Linux arm64",
 	"license": "MIT",
@@ -21,6 +22,10 @@
 		"access": "public"
 	},
 	"scripts": {
-		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs"
+		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs && clean-pkg-json && publint"
+	},
+	"devDependencies": {
+		"clean-pkg-json": "catalog:release",
+		"publint": "catalog:lint"
 	}
 }

--- a/packages/ccusage-linux-x64/package.json
+++ b/packages/ccusage-linux-x64/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@ccusage/ccusage-linux-x64",
+	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Static native ccusage binary for Linux x64",
 	"license": "MIT",
@@ -21,6 +22,10 @@
 		"access": "public"
 	},
 	"scripts": {
-		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs"
+		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs && clean-pkg-json && publint"
+	},
+	"devDependencies": {
+		"clean-pkg-json": "catalog:release",
+		"publint": "catalog:lint"
 	}
 }

--- a/packages/ccusage-win32-arm64/package.json
+++ b/packages/ccusage-win32-arm64/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@ccusage/ccusage-win32-arm64",
+	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for Windows arm64",
 	"license": "MIT",
@@ -21,6 +22,10 @@
 		"access": "public"
 	},
 	"scripts": {
-		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs"
+		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs && clean-pkg-json && publint"
+	},
+	"devDependencies": {
+		"clean-pkg-json": "catalog:release",
+		"publint": "catalog:lint"
 	}
 }

--- a/packages/ccusage-win32-x64/package.json
+++ b/packages/ccusage-win32-x64/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@ccusage/ccusage-win32-x64",
+	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for Windows x64",
 	"license": "MIT",
@@ -21,6 +22,10 @@
 		"access": "public"
 	},
 	"scripts": {
-		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs"
+		"prepack": "node ../../apps/ccusage/scripts/verify-native-package.mjs && clean-pkg-json && publint"
+	},
+	"devDependencies": {
+		"clean-pkg-json": "catalog:release",
+		"publint": "catalog:lint"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,17 +228,59 @@ importers:
         specifier: catalog:docs
         version: 4.91.0
 
-  packages/ccusage-darwin-arm64: {}
+  packages/ccusage-darwin-arm64:
+    devDependencies:
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.3.0
+      publint:
+        specifier: catalog:lint
+        version: 0.3.12
 
-  packages/ccusage-darwin-x64: {}
+  packages/ccusage-darwin-x64:
+    devDependencies:
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.3.0
+      publint:
+        specifier: catalog:lint
+        version: 0.3.12
 
-  packages/ccusage-linux-arm64: {}
+  packages/ccusage-linux-arm64:
+    devDependencies:
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.3.0
+      publint:
+        specifier: catalog:lint
+        version: 0.3.12
 
-  packages/ccusage-linux-x64: {}
+  packages/ccusage-linux-x64:
+    devDependencies:
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.3.0
+      publint:
+        specifier: catalog:lint
+        version: 0.3.12
 
-  packages/ccusage-win32-arm64: {}
+  packages/ccusage-win32-arm64:
+    devDependencies:
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.3.0
+      publint:
+        specifier: catalog:lint
+        version: 0.3.12
 
-  packages/ccusage-win32-x64: {}
+  packages/ccusage-win32-x64:
+    devDependencies:
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.3.0
+      publint:
+        specifier: catalog:lint
+        version: 0.3.12
 
 packages:
 


### PR DESCRIPTION
## Summary

- Runs clean-pkg-json and publint from each native optional package prepack hook after native binary verification.
- Adds package-local catalog devDependencies so the publish lifecycle can resolve both CLIs for every native subpackage.
- Marks native packages as commonjs to keep publint output clean for packages without JavaScript entrypoints.

## Testing

- pnpm run format
- pnpm typecheck
- pnpm --filter ./packages/ccusage-darwin-arm64 exec publint
- env NIX_CONFIG="access-tokens = github.com=$(gh auth token)" nix develop --command pnpm run test


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lint and clean native `@ccusage/*` subpackages during publish to catch manifest issues and match the main package’s checks. `prepack` now runs `clean-pkg-json` and `publint` after verifying the native binary, and packages are marked as CommonJS to reduce lint noise.

- **Bug Fixes**
  - Run `clean-pkg-json` and `publint` in each native subpackage `prepack` after binary verification.
  - Add catalog `devDependencies` for both CLIs so lifecycle scripts resolve per subpackage.
  - Set `"type": "commonjs"` to avoid `publint` warnings for packages without JS entrypoints.

<sup>Written for commit 484a7da30b728b0df149749543d561bbe822bc63. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1073?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configurations for all platform-specific native builds (Darwin, Linux, Windows).
  * Standardized CommonJS module type declaration across native packages.
  * Enhanced pre-release validation with additional package integrity and linting checks.
  * Added supporting development tools to ensure consistent package quality standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->