### PR TITLE
feat(perf): report peak RSS in PR benchmarks

### DIFF
--- a/apps/ccusage/scripts/compare-pr-performance.ts
+++ b/apps/ccusage/scripts/compare-pr-performance.ts
@@ -553,6 +553,10 @@ function ccusageBenchmarkEnv(
 	};
 }
 
+function ccusageCommandArgs(command: string): string[] {
+	return command.split(' ').filter((part) => part.length > 0);
+}
+
 /**
  * Builds the ccusage command that hyperfine will benchmark.
  *
@@ -591,7 +595,7 @@ function createCcusageBenchmarkCommandFromBin(
 	command: string,
 ): BenchmarkCommand {
 	return {
-		args: [execPath, '-b', binEntry, command, '--offline', '--json'],
+		args: [execPath, '-b', binEntry, ...ccusageCommandArgs(command), '--offline', '--json'],
 		env: ccusageBenchmarkEnv(fixtureDir, codexFixtureDir),
 		text: createCcusageCommandFromBin(binEntry, fixtureDir, codexFixtureDir, command),
 	};
@@ -625,7 +629,7 @@ function createCcusageBenchmarkCommandFromRustBinary(
 	command: string,
 ): BenchmarkCommand {
 	return {
-		args: [binEntry, command, '--offline', '--json'],
+		args: [binEntry, ...ccusageCommandArgs(command), '--offline', '--json'],
 		env: ccusageBenchmarkEnv(fixtureDir, codexFixtureDir),
 		text: createCcusageCommandFromRustBinary(binEntry, fixtureDir, codexFixtureDir, command),
 	};
@@ -670,7 +674,16 @@ function createCcusageBenchmarkCommandFromBunxPackage(
 	command: string,
 ): BenchmarkCommand {
 	return {
-		args: [execPath, 'x', '-p', packageUrl, 'ccusage', command, '--offline', '--json'],
+		args: [
+			execPath,
+			'x',
+			'-p',
+			packageUrl,
+			'ccusage',
+			...ccusageCommandArgs(command),
+			'--offline',
+			'--json',
+		],
 		env: {
 			BUN_INSTALL_CACHE_DIR: cacheDir,
 			...ccusageBenchmarkEnv(fixtureDir, codexFixtureDir),
@@ -1734,11 +1747,12 @@ if (import.meta.vitest != null) {
 
 			expect(args).not.toContain('sh');
 			expect(args).not.toContain('-c');
-			expect(args.slice(-6)).toEqual([
+			expect(args.slice(-7)).toEqual([
 				execPath,
 				'-b',
 				'/tmp/head package/node_modules/ccusage/dist/cli.js',
-				'codex session',
+				'codex',
+				'session',
 				'--offline',
 				'--json',
 			]);

--- a/apps/ccusage/scripts/compare-pr-performance.ts
+++ b/apps/ccusage/scripts/compare-pr-performance.ts
@@ -19,6 +19,12 @@ type MemoryMeasurement = {
 	samples: number;
 };
 
+type BenchmarkCommand = {
+	args: string[];
+	env: Record<string, string>;
+	text: string;
+};
+
 type CommandResult = {
 	base: CommandMeasurement;
 	baseMemory?: MemoryMeasurement;
@@ -478,22 +484,29 @@ function parsePeakRssBytes(stderr: string): number {
 	throw new Error('Could not parse peak RSS from time output');
 }
 
-function timeCommandArgs(commandText: string): string[] | undefined {
+function timeCommandArgs(command: BenchmarkCommand): string[] | undefined {
 	if (platform === 'linux') {
-		return ['/usr/bin/time', '-v', 'sh', '-c', `exec ${commandText} >/dev/null`];
+		return ['/usr/bin/time', '-v', ...command.args];
 	}
 	if (platform === 'darwin') {
-		return ['/usr/bin/time', '-l', 'sh', '-c', `exec ${commandText} >/dev/null`];
+		return ['/usr/bin/time', '-l', ...command.args];
 	}
 	return undefined;
 }
 
-async function measureCommandPeakRssBytes(commandText: string, label: string): Promise<number> {
-	const args = timeCommandArgs(commandText);
+async function measureCommandPeakRssBytes(
+	command: BenchmarkCommand,
+	label: string,
+): Promise<number> {
+	const args = timeCommandArgs(command);
 	if (args == null) {
 		throw new Error(`Peak RSS measurement is not supported on ${platform}`);
 	}
 	const child = Bun.spawn(args, {
+		env: {
+			...process.env,
+			...command.env,
+		},
 		stderr: 'pipe',
 		stdout: 'ignore',
 	});
@@ -506,7 +519,7 @@ async function measureCommandPeakRssBytes(commandText: string, label: string): P
 }
 
 async function measureCommandMemory(
-	commandText: string,
+	command: BenchmarkCommand,
 	options: {
 		label: string;
 		runs: number;
@@ -517,12 +530,26 @@ async function measureCommandMemory(
 	}
 	const samples: number[] = [];
 	for (let index = 0; index < options.runs; index++) {
-		samples.push(await measureCommandPeakRssBytes(commandText, options.label));
+		samples.push(await measureCommandPeakRssBytes(command, options.label));
 	}
 	const sorted = [...samples].sort((a, b) => a - b);
 	return {
 		peakRssBytes: sorted[Math.floor(sorted.length / 2)]!,
 		samples: sorted.length,
+	};
+}
+
+function ccusageBenchmarkEnv(
+	fixtureDir: string,
+	codexFixtureDir: string | undefined,
+): Record<string, string> {
+	return {
+		CLAUDE_CONFIG_DIR: fixtureDir,
+		...(codexFixtureDir == null ? {} : { CODEX_HOME: codexFixtureDir }),
+		COLUMNS: '200',
+		LOG_LEVEL: '0',
+		NO_COLOR: '1',
+		TZ: 'UTC',
 	};
 }
 
@@ -557,6 +584,19 @@ export function createCcusageCommandFromBin(
 	].join(' ');
 }
 
+function createCcusageBenchmarkCommandFromBin(
+	binEntry: string,
+	fixtureDir: string,
+	codexFixtureDir: string | undefined,
+	command: string,
+): BenchmarkCommand {
+	return {
+		args: [execPath, '-b', binEntry, command, '--offline', '--json'],
+		env: ccusageBenchmarkEnv(fixtureDir, codexFixtureDir),
+		text: createCcusageCommandFromBin(binEntry, fixtureDir, codexFixtureDir, command),
+	};
+}
+
 export function createCcusageCommandFromRustBinary(
 	binEntry: string,
 	fixtureDir: string,
@@ -576,6 +616,19 @@ export function createCcusageCommandFromRustBinary(
 		'--offline',
 		'--json',
 	].join(' ');
+}
+
+function createCcusageBenchmarkCommandFromRustBinary(
+	binEntry: string,
+	fixtureDir: string,
+	codexFixtureDir: string | undefined,
+	command: string,
+): BenchmarkCommand {
+	return {
+		args: [binEntry, command, '--offline', '--json'],
+		env: ccusageBenchmarkEnv(fixtureDir, codexFixtureDir),
+		text: createCcusageCommandFromRustBinary(binEntry, fixtureDir, codexFixtureDir, command),
+	};
 }
 
 function createBunxStartupCommand(packageUrl: string): string[] {
@@ -607,6 +660,29 @@ export function createCcusageCommandFromBunxPackage(
 		'--offline',
 		'--json',
 	].join(' ');
+}
+
+function createCcusageBenchmarkCommandFromBunxPackage(
+	packageUrl: string,
+	cacheDir: string,
+	fixtureDir: string,
+	codexFixtureDir: string | undefined,
+	command: string,
+): BenchmarkCommand {
+	return {
+		args: [execPath, 'x', '-p', packageUrl, 'ccusage', command, '--offline', '--json'],
+		env: {
+			BUN_INSTALL_CACHE_DIR: cacheDir,
+			...ccusageBenchmarkEnv(fixtureDir, codexFixtureDir),
+		},
+		text: createCcusageCommandFromBunxPackage(
+			packageUrl,
+			cacheDir,
+			fixtureDir,
+			codexFixtureDir,
+			command,
+		),
+	};
 }
 
 async function measureCommandMilliseconds({
@@ -736,6 +812,29 @@ export async function createCcusageCommand(
 	);
 }
 
+async function createCcusageBenchmarkCommand(
+	repoDir: string,
+	fixtureDir: string,
+	codexFixtureDir: string | undefined,
+	command: string,
+	runtime: HeadRuntime = 'package',
+): Promise<BenchmarkCommand> {
+	if (runtime === 'rust') {
+		return createCcusageBenchmarkCommandFromRustBinary(
+			rustBinaryEntry(repoDir),
+			fixtureDir,
+			codexFixtureDir,
+			command,
+		);
+	}
+	return createCcusageBenchmarkCommandFromBin(
+		await packageBinEntry(repoDir),
+		fixtureDir,
+		codexFixtureDir,
+		command,
+	);
+}
+
 export async function createHeadCcusageCommand(options: {
 	command: string;
 	codexFixtureDir?: string;
@@ -762,6 +861,40 @@ export async function createHeadCcusageCommand(options: {
 		);
 	}
 	return createCcusageCommand(
+		options.headDir,
+		options.fixtureDir,
+		options.codexFixtureDir,
+		options.command,
+		options.headRuntime,
+	);
+}
+
+async function createHeadCcusageBenchmarkCommand(options: {
+	command: string;
+	codexFixtureDir?: string;
+	fixtureDir: string;
+	headBinEntry?: string;
+	headDir: string;
+	headNativeBinEntry?: string;
+	headRuntime: HeadRuntime;
+}): Promise<BenchmarkCommand> {
+	if (options.headRuntime === 'package' && options.headBinEntry != null) {
+		return createCcusageBenchmarkCommandFromBin(
+			options.headBinEntry,
+			options.fixtureDir,
+			options.codexFixtureDir,
+			options.command,
+		);
+	}
+	if (options.headRuntime === 'rust' && options.headNativeBinEntry != null) {
+		return createCcusageBenchmarkCommandFromRustBinary(
+			options.headNativeBinEntry,
+			options.fixtureDir,
+			options.codexFixtureDir,
+			options.command,
+		);
+	}
+	return createCcusageBenchmarkCommand(
 		options.headDir,
 		options.fixtureDir,
 		options.codexFixtureDir,
@@ -802,13 +935,13 @@ async function compareCommand(
 	await writeProgress(`${options.fixtureTitle} / ${command} started`);
 	await using fixture = await createFixture({});
 	const exportPath = join(fixture.path, 'hyperfine.json');
-	const baseCommand = createCcusageCommandFromBin(
+	const baseCommand = createCcusageBenchmarkCommandFromBin(
 		options.baseBinEntry,
 		options.fixtureDir,
 		options.codexFixtureDir,
 		command,
 	);
-	const headCommand = await createHeadCcusageCommand({
+	const headCommand = await createHeadCcusageBenchmarkCommand({
 		command,
 		codexFixtureDir: options.codexFixtureDir,
 		fixtureDir: options.fixtureDir,
@@ -838,8 +971,8 @@ async function compareCommand(
 			'base',
 			'--command-name',
 			'PR',
-			baseCommand,
-			headCommand,
+			baseCommand.text,
+			headCommand.text,
 		],
 		{
 			stderr: 'inherit',
@@ -896,14 +1029,14 @@ async function compareBunxCommand(
 	await writeProgress(`${options.fixtureTitle} / bunx ${command} started`);
 	await using fixture = await createFixture({});
 	const exportPath = join(fixture.path, 'hyperfine.json');
-	const baseCommand = createCcusageCommandFromBunxPackage(
+	const baseCommand = createCcusageBenchmarkCommandFromBunxPackage(
 		options.basePackageUrl,
 		options.baseCacheDir,
 		options.fixtureDir,
 		options.codexFixtureDir,
 		command,
 	);
-	const headCommand = createCcusageCommandFromBunxPackage(
+	const headCommand = createCcusageBenchmarkCommandFromBunxPackage(
 		options.headPackageUrl,
 		options.headCacheDir,
 		options.fixtureDir,
@@ -931,8 +1064,8 @@ async function compareBunxCommand(
 			'base',
 			'--command-name',
 			'PR',
-			baseCommand,
-			headCommand,
+			baseCommand.text,
+			headCommand.text,
 		],
 		{
 			stderr: 'inherit',
@@ -1582,6 +1715,37 @@ if (import.meta.vitest != null) {
 			expect(commandText).toContain(
 				' x -p https://pkg.pr.new/ryoppippi/ccusage@abcdef0 ccusage codex --offline --json',
 			);
+		});
+	});
+
+	describe('timeCommandArgs', () => {
+		it('wraps peak RSS measurement around argv without a shell command string', () => {
+			const command = createCcusageBenchmarkCommandFromBin(
+				'/tmp/head package/node_modules/ccusage/dist/cli.js',
+				'/fixtures/claude',
+				'/fixtures/codex',
+				'codex session',
+			);
+
+			const args = timeCommandArgs(command);
+			if (args == null) {
+				return;
+			}
+
+			expect(args).not.toContain('sh');
+			expect(args).not.toContain('-c');
+			expect(args.slice(-6)).toEqual([
+				execPath,
+				'-b',
+				'/tmp/head package/node_modules/ccusage/dist/cli.js',
+				'codex session',
+				'--offline',
+				'--json',
+			]);
+			expect(command.env).toMatchObject({
+				CLAUDE_CONFIG_DIR: '/fixtures/claude',
+				CODEX_HOME: '/fixtures/codex',
+			});
 		});
 	});
 

--- a/apps/ccusage/scripts/compare-pr-performance.ts
+++ b/apps/ccusage/scripts/compare-pr-performance.ts
@@ -497,7 +497,7 @@ function timeCommandArgs(command: BenchmarkCommand): string[] | undefined {
 async function measureCommandPeakRssBytes(
 	command: BenchmarkCommand,
 	label: string,
-): Promise<number> {
+): Promise<number | undefined> {
 	const args = timeCommandArgs(command);
 	if (args == null) {
 		throw new Error(`Peak RSS measurement is not supported on ${platform}`);
@@ -513,9 +513,16 @@ async function measureCommandPeakRssBytes(
 	const exitCode = await child.exited;
 	const stderr = await new Response(child.stderr).text();
 	if (exitCode !== 0) {
-		throw new Error(`${label} peak RSS measurement failed: ${stderr}`);
+		await writeProgress(`${label} peak RSS skipped after exit ${exitCode}: ${stderr}`);
+		return undefined;
 	}
-	return parsePeakRssBytes(stderr);
+	try {
+		return parsePeakRssBytes(stderr);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		await writeProgress(`${label} peak RSS skipped: ${message}`);
+		return undefined;
+	}
 }
 
 async function measureCommandMemory(
@@ -530,7 +537,13 @@ async function measureCommandMemory(
 	}
 	const samples: number[] = [];
 	for (let index = 0; index < options.runs; index++) {
-		samples.push(await measureCommandPeakRssBytes(command, options.label));
+		const sample = await measureCommandPeakRssBytes(command, options.label);
+		if (sample != null) {
+			samples.push(sample);
+		}
+	}
+	if (samples.length === 0) {
+		return undefined;
 	}
 	const sorted = [...samples].sort((a, b) => a - b);
 	return {

--- a/apps/ccusage/scripts/compare-pr-performance.ts
+++ b/apps/ccusage/scripts/compare-pr-performance.ts
@@ -14,10 +14,17 @@ type CommandMeasurement = {
 	samples: number;
 };
 
+type MemoryMeasurement = {
+	peakRssBytes: number;
+	samples: number;
+};
+
 type CommandResult = {
 	base: CommandMeasurement;
+	baseMemory?: MemoryMeasurement;
 	command: string;
 	head: CommandMeasurement;
+	headMemory?: MemoryMeasurement;
 };
 
 type SizeComparison = {
@@ -52,6 +59,7 @@ type FixtureComparison = SampleOptions & {
 	description: string;
 	fixtureDir: string;
 	fixtureStats: FixtureStats;
+	memoryRuns: number;
 	results: CommandResult[];
 	title: string;
 };
@@ -302,6 +310,30 @@ function formatDataSize(bytes: number): string {
 	return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
 }
 
+function formatMemorySize(bytes: number): string {
+	if (bytes >= 1024 * 1024 * 1024) {
+		return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GiB`;
+	}
+	if (bytes >= 1024 * 1024) {
+		return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+	}
+	return `${(bytes / 1024).toFixed(2)} KiB`;
+}
+
+function formatOptionalMemory(measurement: MemoryMeasurement | undefined): string {
+	return measurement == null ? '-' : formatMemorySize(measurement.peakRssBytes);
+}
+
+function formatMemoryRatio(
+	baseMemory: MemoryMeasurement | undefined,
+	headMemory: MemoryMeasurement | undefined,
+): string {
+	if (baseMemory == null || headMemory == null || baseMemory.peakRssBytes === 0) {
+		return '-';
+	}
+	return `${(headMemory.peakRssBytes / baseMemory.peakRssBytes).toFixed(2)}x`;
+}
+
 function measurementFromMilliseconds(times: number[]): CommandMeasurement {
 	if (times.length === 0) {
 		throw new Error('Cannot summarize zero measurements');
@@ -432,6 +464,66 @@ function formatSha(sha: string): string {
 function packageUrlSha(packageUrl: string): string {
 	const match = packageUrl.match(/@([0-9a-f]{7,40})(?:$|[/?#])/i);
 	return match == null ? packageUrl : formatSha(match[1]!);
+}
+
+function parsePeakRssBytes(stderr: string): number {
+	const linuxMatch = stderr.match(/Maximum resident set size \(kbytes\):\s*(\d+)/i);
+	if (linuxMatch != null) {
+		return Number(linuxMatch[1]) * 1024;
+	}
+	const darwinMatch = stderr.match(/^\s*(\d+)\s+maximum resident set size$/im);
+	if (darwinMatch != null) {
+		return Number(darwinMatch[1]);
+	}
+	throw new Error('Could not parse peak RSS from time output');
+}
+
+function timeCommandArgs(commandText: string): string[] | undefined {
+	if (platform === 'linux') {
+		return ['/usr/bin/time', '-v', 'sh', '-c', `exec ${commandText} >/dev/null`];
+	}
+	if (platform === 'darwin') {
+		return ['/usr/bin/time', '-l', 'sh', '-c', `exec ${commandText} >/dev/null`];
+	}
+	return undefined;
+}
+
+async function measureCommandPeakRssBytes(commandText: string, label: string): Promise<number> {
+	const args = timeCommandArgs(commandText);
+	if (args == null) {
+		throw new Error(`Peak RSS measurement is not supported on ${platform}`);
+	}
+	const child = Bun.spawn(args, {
+		stderr: 'pipe',
+		stdout: 'ignore',
+	});
+	const exitCode = await child.exited;
+	const stderr = await new Response(child.stderr).text();
+	if (exitCode !== 0) {
+		throw new Error(`${label} peak RSS measurement failed: ${stderr}`);
+	}
+	return parsePeakRssBytes(stderr);
+}
+
+async function measureCommandMemory(
+	commandText: string,
+	options: {
+		label: string;
+		runs: number;
+	},
+): Promise<MemoryMeasurement | undefined> {
+	if (options.runs === 0) {
+		return undefined;
+	}
+	const samples: number[] = [];
+	for (let index = 0; index < options.runs; index++) {
+		samples.push(await measureCommandPeakRssBytes(commandText, options.label));
+	}
+	const sorted = [...samples].sort((a, b) => a - b);
+	return {
+		peakRssBytes: sorted[Math.floor(sorted.length / 2)]!,
+		samples: sorted.length,
+	};
 }
 
 /**
@@ -702,6 +794,7 @@ async function compareCommand(
 		headDir: string;
 		headNativeBinEntry?: string;
 		headRuntime: HeadRuntime;
+		memoryRuns: number;
 		runs: number;
 		warmup: number;
 	},
@@ -764,14 +857,24 @@ async function compareCommand(
 	}
 	const base = measurementFromHyperfine(baseResult);
 	const head = measurementFromHyperfine(headResult);
+	const baseMemory = await measureCommandMemory(baseCommand, {
+		label: `${options.fixtureTitle} / ${command} base`,
+		runs: options.memoryRuns,
+	});
+	const headMemory = await measureCommandMemory(headCommand, {
+		label: `${options.fixtureTitle} / ${command} PR`,
+		runs: options.memoryRuns,
+	});
 	await writeProgress(
 		`${options.fixtureTitle} / ${command} done: base ${formatDuration(base.median)}, PR ${formatDuration(head.median)}`,
 	);
 
 	return {
 		base,
+		baseMemory,
 		command,
 		head,
+		headMemory,
 	};
 }
 
@@ -785,6 +888,7 @@ async function compareBunxCommand(
 		fixtureDir: string;
 		headCacheDir: string;
 		headPackageUrl: string;
+		memoryRuns: number;
 		runs: number;
 		warmup: number;
 	},
@@ -848,14 +952,24 @@ async function compareBunxCommand(
 	}
 	const base = measurementFromHyperfine(baseResult);
 	const head = measurementFromHyperfine(headResult);
+	const baseMemory = await measureCommandMemory(baseCommand, {
+		label: `${options.fixtureTitle} / bunx ${command} base`,
+		runs: options.memoryRuns,
+	});
+	const headMemory = await measureCommandMemory(headCommand, {
+		label: `${options.fixtureTitle} / bunx ${command} PR`,
+		runs: options.memoryRuns,
+	});
 	await writeProgress(
 		`${options.fixtureTitle} / bunx ${command} done: base ${formatDuration(base.median)}, PR ${formatDuration(head.median)}`,
 	);
 
 	return {
 		base,
+		baseMemory,
 		command,
 		head,
+		headMemory,
 	};
 }
 
@@ -878,6 +992,7 @@ async function compareFixture(options: {
 	headDir: string;
 	headNativeBinEntry?: string;
 	headRuntime: HeadRuntime;
+	memoryRuns: number;
 	runs: number;
 	title: string;
 	warmup: number;
@@ -907,6 +1022,7 @@ async function compareFixture(options: {
 		description: options.description,
 		fixtureDir: options.fixtureDir,
 		fixtureStats,
+		memoryRuns: options.memoryRuns,
 		results,
 		runs: options.runs,
 		title: options.title,
@@ -923,6 +1039,7 @@ async function compareBunxFixture(options: {
 	fixtureDir: string;
 	headCacheDir: string;
 	headPackageUrl: string;
+	memoryRuns: number;
 	runs: number;
 	title: string;
 	warmup: number;
@@ -954,6 +1071,7 @@ async function compareBunxFixture(options: {
 		fixtureDir: options.fixtureDir,
 		fixtureStats,
 		headPackageUrl: options.headPackageUrl,
+		memoryRuns: options.memoryRuns,
 		results,
 		runs: options.runs,
 		title: options.title,
@@ -1163,6 +1281,9 @@ export function renderFixtureSection(
 		headRuntimeDescription?: string;
 	},
 ): string[] {
+	const hasMemory = section.results.some(
+		(result) => result.baseMemory != null || result.headMemory != null,
+	);
 	const baseRuntimeDescription =
 		options.baseRuntimeDescription ??
 		'Base runs the package `ccusage` bin from `apps/ccusage/package.json` through `bun -b`';
@@ -1181,17 +1302,42 @@ export function renderFixtureSection(
 			? `Fixture: \`${formatFixturePath(options.headDir, section.fixtureDir)}\` (${formatFixtureStats(section.fixtureStats)})`
 			: `Fixtures: Claude \`${formatFixturePath(options.headDir, section.fixtureDir)}\` (${formatFixtureStats(section.fixtureStats)}), Codex \`${formatFixturePath(options.headDir, section.codexFixtureDir)}\` (${formatFixtureStats(section.codexFixtureStats ?? section.fixtureStats)})`,
 		`${runtimeText} Both run \`--offline --json\`, measured by \`hyperfine\` with \`${section.warmup}\` warmups and \`${section.runs}\` runs.`,
+		...(hasMemory
+			? [
+					`Peak RSS is measured separately with \`/usr/bin/time\` using \`${section.memoryRuns}\` runs. Lower RSS ratios are better.`,
+				]
+			: []),
 		'',
-		'| Command | Input | Base median | PR median | PR vs base | Base throughput | PR throughput |',
-		'| --- | ---: | ---: | ---: | ---: | ---: | ---: |',
+		hasMemory
+			? '| Command | Input | Base median | PR median | PR vs base | Base peak RSS | PR peak RSS | PR/base RSS | Base throughput | PR throughput |'
+			: '| Command | Input | Base median | PR median | PR vs base | Base throughput | PR throughput |',
+		hasMemory
+			? '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+			: '| --- | ---: | ---: | ---: | ---: | ---: | ---: |',
 	];
 
 	for (const result of section.results) {
 		const speedup = result.base.median / result.head.median;
 		const fixtureStats = fixtureStatsForCommand(section, result.command);
-		lines.push(
-			`| \`${result.command} --offline --json\` | ${formatDataSize(fixtureStats.bytes)} | ${formatDuration(result.base.median)} | ${formatDuration(result.head.median)} | ${speedup.toFixed(2)}x | ${formatThroughput(fixtureStats.bytes, result.base.median)} | ${formatThroughput(fixtureStats.bytes, result.head.median)} |`,
-		);
+		const timeColumns = [
+			`\`${result.command} --offline --json\``,
+			formatDataSize(fixtureStats.bytes),
+			formatDuration(result.base.median),
+			formatDuration(result.head.median),
+			`${speedup.toFixed(2)}x`,
+		];
+		const memoryColumns = hasMemory
+			? [
+					formatOptionalMemory(result.baseMemory),
+					formatOptionalMemory(result.headMemory),
+					formatMemoryRatio(result.baseMemory, result.headMemory),
+				]
+			: [];
+		const throughputColumns = [
+			formatThroughput(fixtureStats.bytes, result.base.median),
+			formatThroughput(fixtureStats.bytes, result.head.median),
+		];
+		lines.push(`| ${[...timeColumns, ...memoryColumns, ...throughputColumns].join(' | ')} |`);
 	}
 
 	return lines;
@@ -1233,6 +1379,9 @@ export function renderBunxFixtureSection(
 		headDir: string;
 	},
 ): string[] {
+	const hasMemory = section.results.some(
+		(result) => result.baseMemory != null || result.headMemory != null,
+	);
 	const lines = [
 		`## ${section.title}`,
 		'',
@@ -1242,17 +1391,42 @@ export function renderBunxFixtureSection(
 			? `Fixture: \`${formatFixturePath(options.headDir, section.fixtureDir)}\` (${formatFixtureStats(section.fixtureStats)})`
 			: `Fixtures: Claude \`${formatFixturePath(options.headDir, section.fixtureDir)}\` (${formatFixtureStats(section.fixtureStats)}), Codex \`${formatFixturePath(options.headDir, section.codexFixtureDir)}\` (${formatFixtureStats(section.codexFixtureStats ?? section.fixtureStats)})`,
 		`Base package: \`${packageUrlSha(section.basePackageUrl)}\`; PR package: \`${packageUrlSha(section.headPackageUrl)}\`. Both run through \`bunx -p <pkg.pr.new URL> ccusage\` using the warmed Bun install cache from package runner startup, measured by \`hyperfine\` with \`${section.warmup}\` warmups and \`${section.runs}\` runs.`,
+		...(hasMemory
+			? [
+					`Peak RSS is measured separately with \`/usr/bin/time\` using \`${section.memoryRuns}\` runs. Lower RSS ratios are better.`,
+				]
+			: []),
 		'',
-		'| Command | Input | Base median | PR median | PR vs base | Base throughput | PR throughput |',
-		'| --- | ---: | ---: | ---: | ---: | ---: | ---: |',
+		hasMemory
+			? '| Command | Input | Base median | PR median | PR vs base | Base peak RSS | PR peak RSS | PR/base RSS | Base throughput | PR throughput |'
+			: '| Command | Input | Base median | PR median | PR vs base | Base throughput | PR throughput |',
+		hasMemory
+			? '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+			: '| --- | ---: | ---: | ---: | ---: | ---: | ---: |',
 	];
 
 	for (const result of section.results) {
 		const speedup = result.base.median / result.head.median;
 		const fixtureStats = fixtureStatsForCommand(section, result.command);
-		lines.push(
-			`| \`bunx -p <pkg> ccusage ${result.command} --offline --json\` | ${formatDataSize(fixtureStats.bytes)} | ${formatDuration(result.base.median)} | ${formatDuration(result.head.median)} | ${speedup.toFixed(2)}x | ${formatThroughput(fixtureStats.bytes, result.base.median)} | ${formatThroughput(fixtureStats.bytes, result.head.median)} |`,
-		);
+		const timeColumns = [
+			`\`bunx -p <pkg> ccusage ${result.command} --offline --json\``,
+			formatDataSize(fixtureStats.bytes),
+			formatDuration(result.base.median),
+			formatDuration(result.head.median),
+			`${speedup.toFixed(2)}x`,
+		];
+		const memoryColumns = hasMemory
+			? [
+					formatOptionalMemory(result.baseMemory),
+					formatOptionalMemory(result.headMemory),
+					formatMemoryRatio(result.baseMemory, result.headMemory),
+				]
+			: [];
+		const throughputColumns = [
+			formatThroughput(fixtureStats.bytes, result.base.median),
+			formatThroughput(fixtureStats.bytes, result.head.median),
+		];
+		lines.push(`| ${[...timeColumns, ...memoryColumns, ...throughputColumns].join(' | ')} |`);
 	}
 
 	return lines;
@@ -1514,6 +1688,7 @@ if (import.meta.vitest != null) {
 						bytes: 1024 * 1024 * 1024,
 						files: 400,
 					},
+					memoryRuns: 0,
 					results: [
 						{
 							base: { max: 2000, median: 2000, min: 2000, samples: 1 },
@@ -1541,6 +1716,41 @@ if (import.meta.vitest != null) {
 			expect(lines.join('\n')).toContain('1.00 GiB/s');
 		});
 
+		it('renders peak RSS measurements when memory samples are available', () => {
+			const lines = renderFixtureSection(
+				{
+					description: 'Fixture description',
+					fixtureDir: '/fixtures/claude',
+					fixtureStats: {
+						bytes: 1024 * 1024 * 1024,
+						files: 400,
+					},
+					memoryRuns: 1,
+					results: [
+						{
+							base: { max: 2000, median: 2000, min: 2000, samples: 1 },
+							baseMemory: { peakRssBytes: 128 * 1024 * 1024, samples: 1 },
+							command: 'claude',
+							head: { max: 1000, median: 1000, min: 1000, samples: 1 },
+							headMemory: { peakRssBytes: 96 * 1024 * 1024, samples: 1 },
+						},
+					],
+					runs: 1,
+					title: 'Large fixture',
+					warmup: 0,
+				},
+				{ headDir: '/repo', headRuntime: 'rust' },
+			);
+			const markdown = lines.join('\n');
+
+			expect(markdown).toContain('Base peak RSS');
+			expect(markdown).toContain('PR peak RSS');
+			expect(markdown).toContain('PR/base RSS');
+			expect(markdown).toContain(
+				'| `claude --offline --json` | 1.00 GiB | 2.000s | 1.000s | 2.00x | 128.00 MiB | 96.00 MiB | 0.75x |',
+			);
+		});
+
 		it('describes the Rust PR runtime when the head benchmark uses the native binary', () => {
 			const lines = renderFixtureSection(
 				{
@@ -1550,6 +1760,7 @@ if (import.meta.vitest != null) {
 						bytes: 1024,
 						files: 1,
 					},
+					memoryRuns: 0,
 					results: [],
 					runs: 1,
 					title: 'Rust fixture',
@@ -1572,6 +1783,7 @@ if (import.meta.vitest != null) {
 						bytes: 1024,
 						files: 1,
 					},
+					memoryRuns: 0,
 					results: [],
 					runs: 1,
 					title: 'Package fixture',
@@ -1633,6 +1845,7 @@ if (import.meta.vitest != null) {
 						files: 400,
 					},
 					headPackageUrl: 'https://pkg.pr.new/ryoppippi/ccusage/ccusage@abcdef0123456789',
+					memoryRuns: 0,
 					results: [
 						{
 							base: { max: 2000, median: 2000, min: 2000, samples: 1 },
@@ -1714,6 +1927,7 @@ if (import.meta.vitest != null) {
 				bytes: 1024,
 				files: 1,
 			},
+			memoryRuns: 0,
 			results: [],
 			runs: 1,
 			title: 'Fixture',
@@ -1785,6 +1999,20 @@ if (import.meta.vitest != null) {
 			expect(markdown).toContain(
 				'| installed native package binary | 2.00 KiB | 1.00 KiB | -1.00 KiB | 2.00x |',
 			);
+		});
+	});
+
+	describe('parsePeakRssBytes', () => {
+		it('parses GNU time verbose maximum resident set size as bytes', () => {
+			expect(
+				parsePeakRssBytes(
+					'Command being timed: "ccusage"\nMaximum resident set size (kbytes): 131072\n',
+				),
+			).toBe(128 * 1024 * 1024);
+		});
+
+		it('parses macOS time maximum resident set size as bytes', () => {
+			expect(parsePeakRssBytes('  134217728  maximum resident set size\n')).toBe(128 * 1024 * 1024);
 		});
 	});
 }
@@ -1873,6 +2101,11 @@ const command = define({
 			default: 0,
 			description: 'Explicit warmup runs before each large-fixture command',
 		},
+		memoryRuns: {
+			type: 'number',
+			default: 1,
+			description: 'Peak RSS samples per measured command; use 0 to skip memory measurement',
+		},
 		headPackageUrl: {
 			type: 'string',
 			description: 'PR/head pkg.pr.new ccusage package URL used for package-runner startup timing',
@@ -1892,6 +2125,9 @@ const command = define({
 		assertSampleOptions({ runs: ctx.values.runs, warmup: ctx.values.warmup }, '');
 		assertSampleOptions({ runs: ctx.values.largeRuns, warmup: ctx.values.largeWarmup }, 'large-');
 		assertSampleOptions({ runs: ctx.values.packageRunnerRuns, warmup: 0 }, 'package-runner-');
+		if (!Number.isInteger(ctx.values.memoryRuns) || ctx.values.memoryRuns < 0) {
+			throw new Error('--memory-runs must be a non-negative integer');
+		}
 		if (ctx.values.baseDir == null && ctx.values.basePackageUrl == null) {
 			throw new Error('Either --base-dir or --base-package-url is required');
 		}
@@ -1951,6 +2187,7 @@ const command = define({
 					? undefined
 					: 'PR runs the published `ccusage` package from `pkg.pr.new`, installed before measurement',
 			headSha: gitSha(resolve(ctx.values.headDir)),
+			memoryRuns: ctx.values.memoryRuns,
 			runs: ctx.values.runs,
 			warmup: ctx.values.warmup,
 		};
@@ -2032,6 +2269,7 @@ const command = define({
 							fixtureDir: resolve(ctx.values.largeFixtureDir),
 							headCacheDir: headBunxCacheDir,
 							headPackageUrl: options.headPackageUrl,
+							memoryRuns: options.memoryRuns,
 							runs: ctx.values.largeRuns,
 							title: 'Cached bunx execution performance',
 							warmup: ctx.values.largeWarmup,


### PR DESCRIPTION
## Summary

Adds peak RSS reporting to the existing PR performance benchmark output. The script keeps \`hyperfine\` as the timing source, then runs each base and PR command through \`/usr/bin/time\` to collect memory usage.

## What Changed

- Parse GNU time and macOS time peak RSS output.
- Add \`Base peak RSS\`, \`PR peak RSS\`, and \`PR/base RSS\` columns to benchmark tables when memory data is present.
- Add \`--memory-runs\`, defaulting to \`1\`, with \`0\` available to skip memory measurement.

## Testing

- \`direnv exec . pnpm run format\`
- \`direnv exec . pnpm typecheck\`
- \`direnv exec . pnpm run test\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report peak RSS in PR benchmark tables to add a memory signal alongside existing timing. Memory is measured with `/usr/bin/time` after `hyperfine` and is best-effort, so failures are skipped without failing the benchmark.

- **New Features**
  - Collect peak RSS for each base and PR command using GNU time `-v` and macOS time `-l`.
  - Add "Base peak RSS", "PR peak RSS", and "PR/base RSS" columns (lower ratios are better).
  - New `--memory-runs` option (default 1); set to 0 to skip; validated as a non‑negative integer.
  - Works for both regular and `bunx` benchmark sections.

- **Bug Fixes**
  - Run RSS measurements without `sh -c`; execute via argv/env to avoid shell parsing and keep spaced bin paths intact.
  - Split benchmark subcommands into argv for RSS runs to match `--shell none` and prevent "unknown command" errors.
  - Keep RSS sampling best-effort: skip non-zero exits or parse errors and show `-` in memory columns while preserving timing results.

<sup>Written for commit 9bef91720894fb43e5cd44649d2aa20e8c4b473e. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1135?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmarks can optionally collect peak RAM (peak RSS) via a new --memory-runs option (default 1; set 0 to skip). Option validated as a non-negative integer and applied across all comparisons, including large-fixture runs.
  * PR comparison reports now show Base peak RSS, PR peak RSS, and PR/Base memory ratio when memory data exists; markdown tables and an explanatory note update conditionally.

* **Tests**
  * Added tests for peak-RSS parsing (GNU/macOS formats) and for the memory-wrapping execution behavior.

* **Chores**
  * Updated test fixtures to declare memoryRuns where applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->