### PR TITLE
fix(all): collapse per-day rows in monthly/weekly all-agent table

### DIFF
--- a/rust/crates/ccusage/src/adapter/all/tests.rs
+++ b/rust/crates/ccusage/src/adapter/all/tests.rs
@@ -132,6 +132,117 @@ fn aggregates_daily_agent_rows_by_period() {
 }
 
 #[test]
+fn merges_same_agent_daily_rows_into_one_monthly_breakdown() {
+    let rows = aggregate_rows(
+        vec![
+            AllRow {
+                period: "2026-01-02".to_string(),
+                agent: "claude",
+                models_used: vec!["claude-sonnet-4-20250514".to_string()],
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_creation_tokens: 1,
+                cache_read_tokens: 2,
+                total_tokens: 18,
+                total_cost: 0.01,
+                metadata: None,
+                metadata_agents: Some(vec!["claude"]),
+                agent_breakdowns: None,
+                model_breakdowns: vec![ModelBreakdown {
+                    model_name: "claude-sonnet-4-20250514".to_string(),
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    cache_creation_tokens: 1,
+                    cache_read_tokens: 2,
+                    cost: 0.01,
+                    ..ModelBreakdown::default()
+                }],
+            },
+            AllRow {
+                period: "2026-01-15".to_string(),
+                agent: "claude",
+                models_used: vec!["claude-opus-4-20250514".to_string()],
+                input_tokens: 20,
+                output_tokens: 10,
+                cache_creation_tokens: 2,
+                cache_read_tokens: 4,
+                total_tokens: 36,
+                total_cost: 0.05,
+                metadata: None,
+                metadata_agents: Some(vec!["claude"]),
+                agent_breakdowns: None,
+                model_breakdowns: vec![ModelBreakdown {
+                    model_name: "claude-opus-4-20250514".to_string(),
+                    input_tokens: 20,
+                    output_tokens: 10,
+                    cache_creation_tokens: 2,
+                    cache_read_tokens: 4,
+                    cost: 0.05,
+                    ..ModelBreakdown::default()
+                }],
+            },
+            AllRow {
+                period: "2026-01-20".to_string(),
+                agent: "codex",
+                models_used: vec!["gpt-5".to_string()],
+                input_tokens: 30,
+                output_tokens: 15,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 6,
+                total_tokens: 51,
+                total_cost: 0.02,
+                metadata: None,
+                metadata_agents: Some(vec!["codex"]),
+                agent_breakdowns: None,
+                model_breakdowns: vec![ModelBreakdown {
+                    model_name: "gpt-5".to_string(),
+                    input_tokens: 30,
+                    output_tokens: 15,
+                    cache_creation_tokens: 0,
+                    cache_read_tokens: 6,
+                    cost: 0.02,
+                    ..ModelBreakdown::default()
+                }],
+            },
+        ],
+        AgentReportKind::Monthly,
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].period, "2026-01");
+    assert_eq!(rows[0].input_tokens, 60);
+    assert_eq!(rows[0].output_tokens, 30);
+    let breakdowns = rows[0].agent_breakdowns.as_ref().unwrap();
+    assert_eq!(
+        breakdowns.len(),
+        2,
+        "expected one breakdown row per agent per month, got {breakdowns:#?}"
+    );
+    let claude = breakdowns
+        .iter()
+        .find(|row| row.agent == "claude")
+        .expect("claude breakdown present");
+    assert_eq!(claude.period, "2026-01");
+    assert_eq!(claude.input_tokens, 30);
+    assert_eq!(claude.output_tokens, 15);
+    assert_eq!(claude.cache_creation_tokens, 3);
+    assert_eq!(claude.cache_read_tokens, 6);
+    assert_eq!(
+        claude.models_used,
+        vec![
+            "claude-opus-4-20250514".to_string(),
+            "claude-sonnet-4-20250514".to_string(),
+        ]
+    );
+    assert_eq!(claude.model_breakdowns.len(), 2);
+    let codex = breakdowns
+        .iter()
+        .find(|row| row.agent == "codex")
+        .expect("codex breakdown present");
+    assert_eq!(codex.input_tokens, 30);
+}
+
+#[test]
 fn renders_all_report_json_with_period_and_agent_metadata() {
     let rows = vec![AllRow {
         period: "2026-01-02".to_string(),

--- a/rust/crates/ccusage/src/adapter/all/tests.rs
+++ b/rust/crates/ccusage/src/adapter/all/tests.rs
@@ -235,6 +235,14 @@ fn merges_same_agent_daily_rows_into_one_monthly_breakdown() {
         ]
     );
     assert_eq!(claude.model_breakdowns.len(), 2);
+    assert_eq!(
+        claude
+            .model_breakdowns
+            .iter()
+            .map(|breakdown| breakdown.model_name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["claude-opus-4-20250514", "claude-sonnet-4-20250514",]
+    );
     let codex = breakdowns
         .iter()
         .find(|row| row.agent == "codex")

--- a/rust/crates/ccusage/src/adapter/all/types.rs
+++ b/rust/crates/ccusage/src/adapter/all/types.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use serde_json::Value;
 
-use crate::ModelBreakdown;
+use crate::{fast::FxHashMap, ModelBreakdown};
 
 #[derive(Debug, Clone)]
 pub(super) struct AllRow {
@@ -55,6 +55,7 @@ pub(super) struct AllAccumulator {
     models: BTreeSet<String>,
     agents: BTreeSet<&'static str>,
     agent_breakdowns: Vec<AllRow>,
+    agent_indexes: FxHashMap<&'static str, usize>,
 }
 
 impl AllAccumulator {
@@ -71,15 +72,25 @@ impl AllAccumulator {
         } else if row.agent != "all" {
             self.agents.insert(row.agent);
         }
-        self.agent_breakdowns.push(AllRow {
-            metadata_agents: Some(vec![row.agent]),
-            agent_breakdowns: None,
-            ..row
-        });
+        match self.agent_indexes.get(row.agent).copied() {
+            Some(index) => merge_agent_breakdown(&mut self.agent_breakdowns[index], row),
+            None => {
+                self.agent_indexes
+                    .insert(row.agent, self.agent_breakdowns.len());
+                self.agent_breakdowns.push(AllRow {
+                    metadata_agents: Some(vec![row.agent]),
+                    agent_breakdowns: None,
+                    ..row
+                });
+            }
+        }
     }
 
     pub(super) fn into_row(self, period: String) -> AllRow {
         let mut agent_breakdowns = self.agent_breakdowns;
+        for breakdown in &mut agent_breakdowns {
+            breakdown.period = period.clone();
+        }
         agent_breakdowns.sort_by(|a, b| a.agent.cmp(b.agent));
         let mut model_breakdowns = aggregate_model_breakdowns(&agent_breakdowns);
         model_breakdowns.sort_by(|a, b| b.cost.total_cmp(&a.cost));
@@ -101,9 +112,47 @@ impl AllAccumulator {
     }
 }
 
-pub(super) fn aggregate_model_breakdowns(rows: &[AllRow]) -> Vec<ModelBreakdown> {
-    use crate::fast::FxHashMap;
+fn merge_agent_breakdown(target: &mut AllRow, source: AllRow) {
+    target.input_tokens += source.input_tokens;
+    target.output_tokens += source.output_tokens;
+    target.cache_creation_tokens += source.cache_creation_tokens;
+    target.cache_read_tokens += source.cache_read_tokens;
+    target.total_tokens += source.total_tokens;
+    target.total_cost += source.total_cost;
+    let mut models: BTreeSet<String> = target.models_used.drain(..).collect();
+    models.extend(source.models_used);
+    target.models_used = models.into_iter().collect();
+    target.model_breakdowns =
+        merge_model_breakdowns(target.model_breakdowns.drain(..), source.model_breakdowns);
+}
 
+fn merge_model_breakdowns(
+    existing: impl IntoIterator<Item = ModelBreakdown>,
+    additional: impl IntoIterator<Item = ModelBreakdown>,
+) -> Vec<ModelBreakdown> {
+    let mut indexes = FxHashMap::<String, usize>::default();
+    let mut breakdowns: Vec<ModelBreakdown> = Vec::new();
+    for item in existing.into_iter().chain(additional) {
+        let index = *indexes.entry(item.model_name.clone()).or_insert_with(|| {
+            let i = breakdowns.len();
+            breakdowns.push(ModelBreakdown {
+                model_name: item.model_name.clone(),
+                ..ModelBreakdown::default()
+            });
+            i
+        });
+        let b = &mut breakdowns[index];
+        b.input_tokens += item.input_tokens;
+        b.output_tokens += item.output_tokens;
+        b.cache_creation_tokens += item.cache_creation_tokens;
+        b.cache_read_tokens += item.cache_read_tokens;
+        b.extra_total_tokens += item.extra_total_tokens;
+        b.cost += item.cost;
+    }
+    breakdowns
+}
+
+pub(super) fn aggregate_model_breakdowns(rows: &[AllRow]) -> Vec<ModelBreakdown> {
     let mut indexes = FxHashMap::<String, usize>::default();
     let mut breakdowns: Vec<ModelBreakdown> = Vec::new();
     for row in rows {

--- a/rust/crates/ccusage/src/adapter/all/types.rs
+++ b/rust/crates/ccusage/src/adapter/all/types.rs
@@ -149,6 +149,7 @@ fn merge_model_breakdowns(
         b.extra_total_tokens += item.extra_total_tokens;
         b.cost += item.cost;
     }
+    breakdowns.sort_by(|a, b| b.cost.total_cmp(&a.cost));
     breakdowns
 }
 


### PR DESCRIPTION
## Summary

Fixes #1109. In v20, `ccusage monthly` (and `weekly`) renders the all-agent
table as if it were a daily view: for each month bucket, every detected agent
shows one breakdown row per day in that month, instead of a single per-agent
subtotal.

### Root cause

In `AllAccumulator::add` (`rust/crates/ccusage/src/adapter/all/types.rs`), each
incoming `AllRow` is pushed directly into `agent_breakdowns`. When the loader
re-buckets daily rows into a month, the accumulator therefore stores N daily
rows per agent in the same month instead of merging them.

`report_json` does not serialize `agent_breakdowns`, which is why the JSON
output stayed correct while the table looked like a daily view, matching the
behavior the reporter described.

### Fix

Index breakdowns by agent inside `AllAccumulator`. When the same agent appears
again in the same bucket, merge token totals, cost, `models_used` (deduped)
and `model_breakdowns` into the existing row instead of appending a new one.
`into_row` then stamps the bucket period (e.g. `2026-01`) on each breakdown,
so JSON and table both expose one breakdown row per agent per bucket.

### Test plan

- [x] `cargo test -p ccusage` (213 tests)
- [x] Added `merges_same_agent_daily_rows_into_one_monthly_breakdown` which
      asserts a single Claude breakdown per month with merged tokens, deduped
      `models_used`, and one breakdown per agent overall.
- [x] `cargo fmt` and `cargo clippy --all-targets -- -D warnings` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017kwZ5UbHC4F6PVLGm53Sx6)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the monthly/weekly all‑agent table in `ccusage` to show a single subtotal per agent per period instead of one row per day, addressing #1109. Also sorts per‑agent model breakdowns by cost to keep the table output stable.

- **Bug Fixes**
  - Merge same‑agent rows in `AllAccumulator` using an `agent_indexes` map; combine token totals and cost, dedupe `models_used`, and merge `model_breakdowns`.
  - Sort merged per‑agent `model_breakdowns` by descending cost to match the aggregate order.
  - Stamp the bucket period on each agent breakdown in `into_row` so monthly/weekly tables and JSON both show one row per agent per bucket.
  - Add `merges_same_agent_daily_rows_into_one_monthly_breakdown` test to verify merged tokens, deduped models, and correct row counts.

<sup>Written for commit 4cfb02bf4b53a2be4a94706ce4076b215b69c27c. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1148?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Monthly aggregation now consolidates multiple daily agent entries into a single monthly report, correctly summing tokens/costs and merging per-agent model breakdowns.

* **Tests**
  * Added a unit test verifying monthly consolidation of daily agent rows and correctness of aggregated period, totals, and per-model breakdowns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->