### PR TITLE
docs: document Nix development setup

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -127,31 +127,43 @@ bunx ccusage monthly --compact  # Compact monthly report
 
 Full documentation is available at **[ccusage.com](https://ccusage.com/)**
 
-## Development Setup
+## Development
 
-### Using Nix (Recommended for Contributors)
+<details>
+<summary>Nix-based contributor setup</summary>
 
-For contributors and developers working on ccusage, we provide a Nix flake-based development environment:
+Development assumes the Nix flake environment. Install [Nix](https://nixos.org/) with flakes enabled and use [nix-direnv](https://github.com/nix-community/nix-direnv) so the repository dev shell loads automatically when you enter the directory:
 
-```bash
+```sh
 # Clone the repository
 git clone https://github.com/ryoppippi/ccusage.git
 cd ccusage
 
-# Allow direnv (automatically loads Nix environment)
+# Allow direnv to load the Nix dev shell
 direnv allow
+```
 
-# Or manually enter the development shell
+The dev shell provides the pinned `pnpm`, Rust toolchain, GitHub CLI, and project utilities from `flake.nix`. It also installs package dependencies from `pnpm-lock.yaml` when needed.
+
+If you do not use direnv, enter the shell manually:
+
+```sh
 nix develop
 ```
 
-This ensures consistent tooling versions across all contributors and CI systems. The development environment is defined in `flake.nix` and automatically activated via direnv when entering the project directory.
+Run the usual checks from inside the Nix environment:
+
+```sh
+pnpm run format
+pnpm typecheck
+pnpm run test
+```
 
 ### Nix Package
 
 The flake exposes `ccusage` as the default package and app:
 
-```bash
+```sh
 nix run github:ryoppippi/ccusage
 nix run github:ryoppippi/ccusage -- codex daily --offline
 nix build github:ryoppippi/ccusage
@@ -166,6 +178,8 @@ nix flake check
 ```
 
 The scheduled `update pricing` workflow runs the same commands and opens a PR when the locked input changes.
+
+</details>
 
 ## Sponsors
 

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -132,7 +132,7 @@ Full documentation is available at **[ccusage.com](https://ccusage.com/)**
 <details>
 <summary>Nix-based contributor setup</summary>
 
-Development assumes the Nix flake environment. Install [Nix](https://nixos.org/) with flakes enabled and use [nix-direnv](https://github.com/nix-community/nix-direnv) so the repository dev shell loads automatically when you enter the directory:
+Use the Nix flake development environment. Install [Nix](https://nixos.org/) with the `nix-command` and `flakes` experimental features enabled, then use [nix-direnv](https://github.com/nix-community/nix-direnv) so the repository dev shell loads automatically when you enter the directory:
 
 ```sh
 # Clone the repository


### PR DESCRIPTION
Adds a collapsed Development section to the README with the Nix flake workflow as the contributor setup path.

It recommends nix-direnv so the pinned dev shell from flake.nix loads automatically, and keeps the existing Nix package notes inside the same accordion.

Testing:
- pnpm run format
- pnpm typecheck
- direnv exec . pnpm run test
- direnv exec . git push -u origin codex/readme-development (pre-push oxfmt + clippy)

@coderabbitai please review this documentation update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents a Nix flake-based development setup for `ccusage`, with a collapsed contributor details block and `nix-direnv` to auto-load the pinned dev shell. Adds explicit prerequisites (Nix with `nix-command` and `flakes`), clarifies running `pnpm` checks in-shell, and notes the pinned `pnpm`, Rust toolchain, and GitHub CLI.

<sup>Written for commit 35760fb316c52ebf7c5a9ddc4190d71ce0ddfc67. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1077?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized development setup documentation with improved clarity on Nix-based contributor environment configuration, including streamlined setup instructions and automated development shell loading guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1077?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->