### PR TITLE
build(nix): lock LiteLLM pricing through repository input

### DIFF
--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: ./.github/actions/setup-nix
       - name: Update LiteLLM pricing input
         run: |
-          nix flake update litellm-pricing
+          nix flake update litellm
           nix run .#update-pricing-fallback
           nix flake check
       - name: Create pull request

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -188,10 +188,10 @@ nix run github:ryoppippi/ccusage -- codex daily --offline
 nix build github:ryoppippi/ccusage
 ```
 
-Nix builds embed the LiteLLM pricing file from the locked `litellm-pricing` flake input, so sandboxed builds do not fetch pricing at build time. To update the locked pricing snapshot and refresh the non-Nix Cargo fallback JSON:
+Nix builds embed the LiteLLM pricing file from the locked `litellm` flake input, so sandboxed builds do not fetch pricing at build time. To update the locked pricing snapshot and refresh the non-Nix Cargo fallback JSON:
 
 ```bash
-nix flake update litellm-pricing
+nix flake update litellm
 nix run .#update-pricing-fallback
 nix flake check
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -15,16 +15,20 @@
         "type": "github"
       }
     },
-    "litellm-pricing": {
+    "litellm": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-GYGEQUcNe4JcHwYNDL4M5yVZpYj0ExjVEOV3vdH4vSc=",
-        "type": "file",
-        "url": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+        "lastModified": 1779231723,
+        "narHash": "sha256-0MG6NXwVytdRQIf+L+nV5T4GZfIDUCJNZPnIlVfCoq0=",
+        "owner": "BerriAI",
+        "repo": "litellm",
+        "rev": "e59e34bed3670a6894d43129c2af16af28057d03",
+        "type": "github"
       },
       "original": {
-        "type": "file",
-        "url": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+        "owner": "BerriAI",
+        "repo": "litellm",
+        "type": "github"
       }
     },
     "nixpkgs": {
@@ -46,7 +50,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "litellm-pricing": "litellm-pricing",
+        "litellm": "litellm",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,8 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.crane.url = "github:ipetkov/crane";
-  inputs.litellm-pricing = {
-    url = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+  inputs.litellm = {
+    url = "github:BerriAI/litellm";
     flake = false;
   };
   inputs.rust-overlay = {
@@ -12,8 +12,9 @@
     inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, crane, litellm-pricing, nixpkgs, rust-overlay, ... }:
+  outputs = { self, crane, litellm, nixpkgs, rust-overlay, ... }:
     let
+      litellm-pricing = "${litellm}/model_prices_and_context_window.json";
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = f:
         nixpkgs.lib.genAttrs systems (system:


### PR DESCRIPTION
Switches the LiteLLM pricing flake input from the raw GitHub JSON URL to the BerriAI/litellm repository input.

The build still embeds model_prices_and_context_window.json, but flake.lock now records the upstream LiteLLM commit metadata instead of only a file hash. The scheduled pricing workflow and README update command now target the renamed litellm input.

Testing:
- nix run .#update-pricing-fallback
- nix flake check --print-build-logs
- pre-commit hook via nix develop
- pre-push hook via nix develop


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch LiteLLM pricing input from a raw GitHub file to the `BerriAI/litellm` repository to improve traceability and reproducibility. The build still embeds `model_prices_and_context_window.json`, now pinned to a specific upstream commit.

- **Refactors**
  - Rename flake input to `litellm` and read pricing from the repo.
  - Update workflow to run `nix flake update litellm`; README reflects the new command.
  - `flake.lock` now records `owner/repo/rev` for LiteLLM instead of a file hash.

<sup>Written for commit bbe1e4bb88456b51d9770b08d3e3cf111b1eb85d. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1099?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified pricing data source integration in the build system.

* **Documentation**
  * Updated contributor setup instructions to reflect build system changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1099?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->