### PR TITLE
ci: add GitHub Actions lint checks

### DIFF
--- a/.github/workflows/approve-contributor.yaml
+++ b/.github/workflows/approve-contributor.yaml
@@ -138,11 +138,13 @@ jobs:
 
       - name: Commit and push
         if: steps.update.outputs.status == 'added' || steps.update.outputs.status == 'updated'
+        env:
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/APPROVED_CONTRIBUTORS
-          git diff --staged --quiet || git commit -m "chore: approve contributor ${{ github.event.issue.user.login }}"
+          git diff --staged --quiet || git commit -m "chore: approve contributor $ISSUE_AUTHOR"
           git push
 
       - name: Comment on issue

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
       - name: Archive native package binary
         shell: bash
         run: tar -cf "ccusage-native-${{ matrix.platform }}-${{ matrix.arch }}.tar" "packages/ccusage-${{ matrix.platform }}-${{ matrix.arch }}/bin"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ccusage-native-${{ matrix.platform }}-${{ matrix.arch }}
           path: ccusage-native-${{ matrix.platform }}-${{ matrix.arch }}.tar
@@ -177,7 +177,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-nix
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: ccusage-native-*
           path: ${{ runner.temp }}/native-packages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Archive native package binary
         shell: bash
         run: tar -cf "ccusage-native-${{ matrix.platform }}-${{ matrix.arch }}.tar" "packages/ccusage-${{ matrix.platform }}-${{ matrix.arch }}/bin"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ccusage-native-${{ matrix.platform }}-${{ matrix.arch }}
           path: ccusage-native-${{ matrix.platform }}-${{ matrix.arch }}.tar
@@ -102,7 +102,7 @@ jobs:
         with:
           registry-url: 'https://registry.npmjs.org'
           node-version: lts/*
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: ccusage-native-*
           path: ${{ runner.temp }}/native-packages

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -36,6 +36,8 @@ in
             typos
             typos-lsp
             oxfmt
+            actionlint
+            zizmor
             oxlint
             prek
             gitleaks

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -52,7 +52,7 @@ in
     {
       treefmt = {
         inherit pkgs;
-        projectRootFile = ".git/config";
+        projectRootFile = "flake.nix";
 
         programs = {
           deadnix.enable = true;
@@ -79,6 +79,37 @@ in
             includes = [ "*" ];
             priority = 4;
           };
+          actionlint = {
+            command = lib.getExe pkgs.actionlint;
+            options = [
+              "-ignore"
+              ''unknown permission scope "code-quality"''
+              "-ignore"
+              "shellcheck reported issue in this script: SC2016:info:"
+            ];
+            includes = [
+              ".github/workflows/*.yaml"
+              ".github/workflows/*.yml"
+            ];
+            priority = 5;
+          };
+          zizmor = {
+            command = lib.getExe pkgs.zizmor;
+            options = [
+              "--offline"
+              "--min-severity"
+              "high"
+              "--min-confidence"
+              "high"
+            ];
+            includes = [
+              ".github/workflows/*.yaml"
+              ".github/workflows/*.yml"
+              ".github/actions/*/action.yaml"
+              ".github/actions/*/action.yml"
+            ];
+            priority = 6;
+          };
           oxlint = {
             command = lib.getExe pkgs.oxlint;
             options = [ "--fix" ];
@@ -90,9 +121,9 @@ in
               "*.ts"
               "*.tsx"
             ];
-            priority = 5;
+            priority = 7;
           };
-          rustfmt.priority = 6;
+          rustfmt.priority = 8;
           schema-gen = {
             command = lib.getExe schemaGen;
             includes = [
@@ -100,7 +131,7 @@ in
               "rust/crates/ccusage/src/config_schema.rs"
               "rust/crates/ccusage/src/bin/generate_config_schema.rs"
             ];
-            priority = 7;
+            priority = 9;
           };
         };
       };


### PR DESCRIPTION
Adds actionlint to the treefmt pipeline so GitHub Actions workflow syntax, expressions, and embedded scripts are checked by the existing pre-commit and flake checks.

Adds zizmor in offline high-severity/high-confidence mode for actionable GitHub Actions security findings. This also pins the remaining artifact actions and moves a PR-controlled commit message value through an environment variable so the new checks pass.

Testing:
- nix fmt
- nix flake check --print-build-logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow dependencies to pinned versions for improved stability and consistency
  * Enhanced development environment with additional code quality analysis tools
  * Updated code formatting configuration for better project consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `actionlint` and `zizmor` to `treefmt` and `nix/dev-shell` so pre-commit and `nix flake check` lint GitHub Actions syntax, scripts, and high-confidence security issues. Pin `actions/upload-artifact` and `actions/download-artifact`, move the approve-contributor commit message through an env var, and set `treefmt` project root to `flake.nix`.

<sup>Written for commit 4788598d3a55af0fe07e589a0e1257216cfae21b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

