### PR TITLE
fix(kimi): price kimi-for-coding by timestamp

### DIFF
--- a/docs/guide/kimi/index.md
+++ b/docs/guide/kimi/index.md
@@ -51,6 +51,10 @@ Expected files are discovered under:
 
 Only `StatusUpdate` messages with non-zero token usage are included.
 
+## Cost Calculation
+
+Kimi rows do not store recorded USD cost, so ccusage estimates cost from token counts and LiteLLM pricing. The default `kimi-for-coding` model is kept as the displayed model name, but pricing resolves to Moonshot K2.5 before `2026-04-20T15:28:10.072Z` and Moonshot K2.6 at or after that timestamp.
+
 ## Environment Variables
 
 | Variable        | Description                                                                            |

--- a/rust/crates/ccusage/src/adapter/kimi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/parser.rs
@@ -15,6 +15,7 @@ use crate::{
 
 const DEFAULT_MODEL: &str = "kimi-for-coding";
 const DEFAULT_PROVIDER: &str = "moonshot";
+const KIMI_FOR_CODING_K2_6_CUTOFF_MS: i64 = 1_776_698_890_072;
 
 #[derive(Debug, Clone)]
 pub(super) struct KimiUsageEntry {
@@ -212,7 +213,7 @@ fn calculate_kimi_cost(
     match mode {
         CostMode::Display => 0.0,
         CostMode::Auto | CostMode::Calculate => {
-            for candidate in model_candidates(&entry.model) {
+            for candidate in model_candidates(entry) {
                 if pricing.find(&candidate).is_some() {
                     return calculate_cost_for_usage(
                         Some(&candidate),
@@ -228,15 +229,27 @@ fn calculate_kimi_cost(
     }
 }
 
-fn model_candidates(model: &str) -> Vec<String> {
-    let mut candidates = vec![
-        format!("{DEFAULT_PROVIDER}/{model}"),
-        format!("kimi/{model}"),
-        model.to_string(),
-    ];
+fn model_candidates(entry: &KimiUsageEntry) -> Vec<String> {
+    let mut candidates = Vec::new();
+    if entry.model == DEFAULT_MODEL {
+        candidates.push(kimi_for_coding_pricing_model(entry.timestamp).to_string());
+    }
+    candidates.extend([
+        format!("{DEFAULT_PROVIDER}/{}", entry.model),
+        format!("kimi/{}", entry.model),
+        entry.model.clone(),
+    ]);
     let mut seen = std::collections::HashSet::new();
     candidates.retain(|candidate| seen.insert(candidate.clone()));
     candidates
+}
+
+fn kimi_for_coding_pricing_model(timestamp: TimestampMs) -> &'static str {
+    if timestamp.as_millis() < KIMI_FOR_CODING_K2_6_CUTOFF_MS {
+        "moonshot/kimi-k2.5"
+    } else {
+        "moonshot/kimi-k2.6"
+    }
 }
 
 #[cfg(test)]
@@ -278,5 +291,44 @@ mod tests {
 
         assert_eq!(entry.output_tokens, 432);
         assert_eq!(entry.extra_total_tokens, 0);
+    }
+
+    #[test]
+    fn prices_default_kimi_model_by_timestamp_without_changing_display_model() {
+        let pricing = PricingMap::load_embedded();
+        let usage = TokenUsageRaw {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_creation_input_tokens: 20,
+            cache_read_input_tokens: 10,
+            speed: None,
+        };
+        let before_cutoff = KimiUsageEntry {
+            timestamp: TimestampMs::from_millis(1_776_698_890_071),
+            timestamp_text: "2026-04-20T15:28:10.071Z".to_string(),
+            session_id: "session-a".to_string(),
+            model: DEFAULT_MODEL.to_string(),
+            message_id: Some("msg-before".to_string()),
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cache_creation_tokens: usage.cache_creation_input_tokens,
+            cache_read_tokens: usage.cache_read_input_tokens,
+            extra_total_tokens: 0,
+        };
+        let at_cutoff = KimiUsageEntry {
+            timestamp: TimestampMs::from_millis(1_776_698_890_072),
+            timestamp_text: "2026-04-20T15:28:10.072Z".to_string(),
+            message_id: Some("msg-at".to_string()),
+            ..before_cutoff.clone()
+        };
+
+        let before_cost = calculate_kimi_cost(&before_cutoff, CostMode::Calculate, &pricing, usage);
+        let at_cost = calculate_kimi_cost(&at_cutoff, CostMode::Calculate, &pricing, usage);
+        let loaded = kimi_entry_to_loaded(at_cutoff, None, CostMode::Calculate, &pricing);
+
+        assert!((before_cost - 0.000226).abs() < f64::EPSILON);
+        assert!((at_cost - 0.00032035).abs() < f64::EPSILON);
+        assert_eq!(loaded.model.as_deref(), Some(DEFAULT_MODEL));
+        assert_eq!(loaded.data.message.model.as_deref(), Some(DEFAULT_MODEL));
     }
 }

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -421,6 +421,36 @@ impl PricingMap {
                 fast_multiplier: 1.0,
             },
         );
+        self.entries.insert(
+            "moonshot/kimi-k2.5".to_string(),
+            Pricing {
+                input: 0.6e-6,
+                output: 3e-6,
+                cache_create: 0.75e-6,
+                cache_read: 0.1e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
+        self.entries.insert(
+            "moonshot/kimi-k2.6".to_string(),
+            Pricing {
+                input: 0.95e-6,
+                output: 4e-6,
+                cache_create: 1.1875e-6,
+                cache_read: 0.16e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
         let gpt_5_1_pricing = Pricing {
             input: 1.25e-6,
             output: 10e-6,
@@ -512,6 +542,10 @@ impl PricingMap {
         self.context_limits
             .insert("grok-4.3".to_string(), 1_000_000);
         self.context_limits.insert("gpt-5.4".to_string(), 1_050_000);
+        self.context_limits
+            .insert("moonshot/kimi-k2.5".to_string(), 262_144);
+        self.context_limits
+            .insert("moonshot/kimi-k2.6".to_string(), 262_144);
 
         for model in [
             "claude-opus-4-5",
@@ -595,6 +629,24 @@ mod tests {
         assert!(pricing.find("gpt-5.5").is_some());
         assert!(pricing.find("grok-4.3").is_some());
         assert_eq!(pricing.context_limit("grok-4.3"), Some(1_000_000));
+    }
+
+    #[test]
+    fn embedded_pricing_includes_moonshot_kimi_for_offline_reports() {
+        let pricing = PricingMap::load_embedded();
+        let kimi_k25 = pricing.find("moonshot/kimi-k2.5").unwrap();
+        let kimi_k26 = pricing.find("moonshot/kimi-k2.6").unwrap();
+
+        assert_eq!(kimi_k25.input, 0.6e-6);
+        assert_eq!(kimi_k25.output, 3e-6);
+        assert_eq!(kimi_k25.cache_read, 0.1e-6);
+        assert!(kimi_k25.cache_read_explicit);
+        assert_eq!(kimi_k26.input, 0.95e-6);
+        assert_eq!(kimi_k26.output, 4e-6);
+        assert_eq!(kimi_k26.cache_read, 0.16e-6);
+        assert!(kimi_k26.cache_read_explicit);
+        assert_eq!(pricing.context_limit("moonshot/kimi-k2.5"), Some(262_144));
+        assert_eq!(pricing.context_limit("moonshot/kimi-k2.6"), Some(262_144));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -421,6 +421,7 @@ impl PricingMap {
                 fast_multiplier: 1.0,
             },
         );
+        // Source: https://platform.kimi.ai/docs/pricing/chat-k25
         self.entries.insert(
             "moonshot/kimi-k2.5".to_string(),
             Pricing {
@@ -436,6 +437,7 @@ impl PricingMap {
                 fast_multiplier: 1.0,
             },
         );
+        // Source: https://platform.kimi.ai/docs/pricing/chat-k26
         self.entries.insert(
             "moonshot/kimi-k2.6".to_string(),
             Pricing {


### PR DESCRIPTION
Fixes #1106.

Kimi CLI logs can use the dynamic \`kimi-for-coding\` model slug, which is not priced directly by LiteLLM. This keeps \`kimi-for-coding\` as the displayed model while resolving cost calculation to Moonshot K2.5 before \`2026-04-20T15:28:10.072Z\` and Moonshot K2.6 at or after that timestamp.

The change also embeds Moonshot K2.5/K2.6 pricing for offline reports and documents the Kimi cost rule.

Testing:
- pnpm run format
- cargo fmt --manifest-path rust/Cargo.toml --all
- cargo test --manifest-path rust/Cargo.toml --workspace embedded_pricing_includes_moonshot_kimi_for_offline_reports
- cargo test --manifest-path rust/Cargo.toml --workspace prices_default_kimi_model_by_timestamp_without_changing_display_model
- pnpm run test
- cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kimi cost calculation by pricing the dynamic `kimi-for-coding` model by timestamp while keeping its name in reports. Uses `moonshot/kimi-k2.5` before 2026-04-20T15:28:10.072Z and `moonshot/kimi-k2.6` at or after.

- **Bug Fixes**
  - Map `kimi-for-coding` to `moonshot/kimi-k2.5`/`moonshot/kimi-k2.6` for pricing; display model remains `kimi-for-coding`.
  - Embed pricing and context limits for `moonshot/kimi-k2.5` and `moonshot/kimi-k2.6` with source links so offline reports match.
  - Document the Kimi cost rule and add regression tests for the cutoff behavior.

<sup>Written for commit 91d6c6c7111bf31c066627e5c52ac2fbf8620088. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1153?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Cost Calculation" section to the Kimi guide explaining how usage costs are estimated from token counts and how displayed pricing switches based on transaction timestamps.

* **New Features**
  * Improved Kimi pricing support to automatically select the appropriate model variant by timestamp, ensuring displayed cost estimates reflect the correct pricing era.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->