### PR TITLE
fix(release): skip native rebuild when packaged binary works

### DIFF
--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -29,8 +29,9 @@
 	},
 	"scripts": {
 		"bench": "node scripts/bench.mjs",
-		"build": "pnpm run generate:schema && tsdown && pnpm run build:rust",
+		"build": "pnpm run generate:schema && tsdown && pnpm run ensure:native-binary",
 		"build:rust": "cargo build --manifest-path ../../rust/Cargo.toml --release --bin ccusage",
+		"ensure:native-binary": "bun scripts/ensure-native-binary.ts",
 		"format": "oxfmt --write .",
 		"generate:schema": "cargo run --quiet --manifest-path ../../rust/Cargo.toml --bin generate-config-schema -- config-schema.json && oxfmt --write config-schema.json && cp config-schema.json ../../docs/public/config-schema.json",
 		"lint": "oxlint .",

--- a/apps/ccusage/scripts/ensure-native-binary.ts
+++ b/apps/ccusage/scripts/ensure-native-binary.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env bun
+
+import { join, resolve } from 'node:path';
+import { arch, platform } from 'node:process';
+
+const nativePackageDirs = new Map([
+	['darwin-arm64', 'ccusage-darwin-arm64'],
+	['darwin-x64', 'ccusage-darwin-x64'],
+	['linux-arm64', 'ccusage-linux-arm64'],
+	['linux-x64', 'ccusage-linux-x64'],
+	['win32-arm64', 'ccusage-win32-arm64'],
+	['win32-x64', 'ccusage-win32-x64'],
+]);
+
+const repoRoot = resolve(import.meta.dir, '../../..');
+const targetKey = `${platform}-${arch}`;
+const nativePackageDir = nativePackageDirs.get(targetKey);
+const binaryName = platform === 'win32' ? 'ccusage.exe' : 'ccusage';
+const nativePackageRoot =
+	nativePackageDir == null ? undefined : join(repoRoot, 'packages', nativePackageDir);
+const nativeBinary =
+	nativePackageRoot == null ? undefined : join(nativePackageRoot, 'bin', binaryName);
+const cargoBinary = join(repoRoot, 'rust', 'target', 'release', binaryName);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value != null && !Array.isArray(value);
+}
+
+async function nativePackageIncludesBinary(packageRoot: string | undefined): Promise<boolean> {
+	if (packageRoot == null) {
+		return false;
+	}
+	const packageJson: unknown = await Bun.file(join(packageRoot, 'package.json')).json();
+	if (!isRecord(packageJson)) {
+		return false;
+	}
+	const files = packageJson.files;
+	return Array.isArray(files) && files.includes(`bin/${binaryName}`);
+}
+
+async function canRunVersion(binary: string | undefined): Promise<boolean> {
+	if (binary == null) {
+		return false;
+	}
+	const result = await Bun.$`${binary} --version`.quiet().nothrow();
+	return result.exitCode === 0;
+}
+
+if ((await nativePackageIncludesBinary(nativePackageRoot)) && (await canRunVersion(nativeBinary))) {
+	process.exit(0);
+}
+
+await Bun.$`cargo build --manifest-path ${join(repoRoot, 'rust', 'Cargo.toml')} --release --bin ccusage`;
+
+if (!(await canRunVersion(cargoBinary))) {
+	throw new Error(`${cargoBinary} did not run --version after cargo build`);
+}

--- a/apps/ccusage/scripts/ensure-native-binary.ts
+++ b/apps/ccusage/scripts/ensure-native-binary.ts
@@ -40,7 +40,12 @@ async function nativePackageIncludesBinary(packageRoot: string | undefined): Pro
 	if (packageRoot == null) {
 		return false;
 	}
-	const packageJson: unknown = await Bun.file(join(packageRoot, 'package.json')).json();
+	let packageJson: unknown;
+	try {
+		packageJson = await Bun.file(join(packageRoot, 'package.json')).json();
+	} catch {
+		return false;
+	}
 	if (!isRecord(packageJson)) {
 		return false;
 	}

--- a/apps/ccusage/scripts/ensure-native-binary.ts
+++ b/apps/ccusage/scripts/ensure-native-binary.ts
@@ -26,6 +26,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value != null && !Array.isArray(value);
 }
 
+async function expectedVersion(): Promise<string> {
+	const packageJson: unknown = await Bun.file(
+		join(repoRoot, 'apps', 'ccusage', 'package.json'),
+	).json();
+	if (!isRecord(packageJson) || typeof packageJson.version !== 'string') {
+		throw new TypeError('apps/ccusage/package.json version is not configured');
+	}
+	return packageJson.version;
+}
+
 async function nativePackageIncludesBinary(packageRoot: string | undefined): Promise<boolean> {
 	if (packageRoot == null) {
 		return false;
@@ -38,20 +48,29 @@ async function nativePackageIncludesBinary(packageRoot: string | undefined): Pro
 	return Array.isArray(files) && files.includes(`bin/${binaryName}`);
 }
 
-async function canRunVersion(binary: string | undefined): Promise<boolean> {
+async function hasExpectedVersion(binary: string | undefined, version: string): Promise<boolean> {
 	if (binary == null) {
 		return false;
 	}
 	const result = await Bun.$`${binary} --version`.quiet().nothrow();
-	return result.exitCode === 0;
+	if (result.exitCode !== 0) {
+		return false;
+	}
+	const actualVersion = result.stdout.toString().trim().split(/\s+/).at(-1);
+	return actualVersion === version;
 }
 
-if ((await nativePackageIncludesBinary(nativePackageRoot)) && (await canRunVersion(nativeBinary))) {
+const version = await expectedVersion();
+
+if (
+	(await nativePackageIncludesBinary(nativePackageRoot)) &&
+	(await hasExpectedVersion(nativeBinary, version))
+) {
 	process.exit(0);
 }
 
 await Bun.$`cargo build --manifest-path ${join(repoRoot, 'rust', 'Cargo.toml')} --release --bin ccusage`;
 
-if (!(await canRunVersion(cargoBinary))) {
-	throw new Error(`${cargoBinary} did not run --version after cargo build`);
+if (!(await hasExpectedVersion(cargoBinary, version))) {
+	throw new Error(`${cargoBinary} did not report version ${version} after cargo build`);
 }


### PR DESCRIPTION
Avoids rebuilding the Rust release binary during ccusage package builds when the current platform native package already contains a working binary.

The new Bun guard checks that the platform package declares the expected binary in package.json#files and that the binary runs --version. If either check fails, it falls back to the previous cargo release build and verifies the rebuilt binary.

Testing:
- nix develop --command oxfmt --check apps/ccusage/package.json apps/ccusage/scripts/ensure-native-binary.ts
- nix develop --command pnpm --filter='./apps/ccusage' typecheck
- nix develop --command pnpm --filter='./apps/ccusage' run ensure:native-binary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip rebuilding the Rust CLI during `apps/ccusage` builds when a working platform-native binary with the same version is available. Adds a Bun guard that verifies the packaged binary and only runs Cargo when checks fail.

- **Refactors**
  - Build uses `ensure:native-binary` (Bun) instead of `build:rust`.
  - Guard only skips Cargo when the platform package (e.g., `ccusage-darwin-arm64`, `ccusage-linux-x64`) lists `bin/ccusage` in `files` and its `--version` matches `apps/ccusage` package.json; missing/invalid metadata or a version mismatch triggers `cargo build --release`, then the rebuilt binary is verified.

<sup>Written for commit 9ee31c0ea813b0d5046d76d3358b39bc0a75a68a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1183?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build flow now verifies a platform-appropriate prebuilt native binary before compiling, reducing unnecessary rebuilds.
  * Added an automated verification step that runs the native binary version check and falls back to building only when verification fails, improving build speed and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->