### PR TITLE
chore(env): run nix gc during worktree cleanup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,16 @@
 					}
 				]
 			}
+		],
+		"WorktreeRemove": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "rm -rf .direnv; command -v nix >/dev/null 2>&1 && nix store gc || true"
+					}
+				]
+			}
 		]
 	}
 }

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -7,3 +7,11 @@ if command -v direnv >/dev/null 2>&1 && [ -f .envrc ]; then
   direnv allow
 fi
 """
+
+[cleanup]
+script = """
+rm -rf .direnv
+if command -v nix >/dev/null 2>&1; then
+  nix store gc || true
+fi
+"""


### PR DESCRIPTION
## Summary
- add a Codex local environment cleanup script that removes .direnv before running nix store gc
- add matching Claude WorktreeRemove cleanup while keeping the existing WorktreeCreate direnv setup

## Validation
- direnv exec . pnpm run format
- Bun.TOML.parse check for .codex/environments/environment.toml
- jq empty .claude/settings.json
- git diff --check

@coderabbitai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `nix store gc` during worktree cleanup and remove the per-worktree `.direnv` so nix-direnv roots don’t keep old dependencies alive.

- **New Features**
  - Added cleanup script in `.codex/environments/environment.toml` to remove `.direnv` and run `nix store gc`.
  - Added matching `WorktreeRemove` hook in `.claude/settings.json`; existing `WorktreeCreate` direnv setup stays the same.

<sup>Written for commit 2d8cb8912970255a00183efa26fe27492a5f006e. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1160?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automatic cleanup of temporary development artifacts when worktrees are removed
  * Enhanced environment teardown procedures for better resource management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->