### PR TITLE
docs(skills): align agent rules with Rust CLI

### DIFF
--- a/.agents/skills/ast-grep/SKILL.md
+++ b/.agents/skills/ast-grep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ast-grep
-description: Guides ccusage structural code searches with ast-grep. Use when finding syntax patterns, validating migrations, or writing AST-based search commands.
+description: Guides ccusage structural code searches with ast-grep. Use when finding Rust or TypeScript syntax patterns, validating migrations, or writing AST-based search commands.
 ---
 
 # ast-grep
@@ -12,12 +12,14 @@ Use ast-grep when a search needs syntax structure rather than plain text. Prefer
 This repo provides `ast-grep` through `flake.nix`. Run commands from the Nix dev shell, or use `direnv exec .` when the shell is not already active:
 
 ```sh
+direnv exec . ast-grep run --lang rust --pattern 'println!($$$ARGS)' rust
 direnv exec . ast-grep run --lang ts --pattern '/$P/' --json=stream apps packages
 ```
 
 If `direnv` is unavailable and this is a one-off search, use comma as a fallback:
 
 ```sh
+, ast-grep run --lang rust --pattern 'println!($$$ARGS)' rust
 , ast-grep run --lang ts --pattern '/$P/' --json=stream apps packages
 ```
 
@@ -33,12 +35,14 @@ If `direnv` is unavailable and this is a one-off search, use comma as a fallback
 For quick pattern searches:
 
 ```sh
+ast-grep run --lang rust --pattern 'pub fn $NAME($$$ARGS) -> $RET { $$$BODY }' rust
 ast-grep run --lang ts --pattern 'console.log($ARG)' apps packages
 ```
 
 For JSON output that scripts can consume:
 
 ```sh
+ast-grep run --lang rust --pattern 'String::from($ARG)' --json=stream rust
 ast-grep run --lang ts --pattern '/$P/' --json=stream apps packages
 ```
 

--- a/.agents/skills/bun-cpu-profile/SKILL.md
+++ b/.agents/skills/bun-cpu-profile/SKILL.md
@@ -1,29 +1,33 @@
 ---
 name: bun-cpu-profile
-description: Profiles Bun TypeScript and JavaScript CLI CPU performance. Use when debugging slow execution, reading CPU profiles, or comparing branch speed with hyperfine.
+description: Profiles Bun TypeScript and JavaScript package scripts. Use for launcher, benchmark, or packaging hot paths; use ccusage-rust-profile for native CLI performance.
 ---
 
 # Bun CPU Profile
+
+Use this skill for TypeScript package scripts. The production CLI is Rust-first,
+so native command performance work should use the `ccusage-rust-profile` skill
+instead.
 
 ## Workflow
 
 Use Bun's markdown CPU profile first because it is grep-friendly and compact enough for agent analysis. Generate `.cpuprofile` as well when a flamegraph or Chrome DevTools / VS Code inspection is useful.
 
 ```sh
-bun --cpu-prof --cpu-prof-md --cpu-prof-dir ./profiles --cpu-prof-name ccusage.cpuprofile ./src/index.ts daily --offline --json
+pnpm exec bun --cpu-prof --cpu-prof-md --cpu-prof-dir ./profiles --cpu-prof-name ccusage-perf.cpuprofile apps/ccusage/scripts/compare-pr-performance.ts --help
 ```
 
 For package scripts, inject profiler flags without rewriting the command:
 
 ```sh
-BUN_OPTIONS="--cpu-prof --cpu-prof-md --cpu-prof-dir ./profiles" pnpm --filter ccusage run start daily --offline --json
+BUN_OPTIONS="--cpu-prof --cpu-prof-md --cpu-prof-dir ./profiles" pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts --help
 ```
 
 Keep benchmark runs quiet and deterministic:
 
 ```sh
-LOG_LEVEL=0 COLUMNS=200 bun --cpu-prof-md ./src/index.ts daily --offline --json >/tmp/ccusage.json
-jq -e . /tmp/ccusage.json >/dev/null
+LOG_LEVEL=0 COLUMNS=200 pnpm exec bun --cpu-prof-md apps/ccusage/scripts/compare-pr-performance.ts --help >/tmp/ccusage-profile.txt
+test -s /tmp/ccusage-profile.txt
 ```
 
 For branch-vs-main profiling, reading profile output, and Bun reference lookup, read `references/profile-workflow.md`.

--- a/.agents/skills/bun-cpu-profile/SKILL.md
+++ b/.agents/skills/bun-cpu-profile/SKILL.md
@@ -11,23 +11,44 @@ instead.
 
 ## Workflow
 
-Use Bun's markdown CPU profile first because it is grep-friendly and compact enough for agent analysis. Generate `.cpuprofile` as well when a flamegraph or Chrome DevTools / VS Code inspection is useful.
+Use Bun's markdown CPU profile first because it is grep-friendly and compact enough for agent analysis. Generate `.cpuprofile` as well when a flamegraph or Chrome DevTools / VS Code inspection is useful. Inspect script options with `--help`, but do not treat help output as a profiling workload.
 
 ```sh
-pnpm exec bun --cpu-prof --cpu-prof-md --cpu-prof-dir ./profiles --cpu-prof-name ccusage-perf.cpuprofile apps/ccusage/scripts/compare-pr-performance.ts --help
+pnpm exec bun --cpu-prof --cpu-prof-md --cpu-prof-dir ./profiles --cpu-prof-name ccusage-perf.cpuprofile apps/ccusage/scripts/compare-pr-performance.ts \
+	--base-dir /tmp/ccusage-main \
+	--head-dir "$PWD" \
+	--fixture-dir apps/ccusage/test/fixtures/claude \
+	--codex-fixture-dir apps/ccusage/test/fixtures/codex \
+	--runs 1 \
+	--warmup 0 \
+	--output /tmp/ccusage-perf-comment.md
 ```
 
 For package scripts, inject profiler flags without rewriting the command:
 
 ```sh
-BUN_OPTIONS="--cpu-prof --cpu-prof-md --cpu-prof-dir ./profiles" pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts --help
+BUN_OPTIONS="--cpu-prof --cpu-prof-md --cpu-prof-dir ./profiles" pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts \
+	--base-dir /tmp/ccusage-main \
+	--head-dir "$PWD" \
+	--fixture-dir apps/ccusage/test/fixtures/claude \
+	--codex-fixture-dir apps/ccusage/test/fixtures/codex \
+	--runs 1 \
+	--warmup 0 \
+	--output /tmp/ccusage-perf-comment.md
 ```
 
 Keep benchmark runs quiet and deterministic:
 
 ```sh
-LOG_LEVEL=0 COLUMNS=200 pnpm exec bun --cpu-prof-md apps/ccusage/scripts/compare-pr-performance.ts --help >/tmp/ccusage-profile.txt
-test -s /tmp/ccusage-profile.txt
+LOG_LEVEL=0 COLUMNS=200 pnpm exec bun --cpu-prof-md apps/ccusage/scripts/compare-pr-performance.ts \
+	--base-dir /tmp/ccusage-main \
+	--head-dir "$PWD" \
+	--fixture-dir apps/ccusage/test/fixtures/claude \
+	--codex-fixture-dir apps/ccusage/test/fixtures/codex \
+	--runs 1 \
+	--warmup 0 \
+	--output /tmp/ccusage-perf-comment.md
+test -s /tmp/ccusage-perf-comment.md
 ```
 
 For branch-vs-main profiling, reading profile output, and Bun reference lookup, read `references/profile-workflow.md`.

--- a/.agents/skills/bun-cpu-profile/references/profile-workflow.md
+++ b/.agents/skills/bun-cpu-profile/references/profile-workflow.md
@@ -14,11 +14,12 @@ pnpm install
 pnpm --filter ccusage build
 ```
 
-Run the same command against both builds. Prefer the published Bun entry shape when profiling bundled CLI performance.
+Run the same command against both builds. Prefer the published package entry
+shape when profiling package startup or launcher behavior.
 
 ```sh
-LOG_LEVEL=0 COLUMNS=200 bun -b apps/ccusage/dist/index.js daily --offline --json >/tmp/head.json
-LOG_LEVEL=0 COLUMNS=200 bun -b /tmp/ccusage-main/apps/ccusage/dist/index.js daily --offline --json >/tmp/main.json
+LOG_LEVEL=0 COLUMNS=200 node apps/ccusage/dist/cli.js daily --offline --json >/tmp/head.json
+LOG_LEVEL=0 COLUMNS=200 node /tmp/ccusage-main/apps/ccusage/dist/cli.js daily --offline --json >/tmp/main.json
 jq -e . /tmp/head.json >/dev/null
 jq -e . /tmp/main.json >/dev/null
 ```
@@ -27,15 +28,15 @@ Measure end-to-end command latency with hyperfine before trusting a CPU profile 
 
 ```sh
 hyperfine --warmup 4 --runs 10 --shell none \
-	"bun -b apps/ccusage/dist/index.js daily --offline --json" \
-	"bun -b /tmp/ccusage-main/apps/ccusage/dist/index.js daily --offline --json" \
+	"node apps/ccusage/dist/cli.js daily --offline --json" \
+	"node /tmp/ccusage-main/apps/ccusage/dist/cli.js daily --offline --json" \
 	--export-json /tmp/ccusage-hyperfine.json
 ```
 
 If `hyperfine` is missing, use comma first:
 
 ```sh
-, hyperfine --warmup 4 --runs 10 --shell none "bun -b apps/ccusage/dist/index.js daily --offline --json"
+, hyperfine --warmup 4 --runs 10 --shell none "node apps/ccusage/dist/cli.js daily --offline --json"
 ```
 
 ## Reading Profiles

--- a/.agents/skills/ccusage-agent-sources/SKILL.md
+++ b/.agents/skills/ccusage-agent-sources/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: ccusage-agent-sources
-description: Guides ccusage agent source work for Claude Code, Codex, OpenCode, Amp, and pi-agent parsers, log paths, token mappings, costs, and reports.
+description: Guides ccusage agent source work for Rust CLI parsers, log paths, token mappings, costs, reports, and adapter command behavior.
 ---
 
 # ccusage Agent Sources
 
-Use this skill when touching data loading, token normalization, cost calculation, or commands for any ccusage app.
+Use this skill when touching data loading, token normalization, cost calculation,
+or commands for any ccusage agent adapter.
 
 ## Shared Report Concepts
 
@@ -44,44 +45,60 @@ Read only the relevant reference before changing parser behavior, token mappings
 ## Implementation Notes
 
 - Treat Codex, OpenCode, Amp, and pi-agent as agent subcommands under the unified `ccusage` CLI.
-- Reuse shared packages such as `@ccusage/terminal`, `@ccusage/internal`, pricing helpers, and logging where appropriate.
+- Reuse shared Rust modules for rendering, table layout, logging, date formatting,
+  progress, pricing, file walking, and aggregation where appropriate.
 - Keep command names and flag semantics aligned unless the source data forces a difference.
 - Internal workspace runtime libraries for bundled/private packages belong in `devDependencies`.
 
 ## Adapter Layout
 
-New or migrated agent implementations belong under `apps/ccusage/src/adapter/<agent>/`.
-Keep agent-specific code there. Split files by responsibility when the implementation grows:
+New or migrated runtime agent implementations belong under
+`rust/crates/ccusage/src/adapter/<agent>/`. Keep agent-specific code there. Split
+files by responsibility when the implementation grows:
 
-- `index.ts` - thin public adapter surface: `detect<Agent>()`, `load<Agent>Rows()`, and high-level wiring.
-- `paths.ts` - environment variables, default directories, and path discovery.
-- `parser.ts` or `loader.ts` - raw log file discovery and parsing.
-- `schema.ts` - validation schemas and small normalization helpers.
-- `pricing.ts` or `pricing-macro.ts` - agent-specific pricing candidates, bundled pricing, or provider filters.
-- `types.ts` - source-local types when they are not shared outside the adapter.
+- `mod.rs` - public adapter surface and command wiring.
+- `paths.rs` - environment variables, default directories, and path discovery.
+- `parser.rs` - raw record parsing and token/model mapping.
+- `loader.rs` - file walking, SQLite reads, dedupe, and date filtering entry points.
+- `report.rs` - JSON/table row shaping when agent-specific.
+- `types.rs` - source-local types when they are not shared outside the adapter.
 
-For Rust work, use the `ccusage-rust` skill and mirror the same responsibility boundaries under `rust/crates/ccusage/src/adapter/<agent>/` where practical: `mod.rs`, `paths.rs`, `parser.rs`, `loader.rs`, and `report.rs`.
+Use `apps/ccusage/src` only for the remaining npm launcher, package scripts,
+schema artifacts, and benchmarks. Do not add new TypeScript runtime adapter
+logic unless the user explicitly scopes work to the package layer.
 
-When moving an existing loader into an adapter, update internal imports to the adapter path instead of adding compatibility re-export shims. Keep old root-level modules only when they are part of the package's declared public exports or are dedicated bundled worker entries. In `apps/ccusage`, `src/data-loader.ts` is a worker/build entry for the optimized Claude `data-loader` chunk from PR #984; do not put new source logic there.
+When moving an existing loader into an adapter, update internal imports to the
+adapter path instead of adding compatibility re-export shims. Keep old root-level
+modules only when they are part of the package's declared public exports or are
+dedicated packaging entries.
 
-Use shared ccusage foundation for rendering, table layout, logging, date formatting, progress, pricing fetcher lifecycle, JSONL walking, worker gating, worker spawn/result ordering, and aggregation wherever the source data permits. Agent adapters should mainly own source-specific log discovery, parsing, token mapping, model mapping, and source-specific metadata.
+Use shared ccusage foundation for rendering, table layout, logging, date
+formatting, progress, pricing fetcher lifecycle, JSONL walking, SQLite loading,
+dedupe, and aggregation wherever the source data permits. Agent adapters should
+mainly own source-specific log discovery, parsing, token mapping, model mapping,
+and source-specific metadata.
 
-Treat "same foundation as Claude" as more than shared file walking. JSONL adapters should use the shared byte marker scanner (`processJSONLFileByMarkers()`) when stable row markers exist, and high-volume worker paths should avoid returning large object arrays when typed-array transfer payloads or worker-side aggregation can preserve the same output.
+Treat "same foundation as Claude" as more than shared file walking. JSONL
+adapters should use shared scanning helpers when stable row markers exist, and
+high-volume paths should avoid returning large intermediate object vectors when
+worker-side aggregation or typed transfer payloads can preserve the same output.
 
-When several adapters expose the same raw-log shape, prefer a small helper such as `defineAgentLogLoader()` over duplicating period/session aggregation. Keep highly specialized loaders such as Codex worker parsing separate when their file format or pricing semantics require it.
-
-Before adding or changing an adapter, read `apps/ccusage/src/adapter/ARCHITECTURE.md` and keep the implementation aligned with its detect, load, parse, aggregate, and parent-return layers.
+When several adapters expose the same raw-log shape, prefer a small shared Rust
+helper over duplicating period/session aggregation. Keep highly specialized
+loaders such as Codex parsing separate when their file format or pricing
+semantics require it.
 
 ## Adapter Migration Checklist
 
 For each migrated or new agent:
 
-- Put all source-specific runtime logic under `apps/ccusage/src/adapter/<agent>/`.
-- Keep agent-specific package logic under `apps/ccusage/src/adapter/<agent>/`.
+- Put all source-specific runtime logic under `rust/crates/ccusage/src/adapter/<agent>/`.
 - Implement fast detection that short-circuits once a usable source file is found.
-- Use shared file walking, JSONL byte marker scanning where applicable, worker gating, logging, pricing fetcher lifecycle, date formatting, table rendering, and all-agent aggregation.
+- Use shared file walking, JSONL scanning where applicable, SQLite loading,
+  logging, pricing fetcher lifecycle, date formatting, table rendering, and
+  all-agent aggregation.
 - Keep adapter code responsible for source paths, raw parsing, token mapping, model mapping, source metadata, and agent-specific pricing.
-- Add fixture-backed tests for path discovery, parser behavior, aggregation totals, and important legacy compatibility.
+- Add Rust fixture-backed tests for path discovery, parser behavior, aggregation totals, and important legacy compatibility.
 - Add skipped local-data smoke tests when real user log directories are useful for catching schema drift.
 - Add or update CLI JSON assertions and table snapshots for affected report modes.
 - Audit every user-facing entrypoint that lists supported agents, commands, options, report modes, or examples. Update the root `README.md`, `apps/ccusage/README.md`, `docs/guide/`, and VitePress navigation when the adapter changes what users can run or discover. Use the `ccusage-docs` skill for docs conventions.

--- a/.agents/skills/ccusage-development/SKILL.md
+++ b/.agents/skills/ccusage-development/SKILL.md
@@ -12,6 +12,10 @@ This is a monorepo. Check the nearest package-specific `CLAUDE.md` before editin
 - `apps/ccusage/CLAUDE.md` - main Claude Code usage CLI and library
 - `docs/CLAUDE.md` - VitePress documentation site
 
+The production CLI implementation is Rust-first under `rust/crates/ccusage`.
+The `apps/ccusage` package now mainly provides npm metadata, a TypeScript bin
+launcher, generated schema artifacts, benchmarks, and release packaging.
+
 The canonical user-facing command is `ccusage` with agent subcommands:
 
 ```sh
@@ -24,7 +28,10 @@ ccusage pi daily
 
 Standalone agent wrapper packages have been removed. Prefer `ccusage <agent> ...` in docs, tests, examples, and new behavior, and do not reintroduce wrapper commands such as `ccusage-codex`, `ccusage-opencode`, `ccusage-amp`, or `ccusage-pi`.
 
-Agent implementations live inside the bundled `ccusage` package. Treat runtime libraries as bundled assets: add dependencies to each package's `devDependencies` unless the user explicitly asks otherwise.
+Agent implementations live in the Rust CLI unless the work is specifically about
+the remaining TypeScript package surface. Treat package runtime libraries as
+bundled assets: add dependencies to each package's `devDependencies` unless the
+user explicitly asks otherwise.
 
 ## Common Commands
 
@@ -46,14 +53,15 @@ Tools are managed by `flake.nix` and `package.json`. Use `comma` or `nix run` fo
 
 ## Code Style
 
-- Use TypeScript strict-mode patterns already present in the package.
-- Prefer `satisfies` and `as const satisfies` over unsafe `as` assertions; use the `typescript-style` skill for details.
-- Use the `ccusage-rust` skill before editing `rust/crates/**`, native packaging behavior, Rust pricing embedding, or Rust performance work.
-- Use `.ts` extensions for local imports.
-- Use Node path utilities for file paths.
-- Use `logger.ts` instead of `console.log`.
-- Prefer `@praha/byethrow` Result patterns for functional error handling; use the `byethrow` skill for details.
-- Use Gunshi for CLI commands; use the `use-gunshi-cli` skill for details.
+- For Rust CLI work, use the `ccusage-rust` skill before editing `rust/crates/**`,
+  native packaging behavior, or Rust pricing embedding. Use
+  `ccusage-rust-profile` for Rust performance work.
+- Keep Rust modules small and responsibility-focused. Prefer `pub(crate)` over
+  broader visibility, avoid unnecessary `String` cloning in hot paths, and put
+  unit tests beside the module they exercise.
+- For TypeScript package/tooling code, use the `ccusage-typescript` skill and
+  `typescript-style` before editing. Keep `satisfies` and `as const satisfies`
+  guidance there instead of mixing TypeScript details into Rust workflow rules.
 - Only export constants, functions, and types used by other modules.
 - Keep internal-only files and helpers private where possible.
 - Dependency additions go in `devDependencies` for bundled/private packages.
@@ -77,7 +85,9 @@ For package-local work, run the narrower package scripts during iteration when t
 
 ## Performance and CLI Output
 
-Use the `bun-cpu-profile` skill for performance optimization, Bun CPU profiles, hyperfine A/B comparisons, and branch-vs-main profiling.
+Use `ccusage-rust-profile` for native CLI performance optimization, Rust
+profiling, hyperfine A/B comparisons, and branch-vs-main profiling. Use
+`bun-cpu-profile` for TypeScript launcher, benchmark, or packaging scripts.
 
 Use the `cmux-debug` skill when validating terminal rendering, responsive tables, long-running CLI output, or output that depends on real terminal geometry.
 

--- a/.agents/skills/ccusage-rust-profile/SKILL.md
+++ b/.agents/skills/ccusage-rust-profile/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: ccusage-rust-profile
+description: Profiles ccusage native Rust CLI performance. Use when debugging slow Rust commands, comparing branch speed, reading profiles, or validating optimization work.
+paths:
+  - 'rust/**/*.rs'
+  - 'rust/**/*.toml'
+  - 'rust/**/build.rs'
+globs: 'rust/**/*.rs,rust/**/*.toml,rust/**/build.rs'
+---
+
+# ccusage Rust Profile
+
+Use this skill for native CLI performance work. Use `bun-cpu-profile` only for
+TypeScript launcher, benchmark, or packaging scripts.
+
+## Preparation
+
+Read the relevant local Rust Performance Book pages before non-trivial
+optimization:
+
+```text
+/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/profiling.md
+/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/io.md
+/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/heap-allocations.md
+/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/parallelism.md
+/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/type-sizes.md
+```
+
+Build release binaries before timing:
+
+```sh
+direnv exec . cargo build --manifest-path rust/Cargo.toml --release --bin ccusage
+```
+
+## Compare End To End
+
+Create a separate main worktree for branch-vs-main comparisons:
+
+```sh
+command git fetch origin main
+command git worktree add /tmp/ccusage-main origin/main
+direnv exec . cargo build --manifest-path rust/Cargo.toml --release --bin ccusage
+cd /tmp/ccusage-main
+direnv exec . cargo build --manifest-path rust/Cargo.toml --release --bin ccusage
+```
+
+Measure real commands with deterministic output settings:
+
+```sh
+hyperfine --warmup 4 --runs 10 --shell none \
+	"env LOG_LEVEL=0 COLUMNS=200 NO_COLOR=1 TZ=UTC rust/target/release/ccusage daily --offline --json" \
+	"env LOG_LEVEL=0 COLUMNS=200 NO_COLOR=1 TZ=UTC /tmp/ccusage-main/rust/target/release/ccusage daily --offline --json" \
+	--export-json /tmp/ccusage-rust-hyperfine.json
+```
+
+For JSON parity, write both outputs and validate with `jq`:
+
+```sh
+env LOG_LEVEL=0 COLUMNS=200 NO_COLOR=1 TZ=UTC rust/target/release/ccusage daily --offline --json >/tmp/head.json
+env LOG_LEVEL=0 COLUMNS=200 NO_COLOR=1 TZ=UTC /tmp/ccusage-main/rust/target/release/ccusage daily --offline --json >/tmp/main.json
+jq -e . /tmp/head.json >/dev/null
+jq -e . /tmp/main.json >/dev/null
+```
+
+## What To Check
+
+- I/O count and buffering before CPU-only tweaks.
+- Avoid unnecessary `String` allocation and cloning on hot paths; prefer borrowed
+  `&str`, `Arc<str>`, or typed summaries where ownership is needed.
+- Avoid returning large intermediate object vectors when aggregation can happen
+  earlier without changing output.
+- Use parallelism only when it improves end-to-end command time on real fixture
+  shapes.
+- Keep binary size visible when adding dependencies or enabling features.
+
+## Validation
+
+Profile before committing an optimization. Validate with end-to-end `hyperfine`
+and JSON/table parity, not only microbenchmarks.
+
+When CI performance comments are relevant, inspect or reproduce the
+`ccusage-rust-perf` workflow command:
+
+```sh
+nix develop --command pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts --head-runtime rust --help
+```

--- a/.agents/skills/ccusage-rust-profile/SKILL.md
+++ b/.agents/skills/ccusage-rust-profile/SKILL.md
@@ -16,15 +16,19 @@ TypeScript launcher, benchmark, or packaging scripts.
 ## Preparation
 
 Read the relevant local Rust Performance Book pages before non-trivial
-optimization:
+optimization. Locate the clone instead of assuming a machine-specific path:
 
-```text
-/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/profiling.md
-/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/io.md
-/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/heap-allocations.md
-/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/parallelism.md
-/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/type-sizes.md
+```fish
+set perf_book_dir (ghq list --full-path nnethercote/perf-book | head -n 1)
+sed -n '1,220p' "$perf_book_dir/src/profiling.md"
+sed -n '1,220p' "$perf_book_dir/src/io.md"
+sed -n '1,220p' "$perf_book_dir/src/heap-allocations.md"
+sed -n '1,220p' "$perf_book_dir/src/parallelism.md"
+sed -n '1,220p' "$perf_book_dir/src/type-sizes.md"
 ```
+
+If there is no local clone, use the hosted Rust Performance Book as fallback:
+`https://nnethercote.github.io/perf-book/`.
 
 Build release binaries before timing:
 
@@ -78,9 +82,23 @@ jq -e . /tmp/main.json >/dev/null
 Profile before committing an optimization. Validate with end-to-end `hyperfine`
 and JSON/table parity, not only microbenchmarks.
 
-When CI performance comments are relevant, inspect or reproduce the
-`ccusage-rust-perf` workflow command:
+When CI performance comments are relevant, inspect options with `--help`, but do
+not treat help output as a profiling workload:
 
 ```sh
 nix develop --command pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts --head-runtime rust --help
+```
+
+To reproduce the workflow shape locally, pass real fixture and worktree inputs:
+
+```sh
+nix develop --command pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts \
+	--base-dir /tmp/ccusage-main \
+	--head-dir "$PWD" \
+	--head-runtime rust \
+	--fixture-dir apps/ccusage/test/fixtures/claude \
+	--codex-fixture-dir apps/ccusage/test/fixtures/codex \
+	--runs 1 \
+	--warmup 0 \
+	--output /tmp/ccusage-rust-perf-comment.md
 ```

--- a/.agents/skills/ccusage-rust/SKILL.md
+++ b/.agents/skills/ccusage-rust/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccusage-rust
-description: Guides ccusage Rust implementation work. Use when editing rust/crates, native packaging, Rust performance, parser/module layout, pricing embedding, or Rust/TypeScript parity.
+description: Guides ccusage Rust implementation work. Use when editing rust/crates, native packaging, parser/module layout, pricing embedding, or Rust/TypeScript parity.
 paths:
   - 'rust/**/*.rs'
   - 'rust/**/*.toml'
@@ -14,20 +14,26 @@ Use this skill for the native Rust CLI under `rust/crates/ccusage` and `rust/cra
 
 ## Source Parity
 
-Rust must match the TypeScript implementation on `origin/main` unless the user explicitly scopes a behavior change. Before implementing or refactoring an agent, inspect the corresponding TypeScript adapter:
+Rust is the production implementation. Preserve existing Rust behavior unless
+the user explicitly scopes a behavior change. Before implementing or refactoring
+an agent, inspect the current Rust adapter and the agent source reference docs:
 
 ```sh
-git ls-tree -r --name-only origin/main apps/ccusage/src/adapter
-git show origin/main:apps/ccusage/src/adapter/<agent>/index.ts
-git show origin/main:apps/ccusage/src/adapter/<agent>/parser.ts
-git show origin/main:apps/ccusage/src/adapter/<agent>/paths.ts
+fd . rust/crates/ccusage/src/adapter/<agent>
+sed -n '1,220p' .agents/skills/ccusage-agent-sources/references/<agent>.md
 ```
+
+When porting behavior from the historical TypeScript implementation, first find
+the relevant commit or tag that still contains `apps/ccusage/src/adapter`, then
+compare against that source. Do not assume `origin/main` still contains the
+TypeScript adapter.
 
 Preserve report semantics, JSON fields, table columns, progress/spinner text, agent grouping, date filtering, `--offline`, `CLAUDE_CONFIG_DIR`, and source-specific environment variables.
 
 ## Module Layout
 
-Do not keep growing `main.rs` or single large adapter files. Mirror the TypeScript responsibility boundaries where practical:
+Do not keep growing `main.rs` or single large adapter files. Use these
+responsibility boundaries where practical:
 
 - `adapter/<agent>/mod.rs` - public adapter surface and command wiring.
 - `adapter/<agent>/paths.rs` - environment variables, defaults, and path discovery.
@@ -51,28 +57,10 @@ When changing pricing:
 - Load the generated build-time snapshot first, then fallback pricing, then runtime fetch when not `--offline`.
 - Add tests for embedded/offline pricing and context limits.
 
-## Performance
-
-Read the local Rust Performance Book clone before non-trivial optimization:
-
-```text
-/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/profiling.md
-/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/io.md
-/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/heap-allocations.md
-/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/parallelism.md
-/Users/ryoppippi/ghq/github.com/nnethercote/perf-book/src/type-sizes.md
-```
-
-Profile before committing an optimization. Validate with end-to-end `hyperfine` and JSON/table parity, not only microbenchmarks.
-
-For ccusage workloads, check:
-
-- I/O count and buffering before CPU-only tweaks.
-- Avoid unnecessary `String` allocation and cloning on hot paths; prefer borrowed `&str`, `Arc<str>`, or typed summaries where ownership is needed.
-- Avoid returning large intermediate object vectors when worker-side aggregation or typed transfer payloads can preserve output.
-- Use parallelism only when it improves end-to-end command time on real fixture shapes.
-- Keep binary size visible when adding dependencies or enabling features.
-
 ## Validation
 
-Use the `ccusage-testing` skill for Rust test commands. For perf or parity work, compare against `origin/main` TypeScript output for a stable fixture window before changing behavior.
+Use the `ccusage-testing` skill for Rust test commands. Use
+`ccusage-rust-profile` for performance work and branch-vs-main comparisons. For
+parity work, compare against the current main branch, a previous release, or a
+pinned historical TypeScript commit for a stable fixture window before changing
+behavior.

--- a/.agents/skills/ccusage-testing/SKILL.md
+++ b/.agents/skills/ccusage-testing/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: ccusage-testing
-description: Guides ccusage tests. Use when adding or fixing in-source Vitest, Rust cargo tests, fs-fixture data, CLI snapshots, Claude model pricing, or LiteLLM compatibility.
+description: Guides ccusage Rust tests. Use when adding or fixing cargo tests, CLI snapshots, Claude model pricing, LiteLLM compatibility, or Rust fixture-backed parser and loader tests.
 ---
 
 # ccusage Testing
 
-Use the `tdd` skill for logic changes and general test readability rules, including the guidance to avoid over-DRYing tests when duplication improves clarity. Use the `fs-fixture` skill when creating filesystem fixtures. This skill adds ccusage-specific Vitest, fixture, model, and pricing rules.
+Use the `tdd` skill for logic changes and general test readability rules,
+including the guidance to avoid over-DRYing tests when duplication improves
+clarity. This skill adds ccusage-specific Rust, fixture, model, and pricing
+rules. Use `ccusage-typescript` for Vitest and TypeScript filesystem fixtures.
 
 ## Rust Tests
 
@@ -27,30 +30,14 @@ Put Rust unit tests near the module they exercise with `#[cfg(test)] mod tests`.
 
 Use fixture-backed Rust tests for parser, path discovery, SQLite loading, dedupe, aggregation, pricing, and CLI output parity. For TDD syntax and focused cargo test examples, read `../tdd/references/rust-examples.md`.
 
-## Vitest Pattern
-
-- Tests live beside implementation in `if (import.meta.vitest != null)` blocks.
-- Use Vitest globals directly: `describe`, `it`, `expect`, `vi`, `assert`.
-- Do not import Vitest globals.
-- Do not use `await import()` or other dynamic imports anywhere, especially in tests.
-- Use `fs-fixture` with `createFixture()` for simulated agent data directories; read the `fs-fixture` skill for API details and README location.
-- Top-level `fs-fixture` imports in implementation files with in-source tests are allowed and preferred over dynamic imports.
-- Use `vi.stubEnv()` instead of mutating `process.env` directly.
-- Prefer testing parser, path resolution, loading, aggregation, pricing, and CLI output behavior over schema-shape tests. Valibot schema declarations usually do not need direct tests unless there is non-trivial normalization logic around them.
-- If schema validation is already exercised through parser or loader tests with realistic log files, do not add separate schema-only tests. Add schema-adjacent tests only when the behavior is not visible through the public loader contract, such as legacy field compatibility or important invalid-record filtering.
-- Path discovery helpers such as `getCodexSessionsPath()` or `getPiAgentPaths()` are real logic. Test explicit path arguments, environment variable paths with `vi.stubEnv()`, missing directories, and default-path fallback when feasible.
-- It is acceptable to add explicitly skipped local-data smoke tests such as `it.skipIf(!hasLocalData)(...)` for real user log directories. These must not fail on clean CI machines.
-
-Utility functions should include concise JSDoc describing their purpose and focused in-source tests for their behavior.
-
 ## Test Readability
 
-- Avoid `try`/`catch` in tests for expected failures. Use `expect(...).toThrow()`, `await expect(...).rejects`, or explicit Result failure assertions.
+- Avoid `try`/`catch` in tests for expected failures. Use `Result` tests, `matches!`, or explicit error assertions.
 - Avoid `if` branches inside test bodies. Split behaviors into separate tests or use `it.each` for table-driven cases.
 - Tests do not need to be DRY. Prefer repeated, explicit setup in each test when it makes the behavior easier to read.
 - Do not hoist one-off values out of tests. Write literals and direct setup values inline in the test body when sharing them would make the behavior harder to read.
 
-For concrete good and bad examples, read `../tdd/references/vitest-examples.md`.
+For concrete Rust examples, read `../tdd/references/rust-examples.md`.
 
 ## CLI Output Tests
 

--- a/.agents/skills/ccusage-testing/SKILL.md
+++ b/.agents/skills/ccusage-testing/SKILL.md
@@ -33,7 +33,7 @@ Use fixture-backed Rust tests for parser, path discovery, SQLite loading, dedupe
 ## Test Readability
 
 - Avoid `try`/`catch` in tests for expected failures. Use `Result` tests, `matches!`, or explicit error assertions.
-- Avoid `if` branches inside test bodies. Split behaviors into separate tests or use `it.each` for table-driven cases.
+- Avoid `if` branches inside test bodies. Split behaviors into separate tests, use `rstest` cases when the crate is already available, iterate over explicit Rust case structs in one table-driven test, or add a small local macro for repeated assertions.
 - Tests do not need to be DRY. Prefer repeated, explicit setup in each test when it makes the behavior easier to read.
 - Do not hoist one-off values out of tests. Write literals and direct setup values inline in the test body when sharing them would make the behavior harder to read.
 
@@ -41,7 +41,9 @@ For concrete Rust examples, read `../tdd/references/rust-examples.md`.
 
 ## CLI Output Tests
 
-Integration tests that exercise human-readable table output must use file snapshots with `toMatchFileSnapshot`. This keeps table layout and responsive behavior reviewable for each affected agent/report combination.
+Integration tests that exercise human-readable table output should use focused
+golden output or explicit layout assertions so table layout and responsive
+behavior stay reviewable for each affected agent/report combination.
 
 Prefer JSON assertions for structured behavior and snapshot assertions for terminal layout.
 

--- a/.agents/skills/ccusage-typescript/SKILL.md
+++ b/.agents/skills/ccusage-typescript/SKILL.md
@@ -46,9 +46,9 @@ Vitest remains relevant for the TypeScript package launcher, schema artifacts,
 benchmark scripts, and docs/package tooling. Prefer Rust tests for production CLI
 runtime behavior.
 
-Read `../tdd/references/vitest-examples.md` for Vitest globals, in-source test
-blocks, `fs-fixture`, environment stubbing, failure assertions, and test
-readability examples.
+Read `references/vitest.md` for ccusage-specific Vitest patterns. Read
+`../tdd/references/vitest-examples.md` for broader TDD examples and Vitest test
+modifiers.
 
 ## Bun And Package Scripts
 

--- a/.agents/skills/ccusage-typescript/SKILL.md
+++ b/.agents/skills/ccusage-typescript/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ccusage-typescript
+description: Guides ccusage TypeScript package and tooling work. Use when editing apps/ccusage .ts/.js files, Vitest tests, Bun scripts, package launchers, schema tooling, or benchmark scripts.
+paths:
+  - 'apps/ccusage/**/*.ts'
+  - 'apps/ccusage/**/*.js'
+  - 'docs/**/*.ts'
+  - 'scripts/**/*.ts'
+globs: 'apps/ccusage/**/*.ts,apps/ccusage/**/*.js,docs/**/*.ts,scripts/**/*.ts'
+---
+
+# ccusage TypeScript
+
+Use this skill for the remaining TypeScript and JavaScript package surface:
+
+- `apps/ccusage/src/cli.ts` native binary launcher.
+- `apps/ccusage/scripts/**` package, schema, benchmark, and native staging scripts.
+- Vitest coverage for TypeScript package/tooling behavior.
+- VitePress and root TypeScript configuration or scripts when the change is not docs-content-only.
+
+Runtime CLI behavior belongs in Rust under `rust/crates/ccusage`. Do not add new
+TypeScript adapter logic unless the user explicitly scopes work to the package
+layer.
+
+## Style
+
+Use `typescript-style` for detailed TypeScript conventions. In this repo:
+
+- Prefer `satisfies` and `as const satisfies` for typed literals, mocks, config objects, and table-driven cases.
+- Avoid unsafe `as` assertions and especially `as any`.
+- Use `.ts` extensions for local imports.
+- Use Node path utilities for file paths.
+- Use `logger.ts` instead of `console.log` in package code.
+- Do not use dynamic imports, especially in Vitest blocks.
+- Keep exports limited to values used outside the module.
+
+Read the focused `typescript-style` references only when they apply:
+
+- `../typescript-style/references/arkregex.md` for new regular expression work.
+- `../typescript-style/references/byethrow.md` for Result-based TypeScript error handling.
+- `../typescript-style/references/gunshi.md` for TypeScript CLI command definitions.
+
+## Vitest
+
+Vitest remains relevant for the TypeScript package launcher, schema artifacts,
+benchmark scripts, and docs/package tooling. Prefer Rust tests for production CLI
+runtime behavior.
+
+Read `../tdd/references/vitest-examples.md` for Vitest globals, in-source test
+blocks, `fs-fixture`, environment stubbing, failure assertions, and test
+readability examples.
+
+## Bun And Package Scripts
+
+Use `bun-api-reference` before changing Bun runtime APIs such as `Bun.$`,
+`Bun.file()`, `Bun.write()`, `Bun.spawn()`, `Bun.argv`, `Bun.stdout`,
+`Bun.stderr`, or `Bun.stringWidth()`.
+
+Use `bun-cpu-profile` for TypeScript launcher, benchmark, or packaging script
+performance. Use `ccusage-rust-profile` for native CLI performance.
+
+## Validation
+
+Run focused checks during iteration, then the normal root workflow before
+finishing:
+
+```sh
+pnpm --filter ccusage typecheck
+pnpm run test:vitest
+pnpm run format
+pnpm typecheck
+pnpm run test
+```

--- a/.agents/skills/ccusage-typescript/SKILL.md
+++ b/.agents/skills/ccusage-typescript/SKILL.md
@@ -59,13 +59,16 @@ Use `bun-api-reference` before changing Bun runtime APIs such as `Bun.$`,
 Use `bun-cpu-profile` for TypeScript launcher, benchmark, or packaging script
 performance. Use `ccusage-rust-profile` for native CLI performance.
 
+There is no TypeScript similarity skill in this repo. Use `ast-grep` or `rg` for
+TypeScript duplication checks unless a dedicated similarity-ts workflow is
+reintroduced.
+
 ## Validation
 
 Run focused checks during iteration, then the normal root workflow before
 finishing:
 
 ```sh
-pnpm --filter ccusage typecheck
 pnpm run test:vitest
 pnpm run format
 pnpm typecheck

--- a/.agents/skills/ccusage-typescript/references/vitest.md
+++ b/.agents/skills/ccusage-typescript/references/vitest.md
@@ -1,0 +1,37 @@
+# ccusage Vitest Reference
+
+Use this reference for TypeScript package launcher, schema artifact, benchmark
+script, and docs/package tooling tests. Production CLI runtime behavior should
+prefer Rust tests through `ccusage-testing`.
+
+## In-Source Tests
+
+- Tests live beside implementation in `if (import.meta.vitest != null)` blocks.
+- Use Vitest globals directly: `describe`, `it`, `test`, `expect`, `vi`,
+  `beforeEach`, and `assert`.
+- Do not import Vitest globals.
+- Do not use `await import()` or other dynamic imports in tests.
+- Top-level `fs-fixture` imports in implementation files with in-source tests are
+  allowed and preferred over dynamic imports.
+
+## Fixtures And Environment
+
+- Use `fs-fixture` with `createFixture()` for simulated filesystem trees.
+- Use `vi.stubEnv()` instead of mutating `process.env` directly.
+- Skipped local-data smoke tests are acceptable when real user log directories
+  catch schema drift, but they must not fail on clean CI machines.
+
+## Assertions
+
+- Prefer behavior-focused tests over schema-shape tests unless schema
+  normalization itself is the behavior.
+- Avoid `try`/`catch` for expected failures. Use `expect(...).toThrow()`,
+  `await expect(...).rejects`, or explicit Result failure assertions.
+- Avoid `if` branches inside test bodies. Split behaviors into separate tests or
+  use `it.each` for table-driven cases.
+- Tests do not need to be DRY. Prefer repeated, explicit setup when duplication
+  makes each behavior easier to read.
+- Do not hoist one-off values out of tests.
+
+For broader TDD examples and modifiers, read
+`../../tdd/references/vitest-examples.md`.

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -57,7 +57,7 @@ For this repo, prefer one or two short sentences, usually around 20-35 words. Do
 Good pattern:
 
 ```yaml
-description: Guides ccusage tests. Use when adding or fixing in-source Vitest, fs-fixture data, CLI snapshots, Claude model pricing, or LiteLLM compatibility.
+description: Guides ccusage Rust tests. Use when adding or fixing cargo tests, CLI snapshots, Claude model pricing, LiteLLM compatibility, or Rust fixture-backed parser and loader tests.
 ```
 
 Weak pattern:

--- a/.claude/skills/byethrow
+++ b/.claude/skills/byethrow
@@ -1,1 +1,0 @@
-../../.agents/skills/byethrow

--- a/.claude/skills/ccusage-rust
+++ b/.claude/skills/ccusage-rust
@@ -1,0 +1,1 @@
+../../.agents/skills/ccusage-rust

--- a/.claude/skills/ccusage-rust-profile
+++ b/.claude/skills/ccusage-rust-profile
@@ -1,0 +1,1 @@
+../../.agents/skills/ccusage-rust-profile

--- a/.claude/skills/ccusage-typescript
+++ b/.claude/skills/ccusage-typescript
@@ -1,0 +1,1 @@
+../../.agents/skills/ccusage-typescript

--- a/.claude/skills/use-gunshi-cli
+++ b/.claude/skills/use-gunshi-cli
@@ -1,1 +1,0 @@
-../../.agents/skills/use-gunshi-cli

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,17 +7,20 @@ This file points agents at the right repo-local skills and keeps only the guidan
 Use these skills before working in this repository:
 
 - `ccusage-development` - monorepo layout, bundled CLI packaging, commands, code style, dependency policy, and post-change checks.
-- `ccusage-testing` - in-source Vitest patterns, fixtures, snapshots, Claude model names, and LiteLLM pricing test rules.
+- `ccusage-rust` - native Rust CLI implementation, parser/module layout, pricing embedding, and TypeScript parity checks.
+- `ccusage-rust-profile` - native Rust CLI profiling, branch-vs-main speed comparisons, profile reading, and optimization validation.
+- `ccusage-testing` - Rust cargo tests, CLI snapshots, Claude model names, and LiteLLM pricing test rules.
+- `ccusage-typescript` - TypeScript package/tooling work, Vitest tests, Bun scripts, package launchers, schema tooling, and benchmark scripts.
 - `fs-fixture` - disposable filesystem trees for tests with `createFixture()` and local README lookup.
-- `ccusage-agent-sources` - Claude Code, Codex, OpenCode, Amp, and pi-agent log locations, token mappings, cost rules, and CLI behavior.
+- `ccusage-agent-sources` - agent adapter log locations, token mappings, cost rules, and CLI behavior.
 - `ccusage-docs` - VitePress docs structure, screenshot placement, accessibility, and markdown linting conventions.
 - `skill-creator` - repo-local skill creation, SKILL.md frontmatter, description trigger quality, and reference layout.
 - `typescript-style` - required before reading or editing `.ts`, `.tsx`, `.js`, or `.jsx`; covers typing, `satisfies`, safe suppressions, and library-specific guidance for arkregex, byethrow, and Gunshi.
-- `ast-grep` - structural code searches and AST-based migration verification with the dev-shell `ast-grep` CLI.
+- `ast-grep` - structural code searches in Rust or TypeScript and AST-based migration verification with the dev-shell `ast-grep` CLI.
 - `bun-api-reference` - local Bun runtime API docs and type references under `node_modules/bun-types`.
 - `tdd` - Red-Green-Refactor workflow for logic changes.
-- `bun-cpu-profile` - Bun CPU profiling and branch-vs-main performance comparisons.
-- `reduce-similarities` - AST-based duplicate TypeScript/JavaScript detection with similarity-ts.
+- `bun-cpu-profile` - Bun/TypeScript profiling for package scripts; use `ccusage-rust-profile` for native CLI performance work.
+- `reduce-similarities` - AST-based duplicate Rust code detection with similarity-rs.
 - `cmux-debug` - terminal UI and responsive table verification in cmux.
 - `pr-ai-review-workflow` - PR review loops with `gh`: request AI/code reviewers, wait for comments, reply to inline review comments, and push small follow-up commits.
 - `fix-ci` - diagnose and fix failing GitHub Actions checks with `gh`, then push small follow-up commits.
@@ -35,10 +38,10 @@ Check the nearest package-specific `CLAUDE.md` before editing package code:
 - Standalone agent wrapper packages have been removed. Do not add docs, tests, or features that promote `ccusage-amp`, `ccusage-codex`, `ccusage-opencode`, or `ccusage-pi`.
 - Runtime libraries for bundled packages belong in `devDependencies` unless explicitly requested otherwise.
 - Prefer tools provided by the Nix dev shell before falling back to ad hoc installs: `rg`, `fd`, `fzf`, `delta`, `dust`, `jq`, `gh`, `hyperfine`, `similarity`, `ast-grep`, `typos`, and `typos-lsp`. When a missing tool would be useful for repeated agent work in this repository, add it to `flake.nix`.
-- Use `logger.ts` instead of `console.log`.
-- Use `.ts` extensions for local imports.
-- Do not use dynamic imports anywhere, especially in Vitest blocks.
-- Vitest globals are enabled; use `describe`, `it`, `expect`, and `vi` without importing them.
+- The production CLI is Rust-first under `rust/crates/ccusage`. Put new runtime behavior there unless the work is specifically about npm packaging, generated schemas, docs tooling, or benchmark scripts.
+- For Rust code, keep modules small, keep `pub(crate)` surfaces narrow, prefer fixture-backed parser/loader tests, and run cargo checks through the root package scripts when possible.
+- TypeScript rules still apply to `.ts`, `.tsx`, `.js`, and `.jsx` package/tooling files. Use `ccusage-typescript` and `typescript-style` there, especially `satisfies` and `as const satisfies` for typed literals.
+- For TypeScript package code, use `logger.ts` instead of `console.log`, use `.ts` extensions for local imports, avoid dynamic imports, and use Vitest globals without importing them.
 - After code changes, run `pnpm run format`, `pnpm typecheck`, and `pnpm run test`.
 - PR branches are squash-merged by default; prefer stacked, small, revertable follow-up commits over `git commit --amend` unless explicitly requested.
 - Use US English for repository-facing GitHub communication, including issue comments, PR descriptions, review replies, triage notes, and bot-directed replies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Use these skills before working in this repository:
 - `bun-api-reference` - local Bun runtime API docs and type references under `node_modules/bun-types`.
 - `tdd` - Red-Green-Refactor workflow for logic changes.
 - `bun-cpu-profile` - Bun/TypeScript profiling for package scripts; use `ccusage-rust-profile` for native CLI performance work.
-- `reduce-similarities` - AST-based duplicate Rust code detection with similarity-rs.
+- `reduce-similarities` - AST-based duplicate Rust code detection with similarity-rs; TypeScript duplication checks use `ccusage-typescript` and `ast-grep`.
 - `cmux-debug` - terminal UI and responsive table verification in cmux.
 - `pr-ai-review-workflow` - PR review loops with `gh`: request AI/code reviewers, wait for comments, reply to inline review comments, and push small follow-up commits.
 - `fix-ci` - diagnose and fix failing GitHub Actions checks with `gh`, then push small follow-up commits.

--- a/apps/ccusage/CLAUDE.md
+++ b/apps/ccusage/CLAUDE.md
@@ -5,9 +5,9 @@ This is the published `ccusage` npm package. The CLI implementation lives in Rus
 ## Skills
 
 - Use `ccusage-development` for commands, bundled CLI dependency policy, style, exports, and validation.
-- Use `ccusage-testing` for in-source Vitest, snapshots, fixtures, Claude models, and LiteLLM pricing tests.
+- Use `ccusage-testing` for Rust cargo tests, snapshots, fixtures, Claude models, and LiteLLM pricing tests.
 - Use `ccusage-agent-sources` for Claude Code data directories, JSONL structure, session naming, cost modes, and report behavior.
-- Use `typescript-style` before reading or editing TypeScript or JavaScript package code.
+- Use `ccusage-typescript` and `typescript-style` before reading or editing TypeScript or JavaScript package code.
 
 ## Package Notes
 


### PR DESCRIPTION
## Summary

- split Rust, Rust profiling, and TypeScript package/tooling guidance into separate repo-local skills
- update agent-source and development routing so runtime adapter work points at rust/crates/ccusage
- sync Claude skill symlinks with the repo-local skill set

## Testing

- pnpm run format
- pnpm typecheck
- direnv exec . pnpm run test
- pnpm run sync:skills:check

@coderabbitai please review this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns agent skills with the Rust-first CLI and routes work by domain. Adds dedicated Rust profiling and TypeScript package/tooling skills, updates testing to Rust-only, and refreshes profiling and search examples.

- **New Features**
  - Added `ccusage-rust-profile` for native CLI profiling with ghq-based Rust Performance Book lookup, release builds, hyperfine, and fixture-backed `compare-pr-performance`; clarify `--help` is for option inspection only.
  - Added `ccusage-typescript` for launcher/bench/schema tooling and a new Vitest reference; TypeScript duplication checks use `ast-grep`.

- **Refactors**
  - Made Rust CLI the source of truth; moved adapter rules to `rust/crates/ccusage` and kept TypeScript runtime logic out.
  - Switched `ccusage-testing` to Rust-only; Vitest guidance lives in the TypeScript skill.
  - Updated `bun-cpu-profile` to profile package scripts with deterministic runs, added Rust examples to `ast-grep`, and synced `CLAUDE.md` plus skill symlinks.

<sup>Written for commit 1460f50334d57d75eb64498c40cdea832fe452f9. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1076?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Shifted guidance to a Rust-first architecture for CLI implementation and testing.
  * Added native Rust profiling guidance and a separate TypeScript/Bun CPU-profiling workflow.
  * Introduced TypeScript package development and Vitest testing reference material.
  * Clarified agent/adapter implementation guidance, workflow commands, and developer reminders for easier navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->