### PR TITLE
chore(nix): move schema gen and rustfmt into treefmt

### DIFF
--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -19,62 +19,6 @@ in
         overlays = [ inputs.rust-overlay.overlays.default ];
       };
       rustToolchain = pkgs.rust-bin.fromRustupToolchainFile (root + /rust-toolchain.toml);
-      checkConfigSchema = pkgs.writeShellApplication {
-        name = "ccusage-hook-check-config-schema";
-        runtimeInputs = [
-          pkgs.coreutils
-          pkgs.oxfmt
-          pkgs.openssl
-          pkgs.pkg-config
-          rustToolchain
-        ]
-        ++ lib.optionals pkgs.stdenv.isDarwin [
-          pkgs.apple-sdk_15
-          pkgs.libiconv
-        ];
-        text = ''
-          tmp_dir="$(mktemp -d)"
-          trap 'rm -rf "$tmp_dir"' EXIT
-
-          generated_schema="$tmp_dir/config-schema.json"
-          generated_docs_schema="$tmp_dir/docs-config-schema.json"
-
-          ${lib.optionalString pkgs.stdenv.isDarwin ''
-            export SDKROOT="${pkgs.apple-sdk_15}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
-            export LIBRARY_PATH="${
-              lib.makeLibraryPath [
-                pkgs.libiconv
-                pkgs.openssl
-              ]
-            }:''${LIBRARY_PATH:-}"
-            export CPATH="${
-              lib.makeIncludePath [
-                pkgs.libiconv
-                pkgs.openssl
-              ]
-            }:''${CPATH:-}"
-          ''}
-
-          cargo run --quiet --manifest-path rust/Cargo.toml --bin generate-config-schema -- "$generated_schema"
-          oxfmt --write "$generated_schema"
-          cp "$generated_schema" "$generated_docs_schema"
-
-          has_errors=0
-          if ! cmp -s "$generated_schema" apps/ccusage/config-schema.json; then
-            echo "apps/ccusage/config-schema.json is out of date." >&2
-            has_errors=1
-          fi
-          if ! cmp -s "$generated_docs_schema" docs/public/config-schema.json; then
-            echo "docs/public/config-schema.json is out of date." >&2
-            has_errors=1
-          fi
-          if [ "$has_errors" -eq 1 ]; then
-            echo "Run: pnpm --filter ccusage run generate:schema" >&2
-            exit 1
-          fi
-          echo "Config schema is up to date"
-        '';
-      };
     in
     {
       pre-commit = {
@@ -84,15 +28,6 @@ in
           src = root;
           package = pkgs.prek;
           hooks = {
-            config-schema = {
-              enable = true;
-              name = "config schema";
-              entry = lib.getExe checkConfigSchema;
-              files = "^(apps/ccusage/package\\.json|rust/crates/ccusage/src/config_schema\\.rs|rust/crates/ccusage/src/bin/generate_config_schema\\.rs)$";
-              pass_filenames = false;
-              stages = [ "pre-commit" ];
-              priority = 0;
-            };
             renovate-config-validator = {
               enable = true;
               entry = "${lib.getExe pkgs.renovate} --strict config-validator";
@@ -121,14 +56,6 @@ in
               always_run = true;
               stages = [ "pre-commit" ];
               priority = 20;
-            };
-            ccusage-rustfmt = {
-              enable = true;
-              name = "rustfmt";
-              entry = lib.getExe' rustToolchain "rustfmt";
-              files = "^rust/.*\\.rs$";
-              stages = [ "pre-commit" ];
-              priority = 10;
             };
             ccusage-treefmt-check = {
               enable = true;

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -59,6 +59,10 @@ in
         programs = {
           deadnix.enable = true;
           nixfmt.enable = true;
+          rustfmt = {
+            enable = true;
+            edition = "2021";
+          };
           statix.enable = true;
           typos = {
             enable = true;
@@ -98,15 +102,7 @@ in
             ];
             priority = 5;
           };
-          rustfmt = {
-            command = lib.getExe' rustToolchain "rustfmt";
-            options = [
-              "--edition"
-              "2021"
-            ];
-            includes = [ "*.rs" ];
-            priority = 6;
-          };
+          rustfmt.priority = 6;
         };
       };
     };

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -62,6 +62,7 @@ in
           rustfmt = {
             enable = true;
             edition = "2021";
+            package = rustToolchain;
           };
           statix.enable = true;
           typos = {

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -3,6 +3,9 @@
   lib,
   ...
 }:
+let
+  root = ./..;
+in
 {
   perSystem =
     { system, ... }:
@@ -10,6 +13,42 @@
       pkgs = import inputs.nixpkgs {
         inherit system;
         overlays = [ inputs.rust-overlay.overlays.default ];
+      };
+      rustToolchain = pkgs.rust-bin.fromRustupToolchainFile (root + /rust-toolchain.toml);
+      schemaGen = pkgs.writeShellApplication {
+        name = "ccusage-schema-gen";
+        runtimeInputs = [
+          pkgs.coreutils
+          pkgs.oxfmt
+          pkgs.openssl
+          pkgs.pkg-config
+          rustToolchain
+        ]
+        ++ lib.optionals pkgs.stdenv.isDarwin [
+          pkgs.apple-sdk_15
+          pkgs.libiconv
+        ];
+        text = ''
+          ${lib.optionalString pkgs.stdenv.isDarwin ''
+            export SDKROOT="${pkgs.apple-sdk_15}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+            export LIBRARY_PATH="${
+              lib.makeLibraryPath [
+                pkgs.libiconv
+                pkgs.openssl
+              ]
+            }:''${LIBRARY_PATH:-}"
+            export CPATH="${
+              lib.makeIncludePath [
+                pkgs.libiconv
+                pkgs.openssl
+              ]
+            }:''${CPATH:-}"
+          ''}
+
+          cargo run --quiet --manifest-path rust/Cargo.toml --bin generate-config-schema -- apps/ccusage/config-schema.json
+          oxfmt --write apps/ccusage/config-schema.json
+          cp apps/ccusage/config-schema.json docs/public/config-schema.json
+        '';
       };
     in
     {
@@ -28,7 +67,18 @@
         };
 
         settings.formatter = {
+          schema-gen = {
+            command = lib.getExe schemaGen;
+            includes = [
+              "apps/ccusage/config-schema.json"
+              "rust/crates/ccusage/src/config_schema.rs"
+              "rust/crates/ccusage/src/bin/generate_config_schema.rs"
+            ];
+            priority = 0;
+          };
           deadnix.priority = 1;
+          statix.priority = 2;
+          nixfmt.priority = 3;
           oxfmt = {
             command = lib.getExe pkgs.oxfmt;
             options = [ "--no-error-on-unmatched-pattern" ];
@@ -48,8 +98,15 @@
             ];
             priority = 5;
           };
-          statix.priority = 2;
-          nixfmt.priority = 3;
+          rustfmt = {
+            command = lib.getExe' rustToolchain "rustfmt";
+            options = [
+              "--edition"
+              "2021"
+            ];
+            includes = [ "*.rs" ];
+            priority = 6;
+          };
         };
       };
     };

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -8,50 +8,44 @@ let
 in
 {
   perSystem =
-    { system, ... }:
+    {
+      config,
+      system,
+      ...
+    }:
     let
       pkgs = import inputs.nixpkgs {
         inherit system;
         overlays = [ inputs.rust-overlay.overlays.default ];
       };
       rustToolchain = pkgs.rust-bin.fromRustupToolchainFile (root + /rust-toolchain.toml);
+      craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+      inherit (config.packages.ccusage.passthru) cargoArtifacts commonArgs;
+      generateConfigSchema = craneLib.buildPackage (
+        commonArgs
+        // {
+          pname = "generate-config-schema";
+          inherit cargoArtifacts;
+          cargoExtraArgs = "-p ccusage --bin generate-config-schema";
+          doCheck = false;
+          meta = {
+            mainProgram = "generate-config-schema";
+          };
+        }
+      );
       schemaGen = pkgs.writeShellApplication {
         name = "ccusage-schema-gen";
         runtimeInputs = [
           pkgs.coreutils
           pkgs.oxfmt
-          pkgs.openssl
-          pkgs.pkg-config
-          rustToolchain
-        ]
-        ++ lib.optionals pkgs.stdenv.isDarwin [
-          pkgs.apple-sdk_15
-          pkgs.libiconv
+          generateConfigSchema
         ];
         text = ''
-          if [ -n "''${NIX_BUILD_TOP:-}" ]; then
-            exit 0
-          fi
-
-          ${lib.optionalString pkgs.stdenv.isDarwin ''
-            export SDKROOT="${pkgs.apple-sdk_15}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
-            export LIBRARY_PATH="${
-              lib.makeLibraryPath [
-                pkgs.libiconv
-                pkgs.openssl
-              ]
-            }:''${LIBRARY_PATH:-}"
-            export CPATH="${
-              lib.makeIncludePath [
-                pkgs.libiconv
-                pkgs.openssl
-              ]
-            }:''${CPATH:-}"
-          ''}
-
-          cargo run --quiet --manifest-path rust/Cargo.toml --bin generate-config-schema -- apps/ccusage/config-schema.json
+          generate-config-schema apps/ccusage/config-schema.json
           oxfmt --write apps/ccusage/config-schema.json
-          cp apps/ccusage/config-schema.json docs/public/config-schema.json
+          if [ -d docs/public ]; then
+            cp apps/ccusage/config-schema.json docs/public/config-schema.json
+          fi
         '';
       };
     in
@@ -76,15 +70,6 @@ in
         };
 
         settings.formatter = {
-          schema-gen = {
-            command = lib.getExe schemaGen;
-            includes = [
-              "apps/ccusage/config-schema.json"
-              "rust/crates/ccusage/src/config_schema.rs"
-              "rust/crates/ccusage/src/bin/generate_config_schema.rs"
-            ];
-            priority = 0;
-          };
           deadnix.priority = 1;
           statix.priority = 2;
           nixfmt.priority = 3;
@@ -108,6 +93,15 @@ in
             priority = 5;
           };
           rustfmt.priority = 6;
+          schema-gen = {
+            command = lib.getExe schemaGen;
+            includes = [
+              "apps/ccusage/config-schema.json"
+              "rust/crates/ccusage/src/config_schema.rs"
+              "rust/crates/ccusage/src/bin/generate_config_schema.rs"
+            ];
+            priority = 7;
+          };
         };
       };
     };

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -29,6 +29,10 @@ in
           pkgs.libiconv
         ];
         text = ''
+          if [ -n "''${NIX_BUILD_TOP:-}" ]; then
+            exit 0
+          fi
+
           ${lib.optionalString pkgs.stdenv.isDarwin ''
             export SDKROOT="${pkgs.apple-sdk_15}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
             export LIBRARY_PATH="${


### PR DESCRIPTION
## Summary

- Register `schema-gen` as a treefmt formatter so `treefmt --fail-on-change` (already wired into the pre-push hook) is the single source of truth for schema drift. It runs `cargo run --bin generate-config-schema`, applies `oxfmt`, and mirrors the result into `docs/public/config-schema.json` — the same pipeline the previous bespoke check used.
- Register `rustfmt` as a treefmt formatter (using the pinned `rust-toolchain.toml` toolchain via `rust-overlay`), so Rust formatting flows through the same treefmt invocation as everything else.
- Drop the now-redundant `config-schema` and `ccusage-rustfmt` pre-commit hooks; both are covered by the treefmt pipeline. Pre-push `ccusage-treefmt-check --fail-on-change` catches drift for either.

The `schema-gen` formatter's `includes` cover both the Rust source files that drive the schema (`config_schema.rs`, `generate_config_schema.rs`) and the tracked output (`apps/ccusage/config-schema.json`), so it runs whenever any of them is staged at pre-commit, and runs over the whole tree at pre-push. `docs/public/config-schema.json` is gitignored and treated as a generated copy (matching today's behavior).

## Test plan

- [ ] `nix flake check` evaluates with the new treefmt formatters
- [ ] `nix develop --command treefmt --fail-on-change` passes on a clean tree
- [ ] Edit `rust/crates/ccusage/src/config_schema.rs` → pre-commit treefmt regenerates `apps/ccusage/config-schema.json`; pre-push without the regenerated JSON staged fails with `--fail-on-change`
- [ ] Edit a Rust file with non-canonical formatting → pre-commit treefmt rustfmt's it

https://claude.ai/code/session_01D65aLJEJgHnG4e3VkB8cRy

---
_Generated by [Claude Code](https://claude.ai/code/session_01D65aLJEJgHnG4e3VkB8cRy)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move config schema generation and Rust formatting into the shared `treefmt` pipeline so the pre-push `treefmt --fail-on-change` check is the single source of truth for drift. The schema generator is now prebuilt with `crane`, so the formatter runs in the Nix sandbox, and legacy hooks are removed.

- **Refactors**
  - Add `schema-gen` formatter to `treefmt`: uses the prebuilt `generate-config-schema` binary, formats with `oxfmt`, and mirrors to `docs/public/config-schema.json` when present.
  - Use `treefmt-nix` `programs.rustfmt` (edition 2021) with `package` pinned to the project `rust-toolchain.toml` via `rust-overlay`.
  - Group formatter priorities by language; place `schema-gen` next to `rustfmt`.
  - Remove redundant pre-commit hooks for config schema and Rust formatting; drift is caught by pre-push `ccusage-treefmt-check --fail-on-change`.

<sup>Written for commit 084906e6db75d8a893a881e1ab26e1172c87beb5. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1142?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed legacy pre-commit hooks, including the config-schema and Rust formatting hooks, to simplify local dev workflows.

* **Chores / Tooling**
  * Added automated config-schema generation into the formatting pipeline.
  * Reordered and expanded the formatter pipeline; enabled Rust formatting (edition 2021) and ensured existing Nix/Rust formatters run before schema generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->