### PR TITLE
ci: drop redundant schema-check job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -371,31 +371,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: nix develop --command pnpm exec bun .github/scripts/upsert-pr-comment.ts
 
-  schema-check:
-    needs: changes
-    if: needs.changes.outputs.code-changed == 'true'
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-nix
-      - name: Generate schema files
-        run: nix develop --command pnpm run generate:schema
-        working-directory: apps/ccusage
-      - name: Check if schema files are up-to-date
-        run: |
-          if git diff --exit-code apps/ccusage/config-schema.json docs/public/config-schema.json; then
-            echo "✅ Schema files are up-to-date"
-          else
-            echo "❌ Schema files are not up-to-date. Please run 'pnpm run generate:schema' and commit the changes."
-            echo ""
-            echo "Changed files:"
-            git diff --name-only apps/ccusage/config-schema.json docs/public/config-schema.json
-            echo ""
-            echo "Diff:"
-            git diff apps/ccusage/config-schema.json docs/public/config-schema.json
-            exit 1
-          fi
-
   action-timeline:
     needs:
       - changes
@@ -406,7 +381,6 @@ jobs:
       - ccusage-preview-e2e
       - ccusage-perf-comment
       - ccusage-rust-perf-comment
-      - schema-check
     if: ${{ always() }}
     runs-on: ubuntu-slim
     steps:


### PR DESCRIPTION
## Summary

Removes the standalone `schema-check` CI job. It is fully redundant with `nix flake check`, which `lint-check` already runs.

## Why it's redundant

`schema-check` ran `pnpm run generate:schema` and diffed the result against the committed schema files. `nix flake check` exposes a `treefmt` check (confirmed via `nix eval .#checks.<system>`), and the `treefmt` config defines a `schema-gen` formatter that does the same work under `--fail-on-change`:

| | `schema-check` job | `treefmt` `schema-gen` (in `nix flake check`) |
|---|---|---|
| generate | `cargo run --bin generate-config-schema` | same `generate-config-schema` binary |
| format | `oxfmt --write` | `oxfmt --write` |
| docs copy | `cp → docs/public/config-schema.json` | `cp → docs/public/config-schema.json` |
| verify | `git diff --exit-code` | `treefmt --fail-on-change` |

Verified empirically: deleting `.properties` from `apps/ccusage/config-schema.json` makes `nix build .#checks.<system>.treefmt` exit 1.

## What changed

- Remove the `schema-check` job from `ci.yaml`.
- Remove `schema-check` from the `action-timeline` job's `needs`.

## Note for merge

The `main` ruleset lists `schema-check` as a required status check. That entry must be removed from the ruleset as well, otherwise PRs would block waiting for a check that no longer runs.

## Result

Drops one full `setup-nix` + schema-gen run from every CI run while keeping the same schema-staleness guarantee through `lint-check`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant `schema-check` CI job. Schema freshness is already enforced by `nix flake check` (via `lint-check` running `treefmt`), reducing duplicate CI work.

- **Refactors**
  - Removed the `schema-check` job from `.github/workflows/ci.yaml`.
  - Dropped `schema-check` from `action-timeline.needs`.

- **Migration**
  - Remove `schema-check` from the `main` ruleset’s required status checks to prevent blocked PRs.

<sup>Written for commit d7ca72d04e3587258a5d522bc403c5a61ce6e898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration workflow by streamlining the build pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->