### PR TITLE
fix(codex): respect terminal width in reports

### DIFF
--- a/rust/crates/ccusage/src/adapter/codex/report.rs
+++ b/rust/crates/ccusage/src/adapter/codex/report.rs
@@ -214,6 +214,7 @@ pub(super) fn print_table_from_groups(
         ],
         shared,
     )
+    .with_terminal_width(crate::terminal_width())
     .with_date_compaction(true);
     let mut total_input = 0;
     let mut total_cached = 0;


### PR DESCRIPTION
## Summary

Pass the detected terminal width into the Codex report table so wide terminals and `$COLUMNS` overrides can prevent unnecessary truncation. This matches the shared usage table behavior in `adapter/all/report.rs` and `adapter/amp/report.rs`, while preserving the existing date compaction.

Before this change, `ccusage codex` (daily/weekly/monthly/session) only enabled date compaction on its `SimpleTable`, so the table fell back to `SimpleTable`'s default width of 120 columns even when `$COLUMNS=400` was set. Token cells like `Input`, `Reasoning`, and `Total Tokens` would render as truncated values such as `132,559…`.

Fixes #1120 (credit to @cnxobo for the original report and one-line fix in #1119).

## Test plan

- [x] `cargo fmt --manifest-path rust/Cargo.toml --all --check`
- [x] `cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::codex`
- [x] `cargo test --manifest-path rust/Cargo.toml -p ccusage-terminal`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzKy16tFyzqYBqyT2xyhTq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect terminal width in Codex usage reports to prevent truncation on wide terminals or when `$COLUMNS` is set. Matches the shared usage tables and preserves date compaction; fixes #1120.

<sup>Written for commit 31e0abf60f5cc40e4f843d590894681cf62a3e37. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1146?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table display in reports to properly utilize terminal width, ensuring better visibility and alignment of data on different screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->