### PR TITLE
chore: format native package manifests

### DIFF
--- a/packages/ccusage-darwin-arm64/package.json
+++ b/packages/ccusage-darwin-arm64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-darwin-arm64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for macOS arm64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"arm64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/ccusage-darwin-x64/package.json
+++ b/packages/ccusage-darwin-x64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-darwin-x64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for macOS x64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"x64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/ccusage-linux-arm64/package.json
+++ b/packages/ccusage-linux-arm64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-linux-arm64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Static native ccusage binary for Linux arm64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"arm64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/ccusage-linux-x64/package.json
+++ b/packages/ccusage-linux-x64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-linux-x64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Static native ccusage binary for Linux x64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"x64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/ccusage-win32-arm64/package.json
+++ b/packages/ccusage-win32-arm64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-win32-arm64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for Windows arm64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"arm64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/ccusage-win32-x64/package.json
+++ b/packages/ccusage-win32-x64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-win32-x64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for Windows x64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"x64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},


### PR DESCRIPTION
Fixes the main CI failure introduced after #1079 by applying oxfmt ordering to the native package manifests added in #1073.

Testing:
- nix flake check --print-build-logs
- pre-push lefthook: oxfmt, typos, gitleaks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reformatted native `@ccusage/*` package.json manifests to follow `oxfmt` key ordering (moves the `type` field). This fixes the repository-wide `oxfmt` check and restores `nix flake check` on main.

<sup>Written for commit 67a4c666364b1e6162c9d3d7bfa2729719dc990c. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1081?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reorganized internal package configuration fields across platform-specific distributions for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->