### PR TITLE
fix(codex): dedupe goal rollout token events

### DIFF
--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -474,22 +474,28 @@ mod tests {
             "sessions/root.jsonl": &usage_line,
             "sessions/goal.jsonl": &usage_line,
         });
-        let shared = SharedArgs {
-            timezone: Some("UTC".to_string()),
-            ..SharedArgs::default()
-        };
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                single_thread,
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            };
 
-        let groups =
-            load_groups_from_directory(&fixture.path("sessions"), &shared, AgentReportKind::Daily)
-                .unwrap();
+            let groups = load_groups_from_directory(
+                &fixture.path("sessions"),
+                &shared,
+                AgentReportKind::Daily,
+            )
+            .unwrap();
 
-        assert_eq!(groups.len(), 1);
-        let group = groups.get("2026-05-29").unwrap();
-        assert_eq!(group.input_tokens, 1_000);
-        assert_eq!(group.cached_input_tokens, 100);
-        assert_eq!(group.output_tokens, 200);
-        assert_eq!(group.reasoning_output_tokens, 20);
-        assert_eq!(group.total_tokens, 1_200);
+            assert_eq!(groups.len(), 1);
+            let group = groups.get("2026-05-29").unwrap();
+            assert_eq!(group.input_tokens, 1_000);
+            assert_eq!(group.cached_input_tokens, 100);
+            assert_eq!(group.output_tokens, 200);
+            assert_eq!(group.reasoning_output_tokens, 20);
+            assert_eq!(group.total_tokens, 1_200);
+        }
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -18,7 +18,18 @@ use crate::{
 
 use super::{parser, paths};
 
-type CodexEventKey = (crate::TimestampMs, u64, usize, u64, u64, u64, u64, u64);
+type CodexEventKey = (
+    u64,
+    usize,
+    crate::TimestampMs,
+    u64,
+    usize,
+    u64,
+    u64,
+    u64,
+    u64,
+    u64,
+);
 type CodexDedupeShards = [Mutex<FxHashSet<CodexEventKey>>];
 
 struct CodexAggregation {
@@ -226,7 +237,7 @@ fn add_event_to_groups(
     };
     let timestamp = parse_ts_timestamp(&event.timestamp)
         .ok_or_else(|| crate::cli_error(format!("Invalid Codex timestamp: {}", event.timestamp)))?;
-    if !insert_event_key(event, timestamp, model, seen) {
+    if !insert_event_key(event, timestamp, model, kind, seen) {
         return Ok(());
     }
     add_deduped_event_to_groups(event, model, timestamp, kind, timezone, shared, groups)
@@ -246,7 +257,7 @@ fn add_event_to_groups_local(
         .ok_or_else(|| crate::cli_error(format!("Invalid Codex timestamp: {}", event.timestamp)))?;
     if !aggregation
         .seen
-        .insert(codex_event_key(event, timestamp, model))
+        .insert(codex_event_key(event, timestamp, model, kind))
     {
         return Ok(());
     }
@@ -330,9 +341,10 @@ fn insert_event_key(
     event: &CodexTokenUsageEvent,
     timestamp: crate::TimestampMs,
     model: &str,
+    kind: AgentReportKind,
     seen: &CodexDedupeShards,
 ) -> bool {
-    let key = codex_event_key(event, timestamp, model);
+    let key = codex_event_key(event, timestamp, model, kind);
     let mut hasher = FxHasher::default();
     key.hash(&mut hasher);
     let shard_index = hasher.finish() as usize % seen.len();
@@ -343,8 +355,16 @@ fn codex_event_key(
     event: &CodexTokenUsageEvent,
     timestamp: crate::TimestampMs,
     model: &str,
+    kind: AgentReportKind,
 ) -> CodexEventKey {
+    let (session_hash, session_len) = if kind == AgentReportKind::Session {
+        (hash_text(&event.session_id), event.session_id.len())
+    } else {
+        (0, 0)
+    };
     (
+        session_hash,
+        session_len,
         timestamp,
         hash_text(model),
         model.len(),
@@ -495,6 +515,50 @@ mod tests {
             assert_eq!(group.output_tokens, 200);
             assert_eq!(group.reasoning_output_tokens, 20);
             assert_eq!(group.total_tokens, 1_200);
+        }
+    }
+
+    #[test]
+    fn keeps_matching_token_usage_in_distinct_session_groups() {
+        let usage_line = json!({
+            "timestamp": "2026-05-29T08:01:00.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "model": "gpt-5.2",
+                    "last_token_usage": {
+                        "input_tokens": 1_000,
+                        "cached_input_tokens": 100,
+                        "output_tokens": 200,
+                        "reasoning_output_tokens": 20,
+                        "total_tokens": 1_200,
+                    },
+                },
+            },
+        })
+        .to_string();
+        let fixture = fs_fixture!({
+            "sessions/root.jsonl": &usage_line,
+            "sessions/goal.jsonl": &usage_line,
+        });
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                single_thread,
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            };
+
+            let groups = load_groups_from_directory(
+                &fixture.path("sessions"),
+                &shared,
+                AgentReportKind::Session,
+            )
+            .unwrap();
+
+            assert_eq!(groups.len(), 2);
+            assert_eq!(groups["root"].input_tokens, 1_000);
+            assert_eq!(groups["goal"].input_tokens, 1_000);
         }
     }
 

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -18,18 +18,7 @@ use crate::{
 
 use super::{parser, paths};
 
-type CodexEventKey = (
-    u64,
-    usize,
-    crate::TimestampMs,
-    u64,
-    usize,
-    u64,
-    u64,
-    u64,
-    u64,
-    u64,
-);
+type CodexEventKey = (crate::TimestampMs, u64, usize, u64, u64, u64, u64, u64);
 type CodexDedupeShards = [Mutex<FxHashSet<CodexEventKey>>];
 
 struct CodexAggregation {
@@ -356,8 +345,6 @@ fn codex_event_key(
     model: &str,
 ) -> CodexEventKey {
     (
-        hash_text(&event.session_id),
-        event.session_id.len(),
         timestamp,
         hash_text(model),
         model.len(),
@@ -462,6 +449,48 @@ mod tests {
     use serde_json::json;
 
     use crate::adapter::codex::paths::CodexUsageSource;
+
+    #[test]
+    fn dedupes_copied_token_usage_across_session_files() {
+        let usage_line = json!({
+            "timestamp": "2026-05-29T08:01:00.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "model": "gpt-5.2",
+                    "last_token_usage": {
+                        "input_tokens": 1_000,
+                        "cached_input_tokens": 100,
+                        "output_tokens": 200,
+                        "reasoning_output_tokens": 20,
+                        "total_tokens": 1_200,
+                    },
+                },
+            },
+        })
+        .to_string();
+        let fixture = fs_fixture!({
+            "sessions/root.jsonl": &usage_line,
+            "sessions/goal.jsonl": &usage_line,
+        });
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let groups =
+            load_groups_from_directory(&fixture.path("sessions"), &shared, AgentReportKind::Daily)
+                .unwrap();
+
+        assert_eq!(groups.len(), 1);
+        let group = groups.get("2026-05-29").unwrap();
+        assert_eq!(group.input_tokens, 1_000);
+        assert_eq!(group.cached_input_tokens, 100);
+        assert_eq!(group.output_tokens, 200);
+        assert_eq!(group.reasoning_output_tokens, 20);
+        assert_eq!(group.total_tokens, 1_200);
+    }
 
     #[test]
     fn aggregates_active_copy_when_archived_file_has_same_relative_path() {

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -96,7 +96,7 @@ mod tests {
     }
 
     #[test]
-    fn keeps_matching_grouped_codex_usage_events_from_distinct_sessions() {
+    fn dedupes_matching_grouped_codex_usage_events_from_distinct_sessions() {
         let usage_line = r#"{"timestamp":"2026-01-02T00:00:00.000Z","type":"event_msg","payload":{"type":"token_count","info":{"model":"gpt-5","last_token_usage":{"input_tokens":100,"cached_input_tokens":10,"output_tokens":50,"reasoning_output_tokens":0,"total_tokens":150}}}}"#;
         let fixture = fs_fixture!({
             "sessions/session-a.jsonl": usage_line,
@@ -113,10 +113,10 @@ mod tests {
 
         assert_eq!(groups.len(), 1);
         let group = groups.get("2026-01-02").unwrap();
-        assert_eq!(group.input_tokens, 200);
-        assert_eq!(group.cached_input_tokens, 20);
-        assert_eq!(group.output_tokens, 100);
-        assert_eq!(group.total_tokens, 300);
+        assert_eq!(group.input_tokens, 100);
+        assert_eq!(group.cached_input_tokens, 10);
+        assert_eq!(group.output_tokens, 50);
+        assert_eq!(group.total_tokens, 150);
     }
 
     #[test]


### PR DESCRIPTION
Deduplicates copied Codex token_count rows when rollout or goal session files contain the same usage event as another session file.

The streaming group aggregation path now uses the same token tuple based dedupe shape as the event loader, so table reports do not count copied session history once per rollout file.

Testing:
- direnv exec . cargo test -p ccusage adapter::codex -- --nocapture
- direnv exec . pnpm run test
- pre-push hook: clippy, treefmt, gitleaks, cargo test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-counting of Codex token usage when rollout or goal session files copy the same events. The streaming aggregator now uses the event loader’s token-tuple key and scopes it by report kind, so daily/weekly/monthly dedupe across files while session reports keep distinct groups.

- **Bug Fixes**
  - Use a token-tuple dedupe key; drop `session_id` for daily/weekly/monthly to dedupe across session files, but include it for session reports to avoid collapsing separate sessions. Tests cover both single-thread and parallel paths.

<sup>Written for commit c7ffd05c10daa51736b99233b36ce072119e4a1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token-usage deduplication: identical events across multiple session files are now deduplicated for aggregated totals, while session-specific reports remain separated so per-session counts are preserved.

* **Tests**
  * Expanded unit tests to verify deduplication across distinct session files (single- and multi-threaded) and to confirm session-kind reports are kept separate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->