### PR TITLE
fix(ccusage): parse root session id lookup

### DIFF
--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -290,7 +290,7 @@ fn parse_command(
         "daily" => parse_all_command(parser, shared, AgentReportKind::Daily, config),
         "monthly" => parse_all_command(parser, shared, AgentReportKind::Monthly, config),
         "weekly" => parse_all_command(parser, shared, AgentReportKind::Weekly, config),
-        "session" => parse_all_command(parser, shared, AgentReportKind::Session, config),
+        "session" => parse_top_level_session_command(parser, shared, config),
         "blocks" => {
             let mut args = BlocksArgs {
                 shared,
@@ -461,6 +461,39 @@ fn parse_all_command(
     Ok(Command::All(AgentCommandArgs {
         shared,
         kind,
+        pi_path: None,
+        open_claw_path: None,
+        codex_speed: CodexSpeed::Auto,
+    }))
+}
+
+fn parse_top_level_session_command(
+    parser: &mut ArgParser,
+    shared: SharedArgs,
+    _config: &ConfigContext,
+) -> Result<Command, String> {
+    let mut args = SessionArgs { shared, id: None };
+    while parser.peek().is_some() {
+        if matches!(parser.peek(), Some("--all")) {
+            parser.next();
+            continue;
+        }
+        if parse_shared_arg_for_command(parser, &mut args.shared)? {
+            continue;
+        }
+        match parser.next_flag()?.as_str() {
+            "-i" | "--id" => args.id = Some(parser.value_for("--id")?),
+            flag => return Err(format!("Unknown session option '{flag}'")),
+        }
+    }
+
+    if args.id.is_some() {
+        return Ok(Command::Session(args));
+    }
+
+    Ok(Command::All(AgentCommandArgs {
+        shared: args.shared,
+        kind: AgentReportKind::Session,
         pi_path: None,
         open_claw_path: None,
         codex_speed: CodexSpeed::Auto,
@@ -1808,6 +1841,16 @@ mod tests {
     }
 
     #[test]
+    fn parses_root_session_as_all_agent_report_without_id() {
+        let cli = parse(&["ccusage", "session", "--json"]);
+        let Some(Command::All(args)) = cli.command else {
+            panic!("expected all-agent command");
+        };
+        assert_eq!(args.kind, AgentReportKind::Session);
+        assert!(args.shared.json);
+    }
+
+    #[test]
     fn applies_config_defaults_and_command_options_before_cli_options() {
         let path = temp_config_path("daily");
         fs::write(
@@ -2379,6 +2422,16 @@ mod tests {
         let cli = parse(&["ccusage", "claude", "session", "--json", "--id", "abc"]);
         let Some(Command::Session(args)) = cli.command else {
             panic!("expected claude session command");
+        };
+        assert!(args.shared.json);
+        assert_eq!(args.id.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn parses_top_level_session_id_lookup() {
+        let cli = parse(&["ccusage", "session", "--json", "--id", "abc"]);
+        let Some(Command::Session(args)) = cli.command else {
+            panic!("expected session command");
         };
         assert!(args.shared.json);
         assert_eq!(args.id.as_deref(), Some("abc"));

--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -1424,10 +1424,15 @@ fn all_report_help(report: &str) -> String {
         "session" => "Show all detected coding (agent) CLI usage grouped by session",
         _ => unreachable!("all-agent report is prevalidated"),
     };
+    let options = if report == "session" {
+        command_options(&[all_agent_options(), session_options()])
+    } else {
+        all_agent_options().to_string()
+    };
     command_help(
         description,
         &format!("ccusage {report} <OPTIONS>"),
-        all_agent_options(),
+        &options,
     )
 }
 
@@ -2074,6 +2079,13 @@ mod tests {
 
         assert!(help.contains("--color"));
         assert!(help.contains("--no-color"));
+    }
+
+    #[test]
+    fn contextual_root_session_help_lists_id_option() {
+        let help = help_text_for_args(&["ccusage".to_string(), "session".to_string()]);
+
+        assert!(help.contains("--id"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1117.

This restores the documented \`ccusage session --id <session-id>\` lookup by routing root session commands with \`--id\` or \`-i\` to the existing Claude session lookup path.

Root \`ccusage session\` without an id still uses the all-agent session report path, so the existing aggregate behavior is preserved.

Testing:
- nix develop --command pnpm run format
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage parses_top_level_session_id_lookup
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage parses_root_session_as_all_agent_report_without_id
- nix develop --command pnpm run typecheck
- nix develop --command pnpm run test
- pre-push hook: cargo test, clippy, oxfmt, typos, gitleaks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `ccusage session --id <session-id>` lookup and makes it discoverable in help. Root `session` accepts `--id`/`-i` to fetch a single session; without an id it returns the aggregate session report.

- **Bug Fixes**
  - Route root `session` through a session-specific parser so `--id`/`-i` work; default to the all‑agent session report when no id is provided.
  - Document `--id`/`-i` in `ccusage session --help` while keeping shared all‑agent options, and add parsing/help tests to prevent regressions.

<sup>Written for commit 99ef0822d340c1a6250fe4ee56bd9015406a3446. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1118?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `session` command now accepts `--id` / `-i` at the top level and the help text includes this option; invoking with `--id` targets a specific session, otherwise it runs the all-agents session report.  
* **Tests**
  * Added unit tests validating `session` parsing and help text for combinations with shared flags (e.g., `--json`).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->