### PR TITLE
ci: upload Rust coverage to GitHub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
     permissions:
       contents: read
       code-quality: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -78,6 +79,7 @@ jobs:
           file: coverage/cobertura.xml
           language: Rust
           label: code-coverage/cargo-llvm-cov
+          fail-on-error: false
 
   build-native-packages:
     needs: changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true' && (github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
     permissions:
       contents: read
       code-quality: write
@@ -72,7 +73,7 @@ jobs:
             --output-path coverage/cobertura.xml
       - name: Upload Rust coverage report
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/upload-code-coverage@v1
+        uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1
         with:
           file: coverage/cobertura.xml
           language: Rust

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,39 @@ jobs:
           mkdir -p "$HOME/.config/claude/projects"
       - run: nix develop --command pnpm run test
 
+  code-coverage:
+    needs: changes
+    if: needs.changes.outputs.code-changed == 'true' && (github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      code-quality: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix
+      - name: Create default Claude directories for tests
+        run: |
+          mkdir -p "$HOME/.claude/projects"
+          mkdir -p "$HOME/.config/claude/projects"
+      - name: Generate Rust coverage report
+        run: |
+          mkdir -p coverage
+          env -u CFLAGS -u CXXFLAGS nix develop --command cargo llvm-cov \
+            --manifest-path rust/Cargo.toml \
+            --workspace \
+            --cobertura \
+            --output-path coverage/cobertura.xml
+      - name: Upload Rust coverage report
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage/cobertura.xml
+          language: Rust
+          label: code-coverage/cargo-llvm-cov
+
   build-native-packages:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,25 +35,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true'
     runs-on: ubuntu-24.04-arm
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-nix
-      - name: Create default Claude directories for tests
-        run: |
-          mkdir -p "$HOME/.claude/projects"
-          mkdir -p "$HOME/.config/claude/projects"
-      - run: nix develop --command pnpm run test
-
-  code-coverage:
-    needs: changes
-    if: needs.changes.outputs.code-changed == 'true' && (github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
-    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     permissions:
       contents: read
       code-quality: write
       pull-requests: read
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -64,7 +51,14 @@ jobs:
         run: |
           mkdir -p "$HOME/.claude/projects"
           mkdir -p "$HOME/.config/claude/projects"
+      - name: Run test suite
+        if: github.event_name != 'pull_request' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+        run: nix develop --command pnpm run test
+      - name: Run Vitest tests
+        if: github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        run: nix develop --command pnpm run test:vitest
       - name: Generate Rust coverage report
+        if: github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           mkdir -p coverage
           env -u CFLAGS -u CXXFLAGS nix develop --command cargo llvm-cov \
@@ -73,7 +67,7 @@ jobs:
             --cobertura \
             --output-path coverage/cobertura.xml
       - name: Upload Rust coverage report
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1
         with:
           file: coverage/cobertura.xml

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -26,6 +26,7 @@ in
             rustToolchain
             cargo-edit
             cargo-insta
+            cargo-llvm-cov
             pkg-config
             openssl
             config.treefmt.build.wrapper

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.85.1"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "llvm-tools-preview", "rustfmt"]


### PR DESCRIPTION
## Summary

Adds a dedicated CI job that generates Rust workspace coverage as Cobertura XML with \`cargo llvm-cov\` and uploads it via \`actions/upload-code-coverage@v1\` for GitHub Code Coverage public preview.

The job runs for pull requests and default-branch pushes after the existing code-change detector passes, so GitHub Code Quality gets both PR coverage data and a default-branch baseline without running on docs-only changes.

@coderabbitai please review this PR.

## Testing

- \`env -u CFLAGS -u CXXFLAGS nix develop --command cargo llvm-cov --manifest-path rust/Cargo.toml --workspace --cobertura --output-path coverage/cobertura.xml\`
- \`nix develop --command pnpm run format\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs Rust coverage inside the existing CI test job using `cargo-llvm-cov`, then uploads Cobertura XML to GitHub Code Coverage. Triggers on PRs and default-branch pushes when code changes are detected, and keeps CI green if the preview API errors.

- **New Features**
  - Coverage is folded into the test job; `Vitest` runs separately when coverage is enabled to avoid re-running Rust tests.
  - Upload uses pinned `actions/upload-code-coverage` (v1) with a 30‑minute timeout and `fail-on-error: false`, and only runs on same-repo PRs and default-branch pushes; grants `pull-requests: read` on push events.

- **Dependencies**
  - Add `cargo-llvm-cov` to the Nix dev shell.
  - Add `llvm-tools-preview` to the Rust toolchain.

<sup>Written for commit 07813a4e8034846889f1b8f19f794bb4473aff9c. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1164?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated code-coverage reporting in CI for pull requests and default-branch commits, generating and uploading Rust Cobertura coverage results.
  * CI test job behavior refined and given an explicit timeout to improve reliability.
  * Updated the development environment and Rust toolchain to include LLVM coverage tooling for local workspace-wide coverage analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->