### PR TITLE
perf(progress): smooth all-agent loading output

### DIFF
--- a/rust/crates/ccusage/src/adapter/all.rs
+++ b/rust/crates/ccusage/src/adapter/all.rs
@@ -82,97 +82,101 @@ fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AllLoadResult
             AgentReportKind::Daily
         }
     };
+    let loader_shared = SharedArgs {
+        json: true,
+        ..shared.clone()
+    };
     let loaded = load_agent_rows_parallel(
         vec![
             AgentLoadSpec {
                 index: 0,
                 agent: "claude",
                 progress_agent: crate::progress::UsageLoadAgent::Claude,
-                load: Box::new(|| load_claude_rows(load_kind, shared)),
+                load: Box::new(|| load_claude_rows(load_kind, &loader_shared)),
             },
             AgentLoadSpec {
                 index: 1,
                 agent: "codex",
                 progress_agent: crate::progress::UsageLoadAgent::Codex,
-                load: Box::new(|| load_codex_rows(load_kind, shared, &pricing)),
+                load: Box::new(|| load_codex_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
                 index: 2,
                 agent: "opencode",
                 progress_agent: crate::progress::UsageLoadAgent::OpenCode,
-                load: Box::new(|| load_opencode_rows(load_kind, shared)),
+                load: Box::new(|| load_opencode_rows(load_kind, &loader_shared)),
             },
             AgentLoadSpec {
                 index: 3,
                 agent: "amp",
                 progress_agent: crate::progress::UsageLoadAgent::Amp,
-                load: Box::new(|| load_amp_rows(load_kind, shared, &pricing)),
+                load: Box::new(|| load_amp_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
                 index: 4,
                 agent: "droid",
                 progress_agent: crate::progress::UsageLoadAgent::Droid,
-                load: Box::new(|| load_droid_rows(load_kind, shared, &pricing)),
+                load: Box::new(|| load_droid_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
                 index: 5,
                 agent: "codebuff",
                 progress_agent: crate::progress::UsageLoadAgent::Codebuff,
-                load: Box::new(|| load_codebuff_rows(load_kind, shared, &pricing)),
+                load: Box::new(|| load_codebuff_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
                 index: 6,
                 agent: "hermes",
                 progress_agent: crate::progress::UsageLoadAgent::Hermes,
-                load: Box::new(|| load_hermes_rows(load_kind, shared, &pricing)),
+                load: Box::new(|| load_hermes_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
                 index: 7,
                 agent: "pi",
                 progress_agent: crate::progress::UsageLoadAgent::Pi,
-                load: Box::new(|| load_pi_rows(load_kind, shared)),
+                load: Box::new(|| load_pi_rows(load_kind, &loader_shared)),
             },
             AgentLoadSpec {
                 index: 8,
                 agent: "goose",
                 progress_agent: crate::progress::UsageLoadAgent::Goose,
-                load: Box::new(|| load_goose_rows(load_kind, shared, &pricing)),
+                load: Box::new(|| load_goose_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
                 index: 9,
                 agent: "openclaw",
                 progress_agent: crate::progress::UsageLoadAgent::OpenClaw,
-                load: Box::new(|| load_openclaw_rows(load_kind, shared)),
+                load: Box::new(|| load_openclaw_rows(load_kind, &loader_shared)),
             },
             AgentLoadSpec {
                 index: 10,
                 agent: "kilo",
                 progress_agent: crate::progress::UsageLoadAgent::Kilo,
-                load: Box::new(|| load_kilo_rows(load_kind, shared, &pricing)),
+                load: Box::new(|| load_kilo_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
                 index: 11,
                 agent: "copilot",
                 progress_agent: crate::progress::UsageLoadAgent::Copilot,
-                load: Box::new(|| load_copilot_rows(load_kind, shared, &pricing)),
+                load: Box::new(|| load_copilot_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
                 index: 12,
                 agent: "gemini",
                 progress_agent: crate::progress::UsageLoadAgent::Gemini,
-                load: Box::new(|| load_gemini_rows(load_kind, shared, &pricing)),
+                load: Box::new(|| load_gemini_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
                 index: 13,
                 agent: "kimi",
                 progress_agent: crate::progress::UsageLoadAgent::Kimi,
-                load: Box::new(|| load_kimi_rows(load_kind, shared, &pricing)),
+                load: Box::new(|| load_kimi_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
                 index: 14,
                 agent: "qwen",
                 progress_agent: crate::progress::UsageLoadAgent::Qwen,
-                load: Box::new(|| load_qwen_rows(load_kind, shared)),
+                load: Box::new(|| load_qwen_rows(load_kind, &loader_shared)),
             },
         ],
         &mut progress,

--- a/rust/crates/ccusage/src/progress.rs
+++ b/rust/crates/ccusage/src/progress.rs
@@ -1,10 +1,7 @@
 use std::{
     cell::RefCell,
     io::{self, IsTerminal, Write},
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
-    },
+    sync::{Arc, Condvar, Mutex},
     thread::{self, JoinHandle},
     time::Duration,
 };
@@ -111,7 +108,7 @@ pub(crate) struct UsageLoadProgress {
     enabled: bool,
     controller: Option<ProgressController>,
     owns_session: bool,
-    running: Option<Arc<AtomicBool>>,
+    running: Option<Arc<(Mutex<bool>, Condvar)>>,
     worker: Option<JoinHandle<()>>,
     stopped: bool,
 }
@@ -126,6 +123,7 @@ struct ProgressState {
     status: Option<String>,
     states: Vec<(UsageLoadAgent, LoadProgressState)>,
     frame: usize,
+    rendered: bool,
 }
 
 impl UsageLoadProgress {
@@ -155,17 +153,24 @@ impl UsageLoadProgress {
         let controller = ProgressController {
             state: Arc::clone(&state),
         };
-        let running = Arc::new(AtomicBool::new(true));
+        let running = Arc::new((Mutex::new(true), Condvar::new()));
         let worker = {
             let running = Arc::clone(&running);
-            Some(thread::spawn(move || {
-                while running.load(Ordering::Acquire) {
-                    if let Ok(mut state) = state.lock() {
-                        if state.has_content() {
-                            state.render();
-                        }
+            Some(thread::spawn(move || loop {
+                if let Ok(mut state) = state.lock() {
+                    if state.has_content() {
+                        state.render();
                     }
-                    thread::sleep(SPINNER_INTERVAL);
+                }
+                let (lock, cvar) = &*running;
+                let Ok(guard) = lock.lock() else {
+                    break;
+                };
+                let Ok((guard, _)) = cvar.wait_timeout(guard, SPINNER_INTERVAL) else {
+                    break;
+                };
+                if !*guard {
+                    break;
                 }
             }))
         };
@@ -203,14 +208,18 @@ impl UsageLoadProgress {
             return;
         }
         if let Some(running) = self.running.take() {
-            running.store(false, Ordering::Release);
+            let (lock, cvar) = &*running;
+            if let Ok(mut is_running) = lock.lock() {
+                *is_running = false;
+                cvar.notify_all();
+            }
         }
         if let Some(worker) = self.worker.take() {
             let _ = worker.join();
         }
         if let Some(controller) = self.controller.as_ref() {
             if let Ok(mut state) = controller.state.lock() {
-                if state.has_content() {
+                if state.rendered {
                     let _ = write!(io::stderr(), "\r\x1b[K\x1b[?25h");
                     let _ = io::stderr().flush();
                 }
@@ -231,7 +240,6 @@ impl UsageLoadProgress {
             return;
         };
         state.status = status;
-        state.render();
     }
 
     fn set_state(&mut self, agent: UsageLoadAgent, state: LoadProgressState) {
@@ -250,7 +258,6 @@ impl UsageLoadProgress {
         } else {
             progress_state.states.push((agent, state));
         }
-        progress_state.render();
     }
 }
 
@@ -277,6 +284,7 @@ impl ProgressState {
             "\r\x1b[K\x1b[?25l\x1b[36m{frame}\x1b[39m {text}"
         );
         let _ = io::stderr().flush();
+        self.rendered = true;
     }
 }
 

--- a/rust/crates/ccusage/src/progress.rs
+++ b/rust/crates/ccusage/src/progress.rs
@@ -166,6 +166,9 @@ impl UsageLoadProgress {
                 let Ok(guard) = lock.lock() else {
                     break;
                 };
+                if !*guard {
+                    break;
+                }
                 let Ok((guard, _)) = cvar.wait_timeout(guard, SPINNER_INTERVAL) else {
                     break;
                 };


### PR DESCRIPTION
Summary:
- Throttles usage progress rendering to the existing spinner tick instead of redrawing on every state mutation.
- Suppresses nested per-agent loader progress during all-agent reports so only the aggregate loader status owns the terminal line.
- Wakes the progress worker immediately on stop so short commands do not wait for the spinner interval.

Why:
The all-agent command can start and finish many loaders quickly, causing bursty terminal redraws that are hard to follow and slower in TTY output. This keeps the visible progress stable while avoiding unnecessary stderr writes and stop-time sleep waits.

Validation:
- pnpm run format
- pnpm typecheck
- direnv exec . pnpm run test
- TTY hyperfine comparisons against the committed Claude/Codex fixtures

@coderabbitai please review this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths all-agent progress by throttling renders to the spinner tick and hiding nested per‑agent loaders. Also ensures immediate stop wake by closing a race, so short runs don’t wait.

- **Refactors**
  - Throttle progress rendering to the spinner interval instead of on every state change.
  - Hide per-agent loaders during all-agent reports by using a `json: true` `loader_shared`, so only the aggregate owns the terminal line.
  - Replace sleep-based loop with a `Condvar` to wake the worker on stop, eliminating stop-time delay.

- **Bug Fixes**
  - Close a race where stop could notify before the worker waited, preventing a full spinner-interval delay.

<sup>Written for commit c763be97578356f23320ba0726c7fde55bd678a6. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1078?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved configuration handling for agent data loading processes.
  * Enhanced progress notification system for better responsiveness during operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1078?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->