### PR TITLE
fix(pricing): fall back to models.dev pricing

### DIFF
--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -211,7 +211,7 @@ impl PricingMap {
         for provider in raw.into_values() {
             for (model_key, model) in provider.models {
                 let model_id = model.id.unwrap_or(model_key);
-                if self.find_entry(&model_id).is_some() {
+                if self.entries.contains_key(&model_id) {
                     continue;
                 }
                 let Some(cost) = model.cost else {
@@ -897,6 +897,11 @@ mod tests {
                     "output_cost_per_token": 0.000010,
                     "cache_read_input_token_cost": 0.0000001,
                     "max_input_tokens": 123
+                },
+                "openrouter/gpt-alias": {
+                    "input_cost_per_token": 0.000003,
+                    "output_cost_per_token": 0.000030,
+                    "max_input_tokens": 321
                 }
             }"#,
         );
@@ -931,6 +936,17 @@ mod tests {
                             "limit": {
                                 "context": 456
                             }
+                        },
+                        "gpt-alias": {
+                            "id": "gpt-alias",
+                            "name": "GPT Alias",
+                            "cost": {
+                                "input": 4.0,
+                                "output": 16.0
+                            },
+                            "limit": {
+                                "context": 654
+                            }
                         }
                     }
                 }
@@ -938,11 +954,12 @@ mod tests {
 
         assert_eq!(
             pricing.load_models_dev_json_missing(models_dev_json),
-            Some(1)
+            Some(2)
         );
 
         let primary = pricing.find("gpt-primary").unwrap();
         let fallback = pricing.find("gpt-fallback").unwrap();
+        let alias = pricing.entries.get("gpt-alias").unwrap();
 
         assert_eq!(primary.input, 1e-6);
         assert_eq!(primary.output, 10e-6);
@@ -957,6 +974,8 @@ mod tests {
         assert_eq!(fallback.output_above_200k, None);
         assert_eq!(fallback.fast_multiplier, 1.0);
         assert_eq!(pricing.context_limit("gpt-fallback"), Some(456));
+        assert!((alias.input - 4e-6).abs() < f64::EPSILON);
+        assert_eq!(pricing.context_limits.get("gpt-alias"), Some(&654));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -58,6 +58,31 @@ struct ModelsDevProvider {
     models: FxHashMap<String, ModelsDevModel>,
 }
 
+struct ModelsDevPricingCache {
+    pricing: OnceLock<PricingMap>,
+}
+
+impl ModelsDevPricingCache {
+    const fn new() -> Self {
+        Self {
+            pricing: OnceLock::new(),
+        }
+    }
+
+    fn get_or_try_load<F>(&self, fetch_json: F) -> Option<&PricingMap>
+    where
+        F: FnOnce() -> std::io::Result<String>,
+    {
+        if let Some(pricing) = self.pricing.get() {
+            return Some(pricing);
+        }
+
+        let map = load_models_dev_pricing(fetch_json)?;
+        let _ = self.pricing.set(map);
+        self.pricing.get()
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct ModelsDevModel {
     id: Option<String>,
@@ -728,30 +753,33 @@ fn should_log_pricing_refresh_details() -> bool {
 }
 
 fn models_dev_pricing() -> Option<&'static PricingMap> {
-    static MODELS_DEV_PRICING: OnceLock<Option<PricingMap>> = OnceLock::new();
-    MODELS_DEV_PRICING
-        .get_or_init(|| {
-            let json = match fetch_models_dev_json() {
-                Ok(json) => json,
-                Err(error) => {
-                    if should_log_pricing_refresh_details() {
-                        eprintln!(
-                            "WARN  Failed to fetch models.dev pricing ({error}); using LiteLLM pricing."
-                        );
-                    }
-                    return None;
-                }
-            };
-            let mut map = PricingMap::default();
-            if map.load_models_dev_json_missing(&json).is_none() {
-                if should_log_pricing_refresh_details() {
-                    eprintln!("WARN  Failed to parse models.dev pricing; using LiteLLM pricing.");
-                }
-                return None;
+    static MODELS_DEV_PRICING: ModelsDevPricingCache = ModelsDevPricingCache::new();
+    MODELS_DEV_PRICING.get_or_try_load(fetch_models_dev_json)
+}
+
+fn load_models_dev_pricing<F>(fetch_json: F) -> Option<PricingMap>
+where
+    F: FnOnce() -> std::io::Result<String>,
+{
+    let json = match fetch_json() {
+        Ok(json) => json,
+        Err(error) => {
+            if should_log_pricing_refresh_details() {
+                eprintln!(
+                    "WARN  Failed to fetch models.dev pricing ({error}); using LiteLLM pricing."
+                );
             }
-            Some(map)
-        })
-        .as_ref()
+            return None;
+        }
+    };
+    let mut map = PricingMap::default();
+    if map.load_models_dev_json_missing(&json).is_none() {
+        if should_log_pricing_refresh_details() {
+            eprintln!("WARN  Failed to parse models.dev pricing; using LiteLLM pricing.");
+        }
+        return None;
+    }
+    Some(map)
 }
 
 fn fetch_pricing_json() -> std::io::Result<String> {
@@ -884,6 +912,51 @@ mod tests {
     fn keeps_models_dev_fallback_disabled_for_embedded_and_offline_pricing() {
         assert!(!PricingMap::load_embedded().models_dev_fallback_enabled());
         assert!(!PricingMap::load(true, false).models_dev_fallback_enabled());
+    }
+
+    #[test]
+    fn retries_models_dev_pricing_after_fetch_failure() {
+        let cache = super::ModelsDevPricingCache::new();
+
+        let failed = cache.get_or_try_load(|| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "temporary failure",
+            ))
+        });
+        assert!(failed.is_none());
+
+        let pricing = cache
+            .get_or_try_load(|| {
+                Ok(r#"{
+                    "openai": {
+                        "id": "openai",
+                        "name": "OpenAI",
+                        "models": {
+                            "gpt-retry": {
+                                "id": "gpt-retry",
+                                "name": "GPT Retry",
+                                "cost": {
+                                    "input": 1.0,
+                                    "output": 2.0
+                                },
+                                "limit": {
+                                    "context": 42
+                                }
+                            }
+                        }
+                    }
+                }"#
+                .to_string())
+            })
+            .expect("models.dev retry should cache successful pricing");
+
+        let gpt_retry = pricing
+            .find_entry("gpt-retry")
+            .expect("successful retry should load pricing");
+        assert_eq!(gpt_retry.input, 0.000001);
+        assert_eq!(gpt_retry.output, 0.000002);
+        assert_eq!(pricing.context_limit_entry("gpt-retry"), Some(42));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, sync::OnceLock, time::Duration};
+use std::{
+    borrow::Cow,
+    sync::{Mutex, OnceLock},
+    time::{Duration, Instant},
+};
 
 use serde::Deserialize;
 
@@ -12,6 +16,7 @@ const LITELLM_PRICING_URL: &str =
 const MODELS_DEV_API_URL: &str = "https://models.dev/api.json";
 const PRICING_FETCH_TIMEOUT_SECONDS: u64 = 10;
 const PRICING_FETCH_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const MODELS_DEV_FAILURE_RETRY_AFTER: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Pricing {
@@ -60,12 +65,16 @@ struct ModelsDevProvider {
 
 struct ModelsDevPricingCache {
     pricing: OnceLock<PricingMap>,
+    last_failure: Mutex<Option<Instant>>,
+    failure_retry_after: Duration,
 }
 
 impl ModelsDevPricingCache {
-    const fn new() -> Self {
+    const fn new(failure_retry_after: Duration) -> Self {
         Self {
             pricing: OnceLock::new(),
+            last_failure: Mutex::new(None),
+            failure_retry_after,
         }
     }
 
@@ -76,9 +85,22 @@ impl ModelsDevPricingCache {
         if let Some(pricing) = self.pricing.get() {
             return Some(pricing);
         }
+        if self.last_failure.lock().is_ok_and(|last_failure| {
+            last_failure.is_some_and(|failed_at| failed_at.elapsed() < self.failure_retry_after)
+        }) {
+            return None;
+        }
 
-        let map = load_models_dev_pricing(fetch_json)?;
+        let Some(map) = load_models_dev_pricing(fetch_json) else {
+            if let Ok(mut last_failure) = self.last_failure.lock() {
+                *last_failure = Some(Instant::now());
+            }
+            return None;
+        };
         let _ = self.pricing.set(map);
+        if let Ok(mut last_failure) = self.last_failure.lock() {
+            *last_failure = None;
+        }
         self.pricing.get()
     }
 }
@@ -753,7 +775,8 @@ fn should_log_pricing_refresh_details() -> bool {
 }
 
 fn models_dev_pricing() -> Option<&'static PricingMap> {
-    static MODELS_DEV_PRICING: ModelsDevPricingCache = ModelsDevPricingCache::new();
+    static MODELS_DEV_PRICING: ModelsDevPricingCache =
+        ModelsDevPricingCache::new(MODELS_DEV_FAILURE_RETRY_AFTER);
     MODELS_DEV_PRICING.get_or_try_load(fetch_models_dev_json)
 }
 
@@ -816,6 +839,7 @@ fn fetch_json_url(url: &str) -> std::io::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{Pricing, PricingMap, BUILD_TIME_PRICING_JSON};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn loads_embedded_claude_pricing() {
@@ -916,7 +940,7 @@ mod tests {
 
     #[test]
     fn retries_models_dev_pricing_after_fetch_failure() {
-        let cache = super::ModelsDevPricingCache::new();
+        let cache = super::ModelsDevPricingCache::new(std::time::Duration::ZERO);
 
         let failed = cache.get_or_try_load(|| {
             Err(std::io::Error::new(
@@ -957,6 +981,44 @@ mod tests {
         assert_eq!(gpt_retry.input, 0.000001);
         assert_eq!(gpt_retry.output, 0.000002);
         assert_eq!(pricing.context_limit_entry("gpt-retry"), Some(42));
+    }
+
+    #[test]
+    fn backs_off_models_dev_pricing_after_fetch_failure() {
+        let cache = super::ModelsDevPricingCache::new(std::time::Duration::from_secs(60));
+        let attempts = AtomicUsize::new(0);
+
+        let failed = cache.get_or_try_load(|| {
+            attempts.fetch_add(1, Ordering::Relaxed);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "temporary failure",
+            ))
+        });
+        assert!(failed.is_none());
+
+        let skipped = cache.get_or_try_load(|| {
+            attempts.fetch_add(1, Ordering::Relaxed);
+            Ok(r#"{
+                "openai": {
+                    "id": "openai",
+                    "name": "OpenAI",
+                    "models": {
+                        "gpt-skipped": {
+                            "id": "gpt-skipped",
+                            "name": "GPT Skipped",
+                            "cost": {
+                                "input": 1.0,
+                                "output": 2.0
+                            }
+                        }
+                    }
+                }
+            }"#
+            .to_string())
+        });
+        assert!(skipped.is_none());
+        assert_eq!(attempts.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -283,8 +283,7 @@ impl PricingMap {
         self.context_limit_entry(model).or_else(|| {
             self.enable_models_dev_fallback
                 .then(|| {
-                    models_dev_pricing()
-                        .and_then(|pricing| pricing.context_limit_entry(model))
+                    models_dev_pricing().and_then(|pricing| pricing.context_limit_entry(model))
                 })
                 .flatten()
         })

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -9,6 +9,7 @@ const BUILD_TIME_PRICING_JSON: &str =
 const FAST_MULTIPLIER_OVERRIDES_JSON: &str = include_str!("fast-multiplier-overrides.json");
 const LITELLM_PRICING_URL: &str =
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+const MODELS_DEV_API_URL: &str = "https://models.dev/api.json";
 const PRICING_FETCH_TIMEOUT_SECONDS: u64 = 10;
 const PRICING_FETCH_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
@@ -49,6 +50,31 @@ struct LiteLlmPricing {
 #[derive(Debug, Deserialize)]
 struct ProviderSpecificEntry {
     fast: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelsDevProvider {
+    models: FxHashMap<String, ModelsDevModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelsDevModel {
+    id: Option<String>,
+    cost: Option<ModelsDevCost>,
+    limit: Option<ModelsDevLimit>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelsDevCost {
+    input: Option<f64>,
+    output: Option<f64>,
+    cache_read: Option<f64>,
+    cache_write: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelsDevLimit {
+    context: Option<u64>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -114,6 +140,29 @@ impl PricingMap {
                 }
             }
         }
+
+        let fetch_result = crate::progress::track_status(
+            log && crate::progress::usage_load_output_is_tty(),
+            "Refreshing fallback model pricing from models.dev...",
+            fetch_models_dev_json,
+        );
+
+        match fetch_result {
+            Ok(json) => {
+                if map.load_models_dev_json_missing(&json).is_none()
+                    && should_log_pricing_refresh_details()
+                {
+                    eprintln!("WARN  Failed to parse models.dev pricing; using LiteLLM pricing.");
+                }
+            }
+            Err(error) => {
+                if should_log_pricing_refresh_details() {
+                    eprintln!(
+                        "WARN  Failed to fetch models.dev pricing ({error}); using LiteLLM pricing."
+                    );
+                }
+            }
+        }
         map
     }
 
@@ -172,6 +221,59 @@ impl PricingMap {
             loaded_count += 1;
         }
         loaded_count
+    }
+
+    fn load_models_dev_json_missing(&mut self, json: &str) -> Option<usize> {
+        let Ok(raw) = serde_json::from_str::<FxHashMap<String, ModelsDevProvider>>(json) else {
+            return None;
+        };
+        let mut loaded_count = 0;
+        for provider in raw.into_values() {
+            for (model_key, model) in provider.models {
+                let model_id = model.id.unwrap_or(model_key);
+                if self.find(&model_id).is_some() {
+                    continue;
+                }
+                let Some(cost) = model.cost else {
+                    continue;
+                };
+                let Some(input) = cost.input else {
+                    continue;
+                };
+                let Some(output) = cost.output else {
+                    continue;
+                };
+                let input = input / 1_000_000.0;
+                let output = output / 1_000_000.0;
+                let cache_read_explicit = cost.cache_read.is_some();
+                self.entries.insert(
+                    model_id.clone(),
+                    Pricing {
+                        input,
+                        output,
+                        cache_create: cost
+                            .cache_write
+                            .map(|value| value / 1_000_000.0)
+                            .unwrap_or(input * 1.25),
+                        cache_read: cost
+                            .cache_read
+                            .map(|value| value / 1_000_000.0)
+                            .unwrap_or(input * 0.1),
+                        cache_read_explicit,
+                        input_above_200k: None,
+                        output_above_200k: None,
+                        cache_create_above_200k: None,
+                        cache_read_above_200k: None,
+                        fast_multiplier: 1.0,
+                    },
+                );
+                if let Some(context_limit) = model.limit.and_then(|limit| limit.context) {
+                    self.context_limits.insert(model_id, context_limit);
+                }
+                loaded_count += 1;
+            }
+        }
+        Some(loaded_count)
     }
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
@@ -623,12 +725,20 @@ fn should_log_pricing_refresh_details() -> bool {
 }
 
 fn fetch_pricing_json() -> std::io::Result<String> {
+    fetch_json_url(LITELLM_PRICING_URL)
+}
+
+fn fetch_models_dev_json() -> std::io::Result<String> {
+    fetch_json_url(MODELS_DEV_API_URL)
+}
+
+fn fetch_json_url(url: &str) -> std::io::Result<String> {
     let agent = ureq::Agent::config_builder()
         .timeout_global(Some(Duration::from_secs(PRICING_FETCH_TIMEOUT_SECONDS)))
         .build()
         .new_agent();
     let mut response = agent
-        .get(LITELLM_PRICING_URL)
+        .get(url)
         .call()
         .map_err(|error| std::io::Error::other(error.to_string()))?;
     if response.status().as_u16() != 200 {
@@ -738,6 +848,78 @@ mod tests {
         assert_eq!(loaded, 1);
         assert!(pricing.find("gpt-valid").is_some());
         assert_eq!(pricing.context_limit("gpt-valid"), Some(123));
+    }
+
+    #[test]
+    fn loads_missing_models_dev_pricing_without_overriding_litellm() {
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{
+                "gpt-primary": {
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000010,
+                    "cache_read_input_token_cost": 0.0000001,
+                    "max_input_tokens": 123
+                }
+            }"#,
+        );
+
+        let models_dev_json = r#"{
+                "openai": {
+                    "id": "openai",
+                    "name": "OpenAI",
+                    "models": {
+                        "gpt-primary": {
+                            "id": "gpt-primary",
+                            "name": "GPT Primary",
+                            "cost": {
+                                "input": 9.0,
+                                "output": 90.0,
+                                "cache_read": 0.9,
+                                "cache_write": 11.25
+                            },
+                            "limit": {
+                                "context": 999
+                            }
+                        },
+                        "gpt-fallback": {
+                            "id": "gpt-fallback",
+                            "name": "GPT Fallback",
+                            "cost": {
+                                "input": 2.0,
+                                "output": 8.0,
+                                "cache_read": 0.2,
+                                "cache_write": 2.5
+                            },
+                            "limit": {
+                                "context": 456
+                            }
+                        }
+                    }
+                }
+            }"#;
+
+        assert_eq!(
+            pricing.load_models_dev_json_missing(models_dev_json),
+            Some(1)
+        );
+
+        let primary = pricing.find("gpt-primary").unwrap();
+        let fallback = pricing.find("gpt-fallback").unwrap();
+
+        assert_eq!(primary.input, 1e-6);
+        assert_eq!(primary.output, 10e-6);
+        assert_eq!(primary.cache_read, 0.1e-6);
+        assert_eq!(pricing.context_limit("gpt-primary"), Some(123));
+        assert!((fallback.input - 2e-6).abs() < f64::EPSILON);
+        assert!((fallback.output - 8e-6).abs() < f64::EPSILON);
+        assert!((fallback.cache_create - 2.5e-6).abs() < f64::EPSILON);
+        assert!((fallback.cache_read - 0.2e-6).abs() < f64::EPSILON);
+        assert!(fallback.cache_read_explicit);
+        assert_eq!(fallback.input_above_200k, None);
+        assert_eq!(fallback.output_above_200k, None);
+        assert_eq!(fallback.fast_multiplier, 1.0);
+        assert_eq!(pricing.context_limit("gpt-fallback"), Some(456));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, time::Duration};
+use std::{borrow::Cow, sync::OnceLock, time::Duration};
 
 use serde::Deserialize;
 
@@ -31,6 +31,7 @@ pub(crate) struct Pricing {
 pub(crate) struct PricingMap {
     entries: FxHashMap<String, Pricing>,
     context_limits: FxHashMap<String, u64>,
+    enable_models_dev_fallback: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -141,28 +142,7 @@ impl PricingMap {
             }
         }
 
-        let fetch_result = crate::progress::track_status(
-            log && crate::progress::usage_load_output_is_tty(),
-            "Refreshing fallback model pricing from models.dev...",
-            fetch_models_dev_json,
-        );
-
-        match fetch_result {
-            Ok(json) => {
-                if map.load_models_dev_json_missing(&json).is_none()
-                    && should_log_pricing_refresh_details()
-                {
-                    eprintln!("WARN  Failed to parse models.dev pricing; using LiteLLM pricing.");
-                }
-            }
-            Err(error) => {
-                if should_log_pricing_refresh_details() {
-                    eprintln!(
-                        "WARN  Failed to fetch models.dev pricing ({error}); using LiteLLM pricing."
-                    );
-                }
-            }
-        }
+        map.enable_models_dev_fallback = true;
         map
     }
 
@@ -231,7 +211,7 @@ impl PricingMap {
         for provider in raw.into_values() {
             for (model_key, model) in provider.models {
                 let model_id = model.id.unwrap_or(model_key);
-                if self.find(&model_id).is_some() {
+                if self.find_entry(&model_id).is_some() {
                     continue;
                 }
                 let Some(cost) = model.cost else {
@@ -277,6 +257,14 @@ impl PricingMap {
     }
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
+        self.find_entry(model).or_else(|| {
+            self.enable_models_dev_fallback
+                .then(|| models_dev_pricing().and_then(|pricing| pricing.find_entry(model)))
+                .flatten()
+        })
+    }
+
+    fn find_entry(&self, model: &str) -> Option<Pricing> {
         self.entries.get(model).copied().or_else(|| {
             let normalized_model = normalized_pricing_key(model);
             self.entries
@@ -292,6 +280,17 @@ impl PricingMap {
     }
 
     pub(crate) fn context_limit(&self, model: &str) -> Option<u64> {
+        self.context_limit_entry(model).or_else(|| {
+            self.enable_models_dev_fallback
+                .then(|| {
+                    models_dev_pricing()
+                        .and_then(|pricing| pricing.context_limit_entry(model))
+                })
+                .flatten()
+        })
+    }
+
+    fn context_limit_entry(&self, model: &str) -> Option<u64> {
         self.context_limits.get(model).copied().or_else(|| {
             let normalized_model = normalized_pricing_key(model);
             self.context_limits
@@ -309,6 +308,11 @@ impl PricingMap {
     #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
         self.entries.len()
+    }
+
+    #[cfg(test)]
+    fn models_dev_fallback_enabled(&self) -> bool {
+        self.enable_models_dev_fallback
     }
 
     fn put_builtin_pricing(&mut self, fast_multiplier_overrides: &FastMultiplierOverrides) {
@@ -724,6 +728,33 @@ fn should_log_pricing_refresh_details() -> bool {
     crate::log_level().is_some_and(|level| level >= 4)
 }
 
+fn models_dev_pricing() -> Option<&'static PricingMap> {
+    static MODELS_DEV_PRICING: OnceLock<Option<PricingMap>> = OnceLock::new();
+    MODELS_DEV_PRICING
+        .get_or_init(|| {
+            let json = match fetch_models_dev_json() {
+                Ok(json) => json,
+                Err(error) => {
+                    if should_log_pricing_refresh_details() {
+                        eprintln!(
+                            "WARN  Failed to fetch models.dev pricing ({error}); using LiteLLM pricing."
+                        );
+                    }
+                    return None;
+                }
+            };
+            let mut map = PricingMap::default();
+            if map.load_models_dev_json_missing(&json).is_none() {
+                if should_log_pricing_refresh_details() {
+                    eprintln!("WARN  Failed to parse models.dev pricing; using LiteLLM pricing.");
+                }
+                return None;
+            }
+            Some(map)
+        })
+        .as_ref()
+}
+
 fn fetch_pricing_json() -> std::io::Result<String> {
     fetch_json_url(LITELLM_PRICING_URL)
 }
@@ -848,6 +879,12 @@ mod tests {
         assert_eq!(loaded, 1);
         assert!(pricing.find("gpt-valid").is_some());
         assert_eq!(pricing.context_limit("gpt-valid"), Some(123));
+    }
+
+    #[test]
+    fn keeps_models_dev_fallback_disabled_for_embedded_and_offline_pricing() {
+        assert!(!PricingMap::load_embedded().models_dev_fallback_enabled());
+        assert!(!PricingMap::load(true, false).models_dev_fallback_enabled());
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Adds models.dev as a runtime pricing fallback after embedded and live LiteLLM pricing.
- Keeps LiteLLM entries authoritative so tiered prices and fast-mode multipliers are not overwritten by models.dev data.
- Converts models.dev per-million-token costs to ccusage per-token pricing and imports context limits for missing models.

Testing:
- nix develop --command pnpm run format
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage pricing::tests::
- nix develop --command pnpm run test
- nix develop --command cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `models.dev` as a lazy, runtime pricing fallback in `ccusage` so new models are priced when `LiteLLM` doesn’t have them. `LiteLLM` stays authoritative; only missing models use `models.dev`.

- Bug Fixes
  - Consults `models.dev` only on lookup miss (`find`/`context_limit`); fetch is lazy, cached only after a successful load, backs off retries for ~60s after a failure, and is disabled for embedded/offline maps; refresh makes no extra calls.
  - Does not override existing `LiteLLM` entries or fast-mode multipliers; uses exact key checks (no fuzzy dedupe) so provider-qualified aliases don’t block distinct `models.dev` ids; preserves main’s numeric-suffix key handling.
  - Converts per-million costs to per-token and imports context limits; defaults cache read/write when absent.
  - Logs fetch/parse failures and continues with `LiteLLM` data. Tests cover missing-only behavior, lazy gating, retry/backoff (including negative cache), unit conversion, context limits, and exact-duplicate handling with provider-qualified aliases.

<sup>Written for commit 18cded8e2686d1d257f1deff0dd518a67b6c7aa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1185?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional fallback to fetch external (models.dev) pricing for missing local entries; enabled after a successful online load and disabled for embedded/offline modes. Lazily caches remote pricing for on-miss lookups.
* **Refactor**
  * Unified remote JSON fetching into a shared helper with retry/backoff and centralized HTTP plumbing.
* **Tests**
  * Added tests for fallback gating, retry/backoff, unit conversions, cache-read handling, forced multiplier, context-limit population, and non-overwrite of existing pricing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->