### PR TITLE
docs(skills): keep references under preview limits

### DIFF
--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -14,8 +14,9 @@ Use this skill when creating or updating repo-local skills under `.agents/skills
 3. Keep `SKILL.md` focused on core workflow and navigation. Move detailed examples, APIs, or long checklists into `references/` files linked directly from `SKILL.md`.
 4. Add scripts under `scripts/` only for deterministic or repeated operations that are better executed than rewritten.
 5. Update the root `AGENTS.md` Skill Routing list when adding a repo-local skill that agents should discover before work.
-6. Let the Nix dev shell refresh generated local agent skill targets through its shell hook.
-7. Run `pnpm run format` after edits and use the normal repo validation level for the change.
+6. Keep skill and reference files below the line budgets in this guide.
+7. Let the Nix dev shell refresh generated local agent skill targets through its shell hook.
+8. Run `pnpm run format` after edits and use the normal repo validation level for the change.
 
 ## Local Skill Management
 
@@ -84,6 +85,27 @@ Keep the body procedural and repo-specific:
 - Small examples that prevent common mistakes.
 
 Avoid explaining generic concepts the model already knows. The skill body is loaded only after the skill triggers, but it still competes with task context once loaded.
+
+## Line Budgets
+
+Assume some agents may preview only the first 200 lines of a skill or reference
+file. Keep each file comfortably below that limit, with the most important
+routing, safety, and workflow instructions near the top.
+
+Targets:
+
+- Keep `SKILL.md` under 160 lines.
+- Keep each `references/*.md` file under 180 lines.
+- Split longer material by decision point or workflow phase, then link the
+  specific file from `SKILL.md`.
+- Do not put required instructions below examples, troubleshooting notes, or
+  optional background.
+
+Audit with:
+
+```sh
+fd . .agents/skills -t f -e md -x wc -l {} | sort -nr
+```
 
 ## References
 

--- a/.agents/skills/tdd/references/vitest-examples.md
+++ b/.agents/skills/tdd/references/vitest-examples.md
@@ -1,0 +1,93 @@
+# Vitest Style Examples
+
+Use this reference when reviewing or teaching Vitest style. The main TDD
+reference keeps the required workflow short; this file preserves expanded
+bad/good examples.
+
+## Expected Failures
+
+Avoid `try`/`catch` for expected failures.
+
+Bad:
+
+```typescript
+it('rejects invalid config', async () => {
+	try {
+		await loadConfig('bad.json');
+		expect.fail('expected loadConfig to throw');
+	} catch (error) {
+		expect(error).toBeInstanceOf(Error);
+	}
+});
+```
+
+Good:
+
+```typescript
+it('rejects invalid config', async () => {
+	await expect(loadConfig('bad.json')).rejects.toThrow(Error);
+});
+```
+
+## Branching
+
+Avoid `if` branches inside test bodies.
+
+Bad:
+
+```typescript
+it('formats output', () => {
+	const output = formatReport(mode);
+
+	if (mode === 'json') {
+		expect(JSON.parse(output)).toEqual(expected);
+	} else {
+		expect(output).toContain('Total');
+	}
+});
+```
+
+Good:
+
+```typescript
+it('formats JSON output', () => {
+	const output = formatReport('json');
+
+	expect(JSON.parse(output)).toEqual(expected);
+});
+
+it('formats table output', () => {
+	const output = formatReport('table');
+
+	expect(output).toContain('Total');
+});
+```
+
+## Helpers
+
+Avoid wrapper/helper functions that hide behavior and assertions.
+
+Bad:
+
+```typescript
+function expectReport(input: UsageEntry[], expected: ReportRow[]) {
+	expect(renderDaily(input)).toEqual(expected);
+}
+
+it('renders daily totals', () => {
+	expectReport(
+		[{ timestamp: '2026-05-16T10:00:00Z', inputTokens: 100 }],
+		[{ date: '2026-05-16', inputTokens: 100 }],
+	);
+});
+```
+
+Good:
+
+```typescript
+it('renders daily totals', () => {
+	const input = [{ timestamp: '2026-05-16T10:00:00Z', inputTokens: 100 }];
+
+	expect(renderDaily(input)).toEqual([{ date: '2026-05-16', inputTokens: 100 }]);
+});
+```

--- a/.agents/skills/tdd/references/vitest.md
+++ b/.agents/skills/tdd/references/vitest.md
@@ -70,8 +70,8 @@ it('rejects invalid config', async () => {
 });
 ```
 
-Read `vitest-examples.md` for expanded bad/good examples when reviewing or
-teaching test style.
+Read [`vitest-examples.md`](./vitest-examples.md) for expanded bad/good
+examples when reviewing or teaching test style.
 
 ## Branching
 

--- a/.agents/skills/tdd/references/vitest.md
+++ b/.agents/skills/tdd/references/vitest.md
@@ -61,22 +61,8 @@ describe(calculateTotal, () => {
 
 ## Expected Failures
 
-Avoid `try`/`catch` for expected failures.
-
-Bad:
-
-```typescript
-it('rejects invalid config', async () => {
-	try {
-		await loadConfig('bad.json');
-		expect.fail('expected loadConfig to throw');
-	} catch (error) {
-		expect(error).toBeInstanceOf(Error);
-	}
-});
-```
-
-Good:
+Avoid `try`/`catch` for expected failures. Assert the rejection or thrown error
+directly:
 
 ```typescript
 it('rejects invalid config', async () => {
@@ -84,25 +70,13 @@ it('rejects invalid config', async () => {
 });
 ```
 
+Read `vitest-examples.md` for expanded bad/good examples when reviewing or
+teaching test style.
+
 ## Branching
 
-Avoid `if` branches inside test bodies. Split behaviors or use `it.each`.
-
-Bad:
-
-```typescript
-it('formats output', () => {
-	const output = formatReport(mode);
-
-	if (mode === 'json') {
-		expect(JSON.parse(output)).toEqual(expected);
-	} else {
-		expect(output).toContain('Total');
-	}
-});
-```
-
-Good:
+Avoid `if` branches inside test bodies. Split behaviors when the assertions are
+meaningfully different:
 
 ```typescript
 it('formats JSON output', () => {
@@ -134,23 +108,6 @@ it.each([
 ## Helpers And Values
 
 Avoid wrapper/helper functions that hide behavior and assertions.
-
-Bad:
-
-```typescript
-function expectReport(input: UsageEntry[], expected: ReportRow[]) {
-	expect(renderDaily(input)).toEqual(expected);
-}
-
-it('renders daily totals', () => {
-	expectReport(
-		[{ timestamp: '2026-05-16T10:00:00Z', inputTokens: 100 }],
-		[{ date: '2026-05-16', inputTokens: 100 }],
-	);
-});
-```
-
-Good:
 
 ```typescript
 it('renders daily totals', () => {


### PR DESCRIPTION
Adds explicit line-budget guidance for repo-local skills so required workflow instructions stay visible when agents preview only the first 200 lines.

The main Vitest TDD reference now links to a separate optional examples file, preserving the expanded bad/good examples without keeping them in the core workflow reference.

Testing:
- , oxfmt --check .
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds line-budget guidance for repo-local skills and trims Vitest TDD docs so key workflow stays visible within 200-line previews. Splits extended Vitest examples into a separate reference and links to it from the main guide.

- **New Features**
  - Add Line Budgets to `.agents/skills/skill-creator/SKILL.md`.
  - Targets: `SKILL.md` ≤160 lines; each `references/*.md` ≤180.
  - Add audit command to check line counts.

- **Refactors**
  - Move expanded bad/good examples from `vitest.md` to `vitest-examples.md`.
  - Keep `vitest.md` focused on core workflow and add explicit link to the examples.

<sup>Written for commit a83cedaa3f539afa371137f02a8da68cd254e985. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1166?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Vitest testing guidance with improved examples and best practices for expected failures, test branching, and clearer assertion patterns.
  * Added a TDD examples reference demonstrating good/bad patterns.
  * Updated the skill-creator workflow with line-budget guidelines, concrete preview limits, and an audit command for counting markdown lines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->