### PR TITLE
test(codex): use fixture macro for group dedupe

### DIFF
--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -90,16 +90,12 @@ mod tests {
 
     #[test]
     fn keeps_matching_grouped_codex_usage_events_from_distinct_sessions() {
-        let suffix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let root = std::env::temp_dir().join(format!("ccusage-codex-group-dedupe-{suffix}"));
-        let sessions_dir = root.join("sessions");
-        fs::create_dir_all(&sessions_dir).unwrap();
         let usage_line = r#"{"timestamp":"2026-01-02T00:00:00.000Z","type":"event_msg","payload":{"type":"token_count","info":{"model":"gpt-5","last_token_usage":{"input_tokens":100,"cached_input_tokens":10,"output_tokens":50,"reasoning_output_tokens":0,"total_tokens":150}}}}"#;
-        fs::write(sessions_dir.join("session-a.jsonl"), usage_line).unwrap();
-        fs::write(sessions_dir.join("session-b.jsonl"), usage_line).unwrap();
+        let fixture = fs_fixture!({
+            "sessions/session-a.jsonl": usage_line,
+            "sessions/session-b.jsonl": usage_line,
+        });
+        let sessions_dir = fixture.path("sessions");
         let shared = SharedArgs {
             timezone: Some("UTC".to_string()),
             ..SharedArgs::default()
@@ -107,7 +103,6 @@ mod tests {
 
         let groups =
             load_groups_from_directory(&sessions_dir, &shared, AgentReportKind::Daily).unwrap();
-        fs::remove_dir_all(root).unwrap();
 
         assert_eq!(groups.len(), 1);
         let group = groups.get("2026-01-02").unwrap();


### PR DESCRIPTION
Fixes the main branch CI failure introduced by the Codex grouped dedupe test.

The test was still using a handwritten temporary directory after the shared fixture macro cleanup, which left SystemTime, UNIX_EPOCH, and fs undeclared in the test module. This switches the test to fs_fixture! and avoids adding any crate or manifest changes.

Testing:
- direnv exec . pnpm run format
- env -u CFLAGS -u CPPFLAGS -u LDFLAGS direnv exec . pnpm run test:rust
- env -u CFLAGS -u CPPFLAGS -u LDFLAGS NIX_CONFIG="access-tokens = github.com=$(gh auth token)" nix flake check --print-build-logs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix main-branch CI by switching the Codex grouped dedupe test to the shared `fs_fixture!` macro. Removes the handwritten temp directory and undeclared `SystemTime`/`UNIX_EPOCH`/`fs` imports, keeping the test aligned with repo fixtures without any manifest changes.

<sup>Written for commit a918deb6e43a41b79612cc2f50f5690383efca7d. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1162?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for usage event grouping validation with better test data setup utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->