### PR TITLE
fix(pricing): resolve Claude dot-separated model aliases

### DIFF
--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -518,11 +518,7 @@ impl PricingMap {
         self.context_limits
             .insert("grok-4.3".to_string(), 1_000_000);
         self.context_limits.insert("gpt-5.4".to_string(), 1_050_000);
-        for model in [
-            "claude-opus-4-7",
-            "claude-opus-4-6",
-            "claude-sonnet-4-6",
-        ] {
+        for model in ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"] {
             self.context_limits.insert(model.to_string(), 1_000_000);
         }
 
@@ -759,7 +755,10 @@ mod tests {
     fn embedded_pricing_resolves_opus_47_dot_model_names() {
         let pricing = PricingMap::load_embedded();
 
-        assert_eq!(pricing.find("claude-opus-4.7-20260416").unwrap().input, 5e-6);
+        assert_eq!(
+            pricing.find("claude-opus-4.7-20260416").unwrap().input,
+            5e-6
+        );
         assert_eq!(pricing.context_limit("claude-opus-4.7"), Some(1_000_000));
         assert_eq!(
             pricing
@@ -780,7 +779,10 @@ mod tests {
             pricing.find("claude-sonnet-4.6-20260416").unwrap().input,
             sonnet_46.input
         );
-        assert_eq!(pricing.find("claude-haiku-4.5").unwrap().input, haiku_45.input);
+        assert_eq!(
+            pricing.find("claude-haiku-4.5").unwrap().input,
+            haiku_45.input
+        );
         assert_eq!(
             pricing.context_limit("claude-sonnet-4.6"),
             pricing.context_limit("claude-sonnet-4-6")

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{borrow::Cow, time::Duration};
 
 use serde::Deserialize;
 
@@ -176,9 +176,12 @@ impl PricingMap {
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
         self.entries.get(model).copied().or_else(|| {
+            let normalized_model = normalized_pricing_key(model);
             self.entries
                 .iter()
-                .filter(|(candidate, _)| model.contains(*candidate) || candidate.contains(model))
+                .filter(|(candidate, _)| {
+                    pricing_key_matches(candidate, model, normalized_model.as_ref())
+                })
                 .max_by(|(left, _), (right, _)| {
                     left.len().cmp(&right.len()).then_with(|| right.cmp(left))
                 })
@@ -188,9 +191,12 @@ impl PricingMap {
 
     pub(crate) fn context_limit(&self, model: &str) -> Option<u64> {
         self.context_limits.get(model).copied().or_else(|| {
+            let normalized_model = normalized_pricing_key(model);
             self.context_limits
                 .iter()
-                .filter(|(candidate, _)| model.contains(*candidate) || candidate.contains(model))
+                .filter(|(candidate, _)| {
+                    pricing_key_matches(candidate, model, normalized_model.as_ref())
+                })
                 .max_by(|(left, _), (right, _)| {
                     left.len().cmp(&right.len()).then_with(|| right.cmp(left))
                 })
@@ -512,14 +518,18 @@ impl PricingMap {
         self.context_limits
             .insert("grok-4.3".to_string(), 1_000_000);
         self.context_limits.insert("gpt-5.4".to_string(), 1_050_000);
+        for model in [
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+        ] {
+            self.context_limits.insert(model.to_string(), 1_000_000);
+        }
 
         for model in [
             "claude-opus-4-5",
-            "claude-opus-4-6",
-            "claude-opus-4-7",
             "claude-haiku-4-5",
             "claude-opus-4",
-            "claude-sonnet-4-6",
             "claude-sonnet-4",
             "claude-3-5-haiku",
             "claude-3-5-haiku-20241022",
@@ -529,6 +539,38 @@ impl PricingMap {
         ] {
             self.context_limits.insert(model.to_string(), 200_000);
         }
+    }
+}
+
+fn pricing_key_matches(candidate: &str, model: &str, normalized_model: &str) -> bool {
+    if contains_pricing_key(model, candidate) || contains_pricing_key(candidate, model) {
+        return true;
+    }
+    let normalized_candidate = normalized_pricing_key(candidate);
+    contains_pricing_key(normalized_model, normalized_candidate.as_ref())
+        || contains_pricing_key(normalized_candidate.as_ref(), normalized_model)
+}
+
+fn contains_pricing_key(value: &str, key: &str) -> bool {
+    value.match_indices(key).any(|(index, _)| {
+        let before = index
+            .checked_sub(1)
+            .and_then(|before| value.as_bytes().get(before))
+            .copied();
+        let after = value.as_bytes().get(index + key.len()).copied();
+        before.is_none_or(is_pricing_key_boundary) && after.is_none_or(is_pricing_key_boundary)
+    })
+}
+
+fn is_pricing_key_boundary(byte: u8) -> bool {
+    !byte.is_ascii_alphanumeric()
+}
+
+fn normalized_pricing_key(value: &str) -> Cow<'_, str> {
+    if value.contains(['.', '@']) {
+        Cow::Owned(value.replace(['.', '@'], "-"))
+    } else {
+        Cow::Borrowed(value)
     }
 }
 
@@ -711,6 +753,79 @@ mod tests {
                 .fast_multiplier,
             6.0
         );
+    }
+
+    #[test]
+    fn embedded_pricing_resolves_opus_47_dot_model_names() {
+        let pricing = PricingMap::load_embedded();
+
+        assert_eq!(pricing.find("claude-opus-4.7-20260416").unwrap().input, 5e-6);
+        assert_eq!(pricing.context_limit("claude-opus-4.7"), Some(1_000_000));
+        assert_eq!(
+            pricing
+                .find("openrouter/anthropic/claude-opus-4.7")
+                .unwrap()
+                .input,
+            5e-6
+        );
+    }
+
+    #[test]
+    fn embedded_pricing_resolves_separator_aliases_for_other_claude_models() {
+        let pricing = PricingMap::load_embedded();
+        let sonnet_46 = pricing.find("claude-sonnet-4-6").unwrap();
+        let haiku_45 = pricing.find("claude-haiku-4-5").unwrap();
+
+        assert_eq!(
+            pricing.find("claude-sonnet-4.6-20260416").unwrap().input,
+            sonnet_46.input
+        );
+        assert_eq!(pricing.find("claude-haiku-4.5").unwrap().input, haiku_45.input);
+        assert_eq!(
+            pricing.context_limit("claude-sonnet-4.6"),
+            pricing.context_limit("claude-sonnet-4-6")
+        );
+        assert_eq!(
+            pricing.context_limit("claude-haiku-4.5"),
+            pricing.context_limit("claude-haiku-4-5")
+        );
+    }
+
+    #[test]
+    fn fuzzy_match_requires_model_key_boundaries() {
+        let mut pricing = PricingMap::default();
+        pricing.entries.insert(
+            "claude-opus-4-7".to_string(),
+            Pricing {
+                input: 5e-6,
+                output: 25e-6,
+                cache_create: 6.25e-6,
+                cache_read: 0.5e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
+        pricing.entries.insert(
+            "claude-opus-4".to_string(),
+            Pricing {
+                input: 15e-6,
+                output: 75e-6,
+                cache_create: 18.75e-6,
+                cache_read: 1.5e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
+
+        assert_eq!(pricing.find("claude-opus-4.70").unwrap().input, 15e-6);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -538,6 +538,7 @@ impl PricingMap {
     }
 }
 
+/// Matches pricing keys across provider/model aliases while preserving version boundaries.
 fn pricing_key_matches(candidate: &str, model: &str, normalized_model: &str) -> bool {
     if contains_pricing_key(model, candidate) || contains_pricing_key(candidate, model) {
         return true;
@@ -547,6 +548,7 @@ fn pricing_key_matches(candidate: &str, model: &str, normalized_model: &str) -> 
         || contains_pricing_key(normalized_candidate.as_ref(), normalized_model)
 }
 
+/// Finds a key only when the surrounding bytes are non-alphanumeric boundaries.
 fn contains_pricing_key(value: &str, key: &str) -> bool {
     value.match_indices(key).any(|(index, _)| {
         let before = index
@@ -558,10 +560,12 @@ fn contains_pricing_key(value: &str, key: &str) -> bool {
     })
 }
 
+/// Treats punctuation separators as boundaries, but not adjacent version digits.
 fn is_pricing_key_boundary(byte: u8) -> bool {
     !byte.is_ascii_alphanumeric()
 }
 
+/// Normalizes known model separator variants without allocating for canonical keys.
 fn normalized_pricing_key(value: &str) -> Cow<'_, str> {
     if value.contains(['.', '@']) {
         Cow::Owned(value.replace(['.', '@'], "-"))


### PR DESCRIPTION
Fixes #1125.

This updates pricing lookup so Claude model identifiers with dot or provider separators, such as claude-opus-4.7, resolve to the same embedded pricing as canonical hyphenated model IDs. It also keeps fuzzy matching boundary-aware so nearby versions like 4.70 do not accidentally match 4.7, and updates embedded context fallbacks for current Claude Opus 4.6, Opus 4.7, and Sonnet 4.6 models.

Testing:
- pnpm run format
- env -u CFLAGS direnv exec . cargo test --manifest-path rust/Cargo.toml -p ccusage pricing::tests:: -- --nocapture
- env -u CFLAGS direnv exec . pnpm run test
- pnpm typecheck
- env -u CFLAGS direnv exec . cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pricing lookup for Claude models with dots or provider prefixes so they resolve to canonical hyphenated keys. Prevents `claude-opus-4.7` from falling back to older Opus 4 pricing and sets correct 1M context windows.

- **Bug Fixes**
  - Normalize pricing keys: map `.` and `@` to `-` (e.g., `claude-opus-4.7` and `openrouter/anthropic/claude-opus-4.7` → `claude-opus-4-7`).
  - Require boundaries in fuzzy matches so `4.70` doesn’t match `4.7`.
  - Set 1M context for `claude-opus-4-6`, `claude-opus-4-7`, and `claude-sonnet-4-6`.

- **Refactors**
  - Apply rustfmt to pricing tests and context limits.
  - Add inline docs clarifying boundary-aware alias matching.

<sup>Written for commit f27ae5e4b582fea7c40af6a23b5982e3bfbf671d. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1154?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Boundary-aware, separator-normalized model-name matching so variants like "claude-opus-4.7" and "claude-opus-4-7" resolve consistently and avoid false matches from similar names (e.g., preventing "claude-opus-4.70" matching "claude-opus-4-7").
* **Updates**
  * Adjusted context window limits: select Claude models set to 1,000,000 tokens; others in the group use 200,000.
* **Tests**
  * Added tests for alias variants, boundary matching, and specific model resolutions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->