### PR TITLE
refactor(cli): tokenize arguments with lexopt

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "compact_str",
  "insta",
  "jiff",
+ "lexopt",
  "memchr",
  "mimalloc",
  "minreq",
@@ -396,6 +397,12 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
 ]
+
+[[package]]
+name = "lexopt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
 
 [[package]]
 name = "libc"

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -19,6 +19,7 @@ jiff = { version = "0.2.24", default-features = false, features = [
 	"tz-system",
 	"tzdb-zoneinfo",
 ] }
+lexopt = "0.3.2"
 memchr = "2"
 compact_str = "0.9"
 phf = { version = "0.13", features = ["macros"] }

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -59,6 +59,10 @@ mod tests {
     use crate::cli::SharedArgs;
     use crate::{CodexModelUsage, CodexTokenUsageEvent};
     use ccusage_test_support::fs_fixture;
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     #[test]
     fn loads_directory_groups_with_date_filter_without_global_event_vector() {

--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -1,5 +1,7 @@
 use std::{env, ffi::OsString, path::PathBuf, process};
 
+use lexopt::Arg;
+
 use crate::{
     config::{
         apply_config_to_agent_args, apply_config_to_blocks_args, apply_config_to_daily_args,
@@ -1086,22 +1088,36 @@ fn parse_cost_source(value: &str) -> Result<CostSource, String> {
 struct ArgParser {
     args: Vec<String>,
     index: usize,
-    pending_value: Option<String>,
 }
 
 impl ArgParser {
     fn new(args: Vec<OsString>) -> Result<Self, String> {
-        let mut parsed = Vec::with_capacity(args.len());
-        for arg in args {
-            parsed.push(
-                arg.into_string()
-                    .map_err(|_| "Arguments must be valid UTF-8".to_string())?,
-            );
+        let mut parser = lexopt::Parser::from_args(args);
+        let mut parsed = Vec::new();
+        while let Some(arg) = parser.next().map_err(|error| error.to_string())? {
+            match arg {
+                Arg::Short(short) => {
+                    let flag = format!("-{short}");
+                    parsed.push(flag.clone());
+                    if option_takes_value(&flag) {
+                        parsed.push(lexopt_value_for(&mut parser, &flag)?);
+                    }
+                }
+                Arg::Long(long) => {
+                    let flag = format!("--{long}");
+                    parsed.push(flag.clone());
+                    if option_takes_value(&flag) {
+                        parsed.push(lexopt_value_for(&mut parser, &flag)?);
+                    } else {
+                        let _ = parser.optional_value();
+                    }
+                }
+                Arg::Value(value) => parsed.push(os_string_to_string(value)?),
+            }
         }
         Ok(Self {
             args: parsed,
             index: 0,
-            pending_value: None,
         })
     }
 
@@ -1122,10 +1138,6 @@ impl ArgParser {
         if matches!(arg.as_str(), "-h" | "--help" | "-v" | "-V" | "--version") {
             print_help_or_version_arg(&arg);
         }
-        if let Some((flag, value)) = arg.split_once('=') {
-            self.pending_value = Some(value.to_string());
-            return Ok(flag.to_string());
-        }
         if arg.starts_with('-') {
             Ok(arg)
         } else {
@@ -1134,12 +1146,6 @@ impl ArgParser {
     }
 
     fn value_for(&mut self, flag: &str) -> Result<String, String> {
-        if let Some(value) = self.pending_value.take() {
-            if value.is_empty() {
-                return Err(format!("Missing value for {flag}"));
-            }
-            return Ok(value);
-        }
         let value = self
             .next()
             .ok_or_else(|| format!("Missing value for {flag}"))?;
@@ -1148,6 +1154,23 @@ impl ArgParser {
         }
         Ok(value)
     }
+}
+
+fn lexopt_value_for(parser: &mut lexopt::Parser, flag: &str) -> Result<String, String> {
+    let value = parser
+        .value()
+        .map_err(|_| format!("Missing value for {flag}"))
+        .and_then(os_string_to_string)?;
+    if value.is_empty() || value.starts_with('-') {
+        return Err(format!("Missing value for {flag}"));
+    }
+    Ok(value)
+}
+
+fn os_string_to_string(value: OsString) -> Result<String, String> {
+    value
+        .into_string()
+        .map_err(|_| "Arguments must be valid UTF-8".to_string())
 }
 
 fn print_help_or_version_arg(arg: &str) -> ! {
@@ -1842,6 +1865,17 @@ mod tests {
         };
         assert_eq!(args.kind, AgentReportKind::Daily);
         assert!(args.shared.json);
+        assert_eq!(args.shared.since.as_deref(), Some("20260102"));
+    }
+
+    #[test]
+    fn parses_standard_short_option_groups_and_attached_values() {
+        let cli = parse(&["ccusage", "-jO", "-s2026-01-02", "daily"]);
+        let Some(Command::All(args)) = cli.command else {
+            panic!("expected all-agent command");
+        };
+        assert!(args.shared.json);
+        assert!(args.shared.offline);
         assert_eq!(args.shared.since.as_deref(), Some("20260102"));
     }
 


### PR DESCRIPTION
Replaces the ccusage CLI option lexer with lexopt while keeping the existing command routing, config defaulting, and manual help text in place.

The observable behavior is intentionally small: existing CLI snapshots keep passing, and standard short option groups / attached short values now work, for example \`-jO -s2026-01-02 daily\`. Subcommand smoke checks covered \`codex daily --speed fast\`, \`claude weekly\`, \`opencode weekly --help\`, \`pi session --pi-path\`, and contextual \`--help\` paths.

Performance / size tradeoff:
- Release binary size: 2,746,400 bytes on origin/main vs 2,746,416 bytes on this branch (+16 bytes).
- \`hyperfine -N --warmup 10 --runs 50 --version\`: 2.30 ms on origin/main vs 2.22 ms on this branch (noise-level difference).
- Fixture \`daily --offline --json\`: 243.25 ms on origin/main vs 243.76 ms on this branch (effectively unchanged).

Testing:
- env -u CFLAGS direnv exec . pnpm run format
- env -u CFLAGS direnv exec . cargo fmt --manifest-path rust/Cargo.toml --all
- env -u CFLAGS direnv exec . pnpm run test
- env -u CFLAGS direnv exec . cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings
- release binary subcommand/help smoke checks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `ccusage` CLI argument tokenization to `lexopt` to support standard short-option groups and attached values, while keeping command routing, help text, and parse errors unchanged. Existing behavior stays the same; e.g., `-jO` and `-s2026-01-02` now parse correctly.

- **Refactors**
  - Replaced custom lexer with a `lexopt`-based tokenizer; preserved routing, config defaults, help, and error wording.
  - Added a test for grouped short options; fixed Codex test imports for clean builds.
  - Perf/size: +16 bytes in release binary; version and fixture timings are effectively unchanged.

- **Dependencies**
  - Added `lexopt@0.3.2`.

<sup>Written for commit 5495960ce7ead833173c78b0ce6d7a3a5bbe6482. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1163?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced CLI argument parsing for improved robustness and consistency

* **Tests**
  * Added test coverage for grouped short-option CLI arguments with values

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->