### PR TITLE
chore(ci): add takumi guard

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -7,6 +7,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup takumi guard
+      uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+
     - name: Install Nix
       uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
       with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `takumi-guard` setup to CI in the composite `.github/actions/setup-nix` workflow so security checks run before Nix installs.

- **Dependencies**
  - Added `flatt-security/setup-takumi-guard-npm` pinned to v1.1.1.

<sup>Written for commit 295317ba36a0ba0e2f562510c2d4877c67288880. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development infrastructure and CI/CD workflows.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->