### PR TITLE
build(nix): update LiteLLM pricing lock hash

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,7 @@
     "litellm-pricing": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-0FvNNOBhUPVF3s7yVnT6Xn2y3x4jgGbO9L2cmbCgasw=",
+        "narHash": "sha256-GYGEQUcNe4JcHwYNDL4M5yVZpYj0ExjVEOV3vdH4vSc=",
         "type": "file",
         "url": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
       },


### PR DESCRIPTION
Updates the pinned LiteLLM pricing file hash in flake.lock.

The upstream pricing JSON changed, so the existing Nix file input narHash no longer matches and CI fails during flake evaluation before reaching the Rust build. This is the minimal base-branch fix needed for #1096 to evaluate cleanly without changing runtime behavior.

Testing:
- nix flake check --print-build-logs
- pre-push hook via direnv exec . git push origin codex/pr-1096-litellm-lock


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `litellm-pricing` file input hash in `flake.lock` to match the upstream pricing JSON so Nix evaluation and CI pass again. No runtime changes.

<sup>Written for commit 736a68c63d515be7d173c75bdb1655a46aa7c400. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1098?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

