### PR TITLE
ci: add actions-timeline job to visualise CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -397,3 +397,19 @@ jobs:
             git diff apps/ccusage/config-schema.json docs/public/config-schema.json
             exit 1
           fi
+
+  action-timeline:
+    needs:
+      - changes
+      - lint-check
+      - test
+      - build-native-packages
+      - npm-publish-dry-run-and-upload-pkg-pr-now
+      - ccusage-preview-e2e
+      - ccusage-perf-comment
+      - ccusage-rust-perf-comment
+      - schema-check
+    if: ${{ always() }}
+    runs-on: ubuntu-slim
+    steps:
+      - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1


### PR DESCRIPTION
Adds a `Kesin11/actions-timeline` job that runs after all CI jobs and renders a Gantt-style timeline of job and step durations in the workflow run summary. The job depends on every other job with `if: ${{ always() }}` so the timeline is generated even when an upstream job fails.

Mirrors the setup already used in the `ryoppippi.com` repository, with the action pinned to the v3.1 commit SHA.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new CI job that uses `Kesin11/actions-timeline` to render a Gantt-style timeline of job and step durations in the workflow run summary. It depends on all jobs and uses `if: ${{ always() }}` so it runs even on failures; pinned to v3.1 and runs on `ubuntu-slim`.

<sup>Written for commit e6163ca1faf51debfdbca0527bbe07ee3f032c67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the continuous integration workflow to include improved timeline tracking for CI job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->