### PR TITLE
perf(ccusage): share JSONL scanning helpers

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -108,6 +108,7 @@ name = "ccusage"
 version = "20.0.5"
 dependencies = [
  "ccusage-cli",
+ "ccusage-jsonl",
  "ccusage-terminal",
  "ccusage-test-support",
  "compact_str",
@@ -132,6 +133,13 @@ version = "20.0.5"
 dependencies = [
  "insta",
  "serde_json",
+]
+
+[[package]]
+name = "ccusage-jsonl"
+version = "0.1.0"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
 	"crates/ccusage",
 	"crates/ccusage-cli",
+	"crates/ccusage-jsonl",
 	"crates/ccusage-terminal",
 	"crates/ccusage-test-support",
 ]

--- a/rust/crates/ccusage-jsonl/Cargo.toml
+++ b/rust/crates/ccusage-jsonl/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ccusage-jsonl"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+memchr = "2"

--- a/rust/crates/ccusage-jsonl/src/lib.rs
+++ b/rust/crates/ccusage-jsonl/src/lib.rs
@@ -1,0 +1,298 @@
+use std::{
+    fs::File,
+    io::{self, BufRead, BufReader},
+    path::Path,
+};
+
+use memchr::{memchr, memmem::Finder, memrchr};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct JsonlLine<'a> {
+    pub bytes: &'a [u8],
+}
+
+impl<'a> JsonlLine<'a> {
+    #[inline]
+    pub fn as_str(self) -> Option<&'a str> {
+        std::str::from_utf8(self.bytes).ok()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MarkerLine<'a> {
+    pub bytes: &'a [u8],
+    pub marker_index: usize,
+    pub marker_id: usize,
+}
+
+impl<'a> MarkerLine<'a> {
+    #[inline]
+    pub fn as_str(self) -> Option<&'a str> {
+        std::str::from_utf8(self.bytes).ok()
+    }
+}
+
+pub struct JsonlLines<'a> {
+    bytes: &'a [u8],
+}
+
+#[derive(Debug)]
+pub struct JsonlFileLines {
+    reader: BufReader<File>,
+    line: Vec<u8>,
+}
+
+impl JsonlFileLines {
+    pub fn open_with_capacity(path: &Path, capacity: usize) -> io::Result<Self> {
+        Ok(Self {
+            reader: BufReader::with_capacity(capacity, File::open(path)?),
+            line: Vec::new(),
+        })
+    }
+
+    pub fn next_line(&mut self) -> io::Result<Option<&[u8]>> {
+        self.line.clear();
+        let bytes_read = self.reader.read_until(b'\n', &mut self.line)?;
+        if bytes_read == 0 {
+            return Ok(None);
+        }
+        Ok(Some(&self.line))
+    }
+}
+
+impl<'a> JsonlLines<'a> {
+    #[inline]
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl<'a> Iterator for JsonlLines<'a> {
+    type Item = JsonlLine<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.bytes.is_empty() {
+            return None;
+        }
+        let (line, rest) = split_next_line(self.bytes);
+        self.bytes = rest;
+        Some(JsonlLine {
+            bytes: trim_trailing_cr(line),
+        })
+    }
+}
+
+impl DoubleEndedIterator for JsonlLines<'_> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.bytes.is_empty() {
+            return None;
+        }
+        if let Some(newline) = memrchr(b'\n', self.bytes.strip_suffix(b"\n").unwrap_or(self.bytes))
+        {
+            let line = &self.bytes[newline + 1..];
+            self.bytes = &self.bytes[..newline];
+            Some(JsonlLine {
+                bytes: trim_trailing_cr(line.strip_suffix(b"\n").unwrap_or(line)),
+            })
+        } else {
+            let line = self.bytes;
+            self.bytes = &[];
+            Some(JsonlLine {
+                bytes: trim_trailing_cr(line.strip_suffix(b"\n").unwrap_or(line)),
+            })
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct JsonlMarkerLines<'a> {
+    bytes: &'a [u8],
+    finder: Finder<'a>,
+    line_start: usize,
+    search_start: usize,
+}
+
+impl<'a> JsonlMarkerLines<'a> {
+    #[inline]
+    pub fn new(bytes: &'a [u8], marker: &'a [u8]) -> Self {
+        Self {
+            bytes,
+            finder: Finder::new(marker),
+            line_start: 0,
+            search_start: if marker.is_empty() { bytes.len() } else { 0 },
+        }
+    }
+}
+
+impl<'a> Iterator for JsonlMarkerLines<'a> {
+    type Item = MarkerLine<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.search_start >= self.bytes.len() {
+            return None;
+        }
+        let marker_index =
+            self.search_start + self.finder.find(&self.bytes[self.search_start..])?;
+        while let Some(newline) = memchr(b'\n', &self.bytes[self.line_start..marker_index]) {
+            self.line_start += newline + 1;
+        }
+        let line_end = line_end_after(self.bytes, marker_index);
+        let line_start = self.line_start;
+        self.line_start = line_end.saturating_add(1);
+        self.search_start = self.line_start;
+        Some(MarkerLine {
+            bytes: trim_trailing_cr(&self.bytes[line_start..line_end]),
+            marker_index: marker_index - line_start,
+            marker_id: 0,
+        })
+    }
+}
+
+#[inline]
+pub fn lines(bytes: &[u8]) -> JsonlLines<'_> {
+    JsonlLines::new(bytes)
+}
+
+#[inline]
+pub fn lines_with_marker<'a>(bytes: &'a [u8], marker: &'a [u8]) -> JsonlMarkerLines<'a> {
+    JsonlMarkerLines::new(bytes, marker)
+}
+
+pub fn lines_with_any_marker<'a>(bytes: &'a [u8], markers: &[&'a [u8]]) -> Vec<MarkerLine<'a>> {
+    if markers.is_empty() {
+        return Vec::new();
+    }
+    if markers.len() == 1 {
+        return lines_with_marker(bytes, markers[0]).collect();
+    }
+
+    let mut matches = Vec::new();
+    for (marker_id, marker) in markers.iter().copied().enumerate() {
+        if marker.is_empty() {
+            continue;
+        }
+        let finder = Finder::new(marker);
+        let mut search_start = 0;
+        while search_start < bytes.len() {
+            let Some(relative_index) = finder.find(&bytes[search_start..]) else {
+                break;
+            };
+            let marker_index = search_start + relative_index;
+            let line_start = line_start_before(bytes, marker_index);
+            let line_end = line_end_after(bytes, marker_index);
+            matches.push(MarkerLine {
+                bytes: trim_trailing_cr(&bytes[line_start..line_end]),
+                marker_index: marker_index - line_start,
+                marker_id,
+            });
+            search_start = marker_index + marker.len();
+        }
+    }
+
+    matches.sort_unstable_by(|left, right| {
+        let left_start = line_start_ptr(bytes, left.bytes);
+        let right_start = line_start_ptr(bytes, right.bytes);
+        left_start
+            .cmp(&right_start)
+            .then(left.marker_index.cmp(&right.marker_index))
+            .then(left.marker_id.cmp(&right.marker_id))
+    });
+    matches.dedup_by(|right, left| std::ptr::eq(left.bytes.as_ptr(), right.bytes.as_ptr()));
+    matches
+}
+
+#[inline]
+pub fn contains(bytes: &[u8], needle: &[u8]) -> bool {
+    Finder::new(needle).find(bytes).is_some()
+}
+
+#[inline]
+fn split_next_line(bytes: &[u8]) -> (&[u8], &[u8]) {
+    if let Some(newline) = memchr(b'\n', bytes) {
+        let (line, rest) = bytes.split_at(newline);
+        (line, &rest[1..])
+    } else {
+        (bytes, &[])
+    }
+}
+
+#[inline]
+fn line_start_before(bytes: &[u8], index: usize) -> usize {
+    memrchr(b'\n', &bytes[..index]).map_or(0, |line_end| line_end + 1)
+}
+
+#[inline]
+fn line_end_after(bytes: &[u8], index: usize) -> usize {
+    index + memchr(b'\n', &bytes[index..]).unwrap_or(bytes.len() - index)
+}
+
+#[inline]
+fn trim_trailing_cr(bytes: &[u8]) -> &[u8] {
+    bytes.strip_suffix(b"\r").unwrap_or(bytes)
+}
+
+#[inline]
+fn line_start_ptr(haystack: &[u8], line: &[u8]) -> usize {
+    line.as_ptr() as usize - haystack.as_ptr() as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{lines, lines_with_any_marker, lines_with_marker};
+
+    #[test]
+    fn lines_splits_lf_and_trims_cr() {
+        let lines = lines(b"{\"a\":1}\r\n{\"b\":2}\n{\"c\":3}")
+            .map(|line| line.bytes)
+            .collect::<Vec<_>>();
+
+        assert_eq!(lines, [b"{\"a\":1}".as_slice(), b"{\"b\":2}", b"{\"c\":3}"]);
+    }
+
+    #[test]
+    fn lines_supports_reverse_iteration() {
+        let lines = lines(b"{\"a\":1}\r\n{\"b\":2}\n{\"c\":3}\n")
+            .rev()
+            .map(|line| line.bytes)
+            .collect::<Vec<_>>();
+
+        assert_eq!(lines, [b"{\"c\":3}".as_slice(), b"{\"b\":2}", b"{\"a\":1}"]);
+    }
+
+    #[test]
+    fn marker_lines_decode_only_matching_lines() {
+        let input = b"{\"type\":\"noise\"}\n{\"usage\":{\"input\":1}}\n{\"type\":\"other\"}\n";
+        let lines = lines_with_marker(input, br#""usage":{"#)
+            .map(|line| (line.bytes, line.marker_index))
+            .collect::<Vec<_>>();
+
+        assert_eq!(lines, [(b"{\"usage\":{\"input\":1}}".as_slice(), 1)]);
+    }
+
+    #[test]
+    fn marker_lines_ignore_empty_marker() {
+        let lines = lines_with_marker(b"{\"a\":1}\n", b"").collect::<Vec<_>>();
+
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn any_marker_returns_file_order_and_dedupes_lines() {
+        let input = b"{\"type\":\"turn_context\"}\n{\"payload\":{\"type\":\"token_count\"}}\n";
+        let lines = lines_with_any_marker(input, &[b"token_count", b"turn_context", b"type"])
+            .into_iter()
+            .map(|line| line.bytes)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            lines,
+            [
+                b"{\"type\":\"turn_context\"}".as_slice(),
+                b"{\"payload\":{\"type\":\"token_count\"}}".as_slice(),
+            ]
+        );
+    }
+}

--- a/rust/crates/ccusage-jsonl/src/lib.rs
+++ b/rust/crates/ccusage-jsonl/src/lib.rs
@@ -36,6 +36,10 @@ pub struct JsonlLines<'a> {
     bytes: &'a [u8],
 }
 
+pub struct ByteLines<'a> {
+    bytes: &'a [u8],
+}
+
 #[derive(Debug)]
 pub struct JsonlFileLines {
     reader: BufReader<File>,
@@ -64,6 +68,33 @@ impl<'a> JsonlLines<'a> {
     #[inline]
     pub fn new(bytes: &'a [u8]) -> Self {
         Self { bytes }
+    }
+}
+
+impl<'a> ByteLines<'a> {
+    #[inline]
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl<'a> Iterator for ByteLines<'a> {
+    type Item = &'a [u8];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.bytes.is_empty() {
+            return None;
+        }
+        if let Some(newline) = memchr(b'\n', self.bytes) {
+            let (line, rest) = self.bytes.split_at(newline);
+            self.bytes = &rest[1..];
+            Some(line)
+        } else {
+            let line = self.bytes;
+            self.bytes = &[];
+            Some(line)
+        }
     }
 }
 
@@ -157,6 +188,11 @@ pub fn lines(bytes: &[u8]) -> JsonlLines<'_> {
 }
 
 #[inline]
+pub fn byte_lines(bytes: &[u8]) -> ByteLines<'_> {
+    ByteLines::new(bytes)
+}
+
+#[inline]
 pub fn lines_with_marker<'a>(bytes: &'a [u8], marker: &'a [u8]) -> JsonlMarkerLines<'a> {
     JsonlMarkerLines::new(bytes, marker)
 }
@@ -241,7 +277,17 @@ fn line_start_ptr(haystack: &[u8], line: &[u8]) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{lines, lines_with_any_marker, lines_with_marker};
+    use super::{byte_lines, lines, lines_with_any_marker, lines_with_marker};
+
+    #[test]
+    fn byte_lines_returns_newline_delimited_slices() {
+        let lines = byte_lines(b"one\ntwo\nthree").collect::<Vec<_>>();
+
+        assert_eq!(
+            lines,
+            [b"one".as_slice(), b"two".as_slice(), b"three".as_slice()]
+        );
+    }
 
     #[test]
     fn lines_splits_lf_and_trims_cr() {

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/bin/generate_config_schema.rs"
 
 [dependencies]
 ccusage-cli = { path = "../ccusage-cli" }
+ccusage-jsonl = { path = "../ccusage-jsonl" }
 ccusage-terminal = { path = "../ccusage-terminal" }
 jiff = { version = "0.2.24", default-features = false, features = [
 	"std",

--- a/rust/crates/ccusage/src/adapter/claude/daily.rs
+++ b/rust/crates/ccusage/src/adapter/claude/daily.rs
@@ -6,6 +6,7 @@ use std::{
     thread,
 };
 
+use ccusage_jsonl::byte_lines;
 use jiff::tz::TimeZone as JiffTimeZone;
 use memchr::memmem;
 use serde::Deserialize;
@@ -13,7 +14,7 @@ use serde::Deserialize;
 use crate::{
     calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
-    fast::{byte_lines, suffix_string, FxHashMap, SmallIndexVec},
+    fast::{suffix_string, FxHashMap, SmallIndexVec},
     format_date_tz, log_level, parse_ts_timestamp, parse_tz, ModelBreakdown, PricingMap, Result,
     Speed, TimestampMs, TokenCounts, TokenUsageRaw, UsageSummary,
 };

--- a/rust/crates/ccusage/src/adapter/claude/mod.rs
+++ b/rust/crates/ccusage/src/adapter/claude/mod.rs
@@ -9,6 +9,7 @@ use std::{
     thread,
 };
 
+use ccusage_jsonl::byte_lines;
 use jiff::tz::TimeZone as JiffTimeZone;
 use memchr::memmem;
 use rustc_hash::FxHasher;
@@ -17,7 +18,7 @@ use crate::{
     calculate_cost,
     cli::{CostMode, SharedArgs},
     debug_log,
-    fast::{byte_lines, suffix_string, FxHashMap, SmallIndexVec},
+    fast::{suffix_string, FxHashMap, SmallIndexVec},
     format_date_tz, log_level, parse_ts_timestamp, parse_tz, progress, LoadedEntry, LoadedFile,
     PricingMap, Result, Speed, TimestampMs, UsageEntry, UsageSummary,
 };

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -94,10 +94,17 @@ fn read_codex_session_files_parallel(
 
 fn read_codex_session_file(sessions_dir: &Path, path: &Path) -> Vec<CodexTokenUsageEvent> {
     let mut events = Vec::new();
-    let _ = visit_codex_session_file(sessions_dir, path, |event| {
+    if let Err(error) = visit_codex_session_file(sessions_dir, path, |event| {
         events.push(event);
         Ok(())
-    });
+    }) {
+        if crate::log_level() != Some(0) {
+            eprintln!(
+                "WARN  Failed to read Codex session file {}: {error}",
+                path.display()
+            );
+        }
+    }
     events
 }
 

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -50,7 +50,15 @@ pub(super) fn visit_codex_session_file(
         let line = match lines.next_line() {
             Ok(Some(line)) => line,
             Ok(None) => break,
-            Err(error) => return Err(error.into()),
+            Err(error) => {
+                if crate::log_level() != Some(0) {
+                    eprintln!(
+                        "WARN  Failed to read Codex session file {}: {error}",
+                        path.display()
+                    );
+                }
+                break;
+            }
         };
         let Some(line_kind) = codex_line_usage_kind(line) else {
             continue;

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -46,7 +46,12 @@ pub(super) fn visit_codex_session_file(
     let mut current_model_is_fallback = false;
     let fallback_timestamp = file_modified_timestamp(path);
 
-    while let Ok(Some(line)) = lines.next_line() {
+    loop {
+        let line = match lines.next_line() {
+            Ok(Some(line)) => line,
+            Ok(None) => break,
+            Err(error) => return Err(error.into()),
+        };
         let Some(line_kind) = codex_line_usage_kind(line) else {
             continue;
         };

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -50,15 +50,7 @@ pub(super) fn visit_codex_session_file(
         let line = match lines.next_line() {
             Ok(Some(line)) => line,
             Ok(None) => break,
-            Err(error) => {
-                if crate::log_level() != Some(0) {
-                    eprintln!(
-                        "WARN  Failed to read Codex session file {}: {error}",
-                        path.display()
-                    );
-                }
-                break;
-            }
+            Err(error) => return Err(error.into()),
         };
         let Some(line_kind) = codex_line_usage_kind(line) else {
             continue;

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -1,11 +1,6 @@
-use std::{
-    borrow::Cow,
-    fs,
-    io::{BufRead, BufReader},
-    path::Path,
-    sync::LazyLock,
-};
+use std::{borrow::Cow, fs, path::Path, sync::LazyLock};
 
+use ccusage_jsonl::JsonlFileLines;
 use memchr::memmem::Finder;
 use serde_json::Value;
 
@@ -31,7 +26,6 @@ static INPUT_TOKENS_FIELD_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""input_tokens":"#));
 static PROMPT_TOKENS_FIELD_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""prompt_tokens":"#));
-
 #[derive(Clone, Copy)]
 enum CodexLineKind {
     Session,
@@ -43,31 +37,22 @@ pub(super) fn visit_codex_session_file(
     path: &Path,
     mut visit: impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
-    let Ok(file) = fs::File::open(path) else {
+    let Ok(mut lines) = JsonlFileLines::open_with_capacity(path, 128 * 1024) else {
         return Ok(());
     };
-    let mut reader = BufReader::with_capacity(128 * 1024, file);
-    let mut line = Vec::new();
     let session_id = codex_session_id(sessions_dir, path);
     let mut previous_totals: Option<CodexRawUsage> = None;
     let mut current_model: Option<String> = None;
     let mut current_model_is_fallback = false;
     let fallback_timestamp = file_modified_timestamp(path);
 
-    loop {
-        line.clear();
-        let Ok(bytes_read) = reader.read_until(b'\n', &mut line) else {
-            return Ok(());
-        };
-        if bytes_read == 0 {
-            break;
-        }
-        let Some(line_kind) = codex_line_usage_kind(&line) else {
+    while let Ok(Some(line)) = lines.next_line() {
+        let Some(line_kind) = codex_line_usage_kind(line) else {
             continue;
         };
         match line_kind {
             CodexLineKind::Session => {
-                let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(&line) else {
+                let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(line) else {
                     continue;
                 };
                 visit_codex_session_entry(
@@ -80,7 +65,7 @@ pub(super) fn visit_codex_session_file(
                 )?;
             }
             CodexLineKind::Headless => {
-                if let Ok(value) = serde_json::from_slice::<CodexLogEntry<'_>>(&line) {
+                if let Ok(value) = serde_json::from_slice::<CodexLogEntry<'_>>(line) {
                     add_codex_exec_event(
                         &session_id,
                         &value,
@@ -92,7 +77,7 @@ pub(super) fn visit_codex_session_file(
                 } else {
                     add_codex_exec_event_from_value(
                         &session_id,
-                        &line,
+                        line,
                         &fallback_timestamp,
                         &mut current_model,
                         &mut current_model_is_fallback,

--- a/rust/crates/ccusage/src/adapter/copilot/parser.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/parser.rs
@@ -4,6 +4,7 @@ use std::{
     path::Path,
 };
 
+use ccusage_jsonl::lines_with_marker;
 use serde_json::{Map, Value};
 
 use crate::{apply_total_token_fallback, Result, TimestampMs, TokenUsageRaw};
@@ -53,11 +54,9 @@ struct CopilotUsageCandidate {
 }
 
 pub(super) fn parse_otel_file(path: &Path) -> Result<Vec<CopilotUsageEntry>> {
-    let content = fs::read_to_string(path)?;
-    let records = content
-        .lines()
-        .filter(|line| line.contains("\"attributes\""))
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+    let content = fs::read(path)?;
+    let records = lines_with_marker(&content, br#""attributes""#)
+        .filter_map(|line| serde_json::from_slice::<Value>(line.bytes).ok())
         .filter_map(|value| value.as_object().cloned())
         .collect::<Vec<_>>();
     let trace_contexts = collect_trace_contexts(&records);

--- a/rust/crates/ccusage/src/adapter/droid/parser.rs
+++ b/rust/crates/ccusage/src/adapter/droid/parser.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, fs, io, path::Path};
 
+use ccusage_jsonl::lines;
 use serde_json::Value;
 
 use crate::{
@@ -284,10 +285,10 @@ fn extract_model_from_sidecar_jsonl(settings_path: &Path) -> Result<Option<Strin
         return Ok(None);
     };
     let sidecar = settings_path.with_file_name(format!("{prefix}.jsonl"));
-    let Ok(content) = fs::read_to_string(sidecar) else {
+    let Ok(content) = fs::read(sidecar) else {
         return Ok(None);
     };
-    for line in content.lines().take(500) {
+    for line in lines(&content).take(500).filter_map(|line| line.as_str()) {
         if let Some(model) = extract_droid_model_from_line(line) {
             return Ok(Some(model));
         }

--- a/rust/crates/ccusage/src/adapter/gemini/parser.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/parser.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fs, path::Path, sync::Arc};
 
+use ccusage_jsonl::lines;
 use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{Map, Value};
 
@@ -92,9 +93,9 @@ pub(super) fn parse_jsonl_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
     let mut current_model = None::<String>;
     let mut events = Vec::new();
     let mut direct_event_indexes = HashMap::<String, usize>::new();
-    let content = fs::read_to_string(path)?;
-    for line in content.lines() {
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
+    let content = fs::read(path)?;
+    for line in lines(&content) {
+        let Ok(value) = serde_json::from_slice::<Value>(line.bytes) else {
             continue;
         };
         let Some(record) = value.as_object() else {

--- a/rust/crates/ccusage/src/adapter/kimi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/parser.rs
@@ -4,6 +4,7 @@ use std::{
     sync::Arc,
 };
 
+use ccusage_jsonl::{contains, lines_with_any_marker};
 use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
@@ -34,13 +35,18 @@ pub(super) struct KimiUsageEntry {
 pub(super) fn read_wire_file(path: &Path) -> Result<Vec<KimiUsageEntry>> {
     let model = read_model_from_config(path);
     let fallback_timestamp = file_modified_timestamp(path);
-    let content = fs::read_to_string(path)?;
-    Ok(content
-        .lines()
-        .filter(|line| line.contains("\"StatusUpdate\"") && line.contains("\"token_usage\""))
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .filter_map(|value| wire_line_to_entry(&value, path, &model, fallback_timestamp))
-        .collect::<Vec<_>>())
+    let content = fs::read(path)?;
+    Ok(
+        lines_with_any_marker(&content, &[br#""StatusUpdate""#, br#""token_usage""#])
+            .into_iter()
+            .filter(|line| {
+                contains(line.bytes, br#""StatusUpdate""#)
+                    && contains(line.bytes, br#""token_usage""#)
+            })
+            .filter_map(|line| serde_json::from_slice::<Value>(line.bytes).ok())
+            .filter_map(|value| wire_line_to_entry(&value, path, &model, fallback_timestamp))
+            .collect::<Vec<_>>(),
+    )
 }
 
 fn read_model_from_config(file_path: &Path) -> String {

--- a/rust/crates/ccusage/src/adapter/openclaw/parser.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/parser.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path, sync::Arc};
 
-use ccusage_jsonl::{contains, lines_with_any_marker};
+use ccusage_jsonl::lines_with_any_marker;
 use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{Map, Value};
 
@@ -39,12 +39,6 @@ pub(super) fn parse_session_file(
         &[br#""model_change""#, br#""model-snapshot""#, br#""usage""#],
     ) {
         let line = line.bytes;
-        if !contains(line, br#""model_change""#)
-            && !contains(line, br#""model-snapshot""#)
-            && !contains(line, br#""usage""#)
-        {
-            continue;
-        }
         let Ok(value) = serde_json::from_slice::<Value>(line) else {
             continue;
         };

--- a/rust/crates/ccusage/src/adapter/openclaw/parser.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/parser.rs
@@ -1,7 +1,12 @@
-use std::{fs, path::Path, sync::Arc};
+use std::{
+    fs,
+    path::Path,
+    sync::{Arc, LazyLock},
+};
 
-use ccusage_jsonl::lines_with_any_marker;
+use ccusage_jsonl::JsonlFileLines;
 use jiff::tz::TimeZone as JiffTimeZone;
+use memchr::memmem::Finder;
 use serde_json::{Map, Value};
 
 use crate::{
@@ -24,21 +29,26 @@ struct OpenClawEntry {
     cost: f64,
 }
 
+static MODEL_CHANGE_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(br#""model_change""#));
+static MODEL_SNAPSHOT_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(br#""model-snapshot""#));
+static USAGE_FINDER: LazyLock<Finder<'static>> = LazyLock::new(|| Finder::new(br#""usage""#));
+
 pub(super) fn parse_session_file(
     path: &Path,
     tz: Option<&JiffTimeZone>,
 ) -> Result<Vec<LoadedEntry>> {
     let session_id = extract_session_id(path);
     let fallback_timestamp = file_modified_timestamp(path);
-    let input = fs::read(path)?;
+    let mut lines = JsonlFileLines::open_with_capacity(path, 128 * 1024)?;
     let mut current_model = None::<String>;
     let mut current_provider = None::<String>;
     let mut entries = Vec::new();
-    for line in lines_with_any_marker(
-        &input,
-        &[br#""model_change""#, br#""model-snapshot""#, br#""usage""#],
-    ) {
-        let line = line.bytes;
+    while let Some(line) = lines.next_line()? {
+        if !has_openclaw_marker(line) {
+            continue;
+        }
         let Ok(value) = serde_json::from_slice::<Value>(line) else {
             continue;
         };
@@ -71,6 +81,12 @@ pub(super) fn parse_session_file(
         }
     }
     Ok(entries)
+}
+
+fn has_openclaw_marker(line: &[u8]) -> bool {
+    MODEL_CHANGE_FINDER.find(line).is_some()
+        || MODEL_SNAPSHOT_FINDER.find(line).is_some()
+        || USAGE_FINDER.find(line).is_some()
 }
 
 fn is_model_change(record: &Map<String, Value>) -> bool {

--- a/rust/crates/ccusage/src/adapter/openclaw/parser.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/parser.rs
@@ -1,10 +1,6 @@
-use std::{
-    fs,
-    io::{BufRead, BufReader},
-    path::Path,
-    sync::Arc,
-};
+use std::{fs, path::Path, sync::Arc};
 
+use ccusage_jsonl::{contains, lines_with_any_marker};
 use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{Map, Value};
 
@@ -34,20 +30,22 @@ pub(super) fn parse_session_file(
 ) -> Result<Vec<LoadedEntry>> {
     let session_id = extract_session_id(path);
     let fallback_timestamp = file_modified_timestamp(path);
-    let input = fs::File::open(path)?;
-    let reader = BufReader::new(input);
+    let input = fs::read(path)?;
     let mut current_model = None::<String>;
     let mut current_provider = None::<String>;
     let mut entries = Vec::new();
-    for line in reader.lines() {
-        let line = line?;
-        if !line.contains("\"model_change\"")
-            && !line.contains("\"model-snapshot\"")
-            && !line.contains("\"usage\"")
+    for line in lines_with_any_marker(
+        &input,
+        &[br#""model_change""#, br#""model-snapshot""#, br#""usage""#],
+    ) {
+        let line = line.bytes;
+        if !contains(line, br#""model_change""#)
+            && !contains(line, br#""model-snapshot""#)
+            && !contains(line, br#""usage""#)
         {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+        let Ok(value) = serde_json::from_slice::<Value>(line) else {
             continue;
         };
         let Some(record) = value.as_object() else {

--- a/rust/crates/ccusage/src/adapter/pi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/pi/parser.rs
@@ -1,5 +1,6 @@
 use std::{fs, path::Path, sync::Arc};
 
+use ccusage_jsonl::{contains, lines_with_any_marker};
 use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
@@ -12,16 +13,17 @@ pub(crate) fn read_session_file(
     path: &Path,
     tz: Option<&JiffTimeZone>,
 ) -> Result<Vec<LoadedEntry>> {
-    let content = fs::read_to_string(path)?;
+    let content = fs::read(path)?;
     let project = extract_project(path);
     let session_id = extract_session_id(path);
     let mut entries = Vec::new();
 
-    for line in content.lines() {
-        if !line.contains("\"usage\"") || !line.contains("\"message\"") {
+    for line in lines_with_any_marker(&content, &[br#""usage""#, br#""message""#]) {
+        let line = line.bytes;
+        if !contains(line, br#""usage""#) || !contains(line, br#""message""#) {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
+        let Ok(value) = serde_json::from_slice::<Value>(line) else {
             continue;
         };
         if !is_pi_message_usage(&value) {

--- a/rust/crates/ccusage/src/adapter/qwen/parser.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/parser.rs
@@ -6,7 +6,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use ccusage_jsonl::lines;
+use ccusage_jsonl::JsonlFileLines;
 use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
@@ -52,10 +52,15 @@ fn read_chat_file(
     shared: &SharedArgs,
 ) -> Result<Vec<LoadedEntry>> {
     let fallback = file_timestamp(file, shared);
-    let input = fs::read(file)?;
+    let mut lines = JsonlFileLines::open_with_capacity(file, 128 * 1024)?;
     let mut entries = Vec::new();
-    for line in lines(&input) {
-        let Ok(value) = serde_json::from_slice::<Value>(line.bytes) else {
+    loop {
+        let line = match lines.next_line() {
+            Ok(Some(line)) => line,
+            Ok(None) => break,
+            Err(error) => return Err(error.into()),
+        };
+        let Ok(value) = serde_json::from_slice::<Value>(line) else {
             continue;
         };
         if let Some(entry) = parse_line(file, fallback, &value, tz, mode, pricing) {

--- a/rust/crates/ccusage/src/adapter/qwen/parser.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/parser.rs
@@ -1,12 +1,12 @@
 use std::{
     collections::HashSet,
-    fs::{self, File},
-    io::{BufRead, BufReader},
+    fs,
     path::Path,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use ccusage_jsonl::lines;
 use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
@@ -52,14 +52,10 @@ fn read_chat_file(
     shared: &SharedArgs,
 ) -> Result<Vec<LoadedEntry>> {
     let fallback = file_timestamp(file, shared);
-    let input = File::open(file)?;
-    let reader = BufReader::new(input);
+    let input = fs::read(file)?;
     let mut entries = Vec::new();
-    for line in reader.lines() {
-        let Ok(line) = line else {
-            continue;
-        };
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+    for line in lines(&input) {
+        let Ok(value) = serde_json::from_slice::<Value>(line.bytes) else {
             continue;
         };
         if let Some(entry) = parse_line(file, fallback, &value, tz, mode, pricing) {

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -6,6 +6,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use ccusage_jsonl::lines;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -569,13 +570,12 @@ fn calculate_context_tokens_from_transcript(
     model_id: Option<&str>,
     offline: bool,
 ) -> Option<HookContext> {
-    let content = fs::read_to_string(path).ok()?;
-    for line in content.lines().rev() {
-        let line = line.trim();
-        if line.is_empty() {
+    let content = fs::read(path).ok()?;
+    for line in lines(&content).rev() {
+        if line.bytes.iter().all(u8::is_ascii_whitespace) {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+        let Ok(value) = serde_json::from_slice::<serde_json::Value>(line.bytes) else {
             continue;
         };
         if value.get("type").and_then(serde_json::Value::as_str) != Some("assistant") {

--- a/rust/crates/ccusage/src/fast.rs
+++ b/rust/crates/ccusage/src/fast.rs
@@ -1,42 +1,8 @@
-use memchr::memchr;
 use smallvec::SmallVec;
 
 pub(crate) type FxHashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 pub(crate) type FxHashSet<T> = rustc_hash::FxHashSet<T>;
 pub(crate) type SmallIndexVec = SmallVec<[usize; 1]>;
-
-pub(crate) struct ByteLines<'a> {
-    bytes: &'a [u8],
-}
-
-impl<'a> ByteLines<'a> {
-    pub(crate) fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes }
-    }
-}
-
-impl<'a> Iterator for ByteLines<'a> {
-    type Item = &'a [u8];
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.bytes.is_empty() {
-            return None;
-        }
-        if let Some(newline) = memchr(b'\n', self.bytes) {
-            let (line, rest) = self.bytes.split_at(newline);
-            self.bytes = &rest[1..];
-            Some(line)
-        } else {
-            let line = self.bytes;
-            self.bytes = &[];
-            Some(line)
-        }
-    }
-}
-
-pub(crate) fn byte_lines(bytes: &[u8]) -> ByteLines<'_> {
-    ByteLines::new(bytes)
-}
 
 pub(crate) fn suffix_string(value: &str, suffix: &str) -> String {
     let mut output = String::with_capacity(value.len() + suffix.len());
@@ -47,17 +13,7 @@ pub(crate) fn suffix_string(value: &str, suffix: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{byte_lines, suffix_string};
-
-    #[test]
-    fn byte_lines_returns_newline_delimited_slices() {
-        let lines = byte_lines(b"one\ntwo\nthree").collect::<Vec<_>>();
-
-        assert_eq!(
-            lines,
-            [b"one".as_slice(), b"two".as_slice(), b"three".as_slice()]
-        );
-    }
+    use super::suffix_string;
 
     #[test]
     fn suffix_string_builds_without_formatting() {


### PR DESCRIPTION
Summary:
- Add an internal ccusage-jsonl crate with byte-slice JSONL line iteration, marker-filtered scanning, and a reusable streaming file-line reader.
- Move JSONL readers onto shared byte-oriented helpers where practical, including Claude using the shared byte_lines primitive while keeping its existing marker checks on the hot path.
- Keep large-file parsers streaming where needed, including Codex and Qwen, and surface streaming read errors instead of treating them as EOF.

Testing:
- nix develop --command cargo fmt --manifest-path rust/Cargo.toml --all
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage-jsonl
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::claude
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::codex
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::openclaw
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::qwen
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::
- nix develop --command cargo build --manifest-path rust/Cargo.toml -p ccusage
- nix develop --command cargo build --manifest-path rust/Cargo.toml --release -p ccusage
- nix develop --command cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings

Output parity:
- bunx ccusage@20.0.5 daily --until 20260526 --offline --json matched the branch release output after jq -S.
- bunx ccusage@20.0.5 monthly --until 20260526 --offline --json matched the branch release output after jq -S.

Local performance:
- Rust release vs origin/main, generated ~64MiB fixtures after the follow-up: Claude claude daily mean 50.3ms -> 48.2ms; Codex daily mean 41.1ms -> 39.1ms.
- Earlier Rust release checks against committed fixtures were parity/no-regression for Claude and Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lightweight, allocation‑light JSONL parser with buffered reading, reverse iteration, CRLF trimming, and marker‑based searches.

* **Refactor**
  * Multiple adapters now consume JSONL as raw bytes via the new parser for more efficient, consistent record handling.

* **Bug Fixes**
  * JSONL iteration and parsing surface I/O/parse errors instead of silently ignoring them.

* **Chores**
  * Integrated the new parser into the workspace and updated adapters to use it.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->