### PR TITLE
ci: skip heavy checks for docs-only changes

### DIFF
--- a/.github/actions/detect-code-changes/action.yaml
+++ b/.github/actions/detect-code-changes/action.yaml
@@ -1,0 +1,43 @@
+name: Detect code changes
+description: Detect whether changed files require full code validation
+outputs:
+  code-changed:
+    description: Whether any changed file is outside documentation-only paths
+    value: ${{ steps.detect.outputs.code-changed }}
+runs:
+  using: composite
+  steps:
+    - id: detect
+      shell: bash
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      run: |
+        set -euo pipefail
+
+        base_sha="$BASE_SHA"
+        head_sha="$HEAD_SHA"
+
+        if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
+          base_sha="$(git rev-list --max-parents=0 "$head_sha")"
+        fi
+
+        if ! git cat-file -e "$base_sha^{commit}" || ! git cat-file -e "$head_sha^{commit}"; then
+          echo "code-changed=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        changed_files="$(mktemp)"
+        git diff --name-only "$base_sha" "$head_sha" > "$changed_files"
+
+        code_changed=false
+        while IFS= read -r path; do
+          [[ -z "$path" ]] && continue
+
+          case "$path" in
+            docs/*|*.md|*.mdx) ;;
+            *) code_changed=true; break ;;
+          esac
+        done < "$changed_files"
+
+        echo "code-changed=$code_changed" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ccusage-perf.yaml
+++ b/.github/workflows/ccusage-perf.yaml
@@ -13,7 +13,21 @@ permissions:
   issues: write
 
 jobs:
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-slim
+    outputs:
+      code-changed: ${{ steps.detect.outputs.code-changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - id: detect
+        uses: ./.github/actions/detect-code-changes
+
   compare:
+    needs: changes
+    if: needs.changes.outputs.code-changed == 'true'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
 

--- a/.github/workflows/ccusage-perf.yaml
+++ b/.github/workflows/ccusage-perf.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: detect
         uses: ./.github/actions/detect-code-changes
 

--- a/.github/workflows/ccusage-rust-perf.yaml
+++ b/.github/workflows/ccusage-rust-perf.yaml
@@ -13,7 +13,21 @@ permissions:
   issues: write
 
 jobs:
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-slim
+    outputs:
+      code-changed: ${{ steps.detect.outputs.code-changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - id: detect
+        uses: ./.github/actions/detect-code-changes
+
   compare:
+    needs: changes
+    if: needs.changes.outputs.code-changed == 'true'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
 

--- a/.github/workflows/ccusage-rust-perf.yaml
+++ b/.github/workflows/ccusage-rust-perf.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: detect
         uses: ./.github/actions/detect-code-changes
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true'
     permissions:
-      artifact-metadata: write
+      actions: write
       contents: read
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -134,7 +134,6 @@ jobs:
     if: needs.changes.outputs.code-changed == 'true'
     permissions:
       actions: read
-      artifact-metadata: read
       contents: read
     runs-on: ubuntu-24.04-arm
     outputs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
 
+permissions: read-all
+
 jobs:
   changes:
     name: Detect code changes
@@ -46,6 +48,9 @@ jobs:
   build-native-packages:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true'
+    permissions:
+      artifact-metadata: write
+      contents: read
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -127,6 +132,10 @@ jobs:
       - changes
       - build-native-packages
     if: needs.changes.outputs.code-changed == 'true'
+    permissions:
+      actions: read
+      artifact-metadata: read
+      contents: read
     runs-on: ubuntu-24.04-arm
     outputs:
       urls: ${{ steps.publish.outputs.urls }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,21 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-slim
+    outputs:
+      code-changed: ${{ steps.detect.outputs.code-changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - id: detect
+        uses: ./.github/actions/detect-code-changes
+
   lint-check:
+    needs: changes
+    if: needs.changes.outputs.code-changed == 'true'
     runs-on: ubuntu-24.04-arm
 
     steps:
@@ -15,6 +29,8 @@ jobs:
       - run: nix develop --command pnpm typecheck
 
   test:
+    needs: changes
+    if: needs.changes.outputs.code-changed == 'true'
     runs-on: ubuntu-24.04-arm
 
     steps:
@@ -27,6 +43,8 @@ jobs:
       - run: nix develop --command pnpm run test
 
   build-native-packages:
+    needs: changes
+    if: needs.changes.outputs.code-changed == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -105,7 +123,9 @@ jobs:
 
   npm-publish-dry-run-and-upload-pkg-pr-now:
     needs:
+      - changes
       - build-native-packages
+    if: needs.changes.outputs.code-changed == 'true'
     runs-on: ubuntu-24.04-arm
     outputs:
       urls: ${{ steps.publish.outputs.urls }}
@@ -127,8 +147,10 @@ jobs:
         run: nix develop --command pnpm pkg-pr-new publish --pnpm --bin './apps/ccusage' './packages/ccusage-*'
 
   ccusage-preview-e2e:
-    if: github.event_name == 'pull_request'
-    needs: npm-publish-dry-run-and-upload-pkg-pr-now
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code-changed == 'true'
+    needs:
+      - changes
+      - npm-publish-dry-run-and-upload-pkg-pr-now
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -174,6 +196,8 @@ jobs:
       - run: nix develop --command typos --config ./typos.toml
 
   schema-check:
+    needs: changes
+    if: needs.changes.outputs.code-changed == 'true'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: detect
         uses: ./.github/actions/detect-code-changes
 


### PR DESCRIPTION
## Summary

Skip the slow code validation, package preview, E2E, schema, and performance comparison jobs when a push or PR only changes documentation files. The workflows still start and report a lightweight change-detection job, so required-check setups do not get stuck waiting for workflows skipped by path filters.

## Testing

- pnpm run format
- pnpm typecheck
- direnv exec . pnpm lint
- direnv exec . pnpm run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip heavy CI jobs when a PR only changes docs. Adds a shared change-detection action so workflows still report a status, hardens checkout, and sets read-only defaults with supported `actions` permissions for artifact handoff.

- **New Features**
  - Added `.github/actions/detect-code-changes` to treat `docs/*`, `*.md`, and `*.mdx` as docs-only changes.
  - CI skips lint, tests, native builds, preview publish, E2E, schema checks, and performance comparisons for docs-only PRs.
  - Performance workflows skip comparison jobs for docs-only PRs.

- **Refactors**
  - Set `persist-credentials: false` on `actions/checkout` in change-detection jobs.
  - Default workflow permissions to read-only (`permissions: read-all`); replace invalid artifact permission with `actions: write` for native builds and `actions: read` for the dry-run publish job, keeping `contents: read` where needed.

<sup>Written for commit 282e8955b71aa8b0ca1dcf5a678f1f16fe10d44e. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1080?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PR detection step that determines whether changes include non-documentation code and exposes a simple true/false output.

* **Chores**
  * CI and performance pipelines now skip downstream jobs (lint, test, build, schema checks, previews, and perf comparisons) for documentation-only PRs, reducing unnecessary runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->