### PR TITLE
ci(pricing): update LiteLLM snapshot automation

### DIFF
--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -2,7 +2,7 @@ name: update pricing
 
 on:
   schedule:
-    - cron: '0 3 * * 1'
+    - cron: '0 */12 * * *'
   workflow_dispatch:
 
 permissions:
@@ -15,9 +15,32 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-nix
+      - name: Capture current LiteLLM pricing JSON
+        run: |
+          rev="$(jq -r '.nodes.litellm.locked.rev' flake.lock)"
+          curl --fail --location --silent --show-error \
+            "https://raw.githubusercontent.com/BerriAI/litellm/${rev}/model_prices_and_context_window.json" \
+            --output /tmp/litellm-pricing-before.json
       - name: Update LiteLLM pricing input
         run: |
           nix flake update litellm
+      - name: Skip lock-only LiteLLM updates
+        run: |
+          rev="$(jq -r '.nodes.litellm.locked.rev' flake.lock)"
+          curl --fail --location --silent --show-error \
+            "https://raw.githubusercontent.com/BerriAI/litellm/${rev}/model_prices_and_context_window.json" \
+            --output /tmp/litellm-pricing-after.json
+
+          if cmp --silent /tmp/litellm-pricing-before.json /tmp/litellm-pricing-after.json; then
+            echo "LiteLLM pricing JSON is unchanged; skipping PR."
+            git checkout -- flake.lock
+          fi
+      - name: Validate updated pricing snapshot
+        run: |
+          if git diff --quiet; then
+            echo "Pricing snapshot is already up to date."
+            exit 0
+          fi
           nix flake check
       - name: Create pull request
         env:

--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
     "litellm": {
       "flake": false,
       "locked": {
-        "lastModified": 1779231723,
-        "narHash": "sha256-0MG6NXwVytdRQIf+L+nV5T4GZfIDUCJNZPnIlVfCoq0=",
+        "lastModified": 1780038305,
+        "narHash": "sha256-os5zGH6kXGKR2xNK9M+CDXbiOEhnztgRZYwieZZeU2g=",
         "owner": "BerriAI",
         "repo": "litellm",
-        "rev": "e59e34bed3670a6894d43129c2af16af28057d03",
+        "rev": "f27df8d516802ce4c1b32973992154fe83b851cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the locked LiteLLM pricing input used by Nix builds.

Also changes the automated pricing update workflow to run every 12 hours and skip opening PRs when the LiteLLM pricing JSON is unchanged after the flake update.

Testing:
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage pricing::tests::
- git diff --check
- Verified the LiteLLM pricing JSON comparison path with the current locked rev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated LiteLLM pricing synchronization workflow to run every 12 hours instead of weekly and improved the update process with additional validation checks to prevent unnecessary changes and ensure data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->