### PR TITLE
fix(terminal): use terminal_size for width detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,12 @@ jobs:
             cargo-${{ runner.os }}-${{ runner.arch }}-
       - name: Build Linux static binary
         if: matrix.platform == 'linux'
-        run: nix build .#ccusage-static
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            NIX_CONFIG="access-tokens =" nix build .#ccusage-static
+          else
+            nix build .#ccusage-static
+          fi
       - name: Verify Linux binary is static
         if: matrix.platform == 'linux'
         shell: bash

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -89,6 +89,7 @@ name = "ccusage-terminal"
 version = "20.0.4"
 dependencies = [
  "insta",
+ "terminal_size",
  "unicode-width",
 ]
 
@@ -668,6 +669,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]

--- a/rust/crates/ccusage-terminal/Cargo.toml
+++ b/rust/crates/ccusage-terminal/Cargo.toml
@@ -4,6 +4,7 @@ version = "20.0.4"
 edition = "2021"
 
 [dependencies]
+terminal_size = "0.4.4"
 unicode-width = "0.2.2"
 
 [dev-dependencies]

--- a/rust/crates/ccusage-terminal/src/terminal.rs
+++ b/rust/crates/ccusage-terminal/src/terminal.rs
@@ -1,59 +1,44 @@
-use std::{
-    env,
-    io::{self, IsTerminal},
-};
-
-#[cfg(unix)]
-use std::os::fd::AsRawFd;
+use std::env;
 
 pub(crate) const DEFAULT_TERMINAL_WIDTH: usize = 120;
 
-#[cfg(all(unix, target_os = "macos"))]
-const TIOCGWINSZ: usize = 0x4008_7468;
-#[cfg(all(unix, target_os = "linux"))]
-const TIOCGWINSZ: usize = 0x5413;
-
 pub fn terminal_width() -> usize {
-    env::var("COLUMNS")
-        .ok()
+    select_terminal_width(env::var("COLUMNS").ok().as_deref(), terminal_size_width())
+}
+
+fn terminal_size_width() -> Option<usize> {
+    terminal_size::terminal_size().map(|(terminal_size::Width(width), _)| width as usize)
+}
+
+fn select_terminal_width(columns: Option<&str>, detected_width: Option<usize>) -> usize {
+    columns
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|width| *width > 0)
-        .or_else(terminal_width_from_ioctl)
+        .or_else(|| detected_width.filter(|width| *width > 0))
         .unwrap_or(DEFAULT_TERMINAL_WIDTH)
 }
 
-#[cfg(unix)]
-fn terminal_width_from_ioctl() -> Option<usize> {
-    if !io::stdout().is_terminal() {
-        return None;
-    }
-    #[repr(C)]
-    struct Winsize {
-        rows: u16,
-        cols: u16,
-        xpixel: u16,
-        ypixel: u16,
-    }
-    let mut size = Winsize {
-        rows: 0,
-        cols: 0,
-        xpixel: 0,
-        ypixel: 0,
-    };
-    let rc = unsafe { ioctl(io::stdout().as_raw_fd(), TIOCGWINSZ, &mut size) };
-    if rc == 0 && size.cols > 0 {
-        Some(size.cols as usize)
-    } else {
-        None
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[cfg(not(unix))]
-fn terminal_width_from_ioctl() -> Option<usize> {
-    None
-}
+    #[test]
+    fn uses_columns_before_detected_width() {
+        assert_eq!(select_terminal_width(Some("80"), Some(100)), 80);
+    }
 
-#[cfg(unix)]
-extern "C" {
-    fn ioctl(fd: i32, request: usize, ...) -> i32;
+    #[test]
+    fn ignores_invalid_columns() {
+        assert_eq!(select_terminal_width(Some("wide"), Some(100)), 100);
+    }
+
+    #[test]
+    fn uses_default_width_when_no_width_is_available() {
+        assert_eq!(select_terminal_width(None, None), DEFAULT_TERMINAL_WIDTH);
+    }
+
+    #[test]
+    fn ignores_zero_detected_width() {
+        assert_eq!(select_terminal_width(None, Some(0)), DEFAULT_TERMINAL_WIDTH);
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the hand-written Unix terminal width ioctl path with the maintained `terminal_size` crate. This keeps the existing `COLUMNS` override and default width fallback while letting the crate handle cross-platform terminal detection.

## Testing

- `cargo test --manifest-path rust/Cargo.toml -p ccusage-terminal terminal::tests`
- `cargo build --manifest-path rust/Cargo.toml --release -p ccusage`
- `pnpm run format`
- `pnpm typecheck`
- `pnpm run test`

Binary size was unchanged in the local release build: `2,729,744` bytes before and after.

@coderabbitai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch terminal width detection to the `terminal_size` crate for reliable cross-platform sizing. Also fix PR Linux static builds by clearing the GitHub token for Nix to avoid 401s on public inputs.

- **Refactors**
  - Use `terminal_size` for width detection; selection order stays `COLUMNS` > detected > default (120).
  - Add focused tests for invalid `COLUMNS`, zero widths, and fallback behavior.

- **Bug Fixes**
  - CI: For pull_request Linux static builds, clear Nix access tokens during `nix build` to fix 401 errors fetching public flake inputs.

<sup>Written for commit d7d1fb78101ba203d6c900d24cb1b63bc7bf8b33. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1134?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal width detection now respects the COLUMNS environment variable, with automatic detection as a fallback.
* **Dependencies**
  * Added terminal_size dependency to improve terminal detection.
* **Tests**
  * Added unit tests covering environment precedence, invalid values, and fallback behavior.
* **Chores**
  * CI: adjusted native build step to conditionally set NIX_CONFIG for pull request runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->