### PR TITLE
perf(codex): speed up report aggregation

### DIFF
--- a/rust/crates/ccusage-terminal/src/lib.rs
+++ b/rust/crates/ccusage-terminal/src/lib.rs
@@ -78,12 +78,13 @@ impl SimpleTable {
         self.headers.len()
     }
 
-    pub fn print(&self) {
+    pub fn print(&self) -> io::Result<()> {
         let stdout = io::stdout();
         let mut stdout = stdout.lock();
         for line in self.render_lines() {
-            writeln!(stdout, "{line}").expect("failed to write table line");
+            writeln!(stdout, "{line}")?;
         }
+        Ok(())
     }
 
     fn render_lines(&self) -> Vec<String> {

--- a/rust/crates/ccusage-terminal/src/lib.rs
+++ b/rust/crates/ccusage-terminal/src/lib.rs
@@ -82,7 +82,7 @@ impl SimpleTable {
         let stdout = io::stdout();
         let mut stdout = stdout.lock();
         for line in self.render_lines() {
-            let _ = writeln!(stdout, "{line}");
+            writeln!(stdout, "{line}").expect("failed to write table line");
         }
     }
 

--- a/rust/crates/ccusage-terminal/src/lib.rs
+++ b/rust/crates/ccusage-terminal/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    io::{self, IsTerminal},
+    io::{self, IsTerminal, Write},
 };
 
 #[cfg(unix)]
@@ -79,8 +79,10 @@ impl SimpleTable {
     }
 
     pub fn print(&self) {
+        let stdout = io::stdout();
+        let mut stdout = stdout.lock();
         for line in self.render_lines() {
-            println!("{line}");
+            let _ = writeln!(stdout, "{line}");
         }
     }
 

--- a/rust/crates/ccusage/src/adapter/all.rs
+++ b/rust/crates/ccusage/src/adapter/all.rs
@@ -64,8 +64,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     if wants_json(&shared) {
         return print_json_or_jq(report_json(&result.rows, args.kind), shared.jq.as_deref());
     }
-    print_table(&result.rows, args.kind, &shared, &result.detected_agents);
-    Ok(())
+    print_table(&result.rows, args.kind, &shared, &result.detected_agents)
 }
 
 fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AllLoadResult> {
@@ -851,11 +850,11 @@ fn print_table(
     kind: AgentReportKind,
     shared: &SharedArgs,
     detected_agents: &[&'static str],
-) {
+) -> Result<()> {
     print_box_title(&all_report_title(kind, rows, detected_agents), shared);
     if rows.is_empty() {
         eprintln!("No usage data found.");
-        return;
+        return Ok(());
     }
     let terminal_width = crate::terminal_width();
     let compact = shared.compact || terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD;
@@ -949,11 +948,12 @@ fn print_table(
             ),
         ]);
     }
-    table.print();
+    table.print()?;
     if compact {
         eprintln!("\nRunning in Compact Mode");
         eprintln!("Expand terminal width to see cache metrics and total tokens");
     }
+    Ok(())
 }
 
 fn all_report_title(

--- a/rust/crates/ccusage/src/adapter/amp.rs
+++ b/rust/crates/ccusage/src/adapter/amp.rs
@@ -30,8 +30,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     if wants_json(&shared) {
         return print_json_or_jq(report_from_rows(&rows, args.kind), shared.jq.as_deref());
     }
-    print_table(args.kind, &rows, &shared);
-    Ok(())
+    print_table(args.kind, &rows, &shared)
 }
 
 pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
@@ -285,8 +284,8 @@ pub(crate) fn print_table(
     kind: AgentReportKind,
     rows: &[crate::UsageSummary],
     shared: &crate::cli::SharedArgs,
-) {
-    print_table_for_agent("Amp", kind, rows, shared);
+) -> Result<()> {
+    print_table_for_agent("Amp", kind, rows, shared)
 }
 
 pub(crate) fn print_table_for_agent(
@@ -294,10 +293,10 @@ pub(crate) fn print_table_for_agent(
     kind: AgentReportKind,
     rows: &[crate::UsageSummary],
     shared: &crate::cli::SharedArgs,
-) {
+) -> Result<()> {
     if rows.is_empty() {
         eprintln!("No {agent_name} usage data found.");
-        return;
+        return Ok(());
     }
     let terminal_width = crate::terminal_width();
     let compact = shared.compact || terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD;
@@ -458,7 +457,8 @@ pub(crate) fn print_table_for_agent(
             ),
         ]);
     }
-    table.print();
+    table.print()?;
+    Ok(())
 }
 
 fn agent_report_label(kind: AgentReportKind) -> &'static str {

--- a/rust/crates/ccusage/src/adapter/codebuff.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff.rs
@@ -59,7 +59,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     if wants_json(&shared) {
         return print_json_or_jq(report_from_rows(&rows, args.kind), shared.jq.as_deref());
     }
-    crate::adapter::amp::print_table_for_agent("Codebuff", args.kind, &rows, &shared);
+    crate::adapter::amp::print_table_for_agent("Codebuff", args.kind, &rows, &shared)?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/codex.rs
+++ b/rust/crates/ccusage/src/adapter/codex.rs
@@ -115,7 +115,7 @@ fn codex_config_requests_fast_service_tier(content: &str) -> bool {
 
 fn load_groups(shared: &SharedArgs, kind: AgentReportKind) -> Result<BTreeMap<String, CodexGroup>> {
     let paths = crate::codex_usage_paths()?;
-    if paths.len() == 1 {
+    if paths.len() == 1 && !wants_json(shared) {
         return load_groups_from_directory(&paths[0], shared, kind);
     }
     let mut groups = BTreeMap::new();

--- a/rust/crates/ccusage/src/adapter/codex.rs
+++ b/rust/crates/ccusage/src/adapter/codex.rs
@@ -37,8 +37,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         let output = report_from_groups(&groups, args.kind, &pricing, speed);
         return print_json_or_jq(output, shared.jq.as_deref());
     }
-    print_table_from_groups(&groups, args.kind, &pricing, speed, &shared);
-    Ok(())
+    print_table_from_groups(&groups, args.kind, &pricing, speed, &shared)
 }
 
 #[cfg(test)]
@@ -139,7 +138,8 @@ fn load_groups_from_directory(
     if shared.single_thread {
         return aggregate_files_local(sessions_dir, &files, shared, kind);
     }
-    aggregate_files_parallel_local(sessions_dir, &files, shared, kind)
+    let seen = create_dedupe_shards();
+    aggregate_files_parallel(sessions_dir, &files, shared, kind, &seen)
 }
 
 fn load_groups_from_directory_with_dedupe(
@@ -275,52 +275,6 @@ fn aggregate_files_local_with_seen(
         )?;
     }
     Ok(aggregation)
-}
-
-fn aggregate_files_parallel_local(
-    sessions_dir: &Path,
-    files: &[PathBuf],
-    shared: &SharedArgs,
-    kind: AgentReportKind,
-) -> Result<BTreeMap<String, CodexGroup>> {
-    let worker_count = thread::available_parallelism()
-        .map(usize::from)
-        .unwrap_or(1)
-        .saturating_mul(3)
-        .min(files.len());
-    if worker_count <= 1 {
-        return aggregate_files_local(sessions_dir, files, shared, kind);
-    }
-
-    let chunks = crate::chunk_file_indexes_by_size(files, worker_count);
-    thread::scope(|scope| {
-        let mut handles = Vec::with_capacity(chunks.len());
-        for chunk in chunks {
-            handles.push(scope.spawn(move || {
-                let mut chunk_files = Vec::with_capacity(chunk.len());
-                for index in chunk {
-                    chunk_files.push(files[index].clone());
-                }
-                aggregate_files_local_with_seen(sessions_dir, &chunk_files, shared, kind)
-            }));
-        }
-
-        let mut groups = BTreeMap::new();
-        let mut seen = FxHashSet::default();
-        for handle in handles {
-            let partial = handle
-                .join()
-                .map_err(|_| crate::cli_error("codex worker panicked"))??;
-            for key in partial.seen {
-                if !seen.insert(key) {
-                    let global_seen = create_dedupe_shards();
-                    return aggregate_files(sessions_dir, files, shared, kind, &global_seen);
-                }
-            }
-            merge_groups(&mut groups, partial.groups);
-        }
-        Ok(groups)
-    })
 }
 
 fn aggregate_file_local(
@@ -707,10 +661,10 @@ fn print_table_from_groups(
     pricing: &PricingMap,
     speed: CodexSpeed,
     shared: &SharedArgs,
-) {
+) -> Result<()> {
     if groups.is_empty() {
         eprintln!("No Codex usage data found.");
-        return;
+        return Ok(());
     }
     let first_column = match kind {
         AgentReportKind::Daily => "Date",
@@ -792,7 +746,8 @@ fn print_table_from_groups(
         color(shared, format_number(total_tokens), Color::Yellow),
         color(shared, format_currency(total_cost), Color::Yellow),
     ]);
-    table.print();
+    table.print()?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/crates/ccusage/src/adapter/codex.rs
+++ b/rust/crates/ccusage/src/adapter/codex.rs
@@ -7,7 +7,6 @@ use std::{
     thread,
 };
 
-use compact_str::CompactString;
 use jiff::tz::TimeZone as JiffTimeZone;
 use rustc_hash::FxHasher;
 use serde_json::{json, Value};
@@ -16,33 +15,29 @@ use crate::{
     cli::{AgentCommandArgs, AgentReportKind, CodexSpeed, SharedArgs, WeekDay},
     color,
     fast::FxHashSet,
-    format_currency, format_date_tz, format_models_multiline, format_number, json_float,
-    json_value_u64, log_level, parse_ts_timestamp, parse_tz, print_box_title, print_json_or_jq,
-    wants_json, week_start, Align, CodexGroup, CodexModelUsage, CodexTokenUsageEvent, Color,
-    PricingMap, Result, SimpleTable,
+    format_currency, format_date_tz, format_models_multiline, format_number, json_float, log_level,
+    parse_ts_timestamp, parse_tz, print_box_title, print_json_or_jq, wants_json, week_start, Align,
+    CodexGroup, CodexModelUsage, CodexTokenUsageEvent, Color, PricingMap, Result, SimpleTable,
 };
 
-type CodexEventKey = (
-    CompactString,
-    Option<CompactString>,
-    u64,
-    u64,
-    u64,
-    u64,
-    u64,
-);
+type CodexEventKey = (crate::TimestampMs, u64, usize, u64, u64, u64, u64, u64);
 type CodexDedupeShards = [Mutex<FxHashSet<CodexEventKey>>];
+
+struct CodexAggregation {
+    groups: BTreeMap<String, CodexGroup>,
+    seen: FxHashSet<CodexEventKey>,
+}
 
 pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     let shared = args.shared;
     let pricing = PricingMap::load(shared.offline, log_level() != Some(0));
     let groups = load_groups(&shared, args.kind)?;
     let speed = resolve_codex_speed(args.codex_speed);
-    let output = report_from_groups(&groups, args.kind, &pricing, speed);
     if wants_json(&shared) {
+        let output = report_from_groups(&groups, args.kind, &pricing, speed);
         return print_json_or_jq(output, shared.jq.as_deref());
     }
-    print_table(&output, args.kind, &shared);
+    print_table_from_groups(&groups, args.kind, &pricing, speed, &shared);
     Ok(())
 }
 
@@ -119,9 +114,13 @@ fn codex_config_requests_fast_service_tier(content: &str) -> bool {
 }
 
 fn load_groups(shared: &SharedArgs, kind: AgentReportKind) -> Result<BTreeMap<String, CodexGroup>> {
+    let paths = crate::codex_usage_paths()?;
+    if paths.len() == 1 {
+        return load_groups_from_directory(&paths[0], shared, kind);
+    }
     let mut groups = BTreeMap::new();
     let seen = create_dedupe_shards();
-    for path in crate::codex_usage_paths()? {
+    for path in paths {
         merge_groups(
             &mut groups,
             load_groups_from_directory_with_dedupe(&path, shared, kind, &seen)?,
@@ -130,14 +129,17 @@ fn load_groups(shared: &SharedArgs, kind: AgentReportKind) -> Result<BTreeMap<St
     Ok(groups)
 }
 
-#[cfg(test)]
 fn load_groups_from_directory(
     sessions_dir: &Path,
     shared: &SharedArgs,
     kind: AgentReportKind,
 ) -> Result<BTreeMap<String, CodexGroup>> {
-    let seen = create_dedupe_shards();
-    load_groups_from_directory_with_dedupe(sessions_dir, shared, kind, &seen)
+    let mut files = Vec::new();
+    crate::collect_usage_files(sessions_dir, &mut files);
+    if shared.single_thread {
+        return aggregate_files_local(sessions_dir, &files, shared, kind);
+    }
+    aggregate_files_parallel_local(sessions_dir, &files, shared, kind)
 }
 
 fn load_groups_from_directory_with_dedupe(
@@ -242,6 +244,98 @@ fn aggregate_file(
     })
 }
 
+fn aggregate_files_local(
+    sessions_dir: &Path,
+    files: &[PathBuf],
+    shared: &SharedArgs,
+    kind: AgentReportKind,
+) -> Result<BTreeMap<String, CodexGroup>> {
+    Ok(aggregate_files_local_with_seen(sessions_dir, files, shared, kind)?.groups)
+}
+
+fn aggregate_files_local_with_seen(
+    sessions_dir: &Path,
+    files: &[PathBuf],
+    shared: &SharedArgs,
+    kind: AgentReportKind,
+) -> Result<CodexAggregation> {
+    let mut aggregation = CodexAggregation {
+        groups: BTreeMap::new(),
+        seen: FxHashSet::default(),
+    };
+    let timezone = parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
+    for file in files {
+        aggregate_file_local(
+            sessions_dir,
+            file,
+            kind,
+            timezone.as_ref(),
+            shared,
+            &mut aggregation,
+        )?;
+    }
+    Ok(aggregation)
+}
+
+fn aggregate_files_parallel_local(
+    sessions_dir: &Path,
+    files: &[PathBuf],
+    shared: &SharedArgs,
+    kind: AgentReportKind,
+) -> Result<BTreeMap<String, CodexGroup>> {
+    let worker_count = thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+        .saturating_mul(3)
+        .min(files.len());
+    if worker_count <= 1 {
+        return aggregate_files_local(sessions_dir, files, shared, kind);
+    }
+
+    let chunks = crate::chunk_file_indexes_by_size(files, worker_count);
+    thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(chunks.len());
+        for chunk in chunks {
+            handles.push(scope.spawn(move || {
+                let mut chunk_files = Vec::with_capacity(chunk.len());
+                for index in chunk {
+                    chunk_files.push(files[index].clone());
+                }
+                aggregate_files_local_with_seen(sessions_dir, &chunk_files, shared, kind)
+            }));
+        }
+
+        let mut groups = BTreeMap::new();
+        let mut seen = FxHashSet::default();
+        for handle in handles {
+            let partial = handle
+                .join()
+                .map_err(|_| crate::cli_error("codex worker panicked"))??;
+            for key in partial.seen {
+                if !seen.insert(key) {
+                    let global_seen = create_dedupe_shards();
+                    return aggregate_files(sessions_dir, files, shared, kind, &global_seen);
+                }
+            }
+            merge_groups(&mut groups, partial.groups);
+        }
+        Ok(groups)
+    })
+}
+
+fn aggregate_file_local(
+    sessions_dir: &Path,
+    file: &Path,
+    kind: AgentReportKind,
+    timezone: Option<&JiffTimeZone>,
+    shared: &SharedArgs,
+    aggregation: &mut CodexAggregation,
+) -> Result<()> {
+    crate::visit_codex_session_file(sessions_dir, file, |event| {
+        add_event_to_groups_local(&event, kind, timezone, shared, aggregation)
+    })
+}
+
 fn add_event_to_groups(
     event: &CodexTokenUsageEvent,
     kind: AgentReportKind,
@@ -250,14 +344,55 @@ fn add_event_to_groups(
     seen: &CodexDedupeShards,
     groups: &mut BTreeMap<String, CodexGroup>,
 ) -> Result<()> {
-    if !insert_event_key(event, seen) {
-        return Ok(());
-    }
     let Some(model) = event.model.as_deref().filter(|model| !model.is_empty()) else {
         return Ok(());
     };
     let timestamp = parse_ts_timestamp(&event.timestamp)
         .ok_or_else(|| crate::cli_error(format!("Invalid Codex timestamp: {}", event.timestamp)))?;
+    if !insert_event_key(event, timestamp, model, seen) {
+        return Ok(());
+    }
+    add_deduped_event_to_groups(event, model, timestamp, kind, timezone, shared, groups)
+}
+
+fn add_event_to_groups_local(
+    event: &CodexTokenUsageEvent,
+    kind: AgentReportKind,
+    timezone: Option<&JiffTimeZone>,
+    shared: &SharedArgs,
+    aggregation: &mut CodexAggregation,
+) -> Result<()> {
+    let Some(model) = event.model.as_deref().filter(|model| !model.is_empty()) else {
+        return Ok(());
+    };
+    let timestamp = parse_ts_timestamp(&event.timestamp)
+        .ok_or_else(|| crate::cli_error(format!("Invalid Codex timestamp: {}", event.timestamp)))?;
+    if !aggregation
+        .seen
+        .insert(codex_event_key(event, timestamp, model))
+    {
+        return Ok(());
+    }
+    add_deduped_event_to_groups(
+        event,
+        model,
+        timestamp,
+        kind,
+        timezone,
+        shared,
+        &mut aggregation.groups,
+    )
+}
+
+fn add_deduped_event_to_groups(
+    event: &CodexTokenUsageEvent,
+    model: &str,
+    timestamp: crate::TimestampMs,
+    kind: AgentReportKind,
+    timezone: Option<&JiffTimeZone>,
+    shared: &SharedArgs,
+    groups: &mut BTreeMap<String, CodexGroup>,
+) -> Result<()> {
     let date = format_date_tz(timestamp, timezone);
     if shared.since.is_some() || shared.until.is_some() {
         let date_key = date.replace('-', "");
@@ -314,20 +449,40 @@ fn create_dedupe_shards() -> Vec<Mutex<FxHashSet<CodexEventKey>>> {
         .collect()
 }
 
-fn insert_event_key(event: &CodexTokenUsageEvent, seen: &CodexDedupeShards) -> bool {
-    let key = (
-        CompactString::new(&event.timestamp),
-        event.model.as_deref().map(CompactString::new),
+fn insert_event_key(
+    event: &CodexTokenUsageEvent,
+    timestamp: crate::TimestampMs,
+    model: &str,
+    seen: &CodexDedupeShards,
+) -> bool {
+    let key = codex_event_key(event, timestamp, model);
+    let mut hasher = FxHasher::default();
+    key.hash(&mut hasher);
+    let shard_index = hasher.finish() as usize % seen.len();
+    seen[shard_index].lock().unwrap().insert(key)
+}
+
+fn codex_event_key(
+    event: &CodexTokenUsageEvent,
+    timestamp: crate::TimestampMs,
+    model: &str,
+) -> CodexEventKey {
+    (
+        timestamp,
+        hash_model_name(model),
+        model.len(),
         event.input_tokens,
         event.cached_input_tokens,
         event.output_tokens,
         event.reasoning_output_tokens,
         event.total_tokens,
-    );
+    )
+}
+
+fn hash_model_name(model: &str) -> u64 {
     let mut hasher = FxHasher::default();
-    key.hash(&mut hasher);
-    let shard_index = hasher.finish() as usize % seen.len();
-    seen[shard_index].lock().unwrap().insert(key)
+    model.hash(&mut hasher);
+    hasher.finish()
 }
 
 fn merge_groups(target: &mut BTreeMap<String, CodexGroup>, source: BTreeMap<String, CodexGroup>) {
@@ -546,13 +701,14 @@ pub(crate) fn calculate_codex_model_cost(
         * multiplier
 }
 
-fn print_table(output: &Value, kind: AgentReportKind, shared: &SharedArgs) {
-    let rows = output
-        .get(rows_key(kind))
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    if rows.is_empty() {
+fn print_table_from_groups(
+    groups: &BTreeMap<String, CodexGroup>,
+    kind: AgentReportKind,
+    pricing: &PricingMap,
+    speed: CodexSpeed,
+    shared: &SharedArgs,
+) {
+    if groups.is_empty() {
         eprintln!("No Codex usage data found.");
         return;
     }
@@ -598,62 +754,43 @@ fn print_table(output: &Value, kind: AgentReportKind, shared: &SharedArgs) {
         shared,
     )
     .with_date_compaction(true);
-    for row in &rows {
-        let label = row
-            .get(period_key(kind))
-            .and_then(Value::as_str)
-            .unwrap_or_default();
-        let models = row
-            .get("models")
-            .and_then(Value::as_object)
-            .map(|models| format_models_multiline(&models.keys().cloned().collect::<Vec<_>>()))
-            .unwrap_or_default();
+    let mut total_input = 0;
+    let mut total_cached = 0;
+    let mut total_output = 0;
+    let mut total_reasoning = 0;
+    let mut total_tokens = 0;
+    let mut total_cost = 0.0;
+    for (label, group) in groups {
+        let input_tokens = non_cached_input_tokens(group.input_tokens, group.cached_input_tokens);
+        let cost = calculate_group_cost(group, pricing, speed);
+        total_input += input_tokens;
+        total_cached += group.cached_input_tokens;
+        total_output += group.output_tokens;
+        total_reasoning += group.reasoning_output_tokens;
+        total_tokens += group.total_tokens;
+        total_cost += cost;
+        let models = format_models_multiline(&group.models.keys().cloned().collect::<Vec<_>>());
         table.push(vec![
-            label.to_string(),
+            label.clone(),
             models,
-            format_number(json_value_u64(row.get("inputTokens"))),
-            format_number(json_value_u64(row.get("outputTokens"))),
-            format_number(json_value_u64(row.get("reasoningOutputTokens"))),
-            format_number(json_value_u64(row.get("cachedInputTokens"))),
-            format_number(json_value_u64(row.get("totalTokens"))),
-            format_currency(row.get("costUSD").and_then(Value::as_f64).unwrap_or(0.0)),
+            format_number(input_tokens),
+            format_number(group.output_tokens),
+            format_number(group.reasoning_output_tokens),
+            format_number(group.cached_input_tokens),
+            format_number(group.total_tokens),
+            format_currency(cost),
         ]);
     }
     table.separator();
-    let totals = output.get("totals").unwrap_or(&Value::Null);
     table.push(vec![
         color(shared, "Total", Color::Yellow),
         String::new(),
-        color(
-            shared,
-            format_number(json_value_u64(totals.get("inputTokens"))),
-            Color::Yellow,
-        ),
-        color(
-            shared,
-            format_number(json_value_u64(totals.get("outputTokens"))),
-            Color::Yellow,
-        ),
-        color(
-            shared,
-            format_number(json_value_u64(totals.get("reasoningOutputTokens"))),
-            Color::Yellow,
-        ),
-        color(
-            shared,
-            format_number(json_value_u64(totals.get("cachedInputTokens"))),
-            Color::Yellow,
-        ),
-        color(
-            shared,
-            format_number(json_value_u64(totals.get("totalTokens"))),
-            Color::Yellow,
-        ),
-        color(
-            shared,
-            format_currency(totals.get("costUSD").and_then(Value::as_f64).unwrap_or(0.0)),
-            Color::Yellow,
-        ),
+        color(shared, format_number(total_input), Color::Yellow),
+        color(shared, format_number(total_output), Color::Yellow),
+        color(shared, format_number(total_reasoning), Color::Yellow),
+        color(shared, format_number(total_cached), Color::Yellow),
+        color(shared, format_number(total_tokens), Color::Yellow),
+        color(shared, format_currency(total_cost), Color::Yellow),
     ]);
     table.print();
 }

--- a/rust/crates/ccusage/src/adapter/copilot.rs
+++ b/rust/crates/ccusage/src/adapter/copilot.rs
@@ -81,7 +81,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         &shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/droid.rs
+++ b/rust/crates/ccusage/src/adapter/droid.rs
@@ -61,7 +61,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         &shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/gemini.rs
+++ b/rust/crates/ccusage/src/adapter/gemini.rs
@@ -65,7 +65,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         &shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/goose.rs
+++ b/rust/crates/ccusage/src/adapter/goose.rs
@@ -45,7 +45,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     if wants_json(&shared) {
         return print_json_or_jq(report_from_rows(&rows, args.kind), shared.jq.as_deref());
     }
-    crate::adapter::amp::print_table(args.kind, &rows, &shared);
+    crate::adapter::amp::print_table(args.kind, &rows, &shared)?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/hermes.rs
+++ b/rust/crates/ccusage/src/adapter/hermes.rs
@@ -52,7 +52,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         &shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/kilo.rs
+++ b/rust/crates/ccusage/src/adapter/kilo.rs
@@ -40,7 +40,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         &shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/kimi.rs
+++ b/rust/crates/ccusage/src/adapter/kimi.rs
@@ -57,7 +57,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         &shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/openclaw.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw.rs
@@ -55,7 +55,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         &args.shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/opencode/mod.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/mod.rs
@@ -30,7 +30,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         &shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/pi.rs
+++ b/rust/crates/ccusage/src/adapter/pi.rs
@@ -36,7 +36,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         &args.shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/qwen/mod.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/mod.rs
@@ -37,7 +37,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         &args.shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/blocks.rs
+++ b/rust/crates/ccusage/src/blocks.rs
@@ -7,9 +7,9 @@ use crate::{
     fast::FxHashSet,
     format_currency, format_date, format_models_multiline, format_number, format_rfc3339_millis,
     format_utc_second, hour_12, json_float, local_parts, print_box_title, terminal_width, utc_now,
-    Align, BurnRate, Color, LoadedEntry, Projection, SessionBlock, SimpleTable, TimestampMs,
-    TokenCounts, BLOCKS_COMPACT_WIDTH_THRESHOLD, BLOCKS_WARNING_THRESHOLD, MILLIS_PER_HOUR,
-    MILLIS_PER_MINUTE,
+    Align, BurnRate, Color, LoadedEntry, Projection, Result, SessionBlock, SimpleTable,
+    TimestampMs, TokenCounts, BLOCKS_COMPACT_WIDTH_THRESHOLD, BLOCKS_WARNING_THRESHOLD,
+    MILLIS_PER_HOUR, MILLIS_PER_MINUTE,
 };
 
 pub(crate) fn identify_session_blocks(
@@ -296,10 +296,10 @@ pub(crate) fn print_blocks_table(
     token_limit: Option<&str>,
     max_tokens: u64,
     shared: &SharedArgs,
-) {
+) -> Result<()> {
     if blocks.is_empty() {
         eprintln!("No Claude usage data found.");
-        return;
+        return Ok(());
     }
     let terminal_width = terminal_width();
     let compact = shared.compact || terminal_width < BLOCKS_COMPACT_WIDTH_THRESHOLD;
@@ -402,7 +402,8 @@ pub(crate) fn print_blocks_table(
             }
         }
     }
-    table.print();
+    table.print()?;
+    Ok(())
 }
 
 pub(crate) fn print_active_block_detail(

--- a/rust/crates/ccusage/src/codex_loader.rs
+++ b/rust/crates/ccusage/src/codex_loader.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Cow,
     env, fs,
-    io::{BufRead, BufReader},
     marker::PhantomData,
     path::{Path, PathBuf},
     sync::LazyLock,
@@ -12,6 +11,7 @@ use compact_str::CompactString;
 use memchr::memmem::Finder;
 use serde::Deserialize;
 
+use crate::fast::byte_lines;
 use crate::{
     chunk_file_indexes_by_size, cli::SharedArgs, cli_error, collect_usage_files, fast::FxHashSet,
     home, progress, CodexRawUsage, CodexTokenUsageEvent, Result, TimestampMs,
@@ -159,31 +159,22 @@ pub(crate) fn visit_codex_session_file(
     path: &Path,
     mut visit: impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
-    let Ok(file) = fs::File::open(path) else {
+    let Ok(content) = fs::read(path) else {
         return Ok(());
     };
-    let mut reader = BufReader::with_capacity(128 * 1024, file);
-    let mut line = Vec::new();
     let session_id = codex_session_id(sessions_dir, path);
     let mut previous_totals: Option<CodexRawUsage> = None;
     let mut current_model: Option<String> = None;
     let mut current_model_is_fallback = false;
     let fallback_timestamp = file_modified_timestamp(path);
 
-    loop {
-        line.clear();
-        let Ok(bytes_read) = reader.read_until(b'\n', &mut line) else {
-            return Ok(());
-        };
-        if bytes_read == 0 {
-            break;
-        }
-        let Some(line_kind) = codex_line_usage_kind(&line) else {
+    for line in byte_lines(&content) {
+        let Some(line_kind) = codex_line_usage_kind(line) else {
             continue;
         };
         match line_kind {
             CodexLineKind::Session => {
-                let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(&line) else {
+                let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(line) else {
                     continue;
                 };
                 visit_codex_session_entry(
@@ -196,7 +187,7 @@ pub(crate) fn visit_codex_session_file(
                 )?;
             }
             CodexLineKind::Headless => {
-                let Ok(value) = serde_json::from_slice::<CodexLogEntry<'_>>(&line) else {
+                let Ok(value) = serde_json::from_slice::<CodexLogEntry<'_>>(line) else {
                     continue;
                 };
                 add_codex_exec_event(

--- a/rust/crates/ccusage/src/codex_loader.rs
+++ b/rust/crates/ccusage/src/codex_loader.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
     env, fs,
+    io::{BufRead, BufReader},
     marker::PhantomData,
     path::{Path, PathBuf},
     sync::LazyLock,
@@ -11,7 +12,6 @@ use compact_str::CompactString;
 use memchr::memmem::Finder;
 use serde::Deserialize;
 
-use crate::fast::byte_lines;
 use crate::{
     chunk_file_indexes_by_size, cli::SharedArgs, cli_error, collect_usage_files, fast::FxHashSet,
     home, progress, CodexRawUsage, CodexTokenUsageEvent, Result, TimestampMs,
@@ -159,22 +159,31 @@ pub(crate) fn visit_codex_session_file(
     path: &Path,
     mut visit: impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
-    let Ok(content) = fs::read(path) else {
+    let Ok(file) = fs::File::open(path) else {
         return Ok(());
     };
+    let mut reader = BufReader::with_capacity(128 * 1024, file);
+    let mut line = Vec::new();
     let session_id = codex_session_id(sessions_dir, path);
     let mut previous_totals: Option<CodexRawUsage> = None;
     let mut current_model: Option<String> = None;
     let mut current_model_is_fallback = false;
     let fallback_timestamp = file_modified_timestamp(path);
 
-    for line in byte_lines(&content) {
-        let Some(line_kind) = codex_line_usage_kind(line) else {
+    loop {
+        line.clear();
+        let Ok(bytes_read) = reader.read_until(b'\n', &mut line) else {
+            return Ok(());
+        };
+        if bytes_read == 0 {
+            break;
+        }
+        let Some(line_kind) = codex_line_usage_kind(&line) else {
             continue;
         };
         match line_kind {
             CodexLineKind::Session => {
-                let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(line) else {
+                let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(&line) else {
                     continue;
                 };
                 visit_codex_session_entry(
@@ -187,7 +196,7 @@ pub(crate) fn visit_codex_session_file(
                 )?;
             }
             CodexLineKind::Headless => {
-                let Ok(value) = serde_json::from_slice::<CodexLogEntry<'_>>(line) else {
+                let Ok(value) = serde_json::from_slice::<CodexLogEntry<'_>>(&line) else {
                     continue;
                 };
                 add_codex_exec_event(
@@ -768,7 +777,10 @@ impl<'de> Deserialize<'de> for CodexRawUsage {
                 .unwrap_or(0),
             output_tokens: output,
             reasoning_output_tokens: reasoning,
-            total_tokens: fields.total_tokens.unwrap_or(input + output + reasoning),
+            total_tokens: fields
+                .total_tokens
+                .filter(|total| *total > 0 || input + output + reasoning == 0)
+                .unwrap_or(input + output + reasoning),
         })
     }
 }
@@ -1032,6 +1044,18 @@ mod tests {
                     },
                 })
                 .to_string(),
+                json!({
+                    "type": "turn.completed",
+                    "timestamp": "2026-01-02T03:06:05.000Z",
+                    "model": "gpt-5.2-codex",
+                    "usage": {
+                        "input_tokens": 9,
+                        "output_tokens": 4,
+                        "reasoning_output_tokens": 1,
+                        "total_tokens": 0,
+                    },
+                })
+                .to_string(),
             ]
             .join("\n"),
         )
@@ -1039,7 +1063,7 @@ mod tests {
 
         let events = load_codex_events_from_directory(&dir, true).unwrap();
 
-        assert_eq!(events.len(), 2);
+        assert_eq!(events.len(), 3);
         assert_eq!(events[0].session_id, "run");
         assert_eq!(events[0].timestamp, "2026-01-02T03:04:05.000Z");
         assert_eq!(events[0].model.as_deref(), Some("gpt-5.2-codex"));
@@ -1053,6 +1077,11 @@ mod tests {
         assert_eq!(events[1].cached_input_tokens, 5);
         assert_eq!(events[1].output_tokens, 12);
         assert_eq!(events[1].total_tokens, 62);
+        assert_eq!(events[2].timestamp, "2026-01-02T03:06:05.000Z");
+        assert_eq!(events[2].input_tokens, 9);
+        assert_eq!(events[2].output_tokens, 4);
+        assert_eq!(events[2].reasoning_output_tokens, 1);
+        assert_eq!(events[2].total_tokens, 14);
 
         fs::remove_dir_all(dir).unwrap();
     }

--- a/rust/crates/ccusage/src/codex_loader.rs
+++ b/rust/crates/ccusage/src/codex_loader.rs
@@ -1,20 +1,38 @@
 use std::{
+    borrow::Cow,
     env, fs,
+    io::{BufRead, BufReader},
+    marker::PhantomData,
     path::{Path, PathBuf},
+    sync::LazyLock,
     thread,
 };
 
 use compact_str::CompactString;
-use serde_json::Value;
+use memchr::memmem::Finder;
+use serde::Deserialize;
 
 use crate::{
-    chunk_file_indexes_by_size,
-    cli::SharedArgs,
-    cli_error, collect_usage_files,
-    fast::{byte_lines, FxHashSet},
-    home, non_empty_json_string, progress, CodexRawUsage, CodexTokenUsageEvent, Result,
-    TimestampMs,
+    chunk_file_indexes_by_size, cli::SharedArgs, cli_error, collect_usage_files, fast::FxHashSet,
+    home, progress, CodexRawUsage, CodexTokenUsageEvent, Result, TimestampMs,
 };
+
+static TURN_CONTEXT_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(b"turn_context"));
+static TOKEN_COUNT_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(b"token_count"));
+static USAGE_FIELD_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(br#""usage":"#));
+static INPUT_TOKENS_FIELD_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(br#""input_tokens":"#));
+static PROMPT_TOKENS_FIELD_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(br#""prompt_tokens":"#));
+
+#[derive(Clone, Copy)]
+enum CodexLineKind {
+    Session,
+    Headless,
+}
 
 pub(crate) fn load_codex_events_from_directory(
     sessions_dir: &Path,
@@ -139,115 +157,145 @@ pub(crate) fn visit_codex_session_file(
     path: &Path,
     mut visit: impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
-    let Ok(content) = fs::read(path) else {
+    let Ok(file) = fs::File::open(path) else {
         return Ok(());
     };
+    let mut reader = BufReader::with_capacity(128 * 1024, file);
+    let mut line = Vec::new();
     let session_id = codex_session_id(sessions_dir, path);
     let mut previous_totals: Option<CodexRawUsage> = None;
     let mut current_model: Option<String> = None;
     let mut current_model_is_fallback = false;
     let fallback_timestamp = file_modified_timestamp(path);
 
-    for line in byte_lines(&content) {
-        if !codex_line_may_contain_usage(line) {
-            continue;
+    loop {
+        line.clear();
+        let Ok(bytes_read) = reader.read_until(b'\n', &mut line) else {
+            return Ok(());
+        };
+        if bytes_read == 0 {
+            break;
         }
-        let Ok(value) = serde_json::from_slice::<Value>(line) else {
+        let Some(line_kind) = codex_line_usage_kind(&line) else {
             continue;
         };
-        let entry_type = value.get("type").and_then(Value::as_str);
-        if entry_type == Some("turn_context") {
-            if let Some(model) = codex_model_from_payload(value.get("payload")) {
-                current_model = Some(model);
-                current_model_is_fallback = false;
+        match line_kind {
+            CodexLineKind::Session => {
+                let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(&line) else {
+                    continue;
+                };
+                visit_codex_session_entry(
+                    &session_id,
+                    value,
+                    &mut previous_totals,
+                    &mut current_model,
+                    &mut current_model_is_fallback,
+                    &mut visit,
+                )?;
             }
-            continue;
+            CodexLineKind::Headless => {
+                let Ok(value) = serde_json::from_slice::<CodexLogEntry<'_>>(&line) else {
+                    continue;
+                };
+                add_codex_exec_event(
+                    &session_id,
+                    &value,
+                    &fallback_timestamp,
+                    &mut current_model,
+                    &mut current_model_is_fallback,
+                    &mut visit,
+                )?;
+            }
         }
-        if entry_type != Some("event_msg") {
-            add_codex_exec_event(
-                &session_id,
-                &value,
-                &fallback_timestamp,
-                &mut current_model,
-                &mut current_model_is_fallback,
-                &mut visit,
-            )?;
-            continue;
-        }
-        let Some(timestamp) = value.get("timestamp").and_then(Value::as_str) else {
-            continue;
-        };
-        let Some(payload) = value.get("payload") else {
-            continue;
-        };
-        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
-            continue;
-        }
-        let info = payload.get("info");
-        let total_usage = info.and_then(|info| {
-            info.get("total_token_usage")
-                .and_then(normalize_codex_raw_usage)
-        });
-        let raw_usage = info
-            .and_then(|info| {
-                info.get("last_token_usage")
-                    .and_then(normalize_codex_raw_usage)
-            })
-            .or_else(|| {
-                total_usage
-                    .as_ref()
-                    .map(|usage| subtract_codex_raw_usage(usage, previous_totals.as_ref()))
-            });
-        if let Some(total_usage) = total_usage {
-            previous_totals = Some(total_usage);
-        }
-        let Some(raw_usage) = raw_usage else {
-            continue;
-        };
-        if raw_usage.input_tokens == 0
-            && raw_usage.cached_input_tokens == 0
-            && raw_usage.output_tokens == 0
-            && raw_usage.reasoning_output_tokens == 0
-        {
-            continue;
-        }
-
-        let parsed_model = codex_model_from_payload(Some(payload))
-            .or_else(|| info.and_then(|info| codex_model_from_payload(Some(info))));
-        if let Some(model) = parsed_model.clone() {
-            current_model = Some(model);
-            current_model_is_fallback = false;
-        }
-        let mut is_fallback_model = false;
-        let model = parsed_model.or_else(|| current_model.clone()).or_else(|| {
-            is_fallback_model = true;
-            current_model_is_fallback = true;
-            current_model = Some("gpt-5".to_string());
-            current_model.clone()
-        });
-        if parsed_model_is_missing(&model, &current_model, current_model_is_fallback) {
-            is_fallback_model = true;
-        }
-
-        visit(CodexTokenUsageEvent {
-            session_id: session_id.clone(),
-            timestamp: timestamp.to_string(),
-            model,
-            input_tokens: raw_usage.input_tokens,
-            cached_input_tokens: raw_usage.cached_input_tokens.min(raw_usage.input_tokens),
-            output_tokens: raw_usage.output_tokens,
-            reasoning_output_tokens: raw_usage.reasoning_output_tokens,
-            total_tokens: raw_usage.total_tokens,
-            is_fallback_model,
-        })?;
     }
 
     Ok(())
 }
 
+fn visit_codex_session_entry(
+    session_id: &str,
+    value: CodexSessionLogEntry<'_>,
+    previous_totals: &mut Option<CodexRawUsage>,
+    current_model: &mut Option<String>,
+    current_model_is_fallback: &mut bool,
+    visit: &mut impl FnMut(CodexTokenUsageEvent) -> Result<()>,
+) -> Result<()> {
+    let entry_type = value.entry_type.as_deref();
+    if entry_type == Some("turn_context") {
+        if let Some(model) = value.payload.as_ref().and_then(codex_model_from_payload) {
+            *current_model = Some(model);
+            *current_model_is_fallback = false;
+        }
+        return Ok(());
+    }
+    if entry_type != Some("event_msg") {
+        return Ok(());
+    }
+    let Some(timestamp) = value.timestamp.as_ref().and_then(CodexTimestamp::as_str) else {
+        return Ok(());
+    };
+    let Some(payload) = value.payload.as_ref() else {
+        return Ok(());
+    };
+    if payload.payload_type.as_deref() != Some("token_count") {
+        return Ok(());
+    }
+    let info = payload.info.as_ref();
+    let total_usage = info.and_then(|info| info.total_token_usage.as_ref().copied());
+    let raw_usage = info
+        .and_then(|info| info.last_token_usage.as_ref().copied())
+        .or_else(|| {
+            total_usage
+                .as_ref()
+                .map(|usage| subtract_codex_raw_usage(usage, previous_totals.as_ref()))
+        });
+    if let Some(total_usage) = total_usage {
+        *previous_totals = Some(total_usage);
+    }
+    let Some(raw_usage) = raw_usage else {
+        return Ok(());
+    };
+    if raw_usage.input_tokens == 0
+        && raw_usage.cached_input_tokens == 0
+        && raw_usage.output_tokens == 0
+        && raw_usage.reasoning_output_tokens == 0
+    {
+        return Ok(());
+    }
+
+    let parsed_model =
+        codex_model_from_payload(payload).or_else(|| info.and_then(codex_model_from_info));
+    if let Some(model) = parsed_model.clone() {
+        *current_model = Some(model);
+        *current_model_is_fallback = false;
+    }
+    let mut is_fallback_model = false;
+    let model = parsed_model.or_else(|| current_model.clone()).or_else(|| {
+        is_fallback_model = true;
+        *current_model_is_fallback = true;
+        *current_model = Some("gpt-5".to_string());
+        current_model.clone()
+    });
+    if parsed_model_is_missing(&model, current_model, *current_model_is_fallback) {
+        is_fallback_model = true;
+    }
+
+    visit(CodexTokenUsageEvent {
+        session_id: session_id.to_string(),
+        timestamp: timestamp.to_string(),
+        model,
+        input_tokens: raw_usage.input_tokens,
+        cached_input_tokens: raw_usage.cached_input_tokens.min(raw_usage.input_tokens),
+        output_tokens: raw_usage.output_tokens,
+        reasoning_output_tokens: raw_usage.reasoning_output_tokens,
+        total_tokens: raw_usage.total_tokens,
+        is_fallback_model,
+    })
+}
+
 fn add_codex_exec_event(
     session_id: &str,
-    value: &Value,
+    value: &CodexLogEntry<'_>,
     fallback_timestamp: &str,
     current_model: &mut Option<String>,
     current_model_is_fallback: &mut bool,
@@ -285,12 +333,17 @@ fn add_codex_exec_event(
     })
 }
 
-fn codex_line_may_contain_usage(line: &[u8]) -> bool {
-    memchr::memmem::find(line, b"turn_context").is_some()
-        || memchr::memmem::find(line, b"token_count").is_some()
-        || memchr::memmem::find(line, br#""usage":"#).is_some()
-        || memchr::memmem::find(line, br#""input_tokens":"#).is_some()
-        || memchr::memmem::find(line, br#""prompt_tokens":"#).is_some()
+fn codex_line_usage_kind(line: &[u8]) -> Option<CodexLineKind> {
+    if TURN_CONTEXT_FINDER.find(line).is_some() || TOKEN_COUNT_FINDER.find(line).is_some() {
+        return Some(CodexLineKind::Session);
+    }
+    if USAGE_FIELD_FINDER.find(line).is_some()
+        || INPUT_TOKENS_FIELD_FINDER.find(line).is_some()
+        || PROMPT_TOKENS_FIELD_FINDER.find(line).is_some()
+    {
+        return Some(CodexLineKind::Headless);
+    }
+    None
 }
 
 fn parsed_model_is_missing(
@@ -315,71 +368,139 @@ fn codex_session_id(sessions_dir: &Path, path: &Path) -> String {
     session_id
 }
 
-fn codex_model_from_payload(value: Option<&Value>) -> Option<String> {
-    let value = value?;
-    ["model", "model_name"]
-        .into_iter()
-        .find_map(|key| non_empty_json_string(value.get(key)))
+fn codex_model_from_payload(value: &CodexPayload<'_>) -> Option<String> {
+    codex_model_from_parts(
+        value.model.as_ref(),
+        value.model_name.as_ref(),
+        value.metadata.as_ref(),
+    )
+}
+
+fn codex_model_from_info(value: &CodexInfo<'_>) -> Option<String> {
+    codex_model_from_parts(
+        value.model.as_ref(),
+        value.model_name.as_ref(),
+        value.metadata.as_ref(),
+    )
+}
+
+fn codex_model_from_result(value: &CodexLogEntry<'_>) -> Option<String> {
+    codex_model_from_entry(value)
+        .or_else(|| value.data.as_ref().and_then(codex_model_from_result_fields))
         .or_else(|| {
             value
-                .get("metadata")
-                .and_then(|metadata| non_empty_json_string(metadata.get("model")))
+                .result
+                .as_ref()
+                .and_then(codex_model_from_result_fields)
+        })
+        .or_else(|| {
+            value
+                .response
+                .as_ref()
+                .and_then(codex_model_from_result_fields)
         })
 }
 
-fn codex_model_from_result(value: &Value) -> Option<String> {
-    codex_model_from_payload(Some(value))
-        .or_else(|| codex_model_from_payload(value.get("data")))
-        .or_else(|| codex_model_from_payload(value.get("result")))
-        .or_else(|| codex_model_from_payload(value.get("response")))
+fn codex_model_from_result_fields(value: &CodexResultFields<'_>) -> Option<String> {
+    codex_model_from_parts(
+        value.model.as_ref(),
+        value.model_name.as_ref(),
+        value.metadata.as_ref(),
+    )
 }
 
-fn usage_from_result(value: &Value) -> Option<&Value> {
+fn codex_model_from_entry(value: &CodexLogEntry<'_>) -> Option<String> {
+    codex_model_from_parts(
+        value.model.as_ref(),
+        value.model_name.as_ref(),
+        value.metadata.as_ref(),
+    )
+}
+
+fn codex_model_from_parts(
+    model: Option<&Cow<'_, str>>,
+    model_name: Option<&Cow<'_, str>>,
+    metadata: Option<&CodexModelMetadata<'_>>,
+) -> Option<String> {
+    non_empty_cow_string(model)
+        .or_else(|| non_empty_cow_string(model_name))
+        .or_else(|| metadata.and_then(|metadata| non_empty_cow_string(metadata.model.as_ref())))
+}
+
+fn non_empty_cow_string(value: Option<&Cow<'_, str>>) -> Option<String> {
+    value.and_then(|text| {
+        let text = text.trim();
+        (!text.is_empty()).then(|| text.to_string())
+    })
+}
+
+fn usage_from_result(value: &CodexLogEntry<'_>) -> Option<CodexRawUsage> {
     value
-        .get("usage")
-        .or_else(|| value.get("data").and_then(|data| data.get("usage")))
-        .or_else(|| value.get("result").and_then(|result| result.get("usage")))
+        .usage
+        .as_ref()
+        .copied()
         .or_else(|| {
             value
-                .get("response")
-                .and_then(|response| response.get("usage"))
+                .data
+                .as_ref()
+                .and_then(|data| data.usage.as_ref().copied())
+        })
+        .or_else(|| {
+            value
+                .result
+                .as_ref()
+                .and_then(|result| result.usage.as_ref().copied())
+        })
+        .or_else(|| {
+            value
+                .response
+                .as_ref()
+                .and_then(|response| response.usage.as_ref().copied())
         })
 }
 
-fn codex_timestamp_from_result(value: &Value) -> Option<String> {
-    normalize_codex_timestamp(value.get("timestamp"))
-        .or_else(|| normalize_codex_timestamp(value.get("created_at")))
-        .or_else(|| normalize_codex_timestamp(value.get("createdAt")))
+fn codex_timestamp_from_result(value: &CodexLogEntry<'_>) -> Option<String> {
+    normalize_codex_timestamp(value.timestamp.as_ref())
+        .or_else(|| normalize_codex_timestamp(value.created_at.as_ref()))
+        .or_else(|| normalize_codex_timestamp(value.created_at_camel.as_ref()))
         .or_else(|| {
             value
-                .get("data")
-                .and_then(|data| normalize_codex_timestamp(data.get("timestamp")))
+                .data
+                .as_ref()
+                .and_then(|data| normalize_result_fields_timestamp(data))
         })
         .or_else(|| {
             value
-                .get("result")
-                .and_then(|result| normalize_codex_timestamp(result.get("timestamp")))
+                .result
+                .as_ref()
+                .and_then(|result| normalize_result_fields_timestamp(result))
         })
         .or_else(|| {
             value
-                .get("response")
-                .and_then(|response| normalize_codex_timestamp(response.get("timestamp")))
+                .response
+                .as_ref()
+                .and_then(|response| normalize_result_fields_timestamp(response))
         })
 }
 
-fn normalize_codex_timestamp(value: Option<&Value>) -> Option<String> {
+fn normalize_result_fields_timestamp(value: &CodexResultFields<'_>) -> Option<String> {
+    normalize_codex_timestamp(value.timestamp.as_ref())
+        .or_else(|| normalize_codex_timestamp(value.created_at.as_ref()))
+        .or_else(|| normalize_codex_timestamp(value.created_at_camel.as_ref()))
+}
+
+fn normalize_codex_timestamp(value: Option<&CodexTimestamp<'_>>) -> Option<String> {
     match value? {
-        Value::String(text) => {
+        CodexTimestamp::String(text) => {
             let text = text.trim();
             if text.is_empty() {
                 return None;
             }
             crate::parse_ts_timestamp(text).map(crate::format_rfc3339_millis)
         }
-        Value::Number(number) => {
-            let raw = number.as_u64()?;
-            let millis = if raw > 10_000_000_000 {
-                raw
+        CodexTimestamp::Number(raw) => {
+            let millis = if *raw > 10_000_000_000 {
+                *raw
             } else {
                 raw.checked_mul(1_000)?
             };
@@ -387,73 +508,20 @@ fn normalize_codex_timestamp(value: Option<&Value>) -> Option<String> {
                 millis.min(i64::MAX as u64) as i64,
             )))
         }
-        _ => None,
     }
 }
 
-fn normalize_headless_codex_usage(value: &Value) -> Option<CodexRawUsage> {
+fn normalize_headless_codex_usage(value: &CodexLogEntry<'_>) -> Option<CodexRawUsage> {
     let usage = usage_from_result(value)?;
-    let input = json_u64(usage.get("input_tokens"))
-        .or_else(|| json_u64(usage.get("prompt_tokens")))
-        .or_else(|| json_u64(usage.get("input")))
-        .unwrap_or(0);
-    let cached = json_u64(usage.get("cached_input_tokens"))
-        .or_else(|| json_u64(usage.get("cache_read_input_tokens")))
-        .or_else(|| json_u64(usage.get("cached_tokens")))
-        .unwrap_or(0);
-    let output = json_u64(usage.get("output_tokens"))
-        .or_else(|| json_u64(usage.get("completion_tokens")))
-        .or_else(|| json_u64(usage.get("output")))
-        .unwrap_or(0);
-    let reasoning = json_u64(usage.get("reasoning_output_tokens"))
-        .or_else(|| json_u64(usage.get("reasoning_tokens")))
-        .unwrap_or(0);
-    let total = json_u64(usage.get("total_tokens")).unwrap_or(0);
-    if input == 0 && cached == 0 && output == 0 && reasoning == 0 && total == 0 {
+    if usage.input_tokens == 0
+        && usage.cached_input_tokens == 0
+        && usage.output_tokens == 0
+        && usage.reasoning_output_tokens == 0
+        && usage.total_tokens == 0
+    {
         return None;
     }
-    Some(CodexRawUsage {
-        input_tokens: input,
-        cached_input_tokens: cached,
-        output_tokens: output,
-        reasoning_output_tokens: reasoning,
-        total_tokens: if total > 0 {
-            total
-        } else {
-            input + output + reasoning
-        },
-    })
-}
-
-fn normalize_codex_raw_usage(value: &Value) -> Option<CodexRawUsage> {
-    if !value.is_object() {
-        return None;
-    }
-    let input = json_u64(value.get("input_tokens"));
-    let cached = json_u64(value.get("cached_input_tokens"))
-        .or_else(|| json_u64(value.get("cache_read_input_tokens")))
-        .unwrap_or(0);
-    let output = json_u64(value.get("output_tokens"));
-    let reasoning = json_u64(value.get("reasoning_output_tokens"));
-    let total = json_u64(value.get("total_tokens"));
-    let input = input.unwrap_or(0);
-    let output = output.unwrap_or(0);
-    let reasoning = reasoning.unwrap_or(0);
-    Some(CodexRawUsage {
-        input_tokens: input,
-        cached_input_tokens: cached,
-        output_tokens: output,
-        reasoning_output_tokens: reasoning,
-        total_tokens: total.unwrap_or(input + output + reasoning),
-    })
-}
-
-fn json_u64(value: Option<&Value>) -> Option<u64> {
-    match value {
-        Some(Value::Number(number)) => number.as_u64(),
-        Some(Value::String(text)) => text.trim().parse::<u64>().ok(),
-        _ => None,
-    }
+    Some(usage)
 }
 
 fn file_modified_timestamp(path: &Path) -> String {
@@ -506,6 +574,389 @@ fn dedupe_codex_events(events: &mut Vec<CodexTokenUsageEvent>) {
             event.total_tokens,
         ))
     });
+}
+
+#[derive(Deserialize)]
+struct CodexSessionLogEntry<'a> {
+    #[serde(rename = "type", borrow, default)]
+    entry_type: Option<Cow<'a, str>>,
+    #[serde(borrow, default)]
+    timestamp: Option<CodexTimestamp<'a>>,
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_optional_object_lossy"
+    )]
+    payload: Option<CodexPayload<'a>>,
+}
+
+#[derive(Deserialize)]
+struct CodexLogEntry<'a> {
+    #[serde(borrow, default)]
+    timestamp: Option<CodexTimestamp<'a>>,
+    #[serde(rename = "created_at", borrow, default)]
+    created_at: Option<CodexTimestamp<'a>>,
+    #[serde(rename = "createdAt", borrow, default)]
+    created_at_camel: Option<CodexTimestamp<'a>>,
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_optional_object_lossy"
+    )]
+    data: Option<CodexResultFields<'a>>,
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_optional_object_lossy"
+    )]
+    result: Option<CodexResultFields<'a>>,
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_optional_object_lossy"
+    )]
+    response: Option<CodexResultFields<'a>>,
+    #[serde(default, deserialize_with = "deserialize_optional_object_lossy")]
+    usage: Option<CodexRawUsage>,
+    #[serde(borrow, default)]
+    model: Option<Cow<'a, str>>,
+    #[serde(rename = "model_name", borrow, default)]
+    model_name: Option<Cow<'a, str>>,
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_optional_object_lossy"
+    )]
+    metadata: Option<CodexModelMetadata<'a>>,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(untagged)]
+enum CodexTimestamp<'a> {
+    String(Cow<'a, str>),
+    Number(u64),
+}
+
+impl CodexTimestamp<'_> {
+    fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::String(text) => Some(text),
+            Self::Number(_) => None,
+        }
+    }
+}
+
+#[derive(Default, Deserialize)]
+struct CodexPayload<'a> {
+    #[serde(rename = "type", borrow, default)]
+    payload_type: Option<Cow<'a, str>>,
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_optional_object_lossy"
+    )]
+    info: Option<CodexInfo<'a>>,
+    #[serde(borrow, default)]
+    model: Option<Cow<'a, str>>,
+    #[serde(rename = "model_name", borrow, default)]
+    model_name: Option<Cow<'a, str>>,
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_optional_object_lossy"
+    )]
+    metadata: Option<CodexModelMetadata<'a>>,
+}
+
+#[derive(Default, Deserialize)]
+struct CodexInfo<'a> {
+    #[serde(default, deserialize_with = "deserialize_optional_object_lossy")]
+    last_token_usage: Option<CodexRawUsage>,
+    #[serde(default, deserialize_with = "deserialize_optional_object_lossy")]
+    total_token_usage: Option<CodexRawUsage>,
+    #[serde(borrow, default)]
+    model: Option<Cow<'a, str>>,
+    #[serde(rename = "model_name", borrow, default)]
+    model_name: Option<Cow<'a, str>>,
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_optional_object_lossy"
+    )]
+    metadata: Option<CodexModelMetadata<'a>>,
+}
+
+#[derive(Default, Deserialize)]
+struct CodexResultFields<'a> {
+    #[serde(borrow, default)]
+    timestamp: Option<CodexTimestamp<'a>>,
+    #[serde(rename = "created_at", borrow, default)]
+    created_at: Option<CodexTimestamp<'a>>,
+    #[serde(rename = "createdAt", borrow, default)]
+    created_at_camel: Option<CodexTimestamp<'a>>,
+    #[serde(default, deserialize_with = "deserialize_optional_object_lossy")]
+    usage: Option<CodexRawUsage>,
+    #[serde(borrow, default)]
+    model: Option<Cow<'a, str>>,
+    #[serde(rename = "model_name", borrow, default)]
+    model_name: Option<Cow<'a, str>>,
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_optional_object_lossy"
+    )]
+    metadata: Option<CodexModelMetadata<'a>>,
+}
+
+#[derive(Deserialize)]
+struct CodexModelMetadata<'a> {
+    #[serde(borrow, default)]
+    model: Option<Cow<'a, str>>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+struct CodexRawUsageFields {
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    input_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    prompt_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    input: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    cached_input_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    cache_read_input_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    cached_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    output_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    completion_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    output: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    reasoning_output_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    reasoning_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional_u64_lossy")]
+    total_tokens: Option<u64>,
+}
+
+impl<'de> Deserialize<'de> for CodexRawUsage {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let fields = CodexRawUsageFields::deserialize(deserializer)?;
+        let input = fields
+            .input_tokens
+            .or(fields.prompt_tokens)
+            .or(fields.input)
+            .unwrap_or(0);
+        let output = fields
+            .output_tokens
+            .or(fields.completion_tokens)
+            .or(fields.output)
+            .unwrap_or(0);
+        let reasoning = fields
+            .reasoning_output_tokens
+            .or(fields.reasoning_tokens)
+            .unwrap_or(0);
+        Ok(Self {
+            input_tokens: input,
+            cached_input_tokens: fields
+                .cached_input_tokens
+                .or(fields.cache_read_input_tokens)
+                .or(fields.cached_tokens)
+                .unwrap_or(0),
+            output_tokens: output,
+            reasoning_output_tokens: reasoning,
+            total_tokens: fields.total_tokens.unwrap_or(input + output + reasoning),
+        })
+    }
+}
+
+fn deserialize_optional_object_lossy<'de, D, T>(
+    deserializer: D,
+) -> std::result::Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    struct OptionalObjectVisitor<T>(PhantomData<T>);
+
+    impl<'de, T> serde::de::Visitor<'de> for OptionalObjectVisitor<T>
+    where
+        T: serde::Deserialize<'de>,
+    {
+        type Value = Option<T>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("an optional object")
+        }
+
+        fn visit_none<E>(self) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserialize_optional_object_lossy(deserializer)
+        }
+
+        fn visit_map<A>(self, map: A) -> std::result::Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            T::deserialize(serde::de::value::MapAccessDeserializer::new(map)).map(Some)
+        }
+
+        fn visit_bool<E>(self, _value: bool) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_i64<E>(self, _value: i64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_u64<E>(self, _value: u64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_f64<E>(self, _value: f64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_str<E>(self, _value: &str) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_seq<A>(self, mut sequence: A) -> std::result::Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            while sequence.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_any(OptionalObjectVisitor(PhantomData))
+}
+
+fn deserialize_optional_u64_lossy<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct OptionalU64Visitor;
+
+    impl<'de> serde::de::Visitor<'de> for OptionalU64Visitor {
+        type Value = Option<u64>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("an optional unsigned integer")
+        }
+
+        fn visit_none<E>(self) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserialize_optional_u64_lossy(deserializer)
+        }
+
+        fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(Some(value))
+        }
+
+        fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(value.trim().parse::<u64>().ok())
+        }
+
+        fn visit_borrowed_str<E>(self, value: &'de str) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_str(value)
+        }
+
+        fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_str(&value)
+        }
+
+        fn visit_i64<E>(self, _value: i64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_f64<E>(self, _value: f64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_bool<E>(self, _value: bool) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_any(OptionalU64Visitor)
 }
 
 #[cfg(test)]

--- a/rust/crates/ccusage/src/codex_loader.rs
+++ b/rust/crates/ccusage/src/codex_loader.rs
@@ -17,10 +17,12 @@ use crate::{
     home, progress, CodexRawUsage, CodexTokenUsageEvent, Result, TimestampMs,
 };
 
-static TURN_CONTEXT_FINDER: LazyLock<Finder<'static>> =
-    LazyLock::new(|| Finder::new(b"turn_context"));
-static TOKEN_COUNT_FINDER: LazyLock<Finder<'static>> =
-    LazyLock::new(|| Finder::new(b"token_count"));
+static EVENT_MSG_TYPE_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(br#""type":"event_msg""#));
+static TURN_CONTEXT_TYPE_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(br#""type":"turn_context""#));
+static TOKEN_COUNT_TYPE_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(br#""type":"token_count""#));
 static USAGE_FIELD_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""usage":"#));
 static INPUT_TOKENS_FIELD_FINDER: LazyLock<Finder<'static>> =
@@ -231,7 +233,7 @@ fn visit_codex_session_entry(
     if entry_type != Some("event_msg") {
         return Ok(());
     }
-    let Some(timestamp) = normalize_codex_timestamp(value.timestamp.as_ref()) else {
+    let Some(timestamp) = codex_session_timestamp(value.timestamp.as_ref()) else {
         return Ok(());
     };
     let Some(payload) = value.payload.as_ref() else {
@@ -334,7 +336,10 @@ fn add_codex_exec_event(
 }
 
 fn codex_line_usage_kind(line: &[u8]) -> Option<CodexLineKind> {
-    if TURN_CONTEXT_FINDER.find(line).is_some() || TOKEN_COUNT_FINDER.find(line).is_some() {
+    if TURN_CONTEXT_TYPE_FINDER.find(line).is_some()
+        || (EVENT_MSG_TYPE_FINDER.find(line).is_some()
+            && TOKEN_COUNT_TYPE_FINDER.find(line).is_some())
+    {
         return Some(CodexLineKind::Session);
     }
     if USAGE_FIELD_FINDER.find(line).is_some()
@@ -344,6 +349,16 @@ fn codex_line_usage_kind(line: &[u8]) -> Option<CodexLineKind> {
         return Some(CodexLineKind::Headless);
     }
     None
+}
+
+fn codex_session_timestamp(value: Option<&CodexTimestamp<'_>>) -> Option<String> {
+    match value? {
+        CodexTimestamp::String(text) => {
+            let text = text.trim();
+            (!text.is_empty()).then(|| text.to_string())
+        }
+        CodexTimestamp::Number(_) => normalize_codex_timestamp(value),
+    }
 }
 
 fn parsed_model_is_missing(
@@ -1098,6 +1113,42 @@ mod tests {
         assert_eq!(events[0].input_tokens, 100);
         assert_eq!(events[0].cached_input_tokens, 10);
         assert_eq!(events[0].output_tokens, 50);
+        assert_eq!(events[0].total_tokens, 150);
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn loads_headless_usage_with_token_count_text_content() {
+        let dir = temp_dir("headless-token-count-content");
+        let file = dir.join("run.jsonl");
+        fs::write(
+            &file,
+            json!({
+                "type": "turn.completed",
+                "timestamp": "2026-01-02T03:04:05.000Z",
+                "model": "gpt-5.2-codex",
+                "content": "debug token_count payload text",
+                "usage": {
+                    "input_tokens": 120,
+                    "cached_input_tokens": 20,
+                    "output_tokens": 30,
+                    "total_tokens": 150,
+                },
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let events = load_codex_events_from_directory(&dir, true).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].session_id, "run");
+        assert_eq!(events[0].timestamp, "2026-01-02T03:04:05.000Z");
+        assert_eq!(events[0].model.as_deref(), Some("gpt-5.2-codex"));
+        assert_eq!(events[0].input_tokens, 120);
+        assert_eq!(events[0].cached_input_tokens, 20);
+        assert_eq!(events[0].output_tokens, 30);
         assert_eq!(events[0].total_tokens, 150);
 
         fs::remove_dir_all(dir).unwrap();

--- a/rust/crates/ccusage/src/codex_loader.rs
+++ b/rust/crates/ccusage/src/codex_loader.rs
@@ -231,7 +231,7 @@ fn visit_codex_session_entry(
     if entry_type != Some("event_msg") {
         return Ok(());
     }
-    let Some(timestamp) = value.timestamp.as_ref().and_then(CodexTimestamp::as_str) else {
+    let Some(timestamp) = normalize_codex_timestamp(value.timestamp.as_ref()) else {
         return Ok(());
     };
     let Some(payload) = value.payload.as_ref() else {
@@ -282,7 +282,7 @@ fn visit_codex_session_entry(
 
     visit(CodexTokenUsageEvent {
         session_id: session_id.to_string(),
-        timestamp: timestamp.to_string(),
+        timestamp,
         model,
         input_tokens: raw_usage.input_tokens,
         cached_input_tokens: raw_usage.cached_input_tokens.min(raw_usage.input_tokens),
@@ -635,15 +635,6 @@ struct CodexLogEntry<'a> {
 enum CodexTimestamp<'a> {
     String(Cow<'a, str>),
     Number(u64),
-}
-
-impl CodexTimestamp<'_> {
-    fn as_str(&self) -> Option<&str> {
-        match self {
-            Self::String(text) => Some(text),
-            Self::Number(_) => None,
-        }
-    }
 }
 
 #[derive(Default, Deserialize)]
@@ -1056,6 +1047,58 @@ mod tests {
         assert_eq!(events[1].cached_input_tokens, 5);
         assert_eq!(events[1].output_tokens, 12);
         assert_eq!(events[1].total_tokens, 62);
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn loads_session_usage_with_numeric_timestamp() {
+        let dir = temp_dir("numeric-session-timestamp");
+        let file = dir.join("session.jsonl");
+        fs::write(
+            &file,
+            [
+                json!({
+                    "timestamp": "2026-01-02T00:00:00.000Z",
+                    "type": "turn_context",
+                    "payload": {
+                        "model": "gpt-5",
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": 1767312001000_u64,
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "total_token_usage": {
+                                "input_tokens": 100,
+                                "cached_input_tokens": 10,
+                                "output_tokens": 50,
+                                "reasoning_output_tokens": 0,
+                                "total_tokens": 150,
+                            },
+                            "model": "gpt-5",
+                        },
+                    },
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let events = load_codex_events_from_directory(&dir, true).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].session_id, "session");
+        assert_eq!(events[0].timestamp, "2026-01-02T00:00:01.000Z");
+        assert_eq!(events[0].model.as_deref(), Some("gpt-5"));
+        assert_eq!(events[0].input_tokens, 100);
+        assert_eq!(events[0].cached_input_tokens, 10);
+        assert_eq!(events[0].output_tokens, 50);
+        assert_eq!(events[0].total_tokens, 150);
 
         fs::remove_dir_all(dir).unwrap();
     }

--- a/rust/crates/ccusage/src/codex_loader.rs
+++ b/rust/crates/ccusage/src/codex_loader.rs
@@ -11,6 +11,7 @@ use std::{
 use compact_str::CompactString;
 use memchr::memmem::Finder;
 use serde::Deserialize;
+use serde_json::Value;
 
 use crate::{
     chunk_file_indexes_by_size, cli::SharedArgs, cli_error, collect_usage_files, fast::FxHashSet,
@@ -199,17 +200,25 @@ pub(crate) fn visit_codex_session_file(
                 )?;
             }
             CodexLineKind::Headless => {
-                let Ok(value) = serde_json::from_slice::<CodexLogEntry<'_>>(&line) else {
-                    continue;
+                if let Ok(value) = serde_json::from_slice::<CodexLogEntry<'_>>(&line) {
+                    add_codex_exec_event(
+                        &session_id,
+                        &value,
+                        &fallback_timestamp,
+                        &mut current_model,
+                        &mut current_model_is_fallback,
+                        &mut visit,
+                    )?;
+                } else {
+                    add_codex_exec_event_from_value(
+                        &session_id,
+                        &line,
+                        &fallback_timestamp,
+                        &mut current_model,
+                        &mut current_model_is_fallback,
+                        &mut visit,
+                    )?;
                 };
-                add_codex_exec_event(
-                    &session_id,
-                    &value,
-                    &fallback_timestamp,
-                    &mut current_model,
-                    &mut current_model_is_fallback,
-                    &mut visit,
-                )?;
             }
         }
     }
@@ -310,6 +319,56 @@ fn add_codex_exec_event(
         return Ok(());
     };
     let parsed_model = codex_model_from_result(value);
+    let timestamp =
+        codex_timestamp_from_result(value).unwrap_or_else(|| fallback_timestamp.to_string());
+    visit_codex_exec_usage_event(
+        session_id,
+        raw_usage,
+        parsed_model,
+        timestamp,
+        current_model,
+        current_model_is_fallback,
+        visit,
+    )
+}
+
+fn add_codex_exec_event_from_value(
+    session_id: &str,
+    line: &[u8],
+    fallback_timestamp: &str,
+    current_model: &mut Option<String>,
+    current_model_is_fallback: &mut bool,
+    visit: &mut impl FnMut(CodexTokenUsageEvent) -> Result<()>,
+) -> Result<()> {
+    let Ok(value) = serde_json::from_slice::<Value>(line) else {
+        return Ok(());
+    };
+    let Some(raw_usage) = normalize_headless_codex_usage_value(&value) else {
+        return Ok(());
+    };
+    let parsed_model = codex_model_from_result_value(&value);
+    let timestamp =
+        codex_timestamp_from_result_value(&value).unwrap_or_else(|| fallback_timestamp.to_string());
+    visit_codex_exec_usage_event(
+        session_id,
+        raw_usage,
+        parsed_model,
+        timestamp,
+        current_model,
+        current_model_is_fallback,
+        visit,
+    )
+}
+
+fn visit_codex_exec_usage_event(
+    session_id: &str,
+    raw_usage: CodexRawUsage,
+    parsed_model: Option<String>,
+    timestamp: String,
+    current_model: &mut Option<String>,
+    current_model_is_fallback: &mut bool,
+    visit: &mut impl FnMut(CodexTokenUsageEvent) -> Result<()>,
+) -> Result<()> {
     if let Some(model) = parsed_model.clone() {
         *current_model = Some(model);
         *current_model_is_fallback = false;
@@ -326,8 +385,7 @@ fn add_codex_exec_event(
     }
     visit(CodexTokenUsageEvent {
         session_id: session_id.to_string(),
-        timestamp: codex_timestamp_from_result(value)
-            .unwrap_or_else(|| fallback_timestamp.to_string()),
+        timestamp,
         model,
         input_tokens: raw_usage.input_tokens,
         cached_input_tokens: raw_usage.cached_input_tokens.min(raw_usage.input_tokens),
@@ -340,12 +398,16 @@ fn add_codex_exec_event(
 
 fn codex_line_usage_kind(line: &[u8]) -> Option<CodexLineKind> {
     let has_event_msg = EVENT_MSG_TYPE_FINDER.find(line).is_some();
-    if TURN_CONTEXT_TYPE_FINDER.find(line).is_some()
-        || (has_event_msg && TOKEN_COUNT_TYPE_FINDER.find(line).is_some())
-    {
+    let has_token_count = has_event_msg && TOKEN_COUNT_TYPE_FINDER.find(line).is_some();
+    if TURN_CONTEXT_TYPE_FINDER.find(line).is_some() || has_token_count {
         return Some(CodexLineKind::Session);
     }
-    if has_event_msg || COMPACT_TYPE_FIELD_FINDER.find(line).is_none() {
+    let has_compact_type = COMPACT_TYPE_FIELD_FINDER.find(line).is_some();
+    let has_nested_token_count = !has_event_msg
+        && has_compact_type
+        && line.len() < 64 * 1024
+        && TOKEN_COUNT_TYPE_FINDER.find(line).is_some();
+    if has_event_msg || has_nested_token_count || !has_compact_type {
         let (has_turn_context, has_event_msg, has_token_count) = codex_line_type_flags(line);
         if has_turn_context || (has_event_msg && has_token_count) {
             return Some(CodexLineKind::Session);
@@ -493,8 +555,36 @@ fn codex_model_from_parts(
         .or_else(|| metadata.and_then(|metadata| non_empty_cow_string(metadata.model.as_ref())))
 }
 
+fn codex_model_from_result_value(value: &Value) -> Option<String> {
+    codex_model_from_value_fields(value)
+        .or_else(|| value.get("data").and_then(codex_model_from_value_fields))
+        .or_else(|| value.get("result").and_then(codex_model_from_value_fields))
+        .or_else(|| {
+            value
+                .get("response")
+                .and_then(codex_model_from_value_fields)
+        })
+}
+
+fn codex_model_from_value_fields(value: &Value) -> Option<String> {
+    non_empty_value_string(value.get("model"))
+        .or_else(|| non_empty_value_string(value.get("model_name")))
+        .or_else(|| {
+            value
+                .get("metadata")
+                .and_then(|metadata| non_empty_value_string(metadata.get("model")))
+        })
+}
+
 fn non_empty_cow_string(value: Option<&Cow<'_, str>>) -> Option<String> {
     value.and_then(|text| {
+        let text = text.trim();
+        (!text.is_empty()).then(|| text.to_string())
+    })
+}
+
+fn non_empty_value_string(value: Option<&Value>) -> Option<String> {
+    value.and_then(Value::as_str).and_then(|text| {
         let text = text.trim();
         (!text.is_empty()).then(|| text.to_string())
     })
@@ -525,6 +615,29 @@ fn usage_from_result(value: &CodexLogEntry<'_>) -> Option<CodexRawUsage> {
         })
 }
 
+fn usage_from_result_value(value: &Value) -> Option<CodexRawUsage> {
+    usage_from_value(value.get("usage"))
+        .or_else(|| {
+            value
+                .get("data")
+                .and_then(|data| usage_from_value(data.get("usage")))
+        })
+        .or_else(|| {
+            value
+                .get("result")
+                .and_then(|result| usage_from_value(result.get("usage")))
+        })
+        .or_else(|| {
+            value
+                .get("response")
+                .and_then(|response| usage_from_value(response.get("usage")))
+        })
+}
+
+fn usage_from_value(value: Option<&Value>) -> Option<CodexRawUsage> {
+    serde_json::from_value(value?.clone()).ok()
+}
+
 fn codex_timestamp_from_result(value: &CodexLogEntry<'_>) -> Option<String> {
     normalize_codex_timestamp(value.timestamp.as_ref())
         .or_else(|| normalize_codex_timestamp(value.created_at.as_ref()))
@@ -549,10 +662,31 @@ fn codex_timestamp_from_result(value: &CodexLogEntry<'_>) -> Option<String> {
         })
 }
 
+fn codex_timestamp_from_result_value(value: &Value) -> Option<String> {
+    normalize_value_fields_timestamp(value)
+        .or_else(|| value.get("data").and_then(normalize_value_fields_timestamp))
+        .or_else(|| {
+            value
+                .get("result")
+                .and_then(normalize_value_fields_timestamp)
+        })
+        .or_else(|| {
+            value
+                .get("response")
+                .and_then(normalize_value_fields_timestamp)
+        })
+}
+
 fn normalize_result_fields_timestamp(value: &CodexResultFields<'_>) -> Option<String> {
     normalize_codex_timestamp(value.timestamp.as_ref())
         .or_else(|| normalize_codex_timestamp(value.created_at.as_ref()))
         .or_else(|| normalize_codex_timestamp(value.created_at_camel.as_ref()))
+}
+
+fn normalize_value_fields_timestamp(value: &Value) -> Option<String> {
+    normalize_value_timestamp(value.get("timestamp"))
+        .or_else(|| normalize_value_timestamp(value.get("created_at")))
+        .or_else(|| normalize_value_timestamp(value.get("createdAt")))
 }
 
 fn normalize_codex_timestamp(value: Option<&CodexTimestamp<'_>>) -> Option<String> {
@@ -577,8 +711,41 @@ fn normalize_codex_timestamp(value: Option<&CodexTimestamp<'_>>) -> Option<Strin
     }
 }
 
+fn normalize_value_timestamp(value: Option<&Value>) -> Option<String> {
+    let value = value?;
+    if let Some(text) = value.as_str() {
+        let text = text.trim();
+        if text.is_empty() {
+            return None;
+        }
+        return crate::parse_ts_timestamp(text).map(crate::format_rfc3339_millis);
+    }
+    let raw = value.as_u64()?;
+    let millis = if raw > 10_000_000_000 {
+        raw
+    } else {
+        raw.checked_mul(1_000)?
+    };
+    Some(crate::format_rfc3339_millis(TimestampMs::from_millis(
+        millis.min(i64::MAX as u64) as i64,
+    )))
+}
+
 fn normalize_headless_codex_usage(value: &CodexLogEntry<'_>) -> Option<CodexRawUsage> {
     let usage = usage_from_result(value)?;
+    if usage.input_tokens == 0
+        && usage.cached_input_tokens == 0
+        && usage.output_tokens == 0
+        && usage.reasoning_output_tokens == 0
+        && usage.total_tokens == 0
+    {
+        return None;
+    }
+    Some(usage)
+}
+
+fn normalize_headless_codex_usage_value(value: &Value) -> Option<CodexRawUsage> {
+    let usage = usage_from_result_value(value)?;
     if usage.input_tokens == 0
         && usage.cached_input_tokens == 0
         && usage.output_tokens == 0
@@ -1198,6 +1365,7 @@ mod tests {
             [
                 r#"{ "timestamp": "2026-01-02T00:00:00.000Z", "type" : "turn_context", "payload": { "model": "gpt-5" } }"#,
                 r#"{ "timestamp": "2026-01-02T00:00:01.000Z", "type" : "event_msg", "payload": { "type" : "token_count", "info": { "total_token_usage": { "input_tokens": 100, "cached_input_tokens": 10, "output_tokens": 50, "total_tokens": 150 }, "model": "gpt-5" } } }"#,
+                r#"{ "timestamp": "2026-01-02T00:00:02.000Z", "type" : "event_msg", "payload": { "type":"token_count", "info": { "total_token_usage": { "input_tokens": 200, "cached_input_tokens": 20, "output_tokens": 75, "total_tokens": 275 }, "model": "gpt-5" } } }"#,
             ]
             .join("\n"),
         )
@@ -1205,12 +1373,54 @@ mod tests {
 
         let events = load_codex_events_from_directory(&dir, true).unwrap();
 
-        assert_eq!(events.len(), 1);
+        assert_eq!(events.len(), 2);
         assert_eq!(events[0].timestamp, "2026-01-02T00:00:01.000Z");
         assert_eq!(events[0].model.as_deref(), Some("gpt-5"));
         assert_eq!(events[0].input_tokens, 100);
         assert_eq!(events[0].cached_input_tokens, 10);
         assert_eq!(events[0].output_tokens, 50);
+        assert_eq!(events[0].total_tokens, 150);
+        assert_eq!(events[1].timestamp, "2026-01-02T00:00:02.000Z");
+        assert_eq!(events[1].input_tokens, 100);
+        assert_eq!(events[1].cached_input_tokens, 10);
+        assert_eq!(events[1].output_tokens, 25);
+        assert_eq!(events[1].total_tokens, 125);
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn loads_headless_usage_with_unexpected_noncritical_field_types() {
+        let dir = temp_dir("headless-lossy-fields");
+        let file = dir.join("run.jsonl");
+        fs::write(
+            &file,
+            json!({
+                "type": "turn.completed",
+                "timestamp": false,
+                "model": {
+                    "name": "unexpected"
+                },
+                "usage": {
+                    "input_tokens": 120,
+                    "cached_input_tokens": 20,
+                    "output_tokens": 30,
+                    "total_tokens": 150,
+                },
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let events = load_codex_events_from_directory(&dir, true).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].session_id, "run");
+        assert_eq!(events[0].model.as_deref(), Some("gpt-5"));
+        assert!(events[0].is_fallback_model);
+        assert_eq!(events[0].input_tokens, 120);
+        assert_eq!(events[0].cached_input_tokens, 20);
+        assert_eq!(events[0].output_tokens, 30);
         assert_eq!(events[0].total_tokens, 150);
 
         fs::remove_dir_all(dir).unwrap();

--- a/rust/crates/ccusage/src/codex_loader.rs
+++ b/rust/crates/ccusage/src/codex_loader.rs
@@ -23,6 +23,9 @@ static TURN_CONTEXT_TYPE_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""type":"turn_context""#));
 static TOKEN_COUNT_TYPE_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""type":"token_count""#));
+static COMPACT_TYPE_FIELD_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(br#""type":"#));
+static TYPE_KEY_FINDER: LazyLock<Finder<'static>> = LazyLock::new(|| Finder::new(br#""type""#));
 static USAGE_FIELD_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""usage":"#));
 static INPUT_TOKENS_FIELD_FINDER: LazyLock<Finder<'static>> =
@@ -336,11 +339,17 @@ fn add_codex_exec_event(
 }
 
 fn codex_line_usage_kind(line: &[u8]) -> Option<CodexLineKind> {
+    let has_event_msg = EVENT_MSG_TYPE_FINDER.find(line).is_some();
     if TURN_CONTEXT_TYPE_FINDER.find(line).is_some()
-        || (EVENT_MSG_TYPE_FINDER.find(line).is_some()
-            && TOKEN_COUNT_TYPE_FINDER.find(line).is_some())
+        || (has_event_msg && TOKEN_COUNT_TYPE_FINDER.find(line).is_some())
     {
         return Some(CodexLineKind::Session);
+    }
+    if has_event_msg || COMPACT_TYPE_FIELD_FINDER.find(line).is_none() {
+        let (has_turn_context, has_event_msg, has_token_count) = codex_line_type_flags(line);
+        if has_turn_context || (has_event_msg && has_token_count) {
+            return Some(CodexLineKind::Session);
+        }
     }
     if USAGE_FIELD_FINDER.find(line).is_some()
         || INPUT_TOKENS_FIELD_FINDER.find(line).is_some()
@@ -349,6 +358,48 @@ fn codex_line_usage_kind(line: &[u8]) -> Option<CodexLineKind> {
         return Some(CodexLineKind::Headless);
     }
     None
+}
+
+fn codex_line_type_flags(line: &[u8]) -> (bool, bool, bool) {
+    let mut start = 0;
+    let mut has_turn_context = false;
+    let mut has_event_msg = false;
+    let mut has_token_count = false;
+    while let Some(index) = TYPE_KEY_FINDER.find(&line[start..]) {
+        let key_start = start + index;
+        let mut cursor = skip_json_whitespace(line, key_start + br#""type""#.len());
+        if line.get(cursor) != Some(&b':') {
+            start = key_start + br#""type""#.len();
+            continue;
+        }
+        cursor = skip_json_whitespace(line, cursor + 1);
+        if line.get(cursor) != Some(&b'"') {
+            start = cursor.saturating_add(1);
+            continue;
+        }
+        cursor += 1;
+        has_turn_context |= json_string_value_matches(line, cursor, b"turn_context");
+        has_event_msg |= json_string_value_matches(line, cursor, b"event_msg");
+        has_token_count |= json_string_value_matches(line, cursor, b"token_count");
+        if has_turn_context || (has_event_msg && has_token_count) {
+            return (has_turn_context, has_event_msg, has_token_count);
+        }
+        start = cursor.saturating_add(1);
+    }
+    (has_turn_context, has_event_msg, has_token_count)
+}
+
+fn json_string_value_matches(line: &[u8], start: usize, value: &[u8]) -> bool {
+    line.get(start..start + value.len())
+        .is_some_and(|candidate| candidate == value)
+        && line.get(start + value.len()) == Some(&b'"')
+}
+
+fn skip_json_whitespace(line: &[u8], mut index: usize) -> usize {
+    while matches!(line.get(index), Some(b' ' | b'\n' | b'\r' | b'\t')) {
+        index += 1;
+    }
+    index
 }
 
 fn codex_session_timestamp(value: Option<&CodexTimestamp<'_>>) -> Option<String> {
@@ -1128,6 +1179,33 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].session_id, "session");
+        assert_eq!(events[0].timestamp, "2026-01-02T00:00:01.000Z");
+        assert_eq!(events[0].model.as_deref(), Some("gpt-5"));
+        assert_eq!(events[0].input_tokens, 100);
+        assert_eq!(events[0].cached_input_tokens, 10);
+        assert_eq!(events[0].output_tokens, 50);
+        assert_eq!(events[0].total_tokens, 150);
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn loads_session_usage_with_spaced_type_fields() {
+        let dir = temp_dir("spaced-session-type");
+        let file = dir.join("session.jsonl");
+        fs::write(
+            &file,
+            [
+                r#"{ "timestamp": "2026-01-02T00:00:00.000Z", "type" : "turn_context", "payload": { "model": "gpt-5" } }"#,
+                r#"{ "timestamp": "2026-01-02T00:00:01.000Z", "type" : "event_msg", "payload": { "type" : "token_count", "info": { "total_token_usage": { "input_tokens": 100, "cached_input_tokens": 10, "output_tokens": 50, "total_tokens": 150 }, "model": "gpt-5" } } }"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let events = load_codex_events_from_directory(&dir, true).unwrap();
+
+        assert_eq!(events.len(), 1);
         assert_eq!(events[0].timestamp, "2026-01-02T00:00:01.000Z");
         assert_eq!(events[0].model.as_deref(), Some("gpt-5"));
         assert_eq!(events[0].input_tokens, 100);

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -62,7 +62,7 @@ pub(crate) fn run_daily(args: DailyArgs) -> Result<()> {
         &shared,
         args.instances,
         args.project_aliases.as_deref(),
-    );
+    )?;
     Ok(())
 }
 
@@ -100,7 +100,7 @@ pub(crate) fn run_bucket(shared: SharedArgs, kind: BucketKind) -> Result<()> {
         BucketKind::Monthly => ("Claude Code Token Usage Report - Monthly", "Month"),
         BucketKind::Weekly => ("Claude Code Token Usage Report - Weekly", "Week"),
     };
-    print_usage_table(title, col, &buckets, &shared, false, None);
+    print_usage_table(title, col, &buckets, &shared, false, None)?;
     Ok(())
 }
 
@@ -136,7 +136,7 @@ pub(crate) fn run_weekly(args: WeeklyArgs) -> Result<()> {
         &shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 
@@ -209,7 +209,7 @@ pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
         &session_shared,
         false,
         None,
-    );
+    )?;
     Ok(())
 }
 
@@ -308,7 +308,7 @@ pub(crate) fn run_blocks(args: BlocksArgs) -> Result<()> {
         print_active_block_detail(&blocks[0], args.token_limit.as_deref(), max_tokens, &shared);
         return Ok(());
     }
-    print_blocks_table(&blocks, args.token_limit.as_deref(), max_tokens, &shared);
+    print_blocks_table(&blocks, args.token_limit.as_deref(), max_tokens, &shared)?;
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/date_utils.rs
+++ b/rust/crates/ccusage/src/date_utils.rs
@@ -7,7 +7,7 @@ pub(crate) const MILLIS_PER_MINUTE: i64 = 60 * MILLIS_PER_SECOND;
 pub(crate) const MILLIS_PER_HOUR: i64 = 60 * MILLIS_PER_MINUTE;
 pub(crate) const MILLIS_PER_DAY: i64 = 24 * MILLIS_PER_HOUR;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct TimestampMs(i64);
 
 #[derive(Debug, Clone, Copy)]

--- a/rust/crates/ccusage/src/output.rs
+++ b/rust/crates/ccusage/src/output.rs
@@ -136,10 +136,10 @@ pub(crate) fn print_usage_table(
     shared: &SharedArgs,
     group_projects: bool,
     project_aliases: Option<&str>,
-) {
+) -> Result<()> {
     if rows.is_empty() {
         eprintln!("{}", empty_usage_table_message());
-        return;
+        return Ok(());
     }
     let terminal_width = terminal_width();
     let compact = shared.compact || terminal_width < USAGE_COMPACT_WIDTH_THRESHOLD;
@@ -292,11 +292,12 @@ pub(crate) fn print_usage_table(
         total_row.push(String::new());
     }
     table.push(total_row);
-    table.print();
+    table.print()?;
     if compact {
         eprintln!("\nRunning in Compact Mode");
         eprintln!("Expand terminal width to see cache metrics and total tokens");
     }
+    Ok(())
 }
 
 fn empty_usage_table_message() -> &'static str {

--- a/rust/crates/ccusage/src/types.rs
+++ b/rust/crates/ccusage/src/types.rs
@@ -104,7 +104,7 @@ pub(crate) struct LoadedFile {
     pub(crate) entries: Vec<LoadedEntry>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct CodexRawUsage {
     pub(crate) input_tokens: u64,
     pub(crate) cached_input_tokens: u64,


### PR DESCRIPTION
## Summary

| Area | Change |
| --- | --- |
| Codex log loading | Parse Codex JSONL with a bounded-memory \`BufReader\` line buffer and keep the common typed deserialization path borrowed and fast. |
| Headless/session classification | Keep compact Codex type checks exact, tolerate whitespace around session type fields, and avoid rescanning large metadata rows that merely contain JSON-looking text. |
| Malformed headless rows | Recover valid usage rows when non-critical fields such as \`timestamp\` or \`model\` have unexpected JSON types by falling back only after typed deserialization fails. |
| Report aggregation | Use the sharded global dedupe path for parallel human table aggregation so duplicate events are handled in one file pass instead of triggering a full reread. |
| Output compatibility | Keep JSON and table output byte-for-byte aligned with \`bunx ccusage codex --offline\` on the validation Codex fixture. |
| Token totals | Preserve TypeScript-compatible fallback for bogus zero \`total_tokens\` when other token fields are non-zero. |
| Terminal output | \`SimpleTable::print\` now returns \`io::Result<()>\`; CLI table renderers propagate stdout write errors instead of panicking or discarding them. |

## Validation

| Check | Result |
| --- | --- |
| Rust Codex tests | \`direnv exec . cargo test --manifest-path rust/Cargo.toml --workspace codex --no-fail-fast\` passed. |
| Release build | \`direnv exec . cargo build --manifest-path rust/Cargo.toml --release --bin ccusage\` passed. |
| Format | \`direnv exec . pnpm run format\` passed. |
| Typecheck | \`direnv exec . pnpm typecheck\` passed. |
| Full test suite | \`direnv exec . pnpm run test\` passed. |
| Pre-push | \`cargo test\`, \`clippy\`, \`typos\`, \`oxfmt\`, and \`gitleaks\` passed. |
| \`bunx ccusage\` parity | JSON and table output diffs are clean against \`bunx ccusage codex --offline\` on \`CODEX_HOME=/tmp/ccusage-large-codex-fixture-local\`. |
| 1GiB JSON speed | PR 584.4 ms ± 27.9 ms vs origin/main 906.9 ms ± 33.0 ms; PR ran 1.55 ± 0.09x faster. |
| Real \`CODEX_HOME\` table speed | \`rust/target/release/ccusage codex daily --offline\` 785.3 ms ± 34.0 ms vs external \`codexusage daily --offline\` 951.5 ms ± 144.9 ms on \`CODEX_HOME=/Users/ryoppippi/.config/codex\`; PR ran 1.21 ± 0.19x faster. |
| Binary size | PR release binary is 2,795,792 bytes vs origin/main 2,762,576 bytes on local darwin-arm64; +33,216 bytes. |

## Scope

| Item | Status |
| --- | --- |
| PR files | Rust \`ccusage\`, \`ccusage-terminal\`, and table-rendering call sites only. |
| External benchmark repo | External \`codexusage\` comparison CLI files are not included in this PR. |
