### PR TITLE
fix(pricing): do not charge GLM cache creation

### DIFF
--- a/rust/crates/ccusage/build.rs
+++ b/rust/crates/ccusage/build.rs
@@ -145,5 +145,6 @@ fn is_embedded_model(model: &str) -> bool {
         || model.starts_with("gpt-")
         || model.starts_with("openai/")
         || model.starts_with("azure/")
+        || model.starts_with("zai/")
         || model.starts_with("openrouter/openai/")
 }

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -840,7 +840,7 @@ impl PricingMap {
         let glm_base = Pricing {
             input: 0.6e-6,
             output: 2.2e-6,
-            cache_create: 0.75e-6,
+            cache_create: 0.0,
             cache_read: 0.11e-6,
             cache_read_explicit: true,
             input_above_200k: None,
@@ -857,7 +857,6 @@ impl PricingMap {
             Pricing {
                 input: 1.0e-6,
                 output: 3.2e-6,
-                cache_create: 1.25e-6,
                 cache_read: 0.2e-6,
                 ..glm_base
             },
@@ -867,7 +866,6 @@ impl PricingMap {
             Pricing {
                 input: 1.2e-6,
                 output: 4.0e-6,
-                cache_create: 1.5e-6,
                 cache_read: 0.24e-6,
                 ..glm_base
             },
@@ -877,7 +875,6 @@ impl PricingMap {
             Pricing {
                 input: 1.4e-6,
                 output: 4.4e-6,
-                cache_create: 1.75e-6,
                 cache_read: 0.26e-6,
                 ..glm_base
             },
@@ -1109,23 +1106,39 @@ mod tests {
         let glm_51 = pricing.find("glm-5.1").unwrap();
         assert_eq!(glm_51.input, 1.4e-6);
         assert_eq!(glm_51.output, 4.4e-6);
+        assert_eq!(glm_51.cache_create, 0.0);
         assert_eq!(glm_51.cache_read, 0.26e-6);
         assert!(glm_51.cache_read_explicit);
 
         let glm_5 = pricing.find("glm-5").unwrap();
         assert_eq!(glm_5.input, 1.0e-6);
         assert_eq!(glm_5.output, 3.2e-6);
+        assert_eq!(glm_5.cache_create, 0.0);
         assert_eq!(glm_5.cache_read, 0.2e-6);
 
         let glm_5_turbo = pricing.find("glm-5-turbo").unwrap();
         assert_eq!(glm_5_turbo.input, 1.2e-6);
         assert_eq!(glm_5_turbo.output, 4.0e-6);
+        assert_eq!(glm_5_turbo.cache_create, 0.0);
         assert_eq!(glm_5_turbo.cache_read, 0.24e-6);
 
         let glm_47 = pricing.find("glm-4.7").unwrap();
         assert_eq!(glm_47.input, 0.6e-6);
         assert_eq!(glm_47.output, 2.2e-6);
+        assert_eq!(glm_47.cache_create, 0.0);
         assert_eq!(glm_47.cache_read, 0.11e-6);
+
+        let glm_46 = pricing.find("glm-4.6").unwrap();
+        assert_eq!(glm_46.input, 0.6e-6);
+        assert_eq!(glm_46.output, 2.2e-6);
+        assert_eq!(glm_46.cache_create, 0.0);
+        assert_eq!(glm_46.cache_read, 0.11e-6);
+
+        let glm_45 = pricing.find("glm-4.5").unwrap();
+        assert_eq!(glm_45.input, 0.6e-6);
+        assert_eq!(glm_45.output, 2.2e-6);
+        assert_eq!(glm_45.cache_create, 0.0);
+        assert_eq!(glm_45.cache_read, 0.11e-6);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -837,11 +837,11 @@ impl PricingMap {
             },
         );
         // Source: https://docs.z.ai/guides/overview/pricing
-        let glm_base = Pricing {
-            input: 0.6e-6,
-            output: 2.2e-6,
+        let glm_pricing = |input: f64, output: f64, cache_read: f64| Pricing {
+            input,
+            output,
             cache_create: 0.0,
-            cache_read: 0.11e-6,
+            cache_read,
             cache_read_explicit: true,
             input_above_200k: None,
             output_above_200k: None,
@@ -849,8 +849,31 @@ impl PricingMap {
             cache_read_above_200k: None,
             fast_multiplier: 1.0,
         };
+        let glm_base = glm_pricing(0.6e-6, 2.2e-6, 0.11e-6);
         self.entries.insert("glm-4.5".to_string(), glm_base);
         self.entries.insert("zai/glm-4.5".to_string(), glm_base);
+        self.entries.insert(
+            "zai/glm-4.5-x".to_string(),
+            glm_pricing(2.2e-6, 8.9e-6, 0.45e-6),
+        );
+        self.entries.insert(
+            "zai/glm-4.5-air".to_string(),
+            glm_pricing(0.2e-6, 1.1e-6, 0.03e-6),
+        );
+        self.entries.insert(
+            "zai/glm-4.5-airx".to_string(),
+            glm_pricing(1.1e-6, 4.5e-6, 0.22e-6),
+        );
+        self.entries.insert(
+            "zai/glm-4.5v".to_string(),
+            glm_pricing(0.6e-6, 1.8e-6, 0.11e-6),
+        );
+        self.entries.insert(
+            "zai/glm-4-32b-0414-128k".to_string(),
+            glm_pricing(0.1e-6, 0.1e-6, 0.0),
+        );
+        self.entries
+            .insert("zai/glm-4.5-flash".to_string(), glm_pricing(0.0, 0.0, 0.0));
         self.entries.insert("glm-4.6".to_string(), glm_base);
         self.entries.insert("glm-4.7".to_string(), glm_base);
         self.entries.insert(
@@ -1148,6 +1171,29 @@ mod tests {
         assert_eq!(zai_glm_45.cache_create, 0.0);
         assert_eq!(zai_glm_45.cache_read, 0.11e-6);
         assert_eq!(pricing.context_limit("zai/glm-4.5"), Some(128_000));
+    }
+
+    #[test]
+    fn embedded_pricing_patches_z_ai_glm_entries_without_litellm_cache_rates() {
+        let pricing = PricingMap::load_embedded();
+
+        let glm_45_air = pricing.find("zai/glm-4.5-air").unwrap();
+        assert_eq!(glm_45_air.input, 0.2e-6);
+        assert_eq!(glm_45_air.output, 1.1e-6);
+        assert_eq!(glm_45_air.cache_create, 0.0);
+        assert_eq!(glm_45_air.cache_read, 0.03e-6);
+
+        let glm_45_x = pricing.find("zai/glm-4.5-x").unwrap();
+        assert_eq!(glm_45_x.input, 2.2e-6);
+        assert_eq!(glm_45_x.output, 8.9e-6);
+        assert_eq!(glm_45_x.cache_create, 0.0);
+        assert_eq!(glm_45_x.cache_read, 0.45e-6);
+
+        let glm_45v = pricing.find("zai/glm-4.5v").unwrap();
+        assert_eq!(glm_45v.input, 0.6e-6);
+        assert_eq!(glm_45v.output, 1.8e-6);
+        assert_eq!(glm_45v.cache_create, 0.0);
+        assert_eq!(glm_45v.cache_read, 0.11e-6);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -850,6 +850,7 @@ impl PricingMap {
             fast_multiplier: 1.0,
         };
         self.entries.insert("glm-4.5".to_string(), glm_base);
+        self.entries.insert("zai/glm-4.5".to_string(), glm_base);
         self.entries.insert("glm-4.6".to_string(), glm_base);
         self.entries.insert("glm-4.7".to_string(), glm_base);
         self.entries.insert(
@@ -1115,6 +1116,7 @@ mod tests {
         assert_eq!(glm_5.output, 3.2e-6);
         assert_eq!(glm_5.cache_create, 0.0);
         assert_eq!(glm_5.cache_read, 0.2e-6);
+        assert_eq!(pricing.context_limit("zai/glm-5"), Some(200_000));
 
         let glm_5_turbo = pricing.find("glm-5-turbo").unwrap();
         assert_eq!(glm_5_turbo.input, 1.2e-6);
@@ -1139,6 +1141,13 @@ mod tests {
         assert_eq!(glm_45.output, 2.2e-6);
         assert_eq!(glm_45.cache_create, 0.0);
         assert_eq!(glm_45.cache_read, 0.11e-6);
+
+        let zai_glm_45 = pricing.find("zai/glm-4.5").unwrap();
+        assert_eq!(zai_glm_45.input, 0.6e-6);
+        assert_eq!(zai_glm_45.output, 2.2e-6);
+        assert_eq!(zai_glm_45.cache_create, 0.0);
+        assert_eq!(zai_glm_45.cache_read, 0.11e-6);
+        assert_eq!(pricing.context_limit("zai/glm-4.5"), Some(128_000));
     }
 
     #[test]


### PR DESCRIPTION
Fixes the Z.AI GLM built-in fallback pricing added in #1225 so cache creation tokens are not charged in offline cost calculations.

Z.AI lists cached input storage for these GLM models as free, and the corresponding LiteLLM direct Z.AI entries use zero cache creation cost. The previous fallback used the generic cache creation assumption and could overstate GLM costs when cache creation tokens were present.

Testing:
- direnv exec . cargo test --manifest-path rust/Cargo.toml --workspace embedded_pricing_includes_z_ai_glm_models_for_offline_reports
- direnv exec . pnpm run format
- direnv exec . pnpm run test
- direnv exec . pnpm typecheck
- pre-push hook: clippy, treefmt, gitleaks, cargo test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop charging cache creation for Z.AI GLM models and embed direct `zai/*` entries from `LiteLLM` so offline pricing matches Z.AI rates and context limits. Also patch GLM 4.5 variant gaps so cached-input reads and free cache creation are applied correctly, fixing overstated cost reports.

- **Bug Fixes**
  - Set GLM `cache_create` to 0.0 in fallback pricing (4.5/4.6/4.7/5/5-turbo/5.1).
  - Embed `zai/*` pricing snapshot and override `zai/glm-4.5` and its variants (`-x`, `-air`, `-airx`, `v`, `-4-32b-0414-128k`, `-flash`) with zero cache creation and official cache-read rates; treat `zai/*` as embedded to retain upstream context limits.

<sup>Written for commit 43271a93d7d96da506c359d7a95711c16b65c5fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Defaulted GLM pricing to use a 0.0 creation cache and removed per-model overrides; also treat zai-prefixed GLM entries as embedded so their pricing is retained.

* **Tests**
  * Expanded unit tests to validate 0.0 creation cache across multiple GLM variants and added assertions for zai/glm-4.5 variants (including context limits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->