### PR TITLE
refactor(rust): reduce agent command duplication

### DIFF
--- a/rust/crates/ccusage/src/adapter/all.rs
+++ b/rust/crates/ccusage/src/adapter/all.rs
@@ -278,6 +278,23 @@ fn append_agent_rows(
     rows.extend(agent_rows.rows);
 }
 
+fn load_summary_agent_rows(
+    agent: &'static str,
+    kind: AgentReportKind,
+    shared: &SharedArgs,
+    load_entries: impl FnOnce() -> Result<Vec<LoadedEntry>>,
+    summarize_entries: impl FnOnce(&[LoadedEntry], AgentReportKind) -> Result<Vec<UsageSummary>>,
+) -> Result<AgentRows> {
+    let mut entries = load_entries()?;
+    let detected = !entries.is_empty();
+    filter_loaded_entries_by_date(&mut entries, shared);
+    let summaries = summarize_entries(&entries, kind)?;
+    Ok(AgentRows {
+        rows: summary_rows(agent, summaries),
+        detected,
+    })
+}
+
 fn load_claude_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRows> {
     let mut entries = crate::load_entries(shared, None)?;
     let detected = !entries.is_empty();
@@ -315,14 +332,13 @@ fn load_codex_rows(
 }
 
 fn load_opencode_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRows> {
-    let mut entries = opencode::loader::load_entries(shared)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = opencode::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("opencode", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "opencode",
+        kind,
+        shared,
+        || opencode::loader::load_entries(shared),
+        opencode::summarize_entries,
+    )
 }
 
 fn load_amp_rows(
@@ -330,14 +346,13 @@ fn load_amp_rows(
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
-    let mut entries = amp::load_entries(shared, pricing)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = amp::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("amp", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "amp",
+        kind,
+        shared,
+        || amp::load_entries(shared, pricing),
+        amp::summarize_entries,
+    )
 }
 
 fn load_droid_rows(
@@ -345,14 +360,13 @@ fn load_droid_rows(
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
-    let mut entries = droid::load_entries(shared, pricing)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = droid::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("droid", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "droid",
+        kind,
+        shared,
+        || droid::load_entries(shared, pricing),
+        droid::summarize_entries,
+    )
 }
 
 fn load_codebuff_rows(
@@ -360,14 +374,13 @@ fn load_codebuff_rows(
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
-    let mut entries = codebuff::load_entries(shared, pricing)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = codebuff::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("codebuff", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "codebuff",
+        kind,
+        shared,
+        || codebuff::load_entries(shared, pricing),
+        codebuff::summarize_entries,
+    )
 }
 
 fn load_hermes_rows(
@@ -375,14 +388,13 @@ fn load_hermes_rows(
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
-    let mut entries = hermes::load_entries(shared, pricing)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = hermes::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("hermes", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "hermes",
+        kind,
+        shared,
+        || hermes::load_entries(shared, pricing),
+        hermes::summarize_entries,
+    )
 }
 
 fn load_pi_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRows> {
@@ -407,25 +419,23 @@ fn load_goose_rows(
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
-    let mut entries = goose::load_entries(shared, pricing)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = goose::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("goose", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "goose",
+        kind,
+        shared,
+        || goose::load_entries(shared, pricing),
+        goose::summarize_entries,
+    )
 }
 
 fn load_openclaw_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRows> {
-    let mut entries = openclaw::load_entries(shared, None)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = openclaw::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("openclaw", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "openclaw",
+        kind,
+        shared,
+        || openclaw::load_entries(shared, None),
+        openclaw::summarize_entries,
+    )
 }
 
 fn load_copilot_rows(
@@ -433,14 +443,13 @@ fn load_copilot_rows(
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
-    let mut entries = copilot::load_entries(shared, pricing)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = copilot::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("copilot", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "copilot",
+        kind,
+        shared,
+        || copilot::load_entries(shared, pricing),
+        copilot::summarize_entries,
+    )
 }
 
 fn load_kilo_rows(
@@ -448,14 +457,13 @@ fn load_kilo_rows(
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
-    let mut entries = kilo::load_entries(shared, pricing)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = kilo::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("kilo", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "kilo",
+        kind,
+        shared,
+        || kilo::load_entries(shared, pricing),
+        kilo::summarize_entries,
+    )
 }
 
 fn load_gemini_rows(
@@ -463,14 +471,13 @@ fn load_gemini_rows(
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
-    let mut entries = gemini::load_entries(shared, pricing)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = gemini::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("gemini", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "gemini",
+        kind,
+        shared,
+        || gemini::load_entries(shared, pricing),
+        gemini::summarize_entries,
+    )
 }
 
 fn load_kimi_rows(
@@ -478,14 +485,13 @@ fn load_kimi_rows(
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
-    let mut entries = kimi::load_entries(shared, pricing)?;
-    let detected = !entries.is_empty();
-    filter_loaded_entries_by_date(&mut entries, shared);
-    let summaries = kimi::summarize_entries(&entries, kind)?;
-    Ok(AgentRows {
-        rows: summary_rows("kimi", summaries),
-        detected,
-    })
+    load_summary_agent_rows(
+        "kimi",
+        kind,
+        shared,
+        || kimi::load_entries(shared, pricing),
+        kimi::summarize_entries,
+    )
 }
 
 fn load_qwen_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRows> {

--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -131,6 +131,19 @@ pub(crate) enum AgentReportKind {
     Session,
 }
 
+const STANDARD_AGENT_REPORTS: &[(&str, AgentReportKind)] = &[
+    ("daily", AgentReportKind::Daily),
+    ("monthly", AgentReportKind::Monthly),
+    ("session", AgentReportKind::Session),
+];
+
+const OPENCODE_AGENT_REPORTS: &[(&str, AgentReportKind)] = &[
+    ("daily", AgentReportKind::Daily),
+    ("weekly", AgentReportKind::Weekly),
+    ("monthly", AgentReportKind::Monthly),
+    ("session", AgentReportKind::Session),
+];
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) enum CodexSpeed {
     #[default]
@@ -353,18 +366,80 @@ fn parse_command(
         }
         "claude" => parse_claude_command(parser, shared, config),
         "codex" => parse_codex_command(parser, shared, config),
-        "opencode" => parse_opencode_command(parser, shared, config),
-        "amp" => parse_amp_command(parser, shared, config),
-        "droid" => parse_droid_command(parser, shared, config),
-        "codebuff" => parse_codebuff_command(parser, shared, config),
-        "hermes" => parse_hermes_command(parser, shared, config),
+        "opencode" => parse_basic_agent_command(
+            parser,
+            shared,
+            "opencode",
+            OPENCODE_AGENT_REPORTS,
+            Command::OpenCode,
+        ),
+        "amp" => {
+            parse_basic_agent_command(parser, shared, "amp", STANDARD_AGENT_REPORTS, Command::Amp)
+        }
+        "droid" => parse_basic_agent_command(
+            parser,
+            shared,
+            "droid",
+            STANDARD_AGENT_REPORTS,
+            Command::Droid,
+        ),
+        "codebuff" => parse_basic_agent_command(
+            parser,
+            shared,
+            "codebuff",
+            STANDARD_AGENT_REPORTS,
+            Command::Codebuff,
+        ),
+        "hermes" => parse_basic_agent_command(
+            parser,
+            shared,
+            "hermes",
+            STANDARD_AGENT_REPORTS,
+            Command::Hermes,
+        ),
         "pi" => parse_pi_command(parser, shared, config),
-        "goose" => parse_goose_command(parser, shared, config),
-        "kilo" => parse_kilo_command(parser, shared, config),
-        "copilot" => parse_copilot_command(parser, shared, config),
-        "gemini" => parse_gemini_command(parser, shared, config),
-        "kimi" => parse_kimi_command(parser, shared, config),
-        "qwen" => parse_qwen_command(parser, shared, config),
+        "goose" => parse_basic_agent_command(
+            parser,
+            shared,
+            "goose",
+            STANDARD_AGENT_REPORTS,
+            Command::Goose,
+        ),
+        "kilo" => parse_basic_agent_command(
+            parser,
+            shared,
+            "kilo",
+            STANDARD_AGENT_REPORTS,
+            Command::Kilo,
+        ),
+        "copilot" => parse_basic_agent_command(
+            parser,
+            shared,
+            "copilot",
+            STANDARD_AGENT_REPORTS,
+            Command::Copilot,
+        ),
+        "gemini" => parse_basic_agent_command(
+            parser,
+            shared,
+            "gemini",
+            STANDARD_AGENT_REPORTS,
+            Command::Gemini,
+        ),
+        "kimi" => parse_basic_agent_command(
+            parser,
+            shared,
+            "kimi",
+            STANDARD_AGENT_REPORTS,
+            Command::Kimi,
+        ),
+        "qwen" => parse_basic_agent_command(
+            parser,
+            shared,
+            "qwen",
+            STANDARD_AGENT_REPORTS,
+            Command::Qwen,
+        ),
         "openclaw" => parse_openclaw_command(parser, shared, config),
         _ => Err(format!("Unknown command '{command}'")),
     }
@@ -499,29 +574,26 @@ fn parse_claude_command(
     }
 }
 
+fn parse_basic_agent_command(
+    parser: &mut ArgParser,
+    mut shared: SharedArgs,
+    agent: &str,
+    reports: &[(&str, AgentReportKind)],
+    command: fn(AgentCommandArgs) -> Command,
+) -> Result<Command, String> {
+    let kind = parse_agent_report_kind(parser, agent, reports)?;
+    while parser.peek().is_some() {
+        parse_shared_arg(parser, &mut shared)?;
+    }
+    Ok(command(agent_command_args(shared, kind)))
+}
+
 fn parse_codex_command(
     parser: &mut ArgParser,
     mut shared: SharedArgs,
     config: &ConfigContext,
 ) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown codex command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
+    let kind = parse_agent_report_kind(parser, "codex", STANDARD_AGENT_REPORTS)?;
     let mut codex_speed = CodexSpeed::Auto;
     apply_config_to_agent_args(&mut codex_speed, None, None, config);
     while parser.peek().is_some() {
@@ -542,208 +614,12 @@ fn parse_codex_command(
     }))
 }
 
-fn parse_opencode_command(
-    parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("weekly") => {
-            parser.next();
-            AgentReportKind::Weekly
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown opencode command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
-    }
-    Ok(Command::OpenCode(AgentCommandArgs {
-        shared,
-        kind,
-        pi_path: None,
-        open_claw_path: None,
-        codex_speed: CodexSpeed::Auto,
-    }))
-}
-
-fn parse_amp_command(
-    parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown amp command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
-    }
-    Ok(Command::Amp(AgentCommandArgs {
-        shared,
-        kind,
-        pi_path: None,
-        open_claw_path: None,
-        codex_speed: CodexSpeed::Auto,
-    }))
-}
-
-fn parse_droid_command(
-    parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown droid command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
-    }
-    Ok(Command::Droid(AgentCommandArgs {
-        shared,
-        kind,
-        pi_path: None,
-        open_claw_path: None,
-        codex_speed: CodexSpeed::Auto,
-    }))
-}
-
-fn parse_codebuff_command(
-    parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown codebuff command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
-    }
-    Ok(Command::Codebuff(AgentCommandArgs {
-        shared,
-        kind,
-        pi_path: None,
-        open_claw_path: None,
-        codex_speed: CodexSpeed::Auto,
-    }))
-}
-
-fn parse_hermes_command(
-    parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown hermes command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
-    }
-    Ok(Command::Hermes(AgentCommandArgs {
-        shared,
-        kind,
-        pi_path: None,
-        open_claw_path: None,
-        codex_speed: CodexSpeed::Auto,
-    }))
-}
-
 fn parse_pi_command(
     parser: &mut ArgParser,
     mut shared: SharedArgs,
     config: &ConfigContext,
 ) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown pi command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
+    let kind = parse_agent_report_kind(parser, "pi", STANDARD_AGENT_REPORTS)?;
     let mut pi_path = None;
     let mut codex_speed = CodexSpeed::Auto;
     apply_config_to_agent_args(&mut codex_speed, Some(&mut pi_path), None, config);
@@ -765,64 +641,12 @@ fn parse_pi_command(
     }))
 }
 
-fn parse_goose_command(
-    parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown goose command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
-    }
-    Ok(Command::Goose(AgentCommandArgs {
-        shared,
-        kind,
-        pi_path: None,
-        open_claw_path: None,
-        codex_speed: CodexSpeed::Auto,
-    }))
-}
-
 fn parse_openclaw_command(
     parser: &mut ArgParser,
     mut shared: SharedArgs,
     config: &ConfigContext,
 ) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown openclaw command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
+    let kind = parse_agent_report_kind(parser, "openclaw", STANDARD_AGENT_REPORTS)?;
     let mut open_claw_path = None;
     let mut codex_speed = CodexSpeed::Auto;
     apply_config_to_agent_args(&mut codex_speed, None, Some(&mut open_claw_path), config);
@@ -844,144 +668,32 @@ fn parse_openclaw_command(
     }))
 }
 
-fn parse_copilot_command(
+fn parse_agent_report_kind(
     parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown copilot command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
+    agent: &str,
+    reports: &[(&str, AgentReportKind)],
+) -> Result<AgentReportKind, String> {
+    let Some(command) = parser.peek() else {
+        return Ok(AgentReportKind::Daily);
     };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
+    if let Some((_, kind)) = reports.iter().find(|(report, _)| *report == command) {
+        parser.next();
+        return Ok(*kind);
     }
-    Ok(Command::Copilot(AgentCommandArgs {
-        shared,
-        kind,
-        pi_path: None,
-        open_claw_path: None,
-        codex_speed: CodexSpeed::Auto,
-    }))
+    if !command.starts_with('-') {
+        return Err(format!("Unknown {agent} command '{command}'"));
+    }
+    Ok(AgentReportKind::Daily)
 }
 
-fn parse_kilo_command(
-    parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown kilo command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
-    }
-    Ok(Command::Kilo(AgentCommandArgs {
+fn agent_command_args(shared: SharedArgs, kind: AgentReportKind) -> AgentCommandArgs {
+    AgentCommandArgs {
         shared,
         kind,
         pi_path: None,
         open_claw_path: None,
         codex_speed: CodexSpeed::Auto,
-    }))
-}
-
-fn parse_gemini_command(
-    parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown gemini command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
     }
-    Ok(Command::Gemini(AgentCommandArgs {
-        shared,
-        kind,
-        pi_path: None,
-        open_claw_path: None,
-        codex_speed: CodexSpeed::Auto,
-    }))
-}
-
-fn parse_kimi_command(
-    parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown kimi command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
-    }
-    Ok(Command::Kimi(AgentCommandArgs {
-        shared,
-        kind,
-        pi_path: None,
-        open_claw_path: None,
-        codex_speed: CodexSpeed::Auto,
-    }))
 }
 
 fn parse_shared_arg_for_command(
@@ -1782,41 +1494,6 @@ fn codebuff_report_help(report: &str) -> String {
         &format!("ccusage codebuff {report} <OPTIONS>"),
         agent_options(),
     )
-}
-
-fn parse_qwen_command(
-    parser: &mut ArgParser,
-    mut shared: SharedArgs,
-    _config: &ConfigContext,
-) -> Result<Command, String> {
-    let kind = match parser.peek() {
-        Some("daily") => {
-            parser.next();
-            AgentReportKind::Daily
-        }
-        Some("monthly") => {
-            parser.next();
-            AgentReportKind::Monthly
-        }
-        Some("session") => {
-            parser.next();
-            AgentReportKind::Session
-        }
-        Some(command) if !command.starts_with('-') => {
-            return Err(format!("Unknown qwen command '{command}'"));
-        }
-        _ => AgentReportKind::Daily,
-    };
-    while parser.peek().is_some() {
-        parse_shared_arg(parser, &mut shared)?;
-    }
-    Ok(Command::Qwen(AgentCommandArgs {
-        shared,
-        kind,
-        pi_path: None,
-        open_claw_path: None,
-        codex_speed: CodexSpeed::Auto,
-    }))
 }
 
 fn qwen_report_help(report: &str) -> String {


### PR DESCRIPTION
## Summary

- Share standard Rust agent report parsing through one helper while leaving Codex, pi-agent, and OpenClaw option parsing explicit.
- Share the common all-agent row loading flow for adapters that only load entries, apply date filters, summarize, and convert rows.
- Stop at the point where further extraction would mostly affect help text, schema mapping, tests, or source-specific parser behavior.

## Validation

- \`direnv exec . similarity-rs rust --threshold 0.90 --min-lines 5\` (duplicate pairs: 350 -> 206)
- \`direnv exec . pnpm run format\`
- \`direnv exec . pnpm typecheck\`
- \`direnv exec . pnpm run test\`
- pre-push hook: \`oxfmt\`, \`clippy\`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors agent CLI parsing and report loading to remove duplication with shared helpers, while keeping `codex`, `pi`, and `openclaw` special cases intact. No behavior changes; similarity duplicates drop from 350 to 206.

- Refactors
  - CLI: adds a generic parser for standard agents (daily/monthly/session) and supports `opencode` weekly; `codex`, `pi`, and `openclaw` keep explicit option handling.
  - Adapters: introduces a shared load/filter/summarize/rows path used by `amp`, `droid`, `codebuff`, `hermes`, `goose`, `copilot`, `kilo`, `gemini`, `kimi`, and `opencode`.
  - Keeps the parallel loading and aggregation logic unchanged.

<sup>Written for commit 6802bbd48e6c635e52b205b11d8bf7b5d21ac62a. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1075?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate agent data processing logic to improve code maintainability and consistency.
  * Simplified command-line parsing infrastructure for better internal organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->