### PR TITLE
chore: add cargo-insta on flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -210,10 +210,12 @@
           buildInputs = with pkgs; [
             # Package manager
             pnpm_11
+            bun
 
             # Development tools
             rustToolchain
             cargo-edit
+            cargo-insta
             pkg-config
             openssl
             typos


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `cargo-insta` and `bun` to the dev shell in `flake.nix` to enable Rust snapshot testing and JavaScript tooling during development.

<sup>Written for commit 5d280d5ecb4abdc13c580c6ecbf22f4237230722. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1128?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment with additional tools for package management and testing capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->