### PR TITLE
fix(codex): sort usage files before loading

### DIFF
--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -18,6 +18,7 @@ pub(crate) fn load_codex_events_from_directory(
 ) -> Result<Vec<CodexTokenUsageEvent>> {
     let mut files = Vec::new();
     collect_usage_files(sessions_dir, &mut files);
+    files.sort_by_cached_key(|path| path.to_string_lossy().into_owned());
     let mut events = if single_thread {
         files
             .iter()


### PR DESCRIPTION
Sorts Codex session files after recursive discovery so event loading no longer depends on filesystem read_dir ordering.

This matches Claude usage file ordering and keeps single-threaded and parallel Codex event loading on the same deterministic baseline.

Fixes #1105

Testing:
- direnv exec . env -u CFLAGS -u CPPFLAGS -u LDFLAGS cargo test --manifest-path rust/Cargo.toml -p ccusage --bin ccusage tests::loads_codex_token_count_events_in_parallel -- --exact
- direnv exec . pnpm run format
- direnv exec . env -u CFLAGS -u CPPFLAGS -u LDFLAGS cargo test --manifest-path rust/Cargo.toml --workspace
- direnv exec . env -u CFLAGS -u CPPFLAGS -u LDFLAGS cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sort Codex usage files by path before loading to remove dependence on filesystem order and match the Claude loader, fixing #1105. Event processing is now deterministic across single-threaded and parallel modes.

<sup>Written for commit 81969e48b8a50f1bb1b8f4aeeb1b91dff19ce707. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1152?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of event loading by ensuring consistent ordering when processing code usage data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->