### PR TITLE
docs(agents): document direnv initialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Check the nearest package-specific `AGENTS.md` before editing package code:
 - The canonical user-facing CLI is `ccusage` with agent subcommands such as `ccusage amp`, `ccusage codex`, `ccusage opencode`, and `ccusage pi`.
 - Standalone agent wrapper packages have been removed. Do not add docs, tests, or features that promote `ccusage-amp`, `ccusage-codex`, `ccusage-opencode`, or `ccusage-pi`.
 - Runtime libraries for bundled packages belong in `devDependencies` unless explicitly requested otherwise.
+- When initializing this repository environment, run `direnv allow` so the pinned Nix dev shell is activated.
 - Prefer tools provided by the Nix dev shell before falling back to ad hoc installs: `rg`, `fd`, `fzf`, `delta`, `dust`, `jq`, `gh`, `hyperfine`, `similarity`, `ast-grep`, `typos`, and `typos-lsp`. When a missing tool would be useful for repeated agent work in this repository, add it to `flake.nix`.
 - The production CLI is Rust-first under `rust/crates/ccusage`. Put new runtime behavior there unless the work is specifically about npm packaging, generated schemas, docs tooling, or benchmark scripts.
 - For Rust code, keep modules small, keep `pub(crate)` surfaces narrow, prefer fixture-backed parser/loader tests, and run cargo checks through the root package scripts when possible.


### PR DESCRIPTION
Adds an always-visible AGENTS.md reminder to run direnv allow when initializing this repository environment.

This points agents at the pinned Nix dev shell before normal repository work starts.

Testing: Not run (documentation-only change).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an always-visible reminder in `AGENTS.md` to run `direnv allow` during repo setup. This ensures the pinned Nix dev shell is activated before any work starts.

<sup>Written for commit e8703d84640adce58db44cb680246300ed0c44bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added initialization reminders to development setup documentation to ensure proper environment configuration during repository setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->