### PR TITLE
fix(pricing): add Claude Opus 4.8 rates

### DIFF
--- a/rust/crates/ccusage/src/fast-multiplier-overrides.json
+++ b/rust/crates/ccusage/src/fast-multiplier-overrides.json
@@ -6,6 +6,7 @@
 	},
 	"normalized_prefix": {
 		"claude-opus-4-6": 6.0,
-		"claude-opus-4-7": 6.0
+		"claude-opus-4-7": 6.0,
+		"claude-opus-4-8": 2.0
 	}
 }

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -11,6 +11,7 @@ const LITELLM_PRICING_URL: &str =
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 const PRICING_FETCH_TIMEOUT_SECONDS: u64 = 10;
 const PRICING_FETCH_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const MODEL_DATE_SUFFIX_DIGITS: usize = 8;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Pricing {
@@ -651,7 +652,7 @@ fn suffix_starts_with_numeric_model_version(key: &str, suffix: &str) -> bool {
         return false;
     }
     let after_digits = rest.as_bytes().get(digit_len).copied();
-    !(digit_len == 8 && after_digits.is_none_or(is_pricing_key_boundary))
+    !(digit_len == MODEL_DATE_SUFFIX_DIGITS && after_digits.is_none_or(is_pricing_key_boundary))
 }
 
 /// Normalizes known model separator variants without allocating for canonical keys.

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -260,6 +260,23 @@ impl PricingMap {
             },
         );
         self.entries.insert(
+            "claude-opus-4-8".to_string(),
+            Pricing {
+                input: 5e-6,
+                output: 25e-6,
+                cache_create: 6.25e-6,
+                cache_read: 0.5e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: fast_multiplier_overrides
+                    .multiplier_for("claude-opus-4-8")
+                    .unwrap_or(1.0),
+            },
+        );
+        self.entries.insert(
             "claude-haiku-4-5".to_string(),
             Pricing {
                 input: 1e-6,
@@ -550,7 +567,12 @@ impl PricingMap {
         self.context_limits
             .insert("grok-4.3".to_string(), 1_000_000);
         self.context_limits.insert("gpt-5.4".to_string(), 1_050_000);
-        for model in ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"] {
+        for model in [
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+        ] {
             self.context_limits.insert(model.to_string(), 1_000_000);
         }
         self.context_limits
@@ -591,14 +613,45 @@ fn contains_pricing_key(value: &str, key: &str) -> bool {
             .checked_sub(1)
             .and_then(|before| value.as_bytes().get(before))
             .copied();
-        let after = value.as_bytes().get(index + key.len()).copied();
-        before.is_none_or(is_pricing_key_boundary) && after.is_none_or(is_pricing_key_boundary)
+        let suffix = &value[index + key.len()..];
+        before.is_none_or(is_pricing_key_boundary) && suffix_allows_pricing_key_match(key, suffix)
     })
 }
 
 /// Treats punctuation separators as boundaries, but not adjacent version digits.
 fn is_pricing_key_boundary(byte: u8) -> bool {
     !byte.is_ascii_alphanumeric()
+}
+
+fn suffix_allows_pricing_key_match(key: &str, suffix: &str) -> bool {
+    let Some(separator) = suffix.as_bytes().first().copied() else {
+        return true;
+    };
+    if !is_pricing_key_boundary(separator) {
+        return false;
+    }
+    !suffix_starts_with_numeric_model_version(key, suffix)
+}
+
+fn suffix_starts_with_numeric_model_version(key: &str, suffix: &str) -> bool {
+    if !key.as_bytes().last().is_some_and(u8::is_ascii_digit) {
+        return false;
+    }
+    if !matches!(suffix.as_bytes().first(), Some(b'-' | b'.')) {
+        return false;
+    }
+
+    let rest = &suffix[1..];
+    let digit_len = rest
+        .as_bytes()
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digit_len == 0 {
+        return false;
+    }
+    let after_digits = rest.as_bytes().get(digit_len).copied();
+    !(digit_len == 8 && after_digits.is_none_or(is_pricing_key_boundary))
 }
 
 /// Normalizes known model separator variants without allocating for canonical keys.
@@ -807,6 +860,13 @@ mod tests {
                 .fast_multiplier,
             6.0
         );
+        assert_eq!(
+            pricing
+                .find("anthropic.claude-opus-4-8")
+                .unwrap()
+                .fast_multiplier,
+            2.0
+        );
     }
 
     #[test]
@@ -825,6 +885,18 @@ mod tests {
                 .input,
             5e-6
         );
+    }
+
+    #[test]
+    fn embedded_pricing_resolves_opus_48_dot_model_names() {
+        let pricing = PricingMap::load_embedded();
+
+        let opus_48 = pricing.find("claude-opus-4.8-20260528").unwrap();
+        assert_eq!(opus_48.input, 5e-6);
+        assert_eq!(opus_48.output, 25e-6);
+        assert_eq!(opus_48.cache_create, 6.25e-6);
+        assert_eq!(opus_48.cache_read, 0.5e-6);
+        assert_eq!(pricing.context_limit("claude-opus-4.8"), Some(1_000_000));
     }
 
     #[test]
@@ -885,7 +957,31 @@ mod tests {
             },
         );
 
-        assert_eq!(pricing.find("claude-opus-4.70").unwrap().input, 15e-6);
+        assert!(pricing.find("claude-opus-4.70").is_none());
+    }
+
+    #[test]
+    fn fuzzy_match_does_not_fall_back_across_numeric_model_versions() {
+        let mut pricing = PricingMap::default();
+        pricing.entries.insert(
+            "claude-opus-4".to_string(),
+            Pricing {
+                input: 15e-6,
+                output: 75e-6,
+                cache_create: 18.75e-6,
+                cache_read: 1.5e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
+
+        assert!(pricing.find("claude-opus-4.8-20260528").is_none());
+        assert!(pricing.find("claude-opus-4.70").is_none());
+        assert!(pricing.find("claude-opus-4-20250514").is_some());
     }
 
     #[test]
@@ -939,6 +1035,10 @@ mod tests {
                     "input_cost_per_token": 0.000005,
                     "output_cost_per_token": 0.000025
                 },
+                "claude-opus-4.8-20260528": {
+                    "input_cost_per_token": 0.000005,
+                    "output_cost_per_token": 0.000025
+                },
                 "claude-opus-4-70": {
                     "input_cost_per_token": 0.000005,
                     "output_cost_per_token": 0.000025
@@ -966,6 +1066,13 @@ mod tests {
                 .unwrap()
                 .fast_multiplier,
             6.0
+        );
+        assert_eq!(
+            pricing
+                .find("claude-opus-4.8-20260528")
+                .unwrap()
+                .fast_multiplier,
+            2.0
         );
         assert_eq!(
             pricing.find("claude-opus-4-70").unwrap().fast_multiplier,

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -11,6 +11,8 @@ const LITELLM_PRICING_URL: &str =
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 const PRICING_FETCH_TIMEOUT_SECONDS: u64 = 10;
 const PRICING_FETCH_MAX_BYTES: u64 = 64 * 1024 * 1024;
+// Anthropic date-suffixed model aliases use YYYYMMDD, while other numeric
+// suffixes are treated as distinct model versions.
 const MODEL_DATE_SUFFIX_DIGITS: usize = 8;
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Adds embedded Claude Opus 4.8 pricing so offline reports and pricing refresh failures use the current Opus 4.8 rates instead of falling back to deprecated Opus 4 pricing.

Also updates Claude fast-mode multipliers so Opus 4.8 uses the current 2x rate, while Opus 4.6 and 4.7 remain at 6x. Pricing-key fuzzy matching now allows date-suffixed aliases but avoids falling back across unknown numeric model versions.

Testing:
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage pricing::tests
- nix develop --command pnpm run format
- pre-push hook via nix develop --command git push -u origin codex/fix-opus-48-pricing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embed Claude Opus 4.8 pricing and set the correct fast-mode rate so offline reports use current costs instead of falling back to deprecated Opus 4. Also tighten model-name matching with a named YYYYMMDD date-suffix rule to allow date aliases without crossing numeric versions.

- New Features
  - Added embedded rates for `claude-opus-4-8` (input 5e-6, output 25e-6; cache create 6.25e-6; cache read 0.5e-6) and a 1,000,000 token context limit.
  - Updated fast multiplier: `claude-opus-4-8` = 2x; `claude-opus-4-6` and `claude-opus-4-7` remain 6x.

- Bug Fixes
  - Offline and pricing-refresh failures no longer fall back from 4.8 to `claude-opus-4`.
  - Fuzzy matching accepts date-suffixed IDs (e.g., `claude-opus-4.8-20260528`) via a documented 8-digit YYYYMMDD rule, and blocks cross-version fallbacks (e.g., `4.8` or `4.70` do not match `4`).

<sup>Written for commit 2688af02546f14c5d5edfe07b6e8c3fdf0fe1905. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1182?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for claude-opus-4-8 with configured fast multiplier and matching context limit.

* **Bug Fixes**
  * Improved model-version matching to prevent incorrect pricing or configuration fallbacks between similar variants.

* **Tests**
  * Extended unit tests and fixtures to validate new model handling and fuzzy-match regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->