### PR TITLE
feat(pricing): embed models.dev snapshot for offline pricing

### DIFF
--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -2,16 +2,17 @@ name: update pricing
 
 on:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   update-pricing:
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup-nix
@@ -70,4 +71,63 @@ jobs:
             printf '%s\n' "$body" | gh pr edit "$branch" --title "chore(pricing): update LiteLLM snapshot" --body-file -
           else
             printf '%s\n' "$body" | gh pr create --base main --head "$branch" --title "chore(pricing): update LiteLLM snapshot" --body-file -
+          fi
+
+  update-models-dev-pricing:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/setup-nix
+      - name: Update models.dev input
+        run: |
+          nix flake update models-dev
+      - name: Regenerate committed models.dev pricing snapshot
+        run: |
+          nix develop --command just gen-models-dev-pricing
+      - name: Skip lock-only models.dev updates
+        run: |
+          # Only the compacted snapshot affects the build; if a models.dev bump
+          # leaves the Anthropic pricing unchanged, drop the lock-only churn.
+          if git diff --quiet -- rust/crates/ccusage/src/models-dev-pricing.json; then
+            echo "models.dev pricing snapshot is unchanged; skipping PR."
+            git checkout -- flake.lock rust/crates/ccusage/src/models-dev-pricing.json
+          fi
+      - name: Validate updated pricing snapshot
+        run: |
+          if git diff --quiet; then
+            echo "Pricing snapshot is already up to date."
+            exit 0
+          fi
+          nix develop --command just check
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet; then
+            echo "Pricing snapshot is already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          branch="automation/models-dev-pricing"
+          git checkout -B "$branch"
+          git add flake.lock rust/crates/ccusage/src/models-dev-pricing.json
+          git commit -m "chore(pricing): update models.dev snapshot"
+          git push --force-with-lease origin "$branch"
+
+          body="$(printf '%s\n' \
+            'Updates the pinned models.dev input and its committed pricing snapshot.' \
+            '' \
+            'Validation:' \
+            '- just check')"
+
+          if gh pr view "$branch" >/dev/null 2>&1; then
+            printf '%s\n' "$body" | gh pr edit "$branch" --title "chore(pricing): update models.dev snapshot" --body-file -
+          else
+            printf '%s\n' "$body" | gh pr create --base main --head "$branch" --title "chore(pricing): update models.dev snapshot" --body-file -
           fi

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -56,6 +56,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          gh auth setup-git
 
           branch="automation/litellm-pricing"
           git checkout -B "$branch"
@@ -119,6 +120,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          gh auth setup-git
 
           branch="automation/models-dev-pricing"
           git checkout -B "$branch"

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -15,6 +15,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-nix
       - name: Capture current LiteLLM pricing JSON
         run: |
@@ -74,12 +76,15 @@ jobs:
           fi
 
   update-models-dev-pricing:
+    needs: update-pricing
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-nix
       - name: Update models.dev input
         run: |

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -77,6 +77,7 @@ jobs:
 
   update-models-dev-pricing:
     needs: update-pricing
+    if: ${{ always() }}
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write

--- a/flake.lock
+++ b/flake.lock
@@ -150,6 +150,22 @@
         "type": "github"
       }
     },
+    "models-dev": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781034000,
+        "narHash": "sha256-Q/0ugMpEDw+ACZ3V3FbMdzX+57rhrvXfb/Ycn8t5X/0=",
+        "owner": "anomalyco",
+        "repo": "models.dev",
+        "rev": "fb13347f59fac093d60025d987556f57f9a35427",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anomalyco",
+        "repo": "models.dev",
+        "type": "github"
+      }
+    },
     "nix-filter": {
       "locked": {
         "lastModified": 1757882181,
@@ -203,6 +219,7 @@
         "flake-parts": "flake-parts",
         "git-hooks": "git-hooks",
         "litellm": "litellm",
+        "models-dev": "models-dev",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,10 @@
       url = "github:BerriAI/litellm";
       flake = false;
     };
+    models-dev = {
+      url = "github:anomalyco/models.dev";
+      flake = false;
+    };
     nix-filter.url = "github:numtide/nix-filter";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";

--- a/justfile
+++ b/justfile
@@ -57,8 +57,10 @@ gen-models-dev-pricing:
     nix fmt rust/crates/ccusage/src/models-dev-pricing.json
 
 # Update the pinned models.dev input, regenerate its pricing snapshot, and validate
-update-models-dev-pricing: && gen-models-dev-pricing check
+update-models-dev-pricing:
     nix flake update models-dev
+    just gen-models-dev-pricing
+    just check
 
 # Bump every package version (Rust included via bump.config.ts), then commit, tag, push
 release: ccusage::typecheck ccusage::build

--- a/justfile
+++ b/justfile
@@ -50,6 +50,16 @@ update-litellm-pricing:
     nix flake update litellm
     just check
 
+# Regenerate the committed models.dev pricing snapshot from the pinned input
+gen-models-dev-pricing:
+    cp "$(nix build .#models-dev-pricing --no-link --print-out-paths)" rust/crates/ccusage/src/models-dev-pricing.json
+    chmod u+w rust/crates/ccusage/src/models-dev-pricing.json
+    nix fmt rust/crates/ccusage/src/models-dev-pricing.json
+
+# Update the pinned models.dev input, regenerate its pricing snapshot, and validate
+update-models-dev-pricing: && gen-models-dev-pricing check
+    nix flake update models-dev
+
 # Bump every package version (Rust included via bump.config.ts), then commit, tag, push
 release: ccusage::typecheck ccusage::build
     pnpm bumpp -r

--- a/nix/models-dev-gen.ts
+++ b/nix/models-dev-gen.ts
@@ -1,0 +1,79 @@
+/**
+ * Generate the committed models.dev pricing snapshot.
+ *
+ * models.dev ships per-model TOML sources rather than a prebuilt catalog, so we
+ * reuse its own `generateCatalog` routine (the same code that backs
+ * https://models.dev/api.json) and then compact the result down to the
+ * Anthropic-relevant models and the few pricing fields ccusage consumes. The
+ * output is committed to the repository and embedded at build time, so every
+ * platform ships the identical, pinned data without any build-time network
+ * access. Run via `just gen-models-dev-pricing` (see `nix/models-dev-pricing.nix`).
+ */
+import { generateCatalog } from './packages/core/src/generate.ts';
+
+/** Model ids/keys we keep; ccusage is Claude-first, so we embed Anthropic models. */
+const KEEP = /claude|anthropic/i;
+
+type Cost = {
+	input?: number | null;
+	output?: number | null;
+	cache_read?: number | null;
+	cache_write?: number | null;
+};
+type Model = { id?: string; cost?: Cost; limit?: { context?: number | null } };
+type Provider = { models?: Record<string, Model> };
+
+const { providers } = (await generateCatalog('.')) as {
+	providers: Record<string, Provider>;
+};
+
+const out: Record<string, { models: Record<string, unknown> }> = {};
+for (const [providerId, provider] of Object.entries(providers)) {
+	const models: Record<string, unknown> = {};
+	for (const [modelId, model] of Object.entries(provider.models ?? {})) {
+		// models.dev also exposes the canonical id under `id`; match either so
+		// provider-prefixed aliases (e.g. us.anthropic.*) are kept too.
+		if (!(KEEP.test(modelId) || KEEP.test(model.id ?? ''))) {
+			continue;
+		}
+		const cost = model.cost ?? {};
+		// Skip entries without the base prices the runtime loader requires.
+		if (cost.input == null || cost.output == null) {
+			continue;
+		}
+		const entry: Record<string, unknown> = {};
+		if (model.id != null) {
+			entry.id = model.id;
+		}
+		entry.cost = {
+			input: cost.input,
+			output: cost.output,
+			...(cost.cache_read != null ? { cache_read: cost.cache_read } : {}),
+			...(cost.cache_write != null ? { cache_write: cost.cache_write } : {}),
+		};
+		if (model.limit?.context != null) {
+			entry.limit = { context: model.limit.context };
+		}
+		models[modelId] = entry;
+	}
+	if (Object.keys(models).length > 0) {
+		out[providerId] = { models };
+	}
+}
+
+// Stable key ordering keeps the committed snapshot's diffs minimal across regenerations.
+const sortObject = (value: unknown): unknown => {
+	if (Array.isArray(value)) {
+		return value.map(sortObject);
+	}
+	if (value != null && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.keys(value as Record<string, unknown>)
+				.sort()
+				.map((key) => [key, sortObject((value as Record<string, unknown>)[key])]),
+		);
+	}
+	return value;
+};
+
+await Bun.write(process.env.OUTFILE!, `${JSON.stringify(sortObject(out), null, 2)}\n`);

--- a/nix/models-dev-gen.ts
+++ b/nix/models-dev-gen.ts
@@ -76,4 +76,9 @@ const sortObject = (value: unknown): unknown => {
 	return value;
 };
 
-await Bun.write(process.env.OUTFILE!, `${JSON.stringify(sortObject(out), null, 2)}\n`);
+const outfile = process.env.OUTFILE;
+if (outfile == null || outfile.length === 0) {
+	throw new Error('OUTFILE environment variable is required');
+}
+
+await Bun.write(outfile, `${JSON.stringify(sortObject(out), null, 2)}\n`);

--- a/nix/models-dev-pricing.nix
+++ b/nix/models-dev-pricing.nix
@@ -1,0 +1,53 @@
+# Reproducibly regenerate the compacted models.dev pricing snapshot from the
+# pinned `models-dev` flake input. The upstream repository ships per-model TOML
+# sources rather than a prebuilt catalog, so we run their own `generateCatalog`
+# routine (via `nix/models-dev-gen.ts`) with Bun. Its only runtime dependencies
+# are `remeda` and `zod` (both zero-dependency packages), which we vendor
+# directly from the registry using the integrity hashes pinned in upstream
+# `bun.lock`.
+#
+# The build output is copied into the repository (see `just gen-models-dev-pricing`)
+# and embedded at build time, so every platform ships identical pinned data
+# without build-time network access.
+{
+  pkgs,
+  modelsDevSrc,
+}:
+let
+  # `fetchurl` accepts npm integrity strings verbatim because they already are
+  # Subresource Integrity (SRI) hashes. Keep these in sync with the matching
+  # entries in `${modelsDevSrc}/bun.lock` whenever the input is bumped.
+  remeda = pkgs.fetchurl {
+    url = "https://registry.npmjs.org/remeda/-/remeda-2.33.7.tgz";
+    hash = "sha512-cXlyjevWx5AcslOUEETG4o8XYi9UkoCXcJmj7XhPFVbla+ITuOBxv6ijBrmbeg+ZhzmDThkNdO+iXKUfrJep1w==";
+  };
+  zod = pkgs.fetchurl {
+    url = "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz";
+    hash = "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==";
+  };
+in
+pkgs.runCommand "models-dev-pricing.json"
+  {
+    nativeBuildInputs = [ pkgs.bun ];
+  }
+  ''
+    export HOME="$TMPDIR"
+
+    # Copy the read-only source tree into a writable workspace so that Bun can
+    # resolve the vendored `node_modules` while importing upstream modules.
+    cp -r ${modelsDevSrc} work
+    chmod -R u+w work
+
+    # Lay out the two runtime dependencies as a flat node_modules at the
+    # workspace root; Bun walks up from each source file to find them.
+    mkdir -p work/node_modules/remeda work/node_modules/zod
+    tar -xzf ${remeda} -C work/node_modules/remeda --strip-components=1
+    tar -xzf ${zod} -C work/node_modules/zod --strip-components=1
+
+    # The generator imports `./packages/core/src/generate.ts`, so it must run
+    # from inside the workspace next to the vendored node_modules.
+    cp ${./models-dev-gen.ts} work/gen.ts
+
+    cd work
+    OUTFILE="$out" bun run gen.ts
+  ''

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -27,6 +27,12 @@ in
           ;
       };
       ccusageProgram = pkgs.lib.getExe' ccusage "ccusage";
+      # Regeneration-only output for the committed models.dev pricing snapshot;
+      # `just gen-models-dev-pricing` builds this and copies it into the source
+      # tree. It is not part of the ccusage build, which embeds the committed file.
+      models-dev-pricing = pkgs.callPackage ../nix/models-dev-pricing.nix {
+        modelsDevSrc = inputs.models-dev;
+      };
     in
     {
       apps = {
@@ -42,7 +48,7 @@ in
 
       packages = {
         default = ccusage;
-        inherit ccusage;
+        inherit ccusage models-dev-pricing;
       };
     };
 }

--- a/package.nix
+++ b/package.nix
@@ -17,7 +17,8 @@ let
       (craneLib.filterCargoSources path type)
       || lib.hasSuffix "/cli-help.json" path
       || lib.hasSuffix "/cli-commands.json" path
-      || lib.hasSuffix "/fast-multiplier-overrides.json" path;
+      || lib.hasSuffix "/fast-multiplier-overrides.json" path
+      || lib.hasSuffix "/models-dev-pricing.json" path;
   };
   commonArgs = {
     pname = "ccusage";

--- a/rust/crates/ccusage/src/models-dev-pricing.json
+++ b/rust/crates/ccusage/src/models-dev-pricing.json
@@ -1,0 +1,5195 @@
+{
+	"302ai": {
+		"models": {
+			"claude-3-5-haiku-20241022": {
+				"cost": {
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "claude-3-5-haiku-20241022",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-5-haiku-latest": {
+				"cost": {
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "claude-3-5-haiku-latest",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5": {
+				"cost": {
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5-20251001": {
+				"cost": {
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5-20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-20250805": {
+				"cost": {
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1-20250805",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-20250805-thinking": {
+				"cost": {
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1-20250805-thinking",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-20250514": {
+				"cost": {
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5": {
+				"cost": {
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5-20251101": {
+				"cost": {
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5-20251101",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5-20251101-thinking": {
+				"cost": {
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5-20251101-thinking",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-6-thinking": {
+				"cost": {
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6-thinking",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-20250514": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5-20250929": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5-20250929",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5-20250929-thinking": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5-20250929-thinking",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-6-thinking": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6-thinking",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"abacus": {
+		"models": {
+			"claude-3-7-sonnet-20250219": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-3-7-sonnet-20250219",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5-20251001": {
+				"cost": {
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5-20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-20250805": {
+				"cost": {
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1-20250805",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-20250514": {
+				"cost": {
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5-20251101": {
+				"cost": {
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5-20251101",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-20250514": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5-20250929": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5-20250929",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"aihubmix": {
+		"models": {
+			"claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-6-think": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6-think",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7-think": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7-think",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-6-think": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6-think",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"amazon-bedrock": {
+		"models": {
+			"anthropic.claude-haiku-4-5-20251001-v1:0": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic.claude-haiku-4-5-20251001-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic.claude-opus-4-1-20250805-v1:0": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic.claude-opus-4-1-20250805-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic.claude-opus-4-5-20251101-v1:0": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic.claude-opus-4-5-20251101-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic.claude-opus-4-6-v1": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic.claude-opus-4-6-v1",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic.claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic.claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic.claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic.claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic.claude-sonnet-4-5-20250929-v1:0": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic.claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic.claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"au.anthropic.claude-opus-4-6-v1": {
+				"cost": {
+					"cache_read": 1.65,
+					"cache_write": 20.625,
+					"input": 16.5,
+					"output": 82.5
+				},
+				"id": "au.anthropic.claude-opus-4-6-v1",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"au.anthropic.claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "au.anthropic.claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"au.anthropic.claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.33,
+					"cache_write": 4.125,
+					"input": 3.3,
+					"output": 16.5
+				},
+				"id": "au.anthropic.claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"eu.anthropic.claude-fable-5": {
+				"cost": {
+					"cache_read": 1.1,
+					"cache_write": 13.75,
+					"input": 11,
+					"output": 55
+				},
+				"id": "eu.anthropic.claude-fable-5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"eu.anthropic.claude-opus-4-6-v1": {
+				"cost": {
+					"cache_read": 0.55,
+					"cache_write": 6.875,
+					"input": 5.5,
+					"output": 27.5
+				},
+				"id": "eu.anthropic.claude-opus-4-6-v1",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"eu.anthropic.claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.55,
+					"cache_write": 6.875,
+					"input": 5.5,
+					"output": 27.5
+				},
+				"id": "eu.anthropic.claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"eu.anthropic.claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.55,
+					"cache_write": 6.875,
+					"input": 5.5,
+					"output": 27.5
+				},
+				"id": "eu.anthropic.claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+				"cost": {
+					"cache_read": 0.33,
+					"cache_write": 4.125,
+					"input": 3.3,
+					"output": 16.5
+				},
+				"id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"eu.anthropic.claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.33,
+					"cache_write": 4.125,
+					"input": 3.3,
+					"output": 16.5
+				},
+				"id": "eu.anthropic.claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"global.anthropic.claude-fable-5": {
+				"cost": {
+					"cache_read": 1,
+					"cache_write": 12.5,
+					"input": 10,
+					"output": 50
+				},
+				"id": "global.anthropic.claude-fable-5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"global.anthropic.claude-opus-4-5-20251101-v1:0": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"global.anthropic.claude-opus-4-6-v1": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "global.anthropic.claude-opus-4-6-v1",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"global.anthropic.claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "global.anthropic.claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"global.anthropic.claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "global.anthropic.claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"global.anthropic.claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "global.anthropic.claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"jp.anthropic.claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "jp.anthropic.claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"jp.anthropic.claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "jp.anthropic.claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"jp.anthropic.claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "jp.anthropic.claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"us.anthropic.claude-fable-5": {
+				"cost": {
+					"cache_read": 1,
+					"cache_write": 12.5,
+					"input": 10,
+					"output": 50
+				},
+				"id": "us.anthropic.claude-fable-5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"us.anthropic.claude-opus-4-1-20250805-v1:0": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"us.anthropic.claude-opus-4-5-20251101-v1:0": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"us.anthropic.claude-opus-4-6-v1": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "us.anthropic.claude-opus-4-6-v1",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"us.anthropic.claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "us.anthropic.claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"us.anthropic.claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "us.anthropic.claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"us.anthropic.claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "us.anthropic.claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"anthropic": {
+		"models": {
+			"claude-3-5-haiku-20241022": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "claude-3-5-haiku-20241022",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-5-haiku-latest": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "claude-3-5-haiku-latest",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-5-sonnet-20240620": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-3-5-sonnet-20240620",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-5-sonnet-20241022": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-3-5-sonnet-20241022",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-7-sonnet-20250219": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-3-7-sonnet-20250219",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-haiku-20240307": {
+				"cost": {
+					"cache_read": 0.03,
+					"cache_write": 0.3,
+					"input": 0.25,
+					"output": 1.25
+				},
+				"id": "claude-3-haiku-20240307",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-opus-20240229": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-3-opus-20240229",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-sonnet-20240229": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 0.3,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-3-sonnet-20240229",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-fable-5": {
+				"cost": {
+					"cache_read": 1,
+					"cache_write": 12.5,
+					"input": 10,
+					"output": 50
+				},
+				"id": "claude-fable-5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5-20251001": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5-20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-0": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-20250805": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1-20250805",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-20250514": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5-20251101": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5-20251101",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-0": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-0",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-20250514": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5-20250929": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5-20250929",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"auriko": {
+		"models": {
+			"claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"azure": {
+		"models": {
+			"claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"azure-cognitive-services": {
+		"models": {
+			"claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"cloudflare-ai-gateway": {
+		"models": {
+			"anthropic/claude-3-5-haiku": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "anthropic/claude-3-5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-3-haiku": {
+				"cost": {
+					"cache_read": 0.03,
+					"cache_write": 0.3,
+					"input": 0.25,
+					"output": 1.25
+				},
+				"id": "anthropic/claude-3-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-3-opus": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-3-opus",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-3-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 0.3,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-3-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-3.5-haiku": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "anthropic/claude-3.5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-3.5-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-3.5-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-fable-5": {
+				"cost": {
+					"cache_read": 1,
+					"cache_write": 12.5,
+					"input": 10,
+					"output": 50
+				},
+				"id": "anthropic/claude-fable-5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4-1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"cortecs": {
+		"models": {
+			"claude-4-5-sonnet": {
+				"cost": {
+					"input": 3.259,
+					"output": 16.296
+				},
+				"id": "claude-4-5-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-4-6-sonnet": {
+				"cost": {
+					"input": 3.59,
+					"output": 17.92
+				},
+				"id": "claude-4-6-sonnet",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-haiku-4-5": {
+				"cost": {
+					"input": 1.09,
+					"output": 5.43
+				},
+				"id": "claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus4-5": {
+				"cost": {
+					"input": 5.98,
+					"output": 29.89
+				},
+				"id": "claude-opus4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus4-6": {
+				"cost": {
+					"input": 5.98,
+					"output": 29.89
+				},
+				"id": "claude-opus4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus4-7": {
+				"cost": {
+					"cache_read": 0.56,
+					"cache_write": 6.99,
+					"input": 5.6,
+					"output": 27.99
+				},
+				"id": "claude-opus4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4": {
+				"cost": {
+					"input": 3.307,
+					"output": 16.536
+				},
+				"id": "claude-sonnet-4",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"databricks": {
+		"models": {
+			"databricks-claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "databricks-claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"databricks-claude-opus-4-1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "databricks-claude-opus-4-1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"databricks-claude-opus-4-5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "databricks-claude-opus-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"databricks-claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "databricks-claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"databricks-claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "databricks-claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"databricks-claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "databricks-claude-sonnet-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"databricks-claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "databricks-claude-sonnet-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"databricks-claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "databricks-claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"digitalocean": {
+		"models": {
+			"anthropic-claude-3-opus": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic-claude-3-opus",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic-claude-3.5-haiku": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "anthropic-claude-3.5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic-claude-3.5-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic-claude-3.5-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic-claude-3.7-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic-claude-3.7-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic-claude-4.1-opus": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic-claude-4.1-opus",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic-claude-4.5-haiku": {
+				"cost": {
+					"cache_read": 1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic-claude-4.5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic-claude-4.5-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic-claude-4.5-sonnet",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic-claude-4.6-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic-claude-4.6-sonnet",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic-claude-haiku-4.5": {
+				"cost": {
+					"cache_read": 1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic-claude-haiku-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic-claude-opus-4": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic-claude-opus-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic-claude-opus-4.5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic-claude-opus-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic-claude-opus-4.6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic-claude-opus-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic-claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic-claude-opus-4.7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic-claude-opus-4.8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic-claude-opus-4.8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic-claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic-claude-sonnet-4",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"fastrouter": {
+		"models": {
+			"anthropic/claude-opus-4.1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4.1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"freemodel": {
+		"models": {
+			"claude-haiku-4-5-20251001": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5-20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"frogbot": {
+		"models": {
+			"claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"github-copilot": {
+		"models": {
+			"claude-haiku-4.5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4.5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4.6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4.6",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4.7",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4.8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4.8",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4",
+				"limit": {
+					"context": 216000
+				}
+			},
+			"claude-sonnet-4.5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4.6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4.6",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"gmicloud": {
+		"models": {
+			"anthropic/claude-opus-4.6": {
+				"cost": {
+					"cache_read": 0.5,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.6",
+				"limit": {
+					"context": 409600
+				}
+			},
+			"anthropic/claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.45,
+					"input": 4.5,
+					"output": 22.5
+				},
+				"id": "anthropic/claude-opus-4.7",
+				"limit": {
+					"context": 409600
+				}
+			},
+			"anthropic/claude-sonnet-4.6": {
+				"cost": {
+					"cache_read": 0.3,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.6",
+				"limit": {
+					"context": 409600
+				}
+			}
+		}
+	},
+	"google-vertex": {
+		"models": {
+			"claude-3-5-haiku@20241022": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "claude-3-5-haiku@20241022",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5@20251001": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5@20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1@20250805": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1@20250805",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5@20251101": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5@20251101",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6@default": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6@default",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7@default": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7@default",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-8@default": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-8@default",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4@20250514": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4@20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5@20250929": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5@20250929",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-6@default": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6@default",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4@20250514": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4@20250514",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"google-vertex-anthropic": {
+		"models": {
+			"claude-3-5-haiku@20241022": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "claude-3-5-haiku@20241022",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5@20251001": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5@20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1@20250805": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1@20250805",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5@20251101": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5@20251101",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6@default": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6@default",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7@default": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7@default",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-8@default": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-8@default",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4@20250514": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4@20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5@20250929": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5@20250929",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-6@default": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6@default",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4@20250514": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4@20250514",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"helicone": {
+		"models": {
+			"claude-3-haiku-20240307": {
+				"cost": {
+					"cache_read": 0.03,
+					"cache_write": 0.3,
+					"input": 0.25,
+					"output": 1.25
+				},
+				"id": "claude-3-haiku-20240307",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3.5-haiku": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.7999999999999999,
+					"output": 4
+				},
+				"id": "claude-3.5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3.5-sonnet-v2": {
+				"cost": {
+					"cache_read": 0.30000000000000004,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-3.5-sonnet-v2",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3.7-sonnet": {
+				"cost": {
+					"cache_read": 0.30000000000000004,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-3.7-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-4.5-haiku": {
+				"cost": {
+					"cache_read": 0.09999999999999999,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-4.5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-4.5-opus": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-4.5-opus",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-4.5-sonnet": {
+				"cost": {
+					"cache_read": 0.30000000000000004,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-4.5-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5-20251001": {
+				"cost": {
+					"cache_read": 0.09999999999999999,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5-20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-20250805": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1-20250805",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.30000000000000004,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5-20250929": {
+				"cost": {
+					"cache_read": 0.30000000000000004,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5-20250929",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"jiekou": {
+		"models": {
+			"claude-haiku-4-5-20251001": {
+				"cost": {
+					"input": 0.9,
+					"output": 4.5
+				},
+				"id": "claude-haiku-4-5-20251001",
+				"limit": {
+					"context": 20000
+				}
+			},
+			"claude-opus-4-1-20250805": {
+				"cost": {
+					"input": 13.5,
+					"output": 67.5
+				},
+				"id": "claude-opus-4-1-20250805",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-20250514": {
+				"cost": {
+					"input": 13.5,
+					"output": 67.5
+				},
+				"id": "claude-opus-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5-20251101": {
+				"cost": {
+					"input": 4.5,
+					"output": 22.5
+				},
+				"id": "claude-opus-4-5-20251101",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-20250514": {
+				"cost": {
+					"input": 2.7,
+					"output": 13.5
+				},
+				"id": "claude-sonnet-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5-20250929": {
+				"cost": {
+					"input": 2.7,
+					"output": 13.5
+				},
+				"id": "claude-sonnet-4-5-20250929",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"kilo": {
+		"models": {
+			"anthropic/claude-3-haiku": {
+				"cost": {
+					"cache_read": 0.03,
+					"cache_write": 0.3,
+					"input": 0.25,
+					"output": 1.25
+				},
+				"id": "anthropic/claude-3-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-3.5-haiku": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "anthropic/claude-3.5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-haiku-4.5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4.1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.6-fast": {
+				"cost": {
+					"cache_read": 3,
+					"cache_write": 37.5,
+					"input": 30,
+					"output": 150
+				},
+				"id": "anthropic/claude-opus-4.6-fast",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.7-fast": {
+				"cost": {
+					"cache_read": 3,
+					"cache_write": 37.5,
+					"input": 30,
+					"output": 150
+				},
+				"id": "anthropic/claude-opus-4.7-fast",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4.5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4.6": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"stealth/claude-opus-4.6": {
+				"cost": {
+					"cache_read": 0.4,
+					"cache_write": 5,
+					"input": 4,
+					"output": 20
+				},
+				"id": "stealth/claude-opus-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"stealth/claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.4,
+					"cache_write": 5,
+					"input": 4,
+					"output": 20
+				},
+				"id": "stealth/claude-opus-4.7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"stealth/claude-sonnet-4.6": {
+				"cost": {
+					"cache_read": 0.24,
+					"cache_write": 3,
+					"input": 2.4,
+					"output": 12
+				},
+				"id": "stealth/claude-sonnet-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"~anthropic/claude-haiku-latest": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "~anthropic/claude-haiku-latest",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"~anthropic/claude-opus-latest": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "~anthropic/claude-opus-latest",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"~anthropic/claude-sonnet-latest": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "~anthropic/claude-sonnet-latest",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"llmgateway": {
+		"models": {
+			"claude-3-5-haiku": {
+				"cost": {
+					"cache_read": 0.08,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "claude-3-5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-5-sonnet-20241022": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-3-5-sonnet-20241022",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-7-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-3-7-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-7-sonnet-20250219": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-3-7-sonnet-20250219",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-3-opus": {
+				"cost": {
+					"cache_read": 1.5,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-3-opus",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5-20251001": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5-20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-20250805": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1-20250805",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-20250514": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5-20251101": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5-20251101",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-20250514": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5-20250929": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5-20250929",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"merge-gateway": {
+		"models": {
+			"anthropic/claude-haiku-4-5-20251001": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-4-5-20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-1-20250805": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4-1-20250805",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-20250514": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-5-20251101": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-5-20251101",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4-20250514": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4-5-20250929": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4-5-20250929",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"nano-gpt": {
+		"models": {
+			"Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled": {
+				"cost": {
+					"cache_read": 0.0306,
+					"input": 0.306,
+					"output": 0.306
+				},
+				"id": "Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled",
+				"limit": {
+					"context": 262144
+				}
+			},
+			"anthropic/claude-haiku-latest": {
+				"cost": {
+					"cache_read": 0.1,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-latest",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.6": {
+				"cost": {
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "anthropic/claude-opus-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.6:thinking": {
+				"cost": {
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "anthropic/claude-opus-4.6:thinking",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.6:thinking:low": {
+				"cost": {
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "anthropic/claude-opus-4.6:thinking:low",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.6:thinking:max": {
+				"cost": {
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "anthropic/claude-opus-4.6:thinking:max",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.6:thinking:medium": {
+				"cost": {
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "anthropic/claude-opus-4.6:thinking:medium",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.4998,
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "anthropic/claude-opus-4.7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.7:thinking": {
+				"cost": {
+					"cache_read": 0.4998,
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "anthropic/claude-opus-4.7:thinking",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.8": {
+				"cost": {
+					"cache_read": 0.4998,
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "anthropic/claude-opus-4.8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.8:thinking": {
+				"cost": {
+					"cache_read": 0.4998,
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "anthropic/claude-opus-4.8:thinking",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-latest": {
+				"cost": {
+					"cache_read": 0.4998,
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "anthropic/claude-opus-latest",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4.6": {
+				"cost": {
+					"input": 2.992,
+					"output": 14.993999999999998
+				},
+				"id": "anthropic/claude-sonnet-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4.6:thinking": {
+				"cost": {
+					"input": 2.992,
+					"output": 14.993999999999998
+				},
+				"id": "anthropic/claude-sonnet-4.6:thinking",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-latest": {
+				"cost": {
+					"cache_read": 0.2992,
+					"input": 2.992,
+					"output": 14.994
+				},
+				"id": "anthropic/claude-sonnet-latest",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-3-5-haiku-20241022": {
+				"cost": {
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "claude-3-5-haiku-20241022",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5-20251001": {
+				"cost": {
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5-20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-haiku-4-5-20251001-thinking": {
+				"cost": {
+					"cache_read": 0.1,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5-20251001-thinking",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-20250805": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-1-20250805",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-thinking": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-1-thinking",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-thinking:1024": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-1-thinking:1024",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-thinking:32000": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-1-thinking:32000",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-thinking:32768": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-1-thinking:32768",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1-thinking:8192": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-1-thinking:8192",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-20250514": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5-20251101": {
+				"cost": {
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "claude-opus-4-5-20251101",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5-20251101:thinking": {
+				"cost": {
+					"input": 4.998,
+					"output": 25.007
+				},
+				"id": "claude-opus-4-5-20251101:thinking",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-thinking": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-thinking",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-thinking:1024": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-thinking:1024",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-thinking:32000": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-thinking:32000",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-thinking:32768": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-thinking:32768",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-thinking:8192": {
+				"cost": {
+					"input": 14.994,
+					"output": 75.004
+				},
+				"id": "claude-opus-4-thinking:8192",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-20250514": {
+				"cost": {
+					"input": 2.992,
+					"output": 14.994
+				},
+				"id": "claude-sonnet-4-20250514",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5-20250929": {
+				"cost": {
+					"input": 2.992,
+					"output": 14.994
+				},
+				"id": "claude-sonnet-4-5-20250929",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-5-20250929-thinking": {
+				"cost": {
+					"input": 2.992,
+					"output": 14.994
+				},
+				"id": "claude-sonnet-4-5-20250929-thinking",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-thinking": {
+				"cost": {
+					"input": 2.992,
+					"output": 14.994
+				},
+				"id": "claude-sonnet-4-thinking",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-thinking:1024": {
+				"cost": {
+					"input": 2.992,
+					"output": 14.994
+				},
+				"id": "claude-sonnet-4-thinking:1024",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-thinking:32768": {
+				"cost": {
+					"input": 2.992,
+					"output": 14.994
+				},
+				"id": "claude-sonnet-4-thinking:32768",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-thinking:64000": {
+				"cost": {
+					"input": 2.992,
+					"output": 14.994
+				},
+				"id": "claude-sonnet-4-thinking:64000",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-thinking:8192": {
+				"cost": {
+					"input": 2.992,
+					"output": 14.994
+				},
+				"id": "claude-sonnet-4-thinking:8192",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"deepclaude": {
+				"cost": {
+					"input": 3,
+					"output": 15
+				},
+				"id": "deepclaude",
+				"limit": {
+					"context": 128000
+				}
+			}
+		}
+	},
+	"nearai": {
+		"models": {
+			"anthropic/claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-6",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15.5
+				},
+				"id": "anthropic/claude-sonnet-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"opencode": {
+		"models": {
+			"claude-3-5-haiku": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "claude-3-5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-fable-5": {
+				"cost": {
+					"cache_read": 1,
+					"cache_write": 12.5,
+					"input": 10,
+					"output": 50
+				},
+				"id": "claude-fable-5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "claude-opus-4-1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"openrouter": {
+		"models": {
+			"anthropic/claude-3-haiku": {
+				"cost": {
+					"cache_read": 0.03,
+					"cache_write": 0.3,
+					"input": 0.25,
+					"output": 1.25
+				},
+				"id": "anthropic/claude-3-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-3.5-haiku": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "anthropic/claude-3.5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-haiku-4.5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4.1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.6-fast": {
+				"cost": {
+					"cache_read": 3,
+					"cache_write": 37.5,
+					"input": 30,
+					"output": 150
+				},
+				"id": "anthropic/claude-opus-4.6-fast",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.7-fast": {
+				"cost": {
+					"cache_read": 3,
+					"cache_write": 37.5,
+					"input": 30,
+					"output": 150
+				},
+				"id": "anthropic/claude-opus-4.7-fast",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.8-fast": {
+				"cost": {
+					"cache_read": 1,
+					"cache_write": 12.5,
+					"input": 10,
+					"output": 50
+				},
+				"id": "anthropic/claude-opus-4.8-fast",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4.5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4.6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"~anthropic/claude-haiku-latest": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "~anthropic/claude-haiku-latest",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"~anthropic/claude-opus-latest": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "~anthropic/claude-opus-latest",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"~anthropic/claude-sonnet-latest": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "~anthropic/claude-sonnet-latest",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"orcarouter": {
+		"models": {
+			"anthropic/claude-haiku-4.5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4.1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4.5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4.6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"perplexity-agent": {
+		"models": {
+			"anthropic/claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-5": {
+				"cost": {
+					"cache_read": 0.5,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-6",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.5,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.3,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4-6",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"poe": {
+		"models": {
+			"anthropic/claude-haiku-3": {
+				"cost": {
+					"cache_read": 0.021,
+					"cache_write": 0.26,
+					"input": 0.21,
+					"output": 1.1
+				},
+				"id": "anthropic/claude-haiku-3",
+				"limit": {
+					"context": 189096
+				}
+			},
+			"anthropic/claude-haiku-3.5": {
+				"cost": {
+					"cache_read": 0.068,
+					"cache_write": 0.85,
+					"input": 0.68,
+					"output": 3.4
+				},
+				"id": "anthropic/claude-haiku-3.5",
+				"limit": {
+					"context": 189096
+				}
+			},
+			"anthropic/claude-haiku-4.5": {
+				"cost": {
+					"cache_read": 0.085,
+					"cache_write": 1.1,
+					"input": 0.85,
+					"output": 4.3
+				},
+				"id": "anthropic/claude-haiku-4.5",
+				"limit": {
+					"context": 192000
+				}
+			},
+			"anthropic/claude-opus-4": {
+				"cost": {
+					"cache_read": 1.3,
+					"cache_write": 16,
+					"input": 13,
+					"output": 64
+				},
+				"id": "anthropic/claude-opus-4",
+				"limit": {
+					"context": 192512
+				}
+			},
+			"anthropic/claude-opus-4.1": {
+				"cost": {
+					"cache_read": 1.3,
+					"cache_write": 16,
+					"input": 13,
+					"output": 64
+				},
+				"id": "anthropic/claude-opus-4.1",
+				"limit": {
+					"context": 196608
+				}
+			},
+			"anthropic/claude-opus-4.5": {
+				"cost": {
+					"cache_read": 0.43,
+					"cache_write": 5.3,
+					"input": 4.3,
+					"output": 21
+				},
+				"id": "anthropic/claude-opus-4.5",
+				"limit": {
+					"context": 196608
+				}
+			},
+			"anthropic/claude-opus-4.6": {
+				"cost": {
+					"cache_read": 0.43,
+					"cache_write": 5.3,
+					"input": 4.3,
+					"output": 21
+				},
+				"id": "anthropic/claude-opus-4.6",
+				"limit": {
+					"context": 983040
+				}
+			},
+			"anthropic/claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.43,
+					"cache_write": 5.4,
+					"input": 4.3,
+					"output": 21
+				},
+				"id": "anthropic/claude-opus-4.7",
+				"limit": {
+					"context": 1048576
+				}
+			},
+			"anthropic/claude-opus-4.8": {
+				"cost": {
+					"input": 4.2929,
+					"output": 21.4646
+				},
+				"id": "anthropic/claude-opus-4.8",
+				"limit": {
+					"context": 1048576
+				}
+			},
+			"anthropic/claude-sonnet-3.5": {
+				"cost": {
+					"cache_read": 0.26,
+					"cache_write": 3.2,
+					"input": 2.6,
+					"output": 13
+				},
+				"id": "anthropic/claude-sonnet-3.5",
+				"limit": {
+					"context": 189096
+				}
+			},
+			"anthropic/claude-sonnet-3.5-june": {
+				"cost": {
+					"cache_read": 0.26,
+					"cache_write": 3.2,
+					"input": 2.6,
+					"output": 13
+				},
+				"id": "anthropic/claude-sonnet-3.5-june",
+				"limit": {
+					"context": 189096
+				}
+			},
+			"anthropic/claude-sonnet-3.7": {
+				"cost": {
+					"cache_read": 0.26,
+					"cache_write": 3.2,
+					"input": 2.6,
+					"output": 13
+				},
+				"id": "anthropic/claude-sonnet-3.7",
+				"limit": {
+					"context": 196608
+				}
+			},
+			"anthropic/claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.26,
+					"cache_write": 3.2,
+					"input": 2.6,
+					"output": 13
+				},
+				"id": "anthropic/claude-sonnet-4",
+				"limit": {
+					"context": 983040
+				}
+			},
+			"anthropic/claude-sonnet-4.5": {
+				"cost": {
+					"cache_read": 0.26,
+					"cache_write": 3.2,
+					"input": 2.6,
+					"output": 13
+				},
+				"id": "anthropic/claude-sonnet-4.5",
+				"limit": {
+					"context": 983040
+				}
+			},
+			"anthropic/claude-sonnet-4.6": {
+				"cost": {
+					"cache_read": 0.26,
+					"cache_write": 3.2,
+					"input": 2.6,
+					"output": 13
+				},
+				"id": "anthropic/claude-sonnet-4.6",
+				"limit": {
+					"context": 983040
+				}
+			}
+		}
+	},
+	"qihang-ai": {
+		"models": {
+			"claude-haiku-4-5-20251001": {
+				"cost": {
+					"input": 0.14,
+					"output": 0.71
+				},
+				"id": "claude-haiku-4-5-20251001",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-opus-4-5-20251101": {
+				"cost": {
+					"input": 0.71,
+					"output": 3.57
+				},
+				"id": "claude-opus-4-5-20251101",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"claude-sonnet-4-5-20250929": {
+				"cost": {
+					"input": 0.43,
+					"output": 2.14
+				},
+				"id": "claude-sonnet-4-5-20250929",
+				"limit": {
+					"context": 200000
+				}
+			}
+		}
+	},
+	"requesty": {
+		"models": {
+			"anthropic/claude-3-7-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-3-7-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-haiku-4-5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4-1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4-5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"sap-ai-core": {
+		"models": {
+			"anthropic--claude-3-haiku": {
+				"cost": {
+					"cache_read": 0.03,
+					"cache_write": 0.3,
+					"input": 0.25,
+					"output": 1.25
+				},
+				"id": "anthropic--claude-3-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic--claude-3-opus": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic--claude-3-opus",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic--claude-3-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic--claude-3-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic--claude-3.5-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic--claude-3.5-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic--claude-3.7-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic--claude-3.7-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic--claude-4-opus": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic--claude-4-opus",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic--claude-4-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic--claude-4-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic--claude-4.5-haiku": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic--claude-4.5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic--claude-4.5-opus": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic--claude-4.5-opus",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic--claude-4.5-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic--claude-4.5-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic--claude-4.6-opus": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic--claude-4.6-opus",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic--claude-4.6-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic--claude-4.6-sonnet",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic--claude-4.7-opus": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic--claude-4.7-opus",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"venice": {
+		"models": {
+			"claude-opus-4-5": {
+				"cost": {
+					"cache_read": 0.6,
+					"cache_write": 7.5,
+					"input": 6,
+					"output": 30
+				},
+				"id": "claude-opus-4-5",
+				"limit": {
+					"context": 198000
+				}
+			},
+			"claude-opus-4-6": {
+				"cost": {
+					"cache_read": 0.6,
+					"cache_write": 7.5,
+					"input": 6,
+					"output": 30
+				},
+				"id": "claude-opus-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-6-fast": {
+				"cost": {
+					"cache_read": 3.6,
+					"cache_write": 45,
+					"input": 36,
+					"output": 180
+				},
+				"id": "claude-opus-4-6-fast",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7": {
+				"cost": {
+					"cache_read": 0.6,
+					"cache_write": 7.5,
+					"input": 6,
+					"output": 30
+				},
+				"id": "claude-opus-4-7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-7-fast": {
+				"cost": {
+					"cache_read": 3.6,
+					"cache_write": 45,
+					"input": 36,
+					"output": 180
+				},
+				"id": "claude-opus-4-7-fast",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-8": {
+				"cost": {
+					"cache_read": 0.6,
+					"cache_write": 7.5,
+					"input": 6,
+					"output": 30
+				},
+				"id": "claude-opus-4-8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-opus-4-8-fast": {
+				"cost": {
+					"cache_read": 1.2,
+					"cache_write": 15,
+					"input": 12,
+					"output": 60
+				},
+				"id": "claude-opus-4-8-fast",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"claude-sonnet-4-5": {
+				"cost": {
+					"cache_read": 0.375,
+					"cache_write": 4.69,
+					"input": 3.75,
+					"output": 18.75
+				},
+				"id": "claude-sonnet-4-5",
+				"limit": {
+					"context": 198000
+				}
+			},
+			"claude-sonnet-4-6": {
+				"cost": {
+					"cache_read": 0.36,
+					"cache_write": 4.5,
+					"input": 3.6,
+					"output": 18
+				},
+				"id": "claude-sonnet-4-6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"vercel": {
+		"models": {
+			"anthropic/claude-3-haiku": {
+				"cost": {
+					"cache_read": 0.03,
+					"cache_write": 0.3,
+					"input": 0.25,
+					"output": 1.25
+				},
+				"id": "anthropic/claude-3-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-3.5-haiku": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "anthropic/claude-3.5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-fable-5": {
+				"cost": {
+					"cache_read": 1,
+					"cache_write": 12.5,
+					"input": 10,
+					"output": 50
+				},
+				"id": "anthropic/claude-fable-5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-haiku-4.5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4.1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4.5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-sonnet-4.6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	},
+	"zenmux": {
+		"models": {
+			"anthropic/claude-3.5-haiku": {
+				"cost": {
+					"cache_read": 0.08,
+					"cache_write": 1,
+					"input": 0.8,
+					"output": 4
+				},
+				"id": "anthropic/claude-3.5-haiku",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-3.7-sonnet": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-3.7-sonnet",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-haiku-4.5": {
+				"cost": {
+					"cache_read": 0.1,
+					"cache_write": 1.25,
+					"input": 1,
+					"output": 5
+				},
+				"id": "anthropic/claude-haiku-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.1": {
+				"cost": {
+					"cache_read": 1.5,
+					"cache_write": 18.75,
+					"input": 15,
+					"output": 75
+				},
+				"id": "anthropic/claude-opus-4.1",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.5": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.5",
+				"limit": {
+					"context": 200000
+				}
+			},
+			"anthropic/claude-opus-4.6": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.7": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.7",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-opus-4.8": {
+				"cost": {
+					"cache_read": 0.5,
+					"cache_write": 6.25,
+					"input": 5,
+					"output": 25
+				},
+				"id": "anthropic/claude-opus-4.8",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4.5": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.5",
+				"limit": {
+					"context": 1000000
+				}
+			},
+			"anthropic/claude-sonnet-4.6": {
+				"cost": {
+					"cache_read": 0.3,
+					"cache_write": 3.75,
+					"input": 3,
+					"output": 15
+				},
+				"id": "anthropic/claude-sonnet-4.6",
+				"limit": {
+					"context": 1000000
+				}
+			}
+		}
+	}
+}

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1469,8 +1469,6 @@ mod tests {
 
     #[test]
     fn embedded_models_dev_snapshot_is_parseable() {
-        // Guards the build-time wiring: the snapshot embedded via build.rs must
-        // always parse, whether it is the populated catalog or an empty `{}`.
         let mut map = PricingMap::default();
         assert!(map
             .load_models_dev_json_missing(BUILD_TIME_MODELS_DEV_JSON)
@@ -1504,14 +1502,9 @@ mod tests {
     #[test]
     fn offline_prices_new_anthropic_model_from_embedded_models_dev() {
         use ccusage_cli::PricingOverride;
-        // claude-fable-5 shipped on models.dev before LiteLLM published it, which
-        // is exactly the gap the embedded snapshot fills for offline runs.
-        if embedded_models_dev_pricing()
+        assert!(embedded_models_dev_pricing()
             .find_entry("claude-fable-5")
-            .is_none()
-        {
-            return;
-        }
+            .is_some());
         let offline = PricingMap::load_with_overrides(
             true,
             false,

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1051,7 +1051,8 @@ fn embedded_models_dev_pricing() -> &'static PricingMap {
     static EMBEDDED_MODELS_DEV_PRICING: OnceLock<PricingMap> = OnceLock::new();
     EMBEDDED_MODELS_DEV_PRICING.get_or_init(|| {
         let mut map = PricingMap::default();
-        map.load_models_dev_json_missing(BUILD_TIME_MODELS_DEV_JSON);
+        map.load_models_dev_json_missing(BUILD_TIME_MODELS_DEV_JSON)
+            .expect("embedded models-dev-pricing.json must parse");
         map
     })
 }
@@ -1502,9 +1503,12 @@ mod tests {
     #[test]
     fn offline_prices_new_anthropic_model_from_embedded_models_dev() {
         use ccusage_cli::PricingOverride;
-        assert!(embedded_models_dev_pricing()
-            .find_entry("claude-fable-5")
-            .is_some());
+        assert!(
+            embedded_models_dev_pricing()
+                .find_entry("claude-fable-5")
+                .is_some(),
+            "embedded models.dev snapshot should include claude-fable-5"
+        );
         let offline = PricingMap::load_with_overrides(
             true,
             false,

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -12,6 +12,7 @@ use crate::fast::FxHashMap;
 
 const BUILD_TIME_PRICING_JSON: &str =
     include_str!(concat!(env!("OUT_DIR"), "/litellm-pricing.json"));
+const BUILD_TIME_MODELS_DEV_JSON: &str = include_str!("models-dev-pricing.json");
 const FAST_MULTIPLIER_OVERRIDES_JSON: &str = include_str!("fast-multiplier-overrides.json");
 const LITELLM_PRICING_URL: &str =
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
@@ -59,6 +60,7 @@ pub(crate) struct PricingMap {
     entries: FxHashMap<String, Pricing>,
     context_limits: FxHashMap<String, u64>,
     enable_models_dev_fallback: bool,
+    enable_embedded_models_dev_fallback: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -180,6 +182,10 @@ impl PricingMap {
         let fast_multiplier_overrides = FastMultiplierOverrides::load();
         map.load_json_with_overrides(BUILD_TIME_PRICING_JSON, &fast_multiplier_overrides);
         map.put_builtin_pricing(&fast_multiplier_overrides);
+        // Resolve models that LiteLLM and the built-in table miss from the
+        // embedded models.dev snapshot. This works offline, unlike the network
+        // source gated by `enable_models_dev_fallback`.
+        map.enable_embedded_models_dev_fallback = true;
         map
     }
 
@@ -328,11 +334,20 @@ impl PricingMap {
     }
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
-        self.find_entry(model).or_else(|| {
-            self.enable_models_dev_fallback
-                .then(|| models_dev_pricing().and_then(|pricing| pricing.find_entry(model)))
-                .flatten()
-        })
+        self.find_entry(model)
+            .or_else(|| {
+                self.enable_models_dev_fallback
+                    .then(|| models_dev_pricing().and_then(|pricing| pricing.find_entry(model)))
+                    .flatten()
+            })
+            // The embedded models.dev snapshot is a separate map, so it only
+            // resolves models the primary table misses and never perturbs its
+            // fuzzy alias matching. It works offline, unlike the network source.
+            .or_else(|| {
+                self.enable_embedded_models_dev_fallback
+                    .then(|| embedded_models_dev_pricing().find_entry(model))
+                    .flatten()
+            })
     }
 
     fn find_entry(&self, model: &str) -> Option<Pricing> {
@@ -351,13 +366,19 @@ impl PricingMap {
     }
 
     pub(crate) fn context_limit(&self, model: &str) -> Option<u64> {
-        self.context_limit_entry(model).or_else(|| {
-            self.enable_models_dev_fallback
-                .then(|| {
-                    models_dev_pricing().and_then(|pricing| pricing.context_limit_entry(model))
-                })
-                .flatten()
-        })
+        self.context_limit_entry(model)
+            .or_else(|| {
+                self.enable_models_dev_fallback
+                    .then(|| {
+                        models_dev_pricing().and_then(|pricing| pricing.context_limit_entry(model))
+                    })
+                    .flatten()
+            })
+            .or_else(|| {
+                self.enable_embedded_models_dev_fallback
+                    .then(|| embedded_models_dev_pricing().context_limit_entry(model))
+                    .flatten()
+            })
     }
 
     fn context_limit_entry(&self, model: &str) -> Option<u64> {
@@ -1021,6 +1042,20 @@ fn models_dev_pricing() -> Option<&'static PricingMap> {
     MODELS_DEV_PRICING.get_or_try_load(fetch_models_dev_json)
 }
 
+/// Pricing built from the models.dev snapshot embedded at build time. Unlike the
+/// network source this is always available, so it lets offline runs price models
+/// that LiteLLM and the built-in table do not cover (for example newly released
+/// Anthropic models). It is kept separate from the primary table so it never
+/// participates in that table's fuzzy alias matching.
+fn embedded_models_dev_pricing() -> &'static PricingMap {
+    static EMBEDDED_MODELS_DEV_PRICING: OnceLock<PricingMap> = OnceLock::new();
+    EMBEDDED_MODELS_DEV_PRICING.get_or_init(|| {
+        let mut map = PricingMap::default();
+        map.load_models_dev_json_missing(BUILD_TIME_MODELS_DEV_JSON);
+        map
+    })
+}
+
 fn load_models_dev_pricing<F>(fetch_json: F) -> Option<PricingMap>
 where
     F: FnOnce() -> std::io::Result<String>,
@@ -1079,7 +1114,10 @@ fn fetch_json_url(url: &str) -> std::io::Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Pricing, PricingMap, BUILD_TIME_PRICING_JSON};
+    use super::{
+        embedded_models_dev_pricing, Pricing, PricingMap, BUILD_TIME_MODELS_DEV_JSON,
+        BUILD_TIME_PRICING_JSON,
+    };
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
@@ -1427,6 +1465,59 @@ mod tests {
         assert_eq!(pricing.context_limit("gpt-fallback"), Some(456));
         assert!((alias.input - 4e-6).abs() < f64::EPSILON);
         assert_eq!(pricing.context_limits.get("gpt-alias"), Some(&654));
+    }
+
+    #[test]
+    fn embedded_models_dev_snapshot_is_parseable() {
+        // Guards the build-time wiring: the snapshot embedded via build.rs must
+        // always parse, whether it is the populated catalog or an empty `{}`.
+        let mut map = PricingMap::default();
+        assert!(map
+            .load_models_dev_json_missing(BUILD_TIME_MODELS_DEV_JSON)
+            .is_some());
+    }
+
+    #[test]
+    fn offline_resolves_models_only_in_embedded_models_dev() {
+        use ccusage_cli::PricingOverride;
+        let offline = PricingMap::load_with_overrides(
+            true,
+            false,
+            std::iter::empty::<(&String, &PricingOverride)>(),
+        );
+        // Pick an embedded model the primary table (LiteLLM + built-ins) cannot
+        // resolve on its own. `find_entry` never consults the fallback.
+        let Some(model) = embedded_models_dev_pricing()
+            .entries
+            .keys()
+            .find(|model| offline.find_entry(model).is_none())
+        else {
+            return;
+        };
+        // The primary table alone misses it, but the offline embedded fallback
+        // resolves it; a bare map without the fallback flag must not.
+        assert!(offline.find_entry(model).is_none());
+        assert!(offline.find(model).is_some());
+        assert!(PricingMap::default().find(model).is_none());
+    }
+
+    #[test]
+    fn offline_prices_new_anthropic_model_from_embedded_models_dev() {
+        use ccusage_cli::PricingOverride;
+        // claude-fable-5 shipped on models.dev before LiteLLM published it, which
+        // is exactly the gap the embedded snapshot fills for offline runs.
+        if embedded_models_dev_pricing()
+            .find_entry("claude-fable-5")
+            .is_none()
+        {
+            return;
+        }
+        let offline = PricingMap::load_with_overrides(
+            true,
+            false,
+            std::iter::empty::<(&String, &PricingOverride)>(),
+        );
+        assert!(offline.find("claude-fable-5").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prices brand-new Anthropic models offline by embedding a pinned, self-generated
models.dev pricing snapshot. Models such as `claude-fable-5` ship on models.dev
before LiteLLM publishes them, so they previously could not be priced without
network access (the models.dev fallback was online-only).

## What changed

- **Pin the source**: add `anomalyco/models.dev` as a flake input.
- **Reproducible generator** (`nix/models-dev-gen.ts` + `nix/models-dev-pricing.nix`):
  models.dev ships per-model TOML, not a prebuilt catalog, so the snapshot is
  built with the project's own `generateCatalog` (Bun + the zero-dependency
  `remeda`/`zod` vendored from the pinned `bun.lock` hashes) and compacted to the
  Anthropic models and pricing fields ccusage consumes. Exposed as the
  `.#models-dev-pricing` package.
- **Commit + embed**: the compacted snapshot is committed at
  `rust/crates/ccusage/src/models-dev-pricing.json` and embedded via
  `include_str!`. No build-time network on any platform (Nix builds and plain
  `cargo build` on macOS/Windows ship identical, pinned data). `build.rs` is
  unchanged.
- **Runtime** (`pricing.rs`): the embedded models.dev data is a separate,
  offline-capable fallback map, consulted only when the primary table misses, so
  it never perturbs the primary table's fuzzy alias matching.
- **Automation** (`.github/workflows/update-pricing.yaml`): refresh the LiteLLM
  and models.dev snapshots **hourly**, each opening its own PR only when the
  pricing actually changes. Workflow permissions scoped per job.
- **Recipes** (`justfile`): `gen-models-dev-pricing` and
  `update-models-dev-pricing`.

## Why

The hardcoded built-in pricing table only covers a fixed set of models, and the
models.dev fallback required network access. Embedding a pinned snapshot closes
the offline gap for newly released models while keeping the data reproducible and
reviewable in git (refreshed automatically).

## Testing

- `just check` (clippy, treefmt, schema drift, gitleaks, nix build) — passed
- `cargo test -p ccusage` pricing suite (52 tests, incl. offline resolution of
  models.dev-only models like `claude-fable-5`) — passed
- `nix build .#ccusage` and `nix build .#models-dev-pricing` — passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embed a pinned `models.dev` pricing snapshot into `ccusage` to enable offline pricing for new Anthropic models when `LiteLLM` hasn’t published them yet. Builds reproducibly with no build-time network, keeps primary pricing behavior unchanged, and fails fast if the embedded snapshot is invalid.

- **New Features**
  - Pin `anomalyco/models.dev` as a flake input.
  - Reproducible snapshot generator (`nix/models-dev-gen.ts` + `nix/models-dev-pricing.nix`) using `Bun` with vendored `remeda`/`zod`; compacts to Anthropic models and required fields; validates `OUTFILE` before write.
  - Commit snapshot to `rust/crates/ccusage/src/models-dev-pricing.json` and embed via `include_str!`; Nix and `cargo` builds ship identical, pinned data.
  - Runtime adds a separate embedded `models.dev` fallback map in `pricing.rs`, used only on misses so fuzzy alias matching in the primary table is unaffected; works offline; treat embedded snapshot parse errors as build-time failures.

- **Automation**
  - `.github/workflows/update-pricing.yaml`: hourly refresh for `LiteLLM` and `models.dev`; serialize the `models.dev` updater after `LiteLLM`; run `models.dev` refresh even if the `LiteLLM` job fails (`always()`).
  - Configure git auth with `gh auth setup-git` for pushes using `GH_TOKEN`; disable persisted checkout credentials; job-scoped permissions.
  - Open PRs only when pricing changes; skip lock-only churn.

<sup>Written for commit 70dca9e6718f861ca4113d22fe35aa853c162ab0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline embedded models.dev pricing snapshot for reliable local access to model pricing and context limits.
  * Improved offline resolution so previously-unavailable Anthropic models can be resolved without network access.
  * Build now includes the generated models.dev pricing snapshot so it’s available at runtime.

* **Chores**
  * Pricing refresh workflow runs hourly and adds an automated job to regenerate, validate, and publish the models.dev pricing snapshot (suppresses PR noise when unchanged).
  * CI step added to ensure git auth before pushing automation branches; added local commands to regenerate the snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->