### PR TITLE
perf(all): stream default agent aggregations

### DIFF
--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -43,15 +43,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 index: 0,
                 agent: "claude",
                 progress_agent: crate::progress::UsageLoadAgent::Claude,
-                load: Box::new(|| {
-                    load_session_capable_summary_agent_rows(
-                        "claude",
-                        load_kind,
-                        &loader_shared,
-                        claude::load_entries,
-                        summarize_entries,
-                    )
-                }),
+                load: Box::new(|| load_claude_rows(load_kind, &loader_shared)),
             },
             AgentLoadSpec {
                 index: 1,
@@ -386,11 +378,55 @@ fn load_session_capable_summary_agent_rows(
     })
 }
 
+fn load_claude_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRows> {
+    if kind == AgentReportKind::Session {
+        return load_session_capable_summary_agent_rows(
+            "claude",
+            kind,
+            shared,
+            claude::load_entries,
+            summarize_entries,
+        );
+    }
+
+    let mut summaries = claude::load_daily_summaries(shared, None, false)?;
+    let detected = !summaries.is_empty();
+    filter_daily_summaries_by_date(&mut summaries, shared);
+    Ok(AgentRows {
+        rows: summary_rows("claude", summaries),
+        detected,
+    })
+}
+
+fn filter_daily_summaries_by_date(rows: &mut Vec<UsageSummary>, shared: &SharedArgs) {
+    if shared.since.is_none() && shared.until.is_none() {
+        return;
+    }
+    rows.retain(|row| {
+        let date = row.date.as_deref().unwrap_or_default().replace('-', "");
+        shared.since.as_ref().is_none_or(|since| &date >= since)
+            && shared.until.as_ref().is_none_or(|until| &date <= until)
+    });
+}
+
 fn load_codex_rows(
     kind: AgentReportKind,
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
+    if shared.since.is_none() && shared.until.is_none() {
+        let groups = codex::load_groups(shared, kind)?;
+        let detected = !groups.is_empty();
+        let speed = codex::resolve_codex_speed(CodexSpeed::Auto);
+        return Ok(AgentRows {
+            rows: groups
+                .iter()
+                .map(|(period, group)| codex_group_row(period, group, pricing, speed))
+                .collect(),
+            detected,
+        });
+    }
+
     let mut events = codex::load_codex_events(shared)?;
     let detected = !events.is_empty();
     codex::filter_events_by_date(&mut events, shared)?;
@@ -630,4 +666,52 @@ pub(super) fn aggregate_rows(rows: Vec<AllRow>, kind: AgentReportKind) -> Vec<Al
         .into_iter()
         .map(|(period, group)| group.into_row(period))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn usage_summary(date: &str, input_tokens: u64) -> UsageSummary {
+        UsageSummary {
+            date: Some(date.to_string()),
+            month: None,
+            week: None,
+            session_id: None,
+            project_path: None,
+            last_activity: None,
+            input_tokens,
+            output_tokens: 0,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            extra_total_tokens: 0,
+            total_cost: 0.0,
+            credits: None,
+            message_count: None,
+            models_used: Vec::new(),
+            model_breakdowns: Vec::new(),
+            project: None,
+            versions: None,
+        }
+    }
+
+    #[test]
+    fn filters_daily_summaries_with_compact_date_bounds() {
+        let mut rows = vec![
+            usage_summary("2026-01-01", 10),
+            usage_summary("2026-01-02", 20),
+            usage_summary("2026-01-03", 30),
+        ];
+        let shared = SharedArgs {
+            since: Some("20260102".to_string()),
+            until: Some("20260102".to_string()),
+            ..SharedArgs::default()
+        };
+
+        filter_daily_summaries_by_date(&mut rows, &shared);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].date.as_deref(), Some("2026-01-02"));
+        assert_eq!(rows[0].input_tokens, 20);
+    }
 }

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -18,7 +18,18 @@ use crate::{
 
 use super::{parser, paths};
 
-type CodexEventKey = (crate::TimestampMs, u64, usize, u64, u64, u64, u64, u64);
+type CodexEventKey = (
+    u64,
+    usize,
+    crate::TimestampMs,
+    u64,
+    usize,
+    u64,
+    u64,
+    u64,
+    u64,
+    u64,
+);
 type CodexDedupeShards = [Mutex<FxHashSet<CodexEventKey>>];
 
 struct CodexAggregation {
@@ -339,8 +350,10 @@ fn codex_event_key(
     model: &str,
 ) -> CodexEventKey {
     (
+        hash_text(&event.session_id),
+        event.session_id.len(),
         timestamp,
-        hash_model_name(model),
+        hash_text(model),
         model.len(),
         event.input_tokens,
         event.cached_input_tokens,
@@ -350,9 +363,9 @@ fn codex_event_key(
     )
 }
 
-fn hash_model_name(model: &str) -> u64 {
+fn hash_text(value: &str) -> u64 {
     let mut hasher = FxHasher::default();
-    model.hash(&mut hasher);
+    value.hash(&mut hasher);
     hasher.finish()
 }
 

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -26,7 +26,7 @@ struct CodexAggregation {
     seen: FxHashSet<CodexEventKey>,
 }
 
-pub(super) fn load_groups(
+pub(crate) fn load_groups(
     shared: &SharedArgs,
     kind: AgentReportKind,
 ) -> Result<BTreeMap<String, CodexGroup>> {

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -8,7 +8,7 @@ mod types;
 
 use crate::{cli::AgentCommandArgs, log_level, print_json_or_jq, wants_json, PricingMap, Result};
 
-pub(crate) use aggregate::{aggregate_events, filter_events_by_date};
+pub(crate) use aggregate::{aggregate_events, filter_events_by_date, load_groups};
 pub(crate) use loader::load_codex_events;
 #[cfg(test)]
 pub(crate) use loader::load_codex_events_from_directory;
@@ -17,7 +17,6 @@ pub(crate) use report::{
 };
 pub(crate) use speed::resolve_codex_speed;
 
-use aggregate::load_groups;
 use report::{print_table_from_groups, report_from_groups};
 
 #[cfg(test)]

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -102,6 +102,35 @@ mod tests {
     }
 
     #[test]
+    fn keeps_matching_grouped_codex_usage_events_from_distinct_sessions() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("ccusage-codex-group-dedupe-{suffix}"));
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let usage_line = r#"{"timestamp":"2026-01-02T00:00:00.000Z","type":"event_msg","payload":{"type":"token_count","info":{"model":"gpt-5","last_token_usage":{"input_tokens":100,"cached_input_tokens":10,"output_tokens":50,"reasoning_output_tokens":0,"total_tokens":150}}}}"#;
+        fs::write(sessions_dir.join("session-a.jsonl"), usage_line).unwrap();
+        fs::write(sessions_dir.join("session-b.jsonl"), usage_line).unwrap();
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let groups =
+            load_groups_from_directory(&sessions_dir, &shared, AgentReportKind::Daily).unwrap();
+        fs::remove_dir_all(root).unwrap();
+
+        assert_eq!(groups.len(), 1);
+        let group = groups.get("2026-01-02").unwrap();
+        assert_eq!(group.input_tokens, 200);
+        assert_eq!(group.cached_input_tokens, 20);
+        assert_eq!(group.output_tokens, 100);
+        assert_eq!(group.total_tokens, 300);
+    }
+
+    #[test]
     fn reports_non_cached_codex_input_separately_from_cached_input() {
         let pricing = PricingMap::default();
         let report = report_json(


### PR DESCRIPTION
Optimizes the default all-agent reports without adding dependencies or increasing the release binary size.

What changed:
- Reuses Claude daily summaries for all-agent date reports instead of loading full Claude entry vectors first.
- Reuses Codex grouped aggregation for unfiltered all-agent reports so large Codex sessions stream directly into report groups instead of materializing an intermediate event vector.

This helps the memory class discussed in #1124 for the default all-agent path; direct Codex reports already stream session JSONL files on current main.

Performance:
- Synthetic 50 MB Codex JSONL fixture, isolated HOME/XDG/CODEX_HOME, after checking background process load.
- main: 259.8 ms mean, 82,132,992 byte max RSS.
- head: 240.9 ms mean, 5,505,024 byte max RSS.
- Release binary size: unchanged at 2,746,368 bytes versus origin/main.

Testing:
- pnpm run format
- pnpm run test
- cargo fmt --manifest-path rust/Cargo.toml --all --check
- cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings
- Fixture JSON parity for all-agent, Claude, and Codex daily reports against origin/main
- Synthetic 50 MB Codex all-agent benchmark and RSS check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamed default all‑agent aggregations to cut peak memory without changing the binary size. Fixed Codex grouped dedupe so events from different sessions aren’t merged.

- **Refactors**
  - Claude all‑agent date path reads daily summaries instead of materializing full entry vectors.
  - Codex all‑agent (no date filters) uses grouped aggregation to stream session JSONL directly into report groups; falls back to events when filters are set.
  - Added compact date‑bound filtering for Claude daily summaries; exposed `load_groups` as `pub(crate)`.
  - Perf (50 MB Codex fixture): 259.8 ms → 240.9 ms; max RSS 82 MB → 5.5 MB; release binary size unchanged.

- **Bug Fixes**
  - Codex grouped dedupe includes session id (hash + length) in the key to keep distinct sessions separate; added regression test.

<sup>Written for commit 2676671f61d31f0aba03134a6e39e2543d24f202. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1158?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized Codex data loading to short-circuit when no date bounds are specified.
  * Improved Claude agent row loading logic with enhanced session handling and daily summary filtering.

* **Tests**
  * Added unit tests for daily summary date filtering validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->