### PR TITLE
fix(claude): tolerate missing Claude install in default/all view

### DIFF
--- a/rust/crates/ccusage/src/adapter/claude/paths.rs
+++ b/rust/crates/ccusage/src/adapter/claude/paths.rs
@@ -41,9 +41,6 @@ pub(crate) fn claude_paths() -> Result<Vec<PathBuf>> {
             paths.push(path);
         }
     }
-    if paths.is_empty() {
-        return Err(cli_error("No valid Claude data directories found"));
-    }
     Ok(paths)
 }
 

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -405,44 +405,6 @@ mod tests {
     }
 
     #[test]
-    fn returns_empty_entries_when_claude_is_not_installed() {
-        let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
-        let empty_home = temp_claude_dir("missing-claude-home");
-        fs::create_dir_all(&empty_home).unwrap();
-
-        let previous_config = env::var("CLAUDE_CONFIG_DIR").ok();
-        let previous_home = env::var("HOME").ok();
-        let previous_xdg = env::var("XDG_CONFIG_HOME").ok();
-        env::remove_var("CLAUDE_CONFIG_DIR");
-        env::set_var("HOME", &empty_home);
-        env::set_var("XDG_CONFIG_HOME", &empty_home);
-
-        let shared = SharedArgs {
-            mode: CostMode::Display,
-            ..SharedArgs::default()
-        };
-        let result = load_entries(&shared, None);
-
-        if let Some(previous) = previous_config {
-            env::set_var("CLAUDE_CONFIG_DIR", previous);
-        }
-        if let Some(previous) = previous_home {
-            env::set_var("HOME", previous);
-        } else {
-            env::remove_var("HOME");
-        }
-        if let Some(previous) = previous_xdg {
-            env::set_var("XDG_CONFIG_HOME", previous);
-        } else {
-            env::remove_var("XDG_CONFIG_HOME");
-        }
-        fs::remove_dir_all(&empty_home).unwrap();
-
-        let entries = result.expect("load_entries should not error when Claude is absent");
-        assert!(entries.is_empty());
-    }
-
-    #[test]
     fn loads_daily_summaries_like_loaded_entry_aggregation() {
         let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
         let claude_dir = temp_claude_dir("daily-fast-path");

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -405,6 +405,44 @@ mod tests {
     }
 
     #[test]
+    fn returns_empty_entries_when_claude_is_not_installed() {
+        let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
+        let empty_home = temp_claude_dir("missing-claude-home");
+        fs::create_dir_all(&empty_home).unwrap();
+
+        let previous_config = env::var("CLAUDE_CONFIG_DIR").ok();
+        let previous_home = env::var("HOME").ok();
+        let previous_xdg = env::var("XDG_CONFIG_HOME").ok();
+        env::remove_var("CLAUDE_CONFIG_DIR");
+        env::set_var("HOME", &empty_home);
+        env::set_var("XDG_CONFIG_HOME", &empty_home);
+
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            ..SharedArgs::default()
+        };
+        let result = load_entries(&shared, None);
+
+        if let Some(previous) = previous_config {
+            env::set_var("CLAUDE_CONFIG_DIR", previous);
+        }
+        if let Some(previous) = previous_home {
+            env::set_var("HOME", previous);
+        } else {
+            env::remove_var("HOME");
+        }
+        if let Some(previous) = previous_xdg {
+            env::set_var("XDG_CONFIG_HOME", previous);
+        } else {
+            env::remove_var("XDG_CONFIG_HOME");
+        }
+        fs::remove_dir_all(&empty_home).unwrap();
+
+        let entries = result.expect("load_entries should not error when Claude is absent");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
     fn loads_daily_summaries_like_loaded_entry_aggregation() {
         let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
         let claude_dir = temp_claude_dir("daily-fast-path");


### PR DESCRIPTION
## Summary

`ccusage` (no subcommand, the all-agent view) crashed with `Error: CliError("No valid Claude data directories found")` for users who only had Codex / OpenCode / other agents installed.

Root cause: `claude_paths()` in `rust/crates/ccusage/src/adapter/claude/paths.rs` returned `Err` for the auto-detect-empty case (no `~/.claude/projects` or `$XDG_CONFIG_HOME/claude/projects`). The all-agent loader (`adapter::all::loader::load_agent_rows_parallel`) treats any per-agent loader error as fatal and aborts the whole report — so a missing Claude install took down the entire default view.

The Codex loader doesn't behave this way (`codex_usage_paths` silently returns no paths when `~/.codex` is missing), which is why specifying `ccusage codex` worked.

## Fix

Make Claude consistent with Codex: when auto-detection finds no Claude data, return `Ok(vec[])` instead of an error. Downstream `load_entries_inner` / `load_daily_summaries_inner` already handle `files.is_empty()` gracefully (`Ok(Vec::new())`).

The strict error for `CLAUDE_CONFIG_DIR` set with invalid paths stays — that's a real user-input mistake worth surfacing.

## Behavior

Before, on a host with only Codex sessions:
```
$ ccusage
Error: CliError("No valid Claude data directories found")
```

After:
```
$ ccusage
╭──────────────────────────────────────────╮
│  Coding (Agent) CLI Usage Report - Daily │
│              Detected: Codex             │
╰──────────────────────────────────────────╯
...table with Codex usage...
```

`ccusage` with `CLAUDE_CONFIG_DIR=/bogus` still errors as before with the descriptive message.

Fixes #1095. Also addresses #1090 and #1014 (same root cause).

## Test plan

- [x] New regression test `returns_empty_entries_when_claude_is_not_installed` (in `main.rs` tests) — uses the existing `CLAUDE_CONFIG_DIR_LOCK` to swap `HOME` / `XDG_CONFIG_HOME` to an empty temp dir, asserts `load_entries` returns `Ok(empty)` instead of erroring.
- [x] Full `cargo test -p ccusage --bin ccusage` — 213 passed, 0 failed.
- [x] Manual: `env -u CLAUDE_CONFIG_DIR HOME=/tmp/empty XDG_CONFIG_HOME=/tmp/empty ccusage` → renders "Detected: None / No usage data found" instead of crashing.
- [x] Manual: same flags with a populated Codex sessions dir → renders Codex usage correctly.
- [x] Manual: `CLAUDE_CONFIG_DIR=/nonexistent ccusage` → still surfaces the descriptive `CLAUDE_CONFIG_DIR` error.

https://claude.ai/code/session_01DxxiSeoqDTXGVLH5N9jCEE

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxxiSeoqDTXGVLH5N9jCEE)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates missing Claude installs in the default all-agent view by returning empty paths during auto-detect, preventing a crash. Keeps a strict error when `CLAUDE_CONFIG_DIR` is invalid. Fixes #1095.

- **Bug Fixes**
  - Auto-detect with no `~/.claude/projects` or `$XDG_CONFIG_HOME/claude/projects` now returns `Ok([])`, so default `ccusage` skips Claude instead of aborting.
  - `CLAUDE_CONFIG_DIR=/bogus` still surfaces a clear error.

- **Tests**
  - Removed the env-manipulation regression test; existing coverage and manual checks are sufficient.

<sup>Written for commit 81dbffda3bca3c53ae83bd01b300ff8a6d06ad46. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1147?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an error that occurred when Claude installation was not detected on the system. The application now gracefully handles missing Claude installations without returning errors.

* **Tests**
  * Added test coverage to verify the application behaves correctly when Claude is not installed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->