### PR TITLE
chore(dev): consolidate checks behind just

### DIFF
--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -41,7 +41,7 @@ jobs:
             echo "Pricing snapshot is already up to date."
             exit 0
           fi
-          nix flake check
+          nix develop --command just check
       - name: Create pull request
         env:
           GH_TOKEN: ${{ github.token }}
@@ -64,7 +64,7 @@ jobs:
             'Updates the locked LiteLLM pricing input used by Nix builds.' \
             '' \
             'Validation:' \
-            '- nix flake check')"
+            '- just check')"
 
           if gh pr view "$branch" >/dev/null 2>&1; then
             printf '%s\n' "$body" | gh pr edit "$branch" --title "chore(pricing): update LiteLLM snapshot" --body-file -

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -155,7 +155,7 @@ Full documentation is available at **[ccusage.com](https://ccusage.com/)**
 <details>
 <summary>Contributor setup</summary>
 
-Contributor setup requires the Nix flake development environment with [nix-direnv](https://github.com/nix-community/nix-direnv). Install [Nix](https://nixos.org/) with the `nix-command` and `flakes` experimental features enabled, then let nix-direnv load the dev shell automatically when you enter the directory:
+Contributor setup uses the Nix flake development environment with [nix-direnv](https://github.com/nix-community/nix-direnv) for pinned tools, and `just` for everyday development tasks. Install [Nix](https://nixos.org/) with the `nix-command` and `flakes` experimental features enabled, then let nix-direnv load the dev shell automatically when you enter the directory:
 
 ```sh
 # Clone the repository
@@ -168,12 +168,12 @@ direnv allow
 
 The dev shell provides the pinned `pnpm`, Rust toolchain, GitHub CLI, git hooks, generated local agent skills, and project utilities from `flake.nix`. It also installs package dependencies from `pnpm-lock.yaml` when needed.
 
-Run the usual checks from inside the Nix environment (`just --list` shows every recipe):
+Run project tasks with `just` from inside the Nix environment (`just --list` shows every recipe):
 
 ```sh
 just fmt
-just typecheck
 just test
+just check
 ```
 
 ### Nix Package
@@ -191,11 +191,10 @@ Nix builds embed the LiteLLM pricing file from the locked `litellm` flake input,
 Non-Nix Cargo builds read the same locked LiteLLM revision from `flake.lock` and fetch the pricing file from that revision at build time.
 
 ```bash
-nix flake update litellm
-nix flake check
+just update-litellm-pricing
 ```
 
-The scheduled `update pricing` workflow runs the same commands and opens a PR when the locked input changes.
+The scheduled `update pricing` workflow runs the same update and validation, then opens a PR when the pricing snapshot changes.
 
 </details>
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -89,28 +89,31 @@ For development or contributing to ccusage:
 git clone https://github.com/ryoppippi/ccusage.git
 cd ccusage
 
-# Install dependencies
-pnpm install
-
-# Run directly from source
-pnpm --filter ccusage start daily
-pnpm --filter ccusage start monthly --json
+# Allow direnv to load the Nix dev shell
+direnv allow
 ```
 
-### Development Scripts
+The Nix dev shell provides the pinned `pnpm`, Rust toolchain, GitHub CLI, git hooks, and project utilities. Run project tasks with `just`:
 
 ```bash
+# Format the tree
+just fmt
+
 # Run tests
 just test
 
-# Type checking
-just typecheck
+# Run static checks
+just check
 
 # Build distribution
 just build
+```
 
-# Lint and format
-just fmt
+You can also run the package directly from source:
+
+```bash
+pnpm --filter ccusage start daily
+pnpm --filter ccusage start monthly --json
 ```
 
 ## Runtime Requirements

--- a/justfile
+++ b/justfile
@@ -37,16 +37,8 @@ test-vitest:
 fmt:
     nix fmt
 
-# Check formatting with treefmt and fail if changes are needed
-fmt-check:
-    treefmt --fail-on-change
-
-# Lint TypeScript and JavaScript sources
-lint:
-    oxlint .
-
-# Run lint, format checks, typechecks, and every flake check (clippy, rustfmt, schema drift, gitleaks, build)
-check: lint fmt-check typecheck
+# Run package typechecks and every flake check (treefmt, oxlint, clippy, schema drift, gitleaks, build)
+check: typecheck
     nix flake check
 
 # Regenerate apps/ccusage/config-schema.json from the Rust source

--- a/justfile
+++ b/justfile
@@ -37,13 +37,26 @@ test-vitest:
 fmt:
     nix fmt
 
-# Run every flake check (clippy, rustfmt, oxlint, schema drift, gitleaks, build)
-check:
+# Check formatting with treefmt and fail if changes are needed
+fmt-check:
+    treefmt --fail-on-change
+
+# Lint TypeScript and JavaScript sources
+lint:
+    oxlint .
+
+# Run lint, format checks, typechecks, and every flake check (clippy, rustfmt, schema drift, gitleaks, build)
+check: lint fmt-check typecheck
     nix flake check
 
 # Regenerate apps/ccusage/config-schema.json from the Rust source
 schema:
     nix run .#generate-schema
+
+# Update the locked LiteLLM pricing snapshot and validate the result
+update-litellm-pricing:
+    nix flake update litellm
+    just check
 
 # Bump every package version (Rust included via bump.config.ts), then commit, tag, push
 release: ccusage::typecheck ccusage::build


### PR DESCRIPTION
Consolidates contributor-facing development validation around just.

This makes just check run package typechecks plus nix flake check, which covers treefmt, oxlint, clippy, schema drift, gitleaks, and the build. It also adds just update-litellm-pricing and updates the README, installation guide, and pricing update workflow to use the same entry points.

Testing:
- nix develop --command just check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer and contributor setup docs to reflect the new Nix-based dev environment and revised task examples, and clarified the pricing update process.

* **Chores**
  * Adjusted scheduled pricing snapshot refresh to open PRs when the locked snapshot changes.
  * Updated validation workflow and top-level development task orchestration.

* **New Features**
  * Added an automated task to update LiteLLM pricing snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->