### PR TITLE
fix(ccusage): restore expanded config schema

### DIFF
--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -2,1533 +2,6 @@
 	"$ref": "#/definitions/ccusage-config",
 	"$schema": "https://json-schema.org/draft-07/schema#",
 	"definitions": {
-		"AmpCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"AmpConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/AmpCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"BlocksOptions": {
-			"additionalProperties": false,
-			"properties": {
-				"active": {
-					"description": "Show the active session block.",
-					"markdownDescription": "Show the active session block.",
-					"type": "boolean"
-				},
-				"all": {
-					"description": "Accepted for compatibility; all detected supported agents are included by default.",
-					"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
-					"type": "boolean"
-				},
-				"breakdown": {
-					"description": "Show per-model cost breakdown.",
-					"markdownDescription": "Show per-model cost breakdown.",
-					"type": "boolean"
-				},
-				"color": {
-					"description": "Enable colored output.",
-					"markdownDescription": "Enable colored output.",
-					"type": "boolean"
-				},
-				"compact": {
-					"description": "Force compact table layout for narrow terminals.",
-					"markdownDescription": "Force compact table layout for narrow terminals.",
-					"type": "boolean"
-				},
-				"debug": {
-					"description": "Show pricing mismatch information for debugging.",
-					"markdownDescription": "Show pricing mismatch information for debugging.",
-					"type": "boolean"
-				},
-				"debugSamples": {
-					"description": "Number of sample discrepancies to show in debug output.",
-					"format": "uint",
-					"markdownDescription": "Number of sample discrepancies to show in debug output.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"jq": {
-					"description": "jq filter to apply to JSON output.",
-					"markdownDescription": "jq filter to apply to JSON output.",
-					"type": "string"
-				},
-				"json": {
-					"description": "Output in JSON format.",
-					"markdownDescription": "Output in JSON format.",
-					"type": "boolean"
-				},
-				"mode": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCostMode"
-						}
-					],
-					"description": "Cost calculation mode.",
-					"markdownDescription": "Cost calculation mode."
-				},
-				"noColor": {
-					"description": "Disable colored output.",
-					"markdownDescription": "Disable colored output.",
-					"type": "boolean"
-				},
-				"noOffline": {
-					"description": "Disable cached pricing data where supported.",
-					"markdownDescription": "Disable cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"offline": {
-					"description": "Use cached pricing data where supported.",
-					"markdownDescription": "Use cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"order": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigSortOrder"
-						}
-					],
-					"description": "Sort order.",
-					"markdownDescription": "Sort order."
-				},
-				"recent": {
-					"description": "Show recent session blocks.",
-					"markdownDescription": "Show recent session blocks.",
-					"type": "boolean"
-				},
-				"sessionLength": {
-					"default": 5.0,
-					"description": "Session block duration in hours.",
-					"format": "double",
-					"markdownDescription": "Session block duration in hours.",
-					"type": "number"
-				},
-				"since": {
-					"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"type": "string"
-				},
-				"singleThread": {
-					"description": "Disable parallel file processing.",
-					"markdownDescription": "Disable parallel file processing.",
-					"type": "boolean"
-				},
-				"timezone": {
-					"description": "Timezone for date grouping (IANA).",
-					"markdownDescription": "Timezone for date grouping (IANA).",
-					"type": "string"
-				},
-				"tokenLimit": {
-					"description": "Token limit for session block calculations.",
-					"markdownDescription": "Token limit for session block calculations.",
-					"type": "string"
-				},
-				"until": {
-					"description": "Filter until date (inclusive).",
-					"markdownDescription": "Filter until date (inclusive).",
-					"type": "string"
-				}
-			},
-			"type": "object"
-		},
-		"ClaudeCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"blocks": {
-					"$ref": "#/definitions/BlocksOptions"
-				},
-				"daily": {
-					"$ref": "#/definitions/DailyOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"statusline": {
-					"$ref": "#/definitions/StatuslineOptions"
-				},
-				"weekly": {
-					"$ref": "#/definitions/WeeklyOptions"
-				}
-			},
-			"type": "object"
-		},
-		"ClaudeConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/ClaudeCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/ClaudeOptions"
-				}
-			},
-			"type": "object"
-		},
-		"ClaudeOptions": {
-			"additionalProperties": false,
-			"properties": {
-				"active": {
-					"description": "Show the active session block.",
-					"markdownDescription": "Show the active session block.",
-					"type": "boolean"
-				},
-				"all": {
-					"description": "Accepted for compatibility; all detected supported agents are included by default.",
-					"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
-					"type": "boolean"
-				},
-				"breakdown": {
-					"description": "Show per-model cost breakdown.",
-					"markdownDescription": "Show per-model cost breakdown.",
-					"type": "boolean"
-				},
-				"cache": {
-					"description": "Enable statusline cache.",
-					"markdownDescription": "Enable statusline cache.",
-					"type": "boolean"
-				},
-				"color": {
-					"description": "Enable colored output.",
-					"markdownDescription": "Enable colored output.",
-					"type": "boolean"
-				},
-				"compact": {
-					"description": "Force compact table layout for narrow terminals.",
-					"markdownDescription": "Force compact table layout for narrow terminals.",
-					"type": "boolean"
-				},
-				"contextLowThreshold": {
-					"description": "Percentage threshold for low context warning.",
-					"format": "uint64",
-					"markdownDescription": "Percentage threshold for low context warning.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"contextMediumThreshold": {
-					"description": "Percentage threshold for medium context warning.",
-					"format": "uint64",
-					"markdownDescription": "Percentage threshold for medium context warning.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"costSource": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCostSource"
-						}
-					],
-					"description": "Source for statusline cost calculation.",
-					"markdownDescription": "Source for statusline cost calculation."
-				},
-				"debug": {
-					"description": "Show statusline debug information.",
-					"markdownDescription": "Show statusline debug information.",
-					"type": "boolean"
-				},
-				"debugSamples": {
-					"description": "Number of sample discrepancies to show in debug output.",
-					"format": "uint",
-					"markdownDescription": "Number of sample discrepancies to show in debug output.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"instances": {
-					"description": "Show per-session project instances.",
-					"markdownDescription": "Show per-session project instances.",
-					"type": "boolean"
-				},
-				"jq": {
-					"description": "jq filter to apply to JSON output.",
-					"markdownDescription": "jq filter to apply to JSON output.",
-					"type": "string"
-				},
-				"json": {
-					"description": "Output in JSON format.",
-					"markdownDescription": "Output in JSON format.",
-					"type": "boolean"
-				},
-				"mode": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCostMode"
-						}
-					],
-					"description": "Cost calculation mode.",
-					"markdownDescription": "Cost calculation mode."
-				},
-				"noCache": {
-					"description": "Disable statusline cache.",
-					"markdownDescription": "Disable statusline cache.",
-					"type": "boolean"
-				},
-				"noColor": {
-					"description": "Disable colored output.",
-					"markdownDescription": "Disable colored output.",
-					"type": "boolean"
-				},
-				"noOffline": {
-					"description": "Disable cached pricing data where supported.",
-					"markdownDescription": "Disable cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"offline": {
-					"description": "Use cached pricing data where supported.",
-					"markdownDescription": "Use cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"order": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigSortOrder"
-						}
-					],
-					"description": "Sort order.",
-					"markdownDescription": "Sort order."
-				},
-				"project": {
-					"description": "Filter to a project name or path.",
-					"markdownDescription": "Filter to a project name or path.",
-					"type": "string"
-				},
-				"projectAliases": {
-					"description": "JSON object or path mapping project paths to display aliases.",
-					"markdownDescription": "JSON object or path mapping project paths to display aliases.",
-					"type": "string"
-				},
-				"recent": {
-					"description": "Show recent session blocks.",
-					"markdownDescription": "Show recent session blocks.",
-					"type": "boolean"
-				},
-				"refreshInterval": {
-					"description": "Statusline refresh interval in seconds.",
-					"format": "uint64",
-					"markdownDescription": "Statusline refresh interval in seconds.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"sessionLength": {
-					"description": "Session block duration in hours.",
-					"format": "double",
-					"markdownDescription": "Session block duration in hours.",
-					"type": "number"
-				},
-				"since": {
-					"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"type": "string"
-				},
-				"singleThread": {
-					"description": "Disable parallel file processing.",
-					"markdownDescription": "Disable parallel file processing.",
-					"type": "boolean"
-				},
-				"startOfWeek": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigWeekDay"
-						}
-					],
-					"description": "First day of week for weekly grouping.",
-					"markdownDescription": "First day of week for weekly grouping."
-				},
-				"timezone": {
-					"description": "Timezone for date grouping (IANA).",
-					"markdownDescription": "Timezone for date grouping (IANA).",
-					"type": "string"
-				},
-				"tokenLimit": {
-					"description": "Token limit for session block calculations.",
-					"markdownDescription": "Token limit for session block calculations.",
-					"type": "string"
-				},
-				"until": {
-					"description": "Filter until date (inclusive).",
-					"markdownDescription": "Filter until date (inclusive).",
-					"type": "string"
-				},
-				"visualBurnRate": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigVisualBurnRate"
-						}
-					],
-					"description": "Visual burn-rate display mode.",
-					"markdownDescription": "Visual burn-rate display mode."
-				}
-			},
-			"type": "object"
-		},
-		"CodebuffCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"CodebuffConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/CodebuffCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"CodexCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/CodexOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/CodexOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/CodexOptions"
-				}
-			},
-			"type": "object"
-		},
-		"CodexConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/CodexCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/CodexOptions"
-				}
-			},
-			"type": "object"
-		},
-		"CodexOptions": {
-			"additionalProperties": false,
-			"properties": {
-				"all": {
-					"description": "Accepted for compatibility; all detected supported agents are included by default.",
-					"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
-					"type": "boolean"
-				},
-				"breakdown": {
-					"description": "Show per-model cost breakdown.",
-					"markdownDescription": "Show per-model cost breakdown.",
-					"type": "boolean"
-				},
-				"color": {
-					"description": "Enable colored output.",
-					"markdownDescription": "Enable colored output.",
-					"type": "boolean"
-				},
-				"compact": {
-					"description": "Force compact table layout for narrow terminals.",
-					"markdownDescription": "Force compact table layout for narrow terminals.",
-					"type": "boolean"
-				},
-				"debug": {
-					"description": "Show pricing mismatch information for debugging.",
-					"markdownDescription": "Show pricing mismatch information for debugging.",
-					"type": "boolean"
-				},
-				"debugSamples": {
-					"description": "Number of sample discrepancies to show in debug output.",
-					"format": "uint",
-					"markdownDescription": "Number of sample discrepancies to show in debug output.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"jq": {
-					"description": "jq filter to apply to JSON output.",
-					"markdownDescription": "jq filter to apply to JSON output.",
-					"type": "string"
-				},
-				"json": {
-					"description": "Output in JSON format.",
-					"markdownDescription": "Output in JSON format.",
-					"type": "boolean"
-				},
-				"mode": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCostMode"
-						}
-					],
-					"description": "Cost calculation mode.",
-					"markdownDescription": "Cost calculation mode."
-				},
-				"noColor": {
-					"description": "Disable colored output.",
-					"markdownDescription": "Disable colored output.",
-					"type": "boolean"
-				},
-				"noOffline": {
-					"description": "Disable cached pricing data where supported.",
-					"markdownDescription": "Disable cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"offline": {
-					"description": "Use cached pricing data where supported.",
-					"markdownDescription": "Use cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"order": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigSortOrder"
-						}
-					],
-					"description": "Sort order.",
-					"markdownDescription": "Sort order."
-				},
-				"since": {
-					"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"type": "string"
-				},
-				"singleThread": {
-					"description": "Disable parallel file processing.",
-					"markdownDescription": "Disable parallel file processing.",
-					"type": "boolean"
-				},
-				"speed": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCodexSpeed"
-						}
-					],
-					"default": "auto",
-					"description": "Codex speed normalization strategy.",
-					"markdownDescription": "Codex speed normalization strategy."
-				},
-				"timezone": {
-					"description": "Timezone for date grouping (IANA).",
-					"markdownDescription": "Timezone for date grouping (IANA).",
-					"type": "string"
-				},
-				"until": {
-					"description": "Filter until date (inclusive).",
-					"markdownDescription": "Filter until date (inclusive).",
-					"type": "string"
-				}
-			},
-			"type": "object"
-		},
-		"ConfigCodexSpeed": {
-			"enum": ["auto", "standard", "fast"],
-			"type": "string"
-		},
-		"ConfigCostMode": {
-			"enum": ["auto", "calculate", "display"],
-			"type": "string"
-		},
-		"ConfigCostSource": {
-			"enum": ["auto", "ccusage", "cc", "both"],
-			"type": "string"
-		},
-		"ConfigSortOrder": {
-			"enum": ["desc", "asc"],
-			"type": "string"
-		},
-		"ConfigVisualBurnRate": {
-			"enum": ["off", "emoji", "text", "emoji-text"],
-			"type": "string"
-		},
-		"ConfigWeekDay": {
-			"enum": ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"],
-			"type": "string"
-		},
-		"CopilotCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"CopilotConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/CopilotCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"DailyOptions": {
-			"additionalProperties": false,
-			"properties": {
-				"all": {
-					"description": "Accepted for compatibility; all detected supported agents are included by default.",
-					"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
-					"type": "boolean"
-				},
-				"breakdown": {
-					"description": "Show per-model cost breakdown.",
-					"markdownDescription": "Show per-model cost breakdown.",
-					"type": "boolean"
-				},
-				"color": {
-					"description": "Enable colored output.",
-					"markdownDescription": "Enable colored output.",
-					"type": "boolean"
-				},
-				"compact": {
-					"description": "Force compact table layout for narrow terminals.",
-					"markdownDescription": "Force compact table layout for narrow terminals.",
-					"type": "boolean"
-				},
-				"debug": {
-					"description": "Show pricing mismatch information for debugging.",
-					"markdownDescription": "Show pricing mismatch information for debugging.",
-					"type": "boolean"
-				},
-				"debugSamples": {
-					"description": "Number of sample discrepancies to show in debug output.",
-					"format": "uint",
-					"markdownDescription": "Number of sample discrepancies to show in debug output.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"instances": {
-					"description": "Show per-session project instances.",
-					"markdownDescription": "Show per-session project instances.",
-					"type": "boolean"
-				},
-				"jq": {
-					"description": "jq filter to apply to JSON output.",
-					"markdownDescription": "jq filter to apply to JSON output.",
-					"type": "string"
-				},
-				"json": {
-					"description": "Output in JSON format.",
-					"markdownDescription": "Output in JSON format.",
-					"type": "boolean"
-				},
-				"mode": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCostMode"
-						}
-					],
-					"description": "Cost calculation mode.",
-					"markdownDescription": "Cost calculation mode."
-				},
-				"noColor": {
-					"description": "Disable colored output.",
-					"markdownDescription": "Disable colored output.",
-					"type": "boolean"
-				},
-				"noOffline": {
-					"description": "Disable cached pricing data where supported.",
-					"markdownDescription": "Disable cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"offline": {
-					"description": "Use cached pricing data where supported.",
-					"markdownDescription": "Use cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"order": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigSortOrder"
-						}
-					],
-					"description": "Sort order.",
-					"markdownDescription": "Sort order."
-				},
-				"project": {
-					"description": "Filter to a project name or path.",
-					"markdownDescription": "Filter to a project name or path.",
-					"type": "string"
-				},
-				"projectAliases": {
-					"description": "JSON object or path mapping project paths to display aliases.",
-					"markdownDescription": "JSON object or path mapping project paths to display aliases.",
-					"type": "string"
-				},
-				"since": {
-					"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"type": "string"
-				},
-				"singleThread": {
-					"description": "Disable parallel file processing.",
-					"markdownDescription": "Disable parallel file processing.",
-					"type": "boolean"
-				},
-				"timezone": {
-					"description": "Timezone for date grouping (IANA).",
-					"markdownDescription": "Timezone for date grouping (IANA).",
-					"type": "string"
-				},
-				"until": {
-					"description": "Filter until date (inclusive).",
-					"markdownDescription": "Filter until date (inclusive).",
-					"type": "string"
-				}
-			},
-			"type": "object"
-		},
-		"DroidCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"DroidConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/DroidCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"GeminiCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"GeminiConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/GeminiCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"GooseCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"GooseConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/GooseCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"HermesCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"HermesConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/HermesCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"KiloCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"KiloConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/KiloCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"KimiCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"KimiConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/KimiCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"OpenClawCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/OpenClawOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/OpenClawOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/OpenClawOptions"
-				}
-			},
-			"type": "object"
-		},
-		"OpenClawConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/OpenClawCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/OpenClawOptions"
-				}
-			},
-			"type": "object"
-		},
-		"OpenClawOptions": {
-			"additionalProperties": false,
-			"properties": {
-				"all": {
-					"description": "Accepted for compatibility; all detected supported agents are included by default.",
-					"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
-					"type": "boolean"
-				},
-				"breakdown": {
-					"description": "Show per-model cost breakdown.",
-					"markdownDescription": "Show per-model cost breakdown.",
-					"type": "boolean"
-				},
-				"color": {
-					"description": "Enable colored output.",
-					"markdownDescription": "Enable colored output.",
-					"type": "boolean"
-				},
-				"compact": {
-					"description": "Force compact table layout for narrow terminals.",
-					"markdownDescription": "Force compact table layout for narrow terminals.",
-					"type": "boolean"
-				},
-				"debug": {
-					"description": "Show pricing mismatch information for debugging.",
-					"markdownDescription": "Show pricing mismatch information for debugging.",
-					"type": "boolean"
-				},
-				"debugSamples": {
-					"description": "Number of sample discrepancies to show in debug output.",
-					"format": "uint",
-					"markdownDescription": "Number of sample discrepancies to show in debug output.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"jq": {
-					"description": "jq filter to apply to JSON output.",
-					"markdownDescription": "jq filter to apply to JSON output.",
-					"type": "string"
-				},
-				"json": {
-					"description": "Output in JSON format.",
-					"markdownDescription": "Output in JSON format.",
-					"type": "boolean"
-				},
-				"mode": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCostMode"
-						}
-					],
-					"description": "Cost calculation mode.",
-					"markdownDescription": "Cost calculation mode."
-				},
-				"noColor": {
-					"description": "Disable colored output.",
-					"markdownDescription": "Disable colored output.",
-					"type": "boolean"
-				},
-				"noOffline": {
-					"description": "Disable cached pricing data where supported.",
-					"markdownDescription": "Disable cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"offline": {
-					"description": "Use cached pricing data where supported.",
-					"markdownDescription": "Use cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"openClawPath": {
-					"description": "Path or comma-separated paths to OpenClaw data directories.",
-					"markdownDescription": "Path or comma-separated paths to OpenClaw data directories.",
-					"type": "string"
-				},
-				"order": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigSortOrder"
-						}
-					],
-					"description": "Sort order.",
-					"markdownDescription": "Sort order."
-				},
-				"since": {
-					"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"type": "string"
-				},
-				"singleThread": {
-					"description": "Disable parallel file processing.",
-					"markdownDescription": "Disable parallel file processing.",
-					"type": "boolean"
-				},
-				"timezone": {
-					"description": "Timezone for date grouping (IANA).",
-					"markdownDescription": "Timezone for date grouping (IANA).",
-					"type": "string"
-				},
-				"until": {
-					"description": "Filter until date (inclusive).",
-					"markdownDescription": "Filter until date (inclusive).",
-					"type": "string"
-				}
-			},
-			"type": "object"
-		},
-		"OpenCodeCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"weekly": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"OpenCodeConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/OpenCodeCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"PiCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/PiOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/PiOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/PiOptions"
-				}
-			},
-			"type": "object"
-		},
-		"PiConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/PiCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/PiOptions"
-				}
-			},
-			"type": "object"
-		},
-		"PiOptions": {
-			"additionalProperties": false,
-			"properties": {
-				"all": {
-					"description": "Accepted for compatibility; all detected supported agents are included by default.",
-					"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
-					"type": "boolean"
-				},
-				"breakdown": {
-					"description": "Show per-model cost breakdown.",
-					"markdownDescription": "Show per-model cost breakdown.",
-					"type": "boolean"
-				},
-				"color": {
-					"description": "Enable colored output.",
-					"markdownDescription": "Enable colored output.",
-					"type": "boolean"
-				},
-				"compact": {
-					"description": "Force compact table layout for narrow terminals.",
-					"markdownDescription": "Force compact table layout for narrow terminals.",
-					"type": "boolean"
-				},
-				"debug": {
-					"description": "Show pricing mismatch information for debugging.",
-					"markdownDescription": "Show pricing mismatch information for debugging.",
-					"type": "boolean"
-				},
-				"debugSamples": {
-					"description": "Number of sample discrepancies to show in debug output.",
-					"format": "uint",
-					"markdownDescription": "Number of sample discrepancies to show in debug output.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"jq": {
-					"description": "jq filter to apply to JSON output.",
-					"markdownDescription": "jq filter to apply to JSON output.",
-					"type": "string"
-				},
-				"json": {
-					"description": "Output in JSON format.",
-					"markdownDescription": "Output in JSON format.",
-					"type": "boolean"
-				},
-				"mode": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCostMode"
-						}
-					],
-					"description": "Cost calculation mode.",
-					"markdownDescription": "Cost calculation mode."
-				},
-				"noColor": {
-					"description": "Disable colored output.",
-					"markdownDescription": "Disable colored output.",
-					"type": "boolean"
-				},
-				"noOffline": {
-					"description": "Disable cached pricing data where supported.",
-					"markdownDescription": "Disable cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"offline": {
-					"description": "Use cached pricing data where supported.",
-					"markdownDescription": "Use cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"order": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigSortOrder"
-						}
-					],
-					"description": "Sort order.",
-					"markdownDescription": "Sort order."
-				},
-				"piPath": {
-					"description": "Path or comma-separated paths to pi-agent sessions directories.",
-					"markdownDescription": "Path or comma-separated paths to pi-agent sessions directories.",
-					"type": "string"
-				},
-				"since": {
-					"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"type": "string"
-				},
-				"singleThread": {
-					"description": "Disable parallel file processing.",
-					"markdownDescription": "Disable parallel file processing.",
-					"type": "boolean"
-				},
-				"timezone": {
-					"description": "Timezone for date grouping (IANA).",
-					"markdownDescription": "Timezone for date grouping (IANA).",
-					"type": "string"
-				},
-				"until": {
-					"description": "Filter until date (inclusive).",
-					"markdownDescription": "Filter until date (inclusive).",
-					"type": "string"
-				}
-			},
-			"type": "object"
-		},
-		"QwenCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"QwenConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"commands": {
-					"$ref": "#/definitions/QwenCommandsConfig"
-				},
-				"defaults": {
-					"$ref": "#/definitions/SharedOptions"
-				}
-			},
-			"type": "object"
-		},
-		"RootCommandsConfig": {
-			"additionalProperties": false,
-			"properties": {
-				"blocks": {
-					"$ref": "#/definitions/BlocksOptions"
-				},
-				"daily": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"monthly": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"session": {
-					"$ref": "#/definitions/SharedOptions"
-				},
-				"statusline": {
-					"$ref": "#/definitions/StatuslineOptions"
-				},
-				"weekly": {
-					"$ref": "#/definitions/WeeklyOptions"
-				}
-			},
-			"type": "object"
-		},
-		"SharedOptions": {
-			"additionalProperties": false,
-			"properties": {
-				"all": {
-					"default": false,
-					"description": "Accepted for compatibility; all detected supported agents are included by default.",
-					"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
-					"type": "boolean"
-				},
-				"breakdown": {
-					"default": false,
-					"description": "Show per-model cost breakdown.",
-					"markdownDescription": "Show per-model cost breakdown.",
-					"type": "boolean"
-				},
-				"color": {
-					"default": false,
-					"description": "Enable colored output.",
-					"markdownDescription": "Enable colored output.",
-					"type": "boolean"
-				},
-				"compact": {
-					"default": false,
-					"description": "Force compact table layout for narrow terminals.",
-					"markdownDescription": "Force compact table layout for narrow terminals.",
-					"type": "boolean"
-				},
-				"debug": {
-					"default": false,
-					"description": "Show pricing mismatch information for debugging.",
-					"markdownDescription": "Show pricing mismatch information for debugging.",
-					"type": "boolean"
-				},
-				"debugSamples": {
-					"default": 5,
-					"description": "Number of sample discrepancies to show in debug output.",
-					"format": "uint",
-					"markdownDescription": "Number of sample discrepancies to show in debug output.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"jq": {
-					"description": "jq filter to apply to JSON output.",
-					"markdownDescription": "jq filter to apply to JSON output.",
-					"type": "string"
-				},
-				"json": {
-					"default": false,
-					"description": "Output in JSON format.",
-					"markdownDescription": "Output in JSON format.",
-					"type": "boolean"
-				},
-				"mode": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCostMode"
-						}
-					],
-					"default": "auto",
-					"description": "Cost calculation mode.",
-					"markdownDescription": "Cost calculation mode."
-				},
-				"noColor": {
-					"default": false,
-					"description": "Disable colored output.",
-					"markdownDescription": "Disable colored output.",
-					"type": "boolean"
-				},
-				"noOffline": {
-					"default": false,
-					"description": "Disable cached pricing data where supported.",
-					"markdownDescription": "Disable cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"offline": {
-					"default": false,
-					"description": "Use cached pricing data where supported.",
-					"markdownDescription": "Use cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"order": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigSortOrder"
-						}
-					],
-					"default": "asc",
-					"description": "Sort order.",
-					"markdownDescription": "Sort order."
-				},
-				"since": {
-					"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"type": "string"
-				},
-				"singleThread": {
-					"default": false,
-					"description": "Disable parallel file processing.",
-					"markdownDescription": "Disable parallel file processing.",
-					"type": "boolean"
-				},
-				"timezone": {
-					"description": "Timezone for date grouping (IANA).",
-					"markdownDescription": "Timezone for date grouping (IANA).",
-					"type": "string"
-				},
-				"until": {
-					"description": "Filter until date (inclusive).",
-					"markdownDescription": "Filter until date (inclusive).",
-					"type": "string"
-				}
-			},
-			"type": "object"
-		},
-		"StatuslineOptions": {
-			"additionalProperties": false,
-			"properties": {
-				"cache": {
-					"default": true,
-					"description": "Enable statusline cache.",
-					"markdownDescription": "Enable statusline cache.",
-					"type": "boolean"
-				},
-				"contextLowThreshold": {
-					"default": 50,
-					"description": "Percentage threshold for low context warning.",
-					"format": "uint64",
-					"markdownDescription": "Percentage threshold for low context warning.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"contextMediumThreshold": {
-					"default": 80,
-					"description": "Percentage threshold for medium context warning.",
-					"format": "uint64",
-					"markdownDescription": "Percentage threshold for medium context warning.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"costSource": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCostSource"
-						}
-					],
-					"default": "auto",
-					"description": "Source for statusline cost calculation.",
-					"markdownDescription": "Source for statusline cost calculation."
-				},
-				"debug": {
-					"default": false,
-					"description": "Show statusline debug information.",
-					"markdownDescription": "Show statusline debug information.",
-					"type": "boolean"
-				},
-				"noCache": {
-					"default": false,
-					"description": "Disable statusline cache.",
-					"markdownDescription": "Disable statusline cache.",
-					"type": "boolean"
-				},
-				"noOffline": {
-					"default": false,
-					"description": "Disable cached pricing data where supported.",
-					"markdownDescription": "Disable cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"offline": {
-					"default": true,
-					"description": "Use cached pricing data where supported.",
-					"markdownDescription": "Use cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"refreshInterval": {
-					"default": 1,
-					"description": "Statusline refresh interval in seconds.",
-					"format": "uint64",
-					"markdownDescription": "Statusline refresh interval in seconds.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"visualBurnRate": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigVisualBurnRate"
-						}
-					],
-					"default": "off",
-					"description": "Visual burn-rate display mode.",
-					"markdownDescription": "Visual burn-rate display mode."
-				}
-			},
-			"type": "object"
-		},
-		"WeeklyOptions": {
-			"additionalProperties": false,
-			"properties": {
-				"all": {
-					"description": "Accepted for compatibility; all detected supported agents are included by default.",
-					"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
-					"type": "boolean"
-				},
-				"breakdown": {
-					"description": "Show per-model cost breakdown.",
-					"markdownDescription": "Show per-model cost breakdown.",
-					"type": "boolean"
-				},
-				"color": {
-					"description": "Enable colored output.",
-					"markdownDescription": "Enable colored output.",
-					"type": "boolean"
-				},
-				"compact": {
-					"description": "Force compact table layout for narrow terminals.",
-					"markdownDescription": "Force compact table layout for narrow terminals.",
-					"type": "boolean"
-				},
-				"debug": {
-					"description": "Show pricing mismatch information for debugging.",
-					"markdownDescription": "Show pricing mismatch information for debugging.",
-					"type": "boolean"
-				},
-				"debugSamples": {
-					"description": "Number of sample discrepancies to show in debug output.",
-					"format": "uint",
-					"markdownDescription": "Number of sample discrepancies to show in debug output.",
-					"minimum": 0.0,
-					"type": "integer"
-				},
-				"jq": {
-					"description": "jq filter to apply to JSON output.",
-					"markdownDescription": "jq filter to apply to JSON output.",
-					"type": "string"
-				},
-				"json": {
-					"description": "Output in JSON format.",
-					"markdownDescription": "Output in JSON format.",
-					"type": "boolean"
-				},
-				"mode": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigCostMode"
-						}
-					],
-					"description": "Cost calculation mode.",
-					"markdownDescription": "Cost calculation mode."
-				},
-				"noColor": {
-					"description": "Disable colored output.",
-					"markdownDescription": "Disable colored output.",
-					"type": "boolean"
-				},
-				"noOffline": {
-					"description": "Disable cached pricing data where supported.",
-					"markdownDescription": "Disable cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"offline": {
-					"description": "Use cached pricing data where supported.",
-					"markdownDescription": "Use cached pricing data where supported.",
-					"type": "boolean"
-				},
-				"order": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigSortOrder"
-						}
-					],
-					"description": "Sort order.",
-					"markdownDescription": "Sort order."
-				},
-				"since": {
-					"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
-					"type": "string"
-				},
-				"singleThread": {
-					"description": "Disable parallel file processing.",
-					"markdownDescription": "Disable parallel file processing.",
-					"type": "boolean"
-				},
-				"startOfWeek": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ConfigWeekDay"
-						}
-					],
-					"default": "sunday",
-					"description": "First day of week for weekly grouping.",
-					"markdownDescription": "First day of week for weekly grouping."
-				},
-				"timezone": {
-					"description": "Timezone for date grouping (IANA).",
-					"markdownDescription": "Timezone for date grouping (IANA).",
-					"type": "string"
-				},
-				"until": {
-					"description": "Filter until date (inclusive).",
-					"markdownDescription": "Filter until date (inclusive).",
-					"type": "string"
-				}
-			},
-			"type": "object"
-		},
 		"ccusage-config": {
 			"additionalProperties": false,
 			"description": "Configuration file for ccusage",
@@ -1540,157 +13,7842 @@
 					"type": "string"
 				},
 				"amp": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/AmpConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Amp configuration.",
-					"markdownDescription": "Amp configuration."
+					"markdownDescription": "Amp configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"claude": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/ClaudeConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Claude Code configuration.",
-					"markdownDescription": "Claude Code configuration."
+					"markdownDescription": "Claude Code configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"blocks": {
+									"additionalProperties": false,
+									"properties": {
+										"active": {
+											"description": "Show the active session block.",
+											"markdownDescription": "Show the active session block.",
+											"type": "boolean"
+										},
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"recent": {
+											"description": "Show recent session blocks.",
+											"markdownDescription": "Show recent session blocks.",
+											"type": "boolean"
+										},
+										"sessionLength": {
+											"default": 5.0,
+											"description": "Session block duration in hours.",
+											"format": "double",
+											"markdownDescription": "Session block duration in hours.",
+											"type": "number"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"tokenLimit": {
+											"description": "Token limit for session block calculations.",
+											"markdownDescription": "Token limit for session block calculations.",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"instances": {
+											"description": "Show per-session project instances.",
+											"markdownDescription": "Show per-session project instances.",
+											"type": "boolean"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"project": {
+											"description": "Filter to a project name or path.",
+											"markdownDescription": "Filter to a project name or path.",
+											"type": "string"
+										},
+										"projectAliases": {
+											"description": "JSON object or path mapping project paths to display aliases.",
+											"markdownDescription": "JSON object or path mapping project paths to display aliases.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"statusline": {
+									"additionalProperties": false,
+									"properties": {
+										"cache": {
+											"default": true,
+											"description": "Enable statusline cache.",
+											"markdownDescription": "Enable statusline cache.",
+											"type": "boolean"
+										},
+										"contextLowThreshold": {
+											"default": 50,
+											"description": "Percentage threshold for low context warning.",
+											"format": "uint64",
+											"markdownDescription": "Percentage threshold for low context warning.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"contextMediumThreshold": {
+											"default": 80,
+											"description": "Percentage threshold for medium context warning.",
+											"format": "uint64",
+											"markdownDescription": "Percentage threshold for medium context warning.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"costSource": {
+											"default": "auto",
+											"description": "Source for statusline cost calculation.",
+											"enum": ["auto", "ccusage", "cc", "both"],
+											"markdownDescription": "Source for statusline cost calculation.",
+											"type": "string"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show statusline debug information.",
+											"markdownDescription": "Show statusline debug information.",
+											"type": "boolean"
+										},
+										"noCache": {
+											"default": false,
+											"description": "Disable statusline cache.",
+											"markdownDescription": "Disable statusline cache.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": true,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"refreshInterval": {
+											"default": 1,
+											"description": "Statusline refresh interval in seconds.",
+											"format": "uint64",
+											"markdownDescription": "Statusline refresh interval in seconds.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"visualBurnRate": {
+											"default": "off",
+											"description": "Visual burn-rate display mode.",
+											"enum": ["off", "emoji", "text", "emoji-text"],
+											"markdownDescription": "Visual burn-rate display mode.",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"weekly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"startOfWeek": {
+											"default": "sunday",
+											"description": "First day of week for weekly grouping.",
+											"enum": [
+												"sunday",
+												"monday",
+												"tuesday",
+												"wednesday",
+												"thursday",
+												"friday",
+												"saturday"
+											],
+											"markdownDescription": "First day of week for weekly grouping.",
+											"type": "string"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"active": {
+									"description": "Show the active session block.",
+									"markdownDescription": "Show the active session block.",
+									"type": "boolean"
+								},
+								"all": {
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"cache": {
+									"description": "Enable statusline cache.",
+									"markdownDescription": "Enable statusline cache.",
+									"type": "boolean"
+								},
+								"color": {
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"contextLowThreshold": {
+									"description": "Percentage threshold for low context warning.",
+									"format": "uint64",
+									"markdownDescription": "Percentage threshold for low context warning.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"contextMediumThreshold": {
+									"description": "Percentage threshold for medium context warning.",
+									"format": "uint64",
+									"markdownDescription": "Percentage threshold for medium context warning.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"costSource": {
+									"description": "Source for statusline cost calculation.",
+									"enum": ["auto", "ccusage", "cc", "both"],
+									"markdownDescription": "Source for statusline cost calculation.",
+									"type": "string"
+								},
+								"debug": {
+									"description": "Show statusline debug information.",
+									"markdownDescription": "Show statusline debug information.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"instances": {
+									"description": "Show per-session project instances.",
+									"markdownDescription": "Show per-session project instances.",
+									"type": "boolean"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noCache": {
+									"description": "Disable statusline cache.",
+									"markdownDescription": "Disable statusline cache.",
+									"type": "boolean"
+								},
+								"noColor": {
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"project": {
+									"description": "Filter to a project name or path.",
+									"markdownDescription": "Filter to a project name or path.",
+									"type": "string"
+								},
+								"projectAliases": {
+									"description": "JSON object or path mapping project paths to display aliases.",
+									"markdownDescription": "JSON object or path mapping project paths to display aliases.",
+									"type": "string"
+								},
+								"recent": {
+									"description": "Show recent session blocks.",
+									"markdownDescription": "Show recent session blocks.",
+									"type": "boolean"
+								},
+								"refreshInterval": {
+									"description": "Statusline refresh interval in seconds.",
+									"format": "uint64",
+									"markdownDescription": "Statusline refresh interval in seconds.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"sessionLength": {
+									"description": "Session block duration in hours.",
+									"format": "double",
+									"markdownDescription": "Session block duration in hours.",
+									"type": "number"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"startOfWeek": {
+									"description": "First day of week for weekly grouping.",
+									"enum": [
+										"sunday",
+										"monday",
+										"tuesday",
+										"wednesday",
+										"thursday",
+										"friday",
+										"saturday"
+									],
+									"markdownDescription": "First day of week for weekly grouping.",
+									"type": "string"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"tokenLimit": {
+									"description": "Token limit for session block calculations.",
+									"markdownDescription": "Token limit for session block calculations.",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								},
+								"visualBurnRate": {
+									"description": "Visual burn-rate display mode.",
+									"enum": ["off", "emoji", "text", "emoji-text"],
+									"markdownDescription": "Visual burn-rate display mode.",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"codebuff": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/CodebuffConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Codebuff configuration.",
-					"markdownDescription": "Codebuff configuration."
+					"markdownDescription": "Codebuff configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"codex": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/CodexConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Codex configuration.",
-					"markdownDescription": "Codex configuration."
+					"markdownDescription": "Codex configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"speed": {
+											"default": "auto",
+											"description": "Codex speed normalization strategy.",
+											"enum": ["auto", "standard", "fast"],
+											"markdownDescription": "Codex speed normalization strategy.",
+											"type": "string"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"speed": {
+											"default": "auto",
+											"description": "Codex speed normalization strategy.",
+											"enum": ["auto", "standard", "fast"],
+											"markdownDescription": "Codex speed normalization strategy.",
+											"type": "string"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"speed": {
+											"default": "auto",
+											"description": "Codex speed normalization strategy.",
+											"enum": ["auto", "standard", "fast"],
+											"markdownDescription": "Codex speed normalization strategy.",
+											"type": "string"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"speed": {
+									"default": "auto",
+									"description": "Codex speed normalization strategy.",
+									"enum": ["auto", "standard", "fast"],
+									"markdownDescription": "Codex speed normalization strategy.",
+									"type": "string"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"commands": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/RootCommandsConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Command-specific configuration for all-agent reports.",
-					"markdownDescription": "Command-specific configuration for all-agent reports."
+					"markdownDescription": "Command-specific configuration for all-agent reports.",
+					"properties": {
+						"blocks": {
+							"additionalProperties": false,
+							"properties": {
+								"active": {
+									"description": "Show the active session block.",
+									"markdownDescription": "Show the active session block.",
+									"type": "boolean"
+								},
+								"all": {
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"recent": {
+									"description": "Show recent session blocks.",
+									"markdownDescription": "Show recent session blocks.",
+									"type": "boolean"
+								},
+								"sessionLength": {
+									"default": 5.0,
+									"description": "Session block duration in hours.",
+									"format": "double",
+									"markdownDescription": "Session block duration in hours.",
+									"type": "number"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"tokenLimit": {
+									"description": "Token limit for session block calculations.",
+									"markdownDescription": "Token limit for session block calculations.",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						},
+						"daily": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"instances": {
+									"description": "Show per-session project instances.",
+									"markdownDescription": "Show per-session project instances.",
+									"type": "boolean"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"project": {
+									"description": "Filter to a project name or path.",
+									"markdownDescription": "Filter to a project name or path.",
+									"type": "string"
+								},
+								"projectAliases": {
+									"description": "JSON object or path mapping project paths to display aliases.",
+									"markdownDescription": "JSON object or path mapping project paths to display aliases.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						},
+						"monthly": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						},
+						"session": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						},
+						"statusline": {
+							"additionalProperties": false,
+							"properties": {
+								"cache": {
+									"default": true,
+									"description": "Enable statusline cache.",
+									"markdownDescription": "Enable statusline cache.",
+									"type": "boolean"
+								},
+								"contextLowThreshold": {
+									"default": 50,
+									"description": "Percentage threshold for low context warning.",
+									"format": "uint64",
+									"markdownDescription": "Percentage threshold for low context warning.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"contextMediumThreshold": {
+									"default": 80,
+									"description": "Percentage threshold for medium context warning.",
+									"format": "uint64",
+									"markdownDescription": "Percentage threshold for medium context warning.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"costSource": {
+									"default": "auto",
+									"description": "Source for statusline cost calculation.",
+									"enum": ["auto", "ccusage", "cc", "both"],
+									"markdownDescription": "Source for statusline cost calculation.",
+									"type": "string"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show statusline debug information.",
+									"markdownDescription": "Show statusline debug information.",
+									"type": "boolean"
+								},
+								"noCache": {
+									"default": false,
+									"description": "Disable statusline cache.",
+									"markdownDescription": "Disable statusline cache.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": true,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"refreshInterval": {
+									"default": 1,
+									"description": "Statusline refresh interval in seconds.",
+									"format": "uint64",
+									"markdownDescription": "Statusline refresh interval in seconds.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"visualBurnRate": {
+									"default": "off",
+									"description": "Visual burn-rate display mode.",
+									"enum": ["off", "emoji", "text", "emoji-text"],
+									"markdownDescription": "Visual burn-rate display mode.",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						},
+						"weekly": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"startOfWeek": {
+									"default": "sunday",
+									"description": "First day of week for weekly grouping.",
+									"enum": [
+										"sunday",
+										"monday",
+										"tuesday",
+										"wednesday",
+										"thursday",
+										"friday",
+										"saturday"
+									],
+									"markdownDescription": "First day of week for weekly grouping.",
+									"type": "string"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"copilot": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/CopilotConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "GitHub Copilot CLI configuration.",
-					"markdownDescription": "GitHub Copilot CLI configuration."
+					"markdownDescription": "GitHub Copilot CLI configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"defaults": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/SharedOptions"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Default values for all-agent reports and legacy Claude commands.",
-					"markdownDescription": "Default values for all-agent reports and legacy Claude commands."
+					"markdownDescription": "Default values for all-agent reports and legacy Claude commands.",
+					"properties": {
+						"all": {
+							"default": false,
+							"description": "Accepted for compatibility; all detected supported agents are included by default.",
+							"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+							"type": "boolean"
+						},
+						"breakdown": {
+							"default": false,
+							"description": "Show per-model cost breakdown.",
+							"markdownDescription": "Show per-model cost breakdown.",
+							"type": "boolean"
+						},
+						"color": {
+							"default": false,
+							"description": "Enable colored output.",
+							"markdownDescription": "Enable colored output.",
+							"type": "boolean"
+						},
+						"compact": {
+							"default": false,
+							"description": "Force compact table layout for narrow terminals.",
+							"markdownDescription": "Force compact table layout for narrow terminals.",
+							"type": "boolean"
+						},
+						"debug": {
+							"default": false,
+							"description": "Show pricing mismatch information for debugging.",
+							"markdownDescription": "Show pricing mismatch information for debugging.",
+							"type": "boolean"
+						},
+						"debugSamples": {
+							"default": 5,
+							"description": "Number of sample discrepancies to show in debug output.",
+							"format": "uint",
+							"markdownDescription": "Number of sample discrepancies to show in debug output.",
+							"minimum": 0.0,
+							"type": "integer"
+						},
+						"jq": {
+							"description": "jq filter to apply to JSON output.",
+							"markdownDescription": "jq filter to apply to JSON output.",
+							"type": "string"
+						},
+						"json": {
+							"default": false,
+							"description": "Output in JSON format.",
+							"markdownDescription": "Output in JSON format.",
+							"type": "boolean"
+						},
+						"mode": {
+							"default": "auto",
+							"description": "Cost calculation mode.",
+							"enum": ["auto", "calculate", "display"],
+							"markdownDescription": "Cost calculation mode.",
+							"type": "string"
+						},
+						"noColor": {
+							"default": false,
+							"description": "Disable colored output.",
+							"markdownDescription": "Disable colored output.",
+							"type": "boolean"
+						},
+						"noOffline": {
+							"default": false,
+							"description": "Disable cached pricing data where supported.",
+							"markdownDescription": "Disable cached pricing data where supported.",
+							"type": "boolean"
+						},
+						"offline": {
+							"default": false,
+							"description": "Use cached pricing data where supported.",
+							"markdownDescription": "Use cached pricing data where supported.",
+							"type": "boolean"
+						},
+						"order": {
+							"default": "asc",
+							"description": "Sort order.",
+							"enum": ["desc", "asc"],
+							"markdownDescription": "Sort order.",
+							"type": "string"
+						},
+						"since": {
+							"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+							"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+							"type": "string"
+						},
+						"singleThread": {
+							"default": false,
+							"description": "Disable parallel file processing.",
+							"markdownDescription": "Disable parallel file processing.",
+							"type": "boolean"
+						},
+						"timezone": {
+							"description": "Timezone for date grouping (IANA).",
+							"markdownDescription": "Timezone for date grouping (IANA).",
+							"type": "string"
+						},
+						"until": {
+							"description": "Filter until date (inclusive).",
+							"markdownDescription": "Filter until date (inclusive).",
+							"type": "string"
+						}
+					},
+					"type": "object"
 				},
 				"droid": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/DroidConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Droid configuration.",
-					"markdownDescription": "Droid configuration."
+					"markdownDescription": "Droid configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"gemini": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/GeminiConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Gemini CLI configuration.",
-					"markdownDescription": "Gemini CLI configuration."
+					"markdownDescription": "Gemini CLI configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"goose": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/GooseConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Goose configuration.",
-					"markdownDescription": "Goose configuration."
+					"markdownDescription": "Goose configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"hermes": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/HermesConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Hermes Agent configuration.",
-					"markdownDescription": "Hermes Agent configuration."
+					"markdownDescription": "Hermes Agent configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"kilo": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/KiloConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Kilo configuration.",
-					"markdownDescription": "Kilo configuration."
+					"markdownDescription": "Kilo configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"kimi": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/KimiConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Kimi configuration.",
-					"markdownDescription": "Kimi configuration."
+					"markdownDescription": "Kimi configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"openclaw": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/OpenClawConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "OpenClaw configuration.",
-					"markdownDescription": "OpenClaw configuration."
+					"markdownDescription": "OpenClaw configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"openClawPath": {
+											"description": "Path or comma-separated paths to OpenClaw data directories.",
+											"markdownDescription": "Path or comma-separated paths to OpenClaw data directories.",
+											"type": "string"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"openClawPath": {
+											"description": "Path or comma-separated paths to OpenClaw data directories.",
+											"markdownDescription": "Path or comma-separated paths to OpenClaw data directories.",
+											"type": "string"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"openClawPath": {
+											"description": "Path or comma-separated paths to OpenClaw data directories.",
+											"markdownDescription": "Path or comma-separated paths to OpenClaw data directories.",
+											"type": "string"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"openClawPath": {
+									"description": "Path or comma-separated paths to OpenClaw data directories.",
+									"markdownDescription": "Path or comma-separated paths to OpenClaw data directories.",
+									"type": "string"
+								},
+								"order": {
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"opencode": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/OpenCodeConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "OpenCode configuration.",
-					"markdownDescription": "OpenCode configuration."
+					"markdownDescription": "OpenCode configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"weekly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"pi": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/PiConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "pi-agent configuration.",
-					"markdownDescription": "pi-agent configuration."
+					"markdownDescription": "pi-agent configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"piPath": {
+											"description": "Path or comma-separated paths to pi-agent sessions directories.",
+											"markdownDescription": "Path or comma-separated paths to pi-agent sessions directories.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"piPath": {
+											"description": "Path or comma-separated paths to pi-agent sessions directories.",
+											"markdownDescription": "Path or comma-separated paths to pi-agent sessions directories.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"piPath": {
+											"description": "Path or comma-separated paths to pi-agent sessions directories.",
+											"markdownDescription": "Path or comma-separated paths to pi-agent sessions directories.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"piPath": {
+									"description": "Path or comma-separated paths to pi-agent sessions directories.",
+									"markdownDescription": "Path or comma-separated paths to pi-agent sessions directories.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				},
 				"qwen": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/QwenConfig"
-						}
-					],
+					"additionalProperties": false,
 					"description": "Qwen configuration.",
-					"markdownDescription": "Qwen configuration."
+					"markdownDescription": "Qwen configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				}
 			},
 			"type": "object"

--- a/rust/crates/ccusage/src/config_schema.rs
+++ b/rust/crates/ccusage/src/config_schema.rs
@@ -51,7 +51,7 @@ pub(crate) struct CcusageConfig {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RootCommandsConfig {
-    pub(crate) daily: Option<SharedOptions>,
+    pub(crate) daily: Option<DailyOptions>,
     pub(crate) weekly: Option<WeeklyOptions>,
     pub(crate) monthly: Option<SharedOptions>,
     pub(crate) session: Option<SharedOptions>,
@@ -665,6 +665,7 @@ pub(crate) fn generate_config_schema_json() -> String {
     }
     enrich_schema(&mut schema);
     add_schema_defaults(&mut schema);
+    inline_schema_references(&mut schema);
     wrap_root_schema(&mut schema);
     let mut json = tab_indent_json(&serde_json::to_string_pretty(&schema).unwrap());
     json.push('\n');
@@ -800,17 +801,92 @@ fn set_definition_defaults(schema: &mut Value, definition: &str, defaults: &[(&s
     }
 }
 
+fn inline_schema_references(schema: &mut Value) {
+    let definitions = schema
+        .get("definitions")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    inline_schema_value(schema, &definitions);
+}
+
+fn inline_schema_value(value: &mut Value, definitions: &Map<String, Value>) {
+    match value {
+        Value::Object(map) => {
+            inline_ref(map, definitions);
+            inline_all_of(map, definitions);
+            for child in map.values_mut() {
+                inline_schema_value(child, definitions);
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                inline_schema_value(child, definitions);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn inline_ref(map: &mut Map<String, Value>, definitions: &Map<String, Value>) {
+    let Some(reference) = map.remove("$ref") else {
+        return;
+    };
+    let Some(reference) = reference.as_str() else {
+        return;
+    };
+    let Some(definition_name) = reference.strip_prefix("#/definitions/") else {
+        return;
+    };
+    let Some(Value::Object(definition)) = definitions.get(definition_name).cloned() else {
+        return;
+    };
+
+    let existing = std::mem::take(map);
+    for (key, value) in definition {
+        map.insert(key, value);
+    }
+    for (key, value) in existing {
+        map.insert(key, value);
+    }
+}
+
+fn inline_all_of(map: &mut Map<String, Value>, definitions: &Map<String, Value>) {
+    let Some(Value::Array(items)) = map.remove("allOf") else {
+        return;
+    };
+    for mut item in items {
+        inline_schema_value(&mut item, definitions);
+        let Value::Object(item) = item else {
+            continue;
+        };
+        merge_schema_object(map, item);
+    }
+}
+
+fn merge_schema_object(target: &mut Map<String, Value>, source: Map<String, Value>) {
+    for (key, value) in source {
+        if key == "properties" {
+            let target_properties = target
+                .entry(key)
+                .or_insert_with(|| Value::Object(Map::new()));
+            if let (Some(target), Value::Object(source)) =
+                (target_properties.as_object_mut(), value)
+            {
+                target.extend(source);
+            }
+            continue;
+        }
+        target.entry(key).or_insert(value);
+    }
+}
+
 fn wrap_root_schema(schema: &mut Value) {
     let Value::Object(root) = schema else {
         return;
     };
-    let mut definitions = root
-        .remove("definitions")
-        .and_then(|definitions| match definitions {
-            Value::Object(definitions) => Some(definitions),
-            _ => None,
-        })
-        .unwrap_or_default();
+    root.remove("definitions");
+    let mut definitions = Map::new();
     let mut root_definition = Map::new();
     for key in [
         "additionalProperties",
@@ -840,7 +916,7 @@ mod tests {
     use super::generate_config_schema_json;
 
     #[test]
-    fn schema_option_definitions_expose_expected_keys() {
+    fn schema_option_sets_expose_expected_keys() {
         let schema = generated_schema();
         let shared = [
             "all",
@@ -862,28 +938,28 @@ mod tests {
             "until",
         ];
 
-        assert_properties(&schema, "SharedOptions", &shared);
-        assert_properties(
+        assert_schema_properties(&schema, &["defaults"], &shared);
+        assert_schema_properties(
             &schema,
-            "DailyOptions",
+            &["commands", "daily"],
             &with_keys(&shared, &["instances", "project", "projectAliases"]),
         );
-        assert_properties(
+        assert_schema_properties(
             &schema,
-            "WeeklyOptions",
+            &["commands", "weekly"],
             &with_keys(&shared, &["startOfWeek"]),
         );
-        assert_properties(
+        assert_schema_properties(
             &schema,
-            "BlocksOptions",
+            &["commands", "blocks"],
             &with_keys(
                 &shared,
                 &["active", "recent", "sessionLength", "tokenLimit"],
             ),
         );
-        assert_properties(
+        assert_schema_properties(
             &schema,
-            "StatuslineOptions",
+            &["commands", "statusline"],
             &[
                 "cache",
                 "contextLowThreshold",
@@ -897,67 +973,39 @@ mod tests {
                 "visualBurnRate",
             ],
         );
-        assert_properties(&schema, "CodexOptions", &with_keys(&shared, &["speed"]));
-        assert_properties(&schema, "PiOptions", &with_keys(&shared, &["piPath"]));
-        assert_properties(
+        assert_schema_properties(
             &schema,
-            "OpenClawOptions",
+            &["codex", "defaults"],
+            &with_keys(&shared, &["speed"]),
+        );
+        assert_schema_properties(
+            &schema,
+            &["pi", "defaults"],
+            &with_keys(&shared, &["piPath"]),
+        );
+        assert_schema_properties(
+            &schema,
+            &["openclaw", "defaults"],
             &with_keys(&shared, &["openClawPath"]),
         );
     }
 
     #[test]
-    fn agent_configs_reference_only_supported_option_sets() {
+    fn agent_configs_expose_only_supported_option_sets() {
         let schema = generated_schema();
 
-        assert_eq!(
-            property_ref(&schema, "CodexConfig", "defaults"),
-            Some("#/definitions/CodexOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "OpenCodeConfig", "defaults"),
-            Some("#/definitions/SharedOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "AmpConfig", "defaults"),
-            Some("#/definitions/SharedOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "DroidConfig", "defaults"),
-            Some("#/definitions/SharedOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "CodebuffConfig", "defaults"),
-            Some("#/definitions/SharedOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "PiConfig", "defaults"),
-            Some("#/definitions/PiOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "GooseConfig", "defaults"),
-            Some("#/definitions/SharedOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "OpenClawConfig", "defaults"),
-            Some("#/definitions/OpenClawOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "KiloConfig", "defaults"),
-            Some("#/definitions/SharedOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "GeminiConfig", "defaults"),
-            Some("#/definitions/SharedOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "KimiConfig", "defaults"),
-            Some("#/definitions/SharedOptions")
-        );
-        assert_eq!(
-            property_ref(&schema, "QwenConfig", "defaults"),
-            Some("#/definitions/SharedOptions")
-        );
+        assert!(schema_property(&schema, &["codex", "defaults", "speed"]).is_some());
+        assert!(schema_property(&schema, &["opencode", "defaults", "speed"]).is_none());
+        assert!(schema_property(&schema, &["amp", "defaults", "speed"]).is_none());
+        assert!(schema_property(&schema, &["droid", "defaults", "speed"]).is_none());
+        assert!(schema_property(&schema, &["codebuff", "defaults", "speed"]).is_none());
+        assert!(schema_property(&schema, &["pi", "defaults", "piPath"]).is_some());
+        assert!(schema_property(&schema, &["goose", "defaults", "piPath"]).is_none());
+        assert!(schema_property(&schema, &["openclaw", "defaults", "openClawPath"]).is_some());
+        assert!(schema_property(&schema, &["kilo", "defaults", "openClawPath"]).is_none());
+        assert!(schema_property(&schema, &["gemini", "defaults", "openClawPath"]).is_none());
+        assert!(schema_property(&schema, &["kimi", "defaults", "openClawPath"]).is_none());
+        assert!(schema_property(&schema, &["qwen", "defaults", "openClawPath"]).is_none());
     }
 
     #[test]
@@ -977,6 +1025,15 @@ mod tests {
             schema["$ref"].as_str(),
             Some("#/definitions/ccusage-config")
         );
+        assert_eq!(
+            schema["definitions"]
+                .as_object()
+                .unwrap()
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            vec!["ccusage-config"]
+        );
         assert_properties(
             &schema,
             "ccusage-config",
@@ -985,6 +1042,10 @@ mod tests {
                 "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi", "qwen",
                 "droid",
             ],
+        );
+        assert!(
+            schema["definitions"]["ccusage-config"]["properties"]["defaults"]["properties"]
+                .is_object()
         );
     }
 
@@ -1128,47 +1189,57 @@ mod tests {
     }
 
     #[test]
+    fn schema_allows_repository_example_config() {
+        let schema = generated_schema();
+        let config =
+            serde_json::from_str::<Value>(include_str!("../../../../ccusage.example.json"))
+                .unwrap();
+
+        assert_value_keys_allowed_by_schema(&config, &schema, &schema);
+    }
+
+    #[test]
     fn generated_schema_exposes_cli_defaults() {
         let schema = generated_schema();
 
         assert_eq!(
-            property_default(&schema, "SharedOptions", "json"),
+            property_default(&schema, &["defaults", "json"]),
             Some(&json!(false))
         );
         assert_eq!(
-            property_default(&schema, "SharedOptions", "mode"),
+            property_default(&schema, &["defaults", "mode"]),
             Some(&json!("auto"))
         );
         assert_eq!(
-            property_default(&schema, "SharedOptions", "debugSamples"),
+            property_default(&schema, &["defaults", "debugSamples"]),
             Some(&json!(5))
         );
         assert_eq!(
-            property_default(&schema, "SharedOptions", "order"),
+            property_default(&schema, &["defaults", "order"]),
             Some(&json!("asc"))
         );
         assert_eq!(
-            property_default(&schema, "WeeklyOptions", "startOfWeek"),
+            property_default(&schema, &["commands", "weekly", "startOfWeek"]),
             Some(&json!("sunday"))
         );
         assert_eq!(
-            property_default(&schema, "BlocksOptions", "sessionLength"),
+            property_default(&schema, &["commands", "blocks", "sessionLength"]),
             Some(&json!(5.0))
         );
         assert_eq!(
-            property_default(&schema, "StatuslineOptions", "offline"),
+            property_default(&schema, &["commands", "statusline", "offline"]),
             Some(&json!(true))
         );
         assert_eq!(
-            property_default(&schema, "StatuslineOptions", "visualBurnRate"),
+            property_default(&schema, &["commands", "statusline", "visualBurnRate"]),
             Some(&json!("off"))
         );
         assert_eq!(
-            property_default(&schema, "StatuslineOptions", "refreshInterval"),
+            property_default(&schema, &["commands", "statusline", "refreshInterval"]),
             Some(&json!(1))
         );
         assert_eq!(
-            property_default(&schema, "CodexOptions", "speed"),
+            property_default(&schema, &["codex", "defaults", "speed"]),
             Some(&json!("auto"))
         );
     }
@@ -1194,16 +1265,38 @@ mod tests {
             .collect()
     }
 
-    fn property_ref<'a>(schema: &'a Value, definition: &str, property: &str) -> Option<&'a str> {
-        schema["definitions"][definition]["properties"][property]["$ref"].as_str()
+    fn assert_schema_properties(schema: &Value, path: &[&str], expected: &[&str]) {
+        assert_eq!(
+            schema_properties(schema, path),
+            expected.iter().copied().collect::<BTreeSet<_>>(),
+            "{path:?} properties did not match"
+        );
     }
 
-    fn property_default<'a>(
-        schema: &'a Value,
-        definition: &str,
-        property: &str,
-    ) -> Option<&'a Value> {
-        schema["definitions"][definition]["properties"][property].get("default")
+    fn schema_properties<'a>(schema: &'a Value, path: &[&str]) -> BTreeSet<&'a str> {
+        schema_node(schema, path)["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect()
+    }
+
+    fn property_default<'a>(schema: &'a Value, path: &[&str]) -> Option<&'a Value> {
+        schema_property(schema, path).and_then(|property| property.get("default"))
+    }
+
+    fn schema_property<'a>(schema: &'a Value, path: &[&str]) -> Option<&'a Value> {
+        let (property, parent_path) = path.split_last().unwrap();
+        schema_node(schema, parent_path)["properties"].get(*property)
+    }
+
+    fn schema_node<'a>(schema: &'a Value, path: &[&str]) -> &'a Value {
+        let mut node = &schema["definitions"]["ccusage-config"];
+        for segment in path {
+            node = &node["properties"][*segment];
+        }
+        node
     }
 
     fn with_keys<'a>(base: &[&'a str], extra: &[&'a str]) -> Vec<&'a str> {


### PR DESCRIPTION
## Summary

- Restores the generated config schema to the v19-style expanded root definition shape.
- Expands internal refs/allOf before publishing so editor consumers see only #/definitions/ccusage-config.
- Documents root commands.daily with daily-specific options so ccusage.example.json is accepted by the schema.

## Testing

- pnpm run format
- pnpm typecheck
- pnpm run test
- cargo run --quiet --manifest-path rust/Cargo.toml -p ccusage --bin ccusage -- --config ccusage.example.json daily --json


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the generated config schema to the legacy v19 expanded shape so editors see a single `ccusage-config` definition with no internal refs/allOf. Also fixes the `daily` command schema so `ccusage.example.json` validates.

- **Bug Fixes**
  - Inline `$ref` and `allOf` before publishing and expose only `definitions.ccusage-config` (v19 expanded shape).
  - Change `RootCommandsConfig.daily` to `DailyOptions` and document daily-only fields; accept `ccusage.example.json`.
  - Update tests to cover the expanded shape, defaults, and repository example config.

<sup>Written for commit 7ae675a777c8498e178ca686454c9d5e8bae7206. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1074?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to ensure the example configuration file conforms to the schema.

* **Changes**
  * Daily command configuration options updated for more specific and targeted settings and defaults.

* **Refactor**
  * Schema generation improved to inline and consolidate references, producing clearer, tighter schema output and more precise default values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1074?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->