### PR TITLE
fix(copilot): explain missing otel usage data

### DIFF
--- a/docs/guide/copilot/index.md
+++ b/docs/guide/copilot/index.md
@@ -26,6 +26,8 @@ pnpm dlx ccusage copilot --help
 
 The CLI reads Copilot OpenTelemetry JSONL files from `~/.copilot/otel/*.jsonl` and also includes the explicit file pointed to by `COPILOT_OTEL_FILE_EXPORTER_PATH`.
 
+Enable these variables before starting or resuming a Copilot CLI session. Sessions that ran without OpenTelemetry file export enabled do not produce local JSONL usage data for ccusage to read.
+
 ```bash
 export COPILOT_OTEL_ENABLED=true
 export COPILOT_OTEL_EXPORTER_TYPE=file
@@ -67,6 +69,8 @@ These views support `--json` for structured output, `--compact` for narrow termi
 
 ::: details No Copilot usage data found
 Ensure OpenTelemetry file export is enabled and the exporter path points to an existing `.jsonl` file, or place exported `.jsonl` files under `~/.copilot/otel/`.
+
+If you are using `copilot --resume`, set the OpenTelemetry environment variables before running the resume command. Earlier activity from sessions started without file export cannot be recovered by ccusage.
 :::
 
 ::: details Costs showing as $0.00

--- a/rust/crates/ccusage/src/adapter/copilot/mod.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/mod.rs
@@ -24,6 +24,10 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     if wants_json(&shared) {
         return print_json_or_jq(report_from_rows(&rows, args.kind), shared.jq.as_deref());
     }
+    if rows.is_empty() {
+        eprintln!("{}", empty_usage_message());
+        return Ok(());
+    }
     print_usage_table(
         "GitHub Copilot CLI Token Usage Report",
         crate::adapter::opencode::first_column(args.kind),
@@ -33,4 +37,21 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         None,
     )?;
     Ok(())
+}
+
+fn empty_usage_message() -> &'static str {
+    "No GitHub Copilot CLI usage data found.\nEnable Copilot OpenTelemetry file export before starting or resuming Copilot sessions.\nSee https://ccusage.com/guide/copilot/#data-source"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_usage_message_links_to_copilot_docs() {
+        assert_eq!(
+            empty_usage_message(),
+            "No GitHub Copilot CLI usage data found.\nEnable Copilot OpenTelemetry file export before starting or resuming Copilot sessions.\nSee https://ccusage.com/guide/copilot/#data-source"
+        );
+    }
 }

--- a/rust/crates/ccusage/src/adapter/copilot/mod.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/mod.rs
@@ -49,9 +49,7 @@ mod tests {
 
     #[test]
     fn empty_usage_message_links_to_copilot_docs() {
-        assert_eq!(
-            empty_usage_message(),
-            "No GitHub Copilot CLI usage data found.\nEnable Copilot OpenTelemetry file export before starting or resuming Copilot sessions.\nSee https://ccusage.com/guide/copilot/#data-source"
-        );
+        let message = empty_usage_message();
+        assert!(message.contains("https://ccusage.com/guide/copilot/#data-source"));
     }
 }


### PR DESCRIPTION
Adds a Copilot-specific empty-data message that points users to the Copilot data source docs when no local OpenTelemetry JSONL usage data is found.

The Copilot guide now also states that OpenTelemetry file export must be enabled before starting or resuming a Copilot CLI session, because earlier activity cannot be reconstructed by ccusage.

Testing:
- direnv exec . cargo fmt --manifest-path rust/Cargo.toml --all --check
- direnv exec . cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::copilot::tests::empty_usage_message_links_to_copilot_docs
- direnv exec . pnpm --filter docs format
- env with temporary HOME: rust/target/debug/ccusage copilot daily --offline
- direnv exec . git push -u origin codex/docs-copilot-otel-resume (pre-push: clippy, treefmt, gitleaks, cargo test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a Copilot-specific empty-state message in `ccusage` when no OpenTelemetry JSONL usage data is found, with a link to the Copilot data source docs. Update the Copilot guide to require enabling file export before starting or resuming sessions, since earlier activity cannot be reconstructed; tests now assert the stable docs link.

<sup>Written for commit 0f6d41123c06b90787ef5969aeb3c36c186f94d0. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1170?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Copilot CLI guide: instructs enabling file-export environment variables before starting or resuming sessions so local usage data is produced and readable.

* **Improvements**
  * When no usage data is available, the tool now prints a clear, actionable message (with a docs link) and exits gracefully instead of showing an empty table or JSON.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->