### PR TITLE
ci(nix): cache the dev-shell closure and drop unused cachix

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -1,9 +1,5 @@
 name: Setup Nix
-description: Install Nix and configure Cachix
-inputs:
-  cachix-auth-token:
-    description: Cachix authentication token
-    required: false
+description: Install Nix and restore the Nix store from the GitHub Actions cache
 runs:
   using: composite
   steps:
@@ -17,24 +13,39 @@ runs:
         extra_nix_config: |
           access-tokens = github.com=${{ github.token }}
 
-    - name: Setup Cachix (numtide)
-      uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-      with:
-        name: numtide
-        authToken: ''
-
-    - name: Setup Cachix (ryoppippi)
-      if: inputs.cachix-auth-token != ''
-      uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-      with:
-        name: ryoppippi
-        authToken: ${{ inputs.cachix-auth-token }}
-
     - name: Cache Nix store
       uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
       with:
-        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock') }}
+        # Hash every input that changes the dev-shell closure, not just
+        # flake.lock. The previous key only hashed flake.lock, so any
+        # Cargo.lock / toolchain change rebuilt `ccusage-deps` (~80s) on every
+        # run while the stale cache stayed frozen and was never re-saved.
+        #
+        # `package.json` is the root manifest only: its `version` is read by
+        # package.nix and baked into the crane derivation name
+        # (`ccusage-deps-<version>`), so a version bump must rotate the key.
+        #
+        # pnpm-lock.yaml and the workspace package.json files are intentionally
+        # NOT hashed: no Nix derivation consumes JS dependencies. `pnpm install`
+        # runs in the dev-shell shellHook and writes node_modules in the working
+        # tree, outside the Nix store, so JS deps never change this cache.
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'package.json', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}
+        # On a key miss, warm-start from the newest cache for this os/arch so
+        # only the changed derivations rebuild before the fresh key is saved.
         restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-
+        # Bound a single cache so the repo stays under the 10 GB limit. This
+        # action only runs on Linux (arm64 + x64), so at most two Nix caches
+        # exist. 3.5 GB each leaves headroom for the small per-platform Cargo
+        # caches (~1 GB total) used by the macOS/Windows build jobs. The
+        # dev-shell closure (~2.5 GB) is a gc root, so it survives this trim.
+        gc-max-store-size-linux: 3500000000
+        # Purge superseded caches for this os/arch on every run. Without this
+        # the more frequently rotating key would accumulate stale caches and
+        # push the repo past the 10 GB limit, evicting the fresh cache via LRU.
+        purge: true
+        purge-prefixes: nix-${{ runner.os }}-${{ runner.arch }}-
+        purge-created: 604800
+        purge-primary-key: never
 
     - name: Load Nix development environment
       shell: bash

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -42,9 +42,13 @@ runs:
         # Purge superseded caches for this os/arch on every run. Without this
         # the more frequently rotating key would accumulate stale caches and
         # push the repo past the 10 GB limit, evicting the fresh cache via LRU.
+        # 2 days (not 7) so that several key rotations in one week (e.g.
+        # repeated Cargo.lock bumps) cannot pile up multiple ~2.5 GB caches.
+        # The active cache is always the current primary-key, which
+        # purge-primary-key keeps regardless of age.
         purge: true
         purge-prefixes: nix-${{ runner.os }}-${{ runner.arch }}-
-        purge-created: 604800
+        purge-created: 172800
         purge-primary-key: never
 
     - name: Load Nix development environment

--- a/.github/workflows/cache-gc.yaml
+++ b/.github/workflows/cache-gc.yaml
@@ -25,7 +25,10 @@ jobs:
           # by CI. This sweep also reclaims caches left behind by merged or
           # abandoned branches that no longer trigger CI.
           cutoff=$(date -u -d '14 days ago' +%s)
-          gh cache list --limit 100 --json id,key,lastAccessedAt \
+          # Sort least-recently-accessed first so the stalest caches are the
+          # ones fetched under --limit; the default order is descending and
+          # would fetch the freshest caches instead, never reaching old ones.
+          gh cache list --limit 100 --sort last_accessed_at --order asc --json id,key,lastAccessedAt \
             --jq '.[] | [.id, .lastAccessedAt, .key] | @tsv' \
             | while IFS=$'\t' read -r id last key; do
                 last_epoch=$(date -u -d "$last" +%s)

--- a/.github/workflows/cache-gc.yaml
+++ b/.github/workflows/cache-gc.yaml
@@ -1,0 +1,36 @@
+name: Cache GC
+
+on:
+  schedule:
+    # Weekly on Sunday 03:00 UTC.
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  gc:
+    name: Garbage-collect old Actions caches
+    runs-on: ubuntu-slim
+    permissions:
+      actions: write
+    steps:
+      - name: Delete caches not accessed in the last 14 days
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          # The per-run `purge` in setup-nix only trims superseded keys created
+          # by CI. This sweep also reclaims caches left behind by merged or
+          # abandoned branches that no longer trigger CI.
+          cutoff=$(date -u -d '14 days ago' +%s)
+          gh cache list --limit 100 --json id,key,lastAccessedAt \
+            --jq '.[] | [.id, .lastAccessedAt, .key] | @tsv' \
+            | while IFS=$'\t' read -r id last key; do
+                last_epoch=$(date -u -d "$last" +%s)
+                if [ "$last_epoch" -lt "$cutoff" ]; then
+                  echo "Deleting stale cache: $key (last accessed $last)"
+                  gh cache delete "$id"
+                fi
+              done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,8 +116,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-nix
         if: matrix.platform == 'linux'
-        with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Cache Cargo build
         if: matrix.platform != 'linux'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,8 +44,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup-nix
         if: matrix.platform == 'linux'
-        with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Cache Cargo build
         if: matrix.platform != 'linux'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4


### PR DESCRIPTION
## Summary

`setup-nix` took ~200s per CI job and the Nix store cache was effectively useless. This makes the `cache-nix-action` cache actually work, removes the dead `cachix-action` steps, and bounds the cache budget.

## The problem

Profiling a recent run ([#27076169962](https://github.com/ryoppippi/ccusage/actions/runs/27076169962)), each `setup-nix` step spent ~200s, broken down as:

| sub-step | time |
|---|---|
| Install Nix | ~5s |
| Setup Cachix (numtide) | ~3s |
| **Cache restore (`cache-nix-action`)** | **~76s** |
| **`nix develop --command true`** | **~113s** |
| ↳ build `ccusage-deps` (crane Rust deps) | ~81s |
| ↳ build `generate-config-schema` + treefmt | ~11s |
| ↳ pnpm install (shellHook) | ~10s |

The cache *hit* (exact key, 2.1 GB restored) yet `ccusage-deps` rebuilt for 80s every run. Root cause: the `cache-nix-action` primary-key only hashed `flake.lock`, but the dev-shell closure also depends on the Rust toolchain and the crane `ccusage-deps` derivation (keyed on `Cargo.lock`, the Cargo manifests, `rust-toolchain.toml`, and the `version` from the root `package.json`). With none of those in the key:

1. `flake.lock` unchanged → key hit → stale closure restored
2. current `Cargo.lock` differs → `ccusage-deps` not present → 80s rebuild
3. exact-key hit → `cache-nix-action` skips the save → fresh deps never cached
4. repeat forever until `flake.lock` changes

Separately, the `cachix-action` steps were dead weight: the `ryoppippi` cache was only push-configured in the job that builds `ccusage-static` (musl), so the glibc dev-shell artefacts were never pushed, and the pull step was gated behind the push token so other jobs couldn't substitute from it either.

## What changed

- **Fix the cache key** to hash every input that changes the dev-shell closure: `flake.lock`, `flake.nix`, `default.nix`, `package.nix`, `nix/**/*.nix`, root `package.json` (version → crane drv name), `rust-toolchain.toml`, `rust/Cargo.lock`, `rust/**/Cargo.toml`. `pnpm-lock.yaml` and the workspace `package.json` files are deliberately excluded (no Nix derivation consumes JS deps — pnpm install runs in the shellHook into `node_modules`, outside the Nix store); this is documented inline.
- **Remove both `cachix-action` steps** and the unused `cachix-auth-token` input (plus its callers in `ci.yaml` and `release.yaml`), consolidating on `cache-nix-action`.
- **Bound the cache budget**: `gc-max-store-size-linux` caps each of the two Linux caches at 3.5 GB (the closure is a gc root, so it survives the trim), and per-run `purge` removes superseded keys so the more frequently rotating key can't push the repo past the 10 GB Actions cache limit. Nix caching only runs on Linux (arm64 + x64); macOS/Windows are untouched and keep their existing small Cargo `actions/cache`.
- **Add a weekly `Cache GC` workflow** that deletes caches not accessed in the last 14 days, reclaiming caches left behind by merged/abandoned branches.

## Why

After the first run on a new key rebuilds and *saves* the closure, subsequent runs restore it and skip the ~80s `ccusage-deps` rebuild (and the redundant ~3s cachix install + ~76s double-cache overhead is gone), which should bring `setup-nix` down substantially on warm runs.

## Testing

- `actionlint` + `zizmor` (high/high) clean on the new/changed workflow and action files
- `treefmt --fail-on-change` clean
- Real timing impact will be visible on this PR's own CI runs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up CI by making the Nix dev‑shell cache actually hit, removing unused Cachix, and adding a weekly cache GC. Warm runs now skip the ~80s `ccusage-deps` rebuild; purge and GC are tuned to avoid evicting fresh caches.

- **Refactors**
  - Fix `nix-community/cache-nix-action` key to hash all dev‑shell inputs (`flake.lock`, `flake.nix`, Nix files, Rust toolchain/Cargo manifests, root `package.json` version); JS deps excluded by design.
  - Bound cache size and purge superseded keys after 2 days to stay under the 10 GB Actions limit; caching runs on Linux only.
  - Remove `cachix/cachix-action` steps and the `cachix-auth-token` input; callers updated to use only `cache-nix-action`.

- **New Features**
  - Add a weekly Cache GC workflow that deletes caches not accessed in 14 days.
  - Sort caches by last accessed ascending so the sweep deletes the stalest entries first.

<sup>Written for commit 5a85b7906b4390a5313e0d6b2d78a477bb7d9a2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build caching with broader hashing of Nix and Rust inputs for more reliable cache hits.
  * Added a weekly cache garbage-collection workflow to remove stale caches automatically.
  * Removed the external cache authentication step, simplifying CI configuration.
  * Adjusted build workflow to run the Nix setup step only for Linux builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->