### PR TITLE
feat(codex): include archived sessions

### DIFF
--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -23,7 +23,7 @@ Most users can start with unified reports such as `ccusage daily`. Add the `code
 
 ## Data Source
 
-The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to `~/.codex`). `CODEX_HOME` can be one directory or a comma-separated list of directories. Entries with a `sessions/` directory are treated as Codex homes; entries without `sessions/` are read directly as JSONL directories, which lets saved `codex exec --json` output live beside normal Codex homes.
+The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to `~/.codex`). `CODEX_HOME` can be one directory or a comma-separated list of directories. Entries with a `sessions/` directory are treated as Codex homes, and matching `archived_sessions/` directories are read automatically. Entries without `sessions/` are read directly as JSONL directories, which lets saved `codex exec --json` output live beside normal Codex homes.
 
 ```bash
 CODEX_HOME="$HOME/.codex,$HOME/.codex-work,$HOME/codex-exec-logs" ccusage codex daily

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -23,7 +23,7 @@ Most users can start with unified reports such as `ccusage daily`. Add the `code
 
 ## Data Source
 
-The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to `~/.codex`). `CODEX_HOME` can be one directory or a comma-separated list of directories. Entries with a `sessions/` directory are treated as Codex homes, and matching `archived_sessions/` directories are read automatically. Entries without `sessions/` are read directly as JSONL directories, which lets saved `codex exec --json` output live beside normal Codex homes.
+The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to `~/.codex`). `CODEX_HOME` can be one directory or a comma-separated list of directories. For each entry, ccusage discovers `sessions/` and `archived_sessions/` independently, so an entry with only `archived_sessions/` still contributes archived Codex logs. When neither directory exists, the entry is read directly as a JSONL directory, which lets saved `codex exec --json` output live beside normal Codex homes.
 
 ```bash
 CODEX_HOME="$HOME/.codex,$HOME/.codex-work,$HOME/codex-exec-logs" ccusage codex daily

--- a/rust/crates/ccusage/src/adapter/codex/README.md
+++ b/rust/crates/ccusage/src/adapter/codex/README.md
@@ -4,6 +4,7 @@ Data source:
 
 ```text
 ${CODEX_HOME:-~/.codex}/sessions/
+${CODEX_HOME:-~/.codex}/archived_sessions/
 ```
 
 Relevant JSONL event:

--- a/rust/crates/ccusage/src/adapter/codex/paths.rs
+++ b/rust/crates/ccusage/src/adapter/codex/paths.rs
@@ -68,4 +68,34 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn uses_sessions_without_missing_archived_sessions_path() {
+        let fixture = Fixture::new();
+        let _ = fixture.create_dir_all("codex/sessions");
+
+        let paths = codex_usage_paths_from_homes(vec![fixture.path("codex")]);
+
+        assert_eq!(paths, vec![fixture.path("codex/sessions")]);
+    }
+
+    #[test]
+    fn uses_archived_sessions_without_direct_path_fallback() {
+        let fixture = Fixture::new();
+        let _ = fixture.create_dir_all("codex/archived_sessions");
+
+        let paths = codex_usage_paths_from_homes(vec![fixture.path("codex")]);
+
+        assert_eq!(paths, vec![fixture.path("codex/archived_sessions")]);
+    }
+
+    #[test]
+    fn falls_back_to_direct_path_when_no_session_directories_exist() {
+        let fixture = Fixture::new();
+        let home = fixture.create_dir_all("codex");
+
+        let paths = codex_usage_paths_from_homes(vec![home.clone()]);
+
+        assert_eq!(paths, vec![home]);
+    }
 }

--- a/rust/crates/ccusage/src/adapter/codex/paths.rs
+++ b/rust/crates/ccusage/src/adapter/codex/paths.rs
@@ -98,4 +98,15 @@ mod tests {
 
         assert_eq!(paths, vec![home]);
     }
+
+    #[test]
+    fn deduplicates_usage_paths_across_repeated_homes() {
+        let fixture = Fixture::new();
+        let home = fixture.create_dir_all("codex");
+        let _ = fixture.create_dir_all("codex/sessions");
+
+        let paths = codex_usage_paths_from_homes(vec![home.clone(), home]);
+
+        assert_eq!(paths, vec![fixture.path("codex/sessions")]);
+    }
 }

--- a/rust/crates/ccusage/src/adapter/codex/paths.rs
+++ b/rust/crates/ccusage/src/adapter/codex/paths.rs
@@ -3,19 +3,33 @@ use std::{env, path::PathBuf};
 use crate::{cli_error, fast::FxHashSet, home, Result};
 
 pub(super) fn codex_usage_paths() -> Result<Vec<PathBuf>> {
+    Ok(codex_usage_paths_from_homes(codex_home_paths()?))
+}
+
+fn codex_usage_paths_from_homes(homes: Vec<PathBuf>) -> Vec<PathBuf> {
     let mut paths = Vec::new();
     let mut seen = FxHashSet::default();
-    for path in codex_home_paths()? {
+    for path in homes {
         let sessions = path.join("sessions");
+        let archived_sessions = path.join("archived_sessions");
+        let mut found_usage_dir = false;
         if sessions.is_dir() {
             if seen.insert(sessions.clone()) {
                 paths.push(sessions);
             }
-        } else if seen.insert(path.clone()) {
+            found_usage_dir = true;
+        }
+        if archived_sessions.is_dir() {
+            if seen.insert(archived_sessions.clone()) {
+                paths.push(archived_sessions);
+            }
+            found_usage_dir = true;
+        }
+        if !found_usage_dir && seen.insert(path.clone()) {
             paths.push(path);
         }
     }
-    Ok(paths)
+    paths
 }
 
 pub(super) fn codex_home_paths() -> Result<Vec<PathBuf>> {
@@ -30,4 +44,28 @@ pub(super) fn codex_home_paths() -> Result<Vec<PathBuf>> {
 
     let home = home::home_dir().ok_or_else(|| cli_error("home directory is not set"))?;
     Ok(vec![home.join(".codex")])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ccusage_test_support::Fixture;
+
+    #[test]
+    fn includes_archived_sessions_next_to_sessions() {
+        let fixture = Fixture::new();
+        let _ = fixture.create_dir_all("codex/sessions");
+        let _ = fixture.create_dir_all("codex/archived_sessions");
+
+        let paths = codex_usage_paths_from_homes(vec![fixture.path("codex")]);
+
+        assert_eq!(
+            paths,
+            vec![
+                fixture.path("codex/sessions"),
+                fixture.path("codex/archived_sessions"),
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Loads Codex JSONL files from archived_sessions next to each CODEX_HOME sessions directory so archived Codex usage remains included in reports.

The direct JSONL directory fallback is preserved for saved codex exec --json outputs, and the Codex guide now documents the archived source.

Testing:
- direnv exec . cargo test -p ccusage adapter::codex
- direnv exec . cargo fmt -p ccusage
- direnv exec . pnpm run format
- direnv exec . cargo run -q -p ccusage --bin ccusage -- codex daily --json --offline
- pre-push hooks: clippy, treefmt, gitleaks, cargo test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include archived Codex sessions in usage reports by reading JSONL from `archived_sessions` alongside `sessions`. Keeps the direct JSONL fallback and avoids duplicate reads when `CODEX_HOME` entries repeat.

- **New Features**
  - Discover `sessions/` and `archived_sessions/` independently for each `CODEX_HOME`.
  - Fall back to the home path as a direct JSONL directory only when neither directory exists.
  - Clarify docs and add tests for sessions-only, archived-only, fallback, and deduped `CODEX_HOME` entries.

<sup>Written for commit b01fd43b18bf106bd4f0039816f4a4812095b106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex scanning now recognizes both active sessions and archived session directories and includes them when present; if neither exists, the entry itself is used as a fallback.

* **Documentation**
  * Updated guidance to clarify how Codex homes are discovered and how archived-session directories are handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->