### PR TITLE
ci(lefthook): run cargo tests before push

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -65,3 +65,10 @@ pre-push:
     - name: vitest related
       glob: '*.{ts,tsx,js,jsx,mjs,cjs}'
       run: pnpm vitest related --run {push_files}
+
+    - name: cargo test
+      glob:
+        - 'rust/**/*.rs'
+        - 'rust/**/Cargo.toml'
+        - 'rust/Cargo.lock'
+      run: cargo test --manifest-path rust/Cargo.toml --workspace

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -71,4 +71,4 @@ pre-push:
         - 'rust/**/*.rs'
         - 'rust/**/Cargo.toml'
         - 'rust/Cargo.lock'
-      run: cargo test --manifest-path rust/Cargo.toml --workspace
+      run: cargo test --manifest-path rust/Cargo.toml --workspace --all-targets

--- a/packages/ccusage-darwin-arm64/package.json
+++ b/packages/ccusage-darwin-arm64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-darwin-arm64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for macOS arm64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"arm64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/ccusage-darwin-x64/package.json
+++ b/packages/ccusage-darwin-x64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-darwin-x64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for macOS x64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"x64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/ccusage-linux-arm64/package.json
+++ b/packages/ccusage-linux-arm64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-linux-arm64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Static native ccusage binary for Linux arm64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"arm64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/ccusage-linux-x64/package.json
+++ b/packages/ccusage-linux-x64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-linux-x64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Static native ccusage binary for Linux x64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"x64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/ccusage-win32-arm64/package.json
+++ b/packages/ccusage-win32-arm64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-win32-arm64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for Windows arm64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"arm64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/ccusage-win32-x64/package.json
+++ b/packages/ccusage-win32-x64/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@ccusage/ccusage-win32-x64",
-	"type": "commonjs",
 	"version": "19.0.3",
 	"description": "Native ccusage binary for Windows x64",
 	"license": "MIT",
@@ -18,6 +17,7 @@
 	"cpu": [
 		"x64"
 	],
+	"type": "commonjs",
 	"publishConfig": {
 		"access": "public"
 	},


### PR DESCRIPTION
## Summary

Adds a lefthook pre-push \`cargo test --manifest-path rust/Cargo.toml --workspace\` job for Rust source and Cargo manifest changes. This closes the gap where pre-push ran clippy but did not run the Rust test suite.

Also applies the current formatter output to native package manifests so the existing pre-push \`oxfmt --check .\` job passes.

## Testing

- \`direnv exec . pnpm run format\`
- \`direnv exec . pnpm typecheck\`
- \`direnv exec . pnpm run test\`
- \`direnv exec . lefthook run pre-push --all-files\`
- \`direnv exec . git push -u origin codex/add-lefthook-cargo-test\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a lefthook pre-push job to run `cargo test --manifest-path rust/Cargo.toml --workspace --all-targets` when Rust sources, Cargo manifests, or `Cargo.lock` change, so pushes run the full Rust test suite (including integration tests and examples), not just clippy.
Also formats native `@ccusage/*` package manifests so the `oxfmt --check` pre-push step passes.

<sup>Written for commit fc29e6860b22ffe84350dee0f87be1b75be9b9ad. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1082?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a pre-push check that runs the Rust test suite for the repository when Rust files are involved.

* **Chores**
  * Reorganized the package manifest "type" field across platform-specific packages for consistent ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1082?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->