### PR TITLE
ci(nix): validate ccusage.example.json against config schema

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -74,6 +74,9 @@ in
         gitleaks = mkRepoCheck "gitleaks-check" [ pkgs.gitleaks ] ''
           gitleaks detect --source . --config .gitleaks.toml --no-git
         '';
+        config-example = mkRepoCheck "config-example-check" [ pkgs.check-jsonschema ] ''
+          check-jsonschema --schemafile apps/ccusage/config-schema.json ccusage.example.json
+        '';
       };
     };
 }


### PR DESCRIPTION
## Summary

Adds a `nix flake check` that validates `ccusage.example.json` against the generated `config-schema.json`. CI already runs `nix flake check` in the `lint-check` job, so the example config is now verified on every PR and locally — no workflow changes needed.

## What changed

- New `config-example` check in `nix/checks.nix` using the existing `mkRepoCheck` helper:
  ```nix
  config-example = mkRepoCheck "config-example-check" [ pkgs.check-jsonschema ] ''
    check-jsonschema --schemafile apps/ccusage/config-schema.json ccusage.example.json
  '';
  ```

## Why

The example config can silently drift from the schema (typo'd keys, wrong types, invalid enum values). Since `config-schema.json` is generated from the Rust config types, this check follows automatically when those types change — no separate validator to keep in sync.

## Testing

- `nix build .#checks.aarch64-darwin.config-example` → passes (`ok -- validation done`)
- Negative check: injecting an unknown key is rejected (`additionalProperties` → exit 1), confirming the validator actually enforces the schema
- `treefmt --fail-on-change` on the edited file → no changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `nix flake check` named `config-example` that validates `ccusage.example.json` against the generated `apps/ccusage/config-schema.json` via `check-jsonschema`. This runs in CI’s lint-check and locally, catching drift like unknown keys and wrong types.

<sup>Written for commit 54e5c487b0f66c9025411a860fdce04365fb0c49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new configuration validation check to the build process, enhancing configuration integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->