### PR TITLE
fix(nix): stabilise crane dependency cache

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,7 +7,9 @@ if has nix; then
   # dev shell — e.g. an outdated treefmt wrapper in the installed git hooks.
   watch_file flake.nix
   watch_file flake.lock
+  watch_file dev/flake.nix
+  watch_file dev/flake.lock
   watch_file rust-toolchain.toml
   watch_dir nix
-  use flake
+  use flake ./dev
 fi

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -47,7 +47,7 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        for path in /nix/store /nix/var/log/nix /nix/var/nix; do
+        for path in /nix/var/log/nix /nix/var/nix; do
           if [ -e "$path" ]; then
             sudo chown -R "$USER:$(id -gn)" "$path"
           fi

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -46,7 +46,7 @@ runs:
     - name: Fix single-user Nix store ownership
       if: runner.os == 'Linux'
       shell: bash
-      run: sudo chown -R "$USER:$(id -gn)" /nix/store /nix/var/nix
+      run: sudo chown -R "$USER:$(id -gn)" /nix/store /nix/var/log/nix /nix/var/nix
 
     - name: Load Nix CI development environment
       if: inputs.warm-dev-shell == 'true'

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -43,6 +43,11 @@ runs:
         purge-created: 172800
         purge-primary-key: never
 
+    - name: Fix single-user Nix store ownership
+      if: runner.os == 'Linux'
+      shell: bash
+      run: sudo chown -R "$USER:$(id -gn)" /nix/store /nix/var/nix
+
     - name: Load Nix CI development environment
       if: inputs.warm-dev-shell == 'true'
       shell: bash

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -44,9 +44,14 @@ runs:
         purge-primary-key: never
 
     - name: Fix single-user Nix store ownership
-      if: runner.os == 'Linux'
+      if: runner.os != 'Windows'
       shell: bash
-      run: sudo chown -R "$USER:$(id -gn)" /nix/store /nix/var/log/nix /nix/var/nix
+      run: |
+        for path in /nix/store /nix/var/log/nix /nix/var/nix; do
+          if [ -e "$path" ]; then
+            sudo chown -R "$USER:$(id -gn)" "$path"
+          fi
+        done
 
     - name: Load Nix CI development environment
       if: inputs.warm-dev-shell == 'true'

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -1,53 +1,49 @@
 name: Setup Nix
 description: Install Nix and restore the Nix store from the GitHub Actions cache
+inputs:
+  cache-profile:
+    description: Which Nix cache key scope to use
+    default: package
+  warm-dev-shell:
+    description: Whether to instantiate the CI dev shell during setup
+    default: 'false'
 runs:
   using: composite
   steps:
     - name: Install Nix
-      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+      uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
       with:
         github_access_token: ${{ github.token }}
-        extra_nix_config: |
+        nix_conf: |
           access-tokens = github.com=${{ github.token }}
 
-    - name: Cache Nix store
+    - name: Cache Nix store for package builds
+      if: inputs.cache-profile == 'package'
       uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
       with:
-        # Hash every input that changes the dev-shell closure, not just
-        # flake.lock. The previous key only hashed flake.lock, so any
-        # Cargo.lock / toolchain change rebuilt `ccusage-deps` (~80s) on every
-        # run while the stale cache stayed frozen and was never re-saved.
-        #
-        # `package.json` is the root manifest only: its `version` is read by
-        # package.nix and baked into the crane derivation name
-        # (`ccusage-deps-<version>`), so a version bump must rotate the key.
-        #
-        # pnpm-lock.yaml and the workspace package.json files are intentionally
-        # NOT hashed: no Nix derivation consumes JS dependencies. `pnpm install`
-        # runs in the dev-shell shellHook and writes node_modules in the working
-        # tree, outside the Nix store, so JS deps never change this cache.
+        # Package jobs should not rotate when only development tooling changes.
         primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'package.json', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}
-        # On a key miss, warm-start from the newest cache for this os/arch so
-        # only the changed derivations rebuild before the fresh key is saved.
         restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-
-        # Bound a single cache so the repo stays under the 10 GB limit. This
-        # action only runs on Linux (arm64 + x64), so at most two Nix caches
-        # exist. 3.5 GB each leaves headroom for the small per-platform Cargo
-        # caches (~1 GB total) used by the macOS/Windows build jobs. The
-        # dev-shell closure (~2.5 GB) is a gc root, so it survives this trim.
         gc-max-store-size-linux: 3500000000
-        # Purge superseded caches for this os/arch on every run. Without this
-        # the more frequently rotating key would accumulate stale caches and
-        # push the repo past the 10 GB limit, evicting the fresh cache via LRU.
-        # 2 days (not 7) so that several key rotations in one week (e.g.
-        # repeated Cargo.lock bumps) cannot pile up multiple ~2.5 GB caches.
-        # The active cache is always the current primary-key, which
-        # purge-primary-key keeps regardless of age.
         purge: true
         purge-prefixes: nix-${{ runner.os }}-${{ runner.arch }}-
         purge-created: 172800
         purge-primary-key: never
 
-    - name: Load Nix development environment
+    - name: Cache Nix store for development jobs
+      if: inputs.cache-profile == 'dev'
+      uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      with:
+        # Development jobs include the separate dev flake and its tooling lock.
+        primary-key: nix-dev-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'dev/flake.lock', 'dev/flake.nix', 'default.nix', 'package.nix', 'package.json', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}
+        restore-prefixes-first-match: nix-dev-${{ runner.os }}-${{ runner.arch }}-
+        gc-max-store-size-linux: 3500000000
+        purge: true
+        purge-prefixes: nix-dev-${{ runner.os }}-${{ runner.arch }}-
+        purge-created: 172800
+        purge-primary-key: never
+
+    - name: Load Nix CI development environment
+      if: inputs.warm-dev-shell == 'true'
       shell: bash
-      run: nix develop --command true
+      run: nix develop ./dev#ci --command true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup-nix
+        with:
+          cache-profile: dev
       - run: nix flake check --print-build-logs
-      - run: nix develop --command just typecheck
+      - run: nix flake check ./dev --print-build-logs
+      - run: nix develop ./dev#ci --command just install
+      - run: nix develop ./dev#ci --command just typecheck
 
   test:
     needs: changes
@@ -47,21 +51,24 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
+        with:
+          cache-profile: dev
+      - run: nix develop ./dev#ci --command just install
       - name: Create default Claude directories for tests
         run: |
           mkdir -p "$HOME/.claude/projects"
           mkdir -p "$HOME/.config/claude/projects"
       - name: Run test suite
         if: github.event_name != 'pull_request' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
-        run: nix develop --command just test
+        run: nix develop ./dev#ci --command just test
       - name: Run Vitest tests
         if: github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        run: nix develop --command just test-vitest
+        run: nix develop ./dev#ci --command just test-vitest
       - name: Generate Rust coverage report
         if: github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           mkdir -p coverage
-          env -u CFLAGS -u CXXFLAGS nix develop --command cargo llvm-cov \
+          env -u CFLAGS -u CXXFLAGS nix develop ./dev#ci --command cargo llvm-cov \
             --manifest-path rust/Cargo.toml \
             --workspace \
             --cobertura \
@@ -185,8 +192,9 @@ jobs:
           for archive in "$RUNNER_TEMP"/native-packages/*.tar; do
             tar -xf "$archive"
           done
+      - run: nix develop ./dev#ci --command just install
       - id: publish
-        run: nix develop --command pnpm pkg-pr-new publish --pnpm --bin './apps/ccusage' './packages/ccusage-*'
+        run: nix develop ./dev#ci --command pnpm pkg-pr-new publish --pnpm --bin './apps/ccusage' './packages/ccusage-*'
 
   ccusage-preview-e2e:
     if: github.event_name == 'pull_request' && needs.changes.outputs.code-changed == 'true'
@@ -252,6 +260,8 @@ jobs:
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
+        with:
+          cache-profile: dev
 
       - name: Resolve PR preview package URL
         env:
@@ -264,14 +274,15 @@ jobs:
 
       - name: Generate large ccusage fixture
         run: |
-          nix develop --command pnpm exec bun apps/ccusage/scripts/generate-large-fixture.ts \
-            --output-dir "$RUNNER_TEMP/ccusage-large-fixture" \
-            --codex-output-dir "$RUNNER_TEMP/ccusage-large-codex-fixture" \
-            --size-mib 1024
+          nix develop ./dev#ci --command just install
+          nix develop ./dev#ci --command just generate-large-fixture \
+            "$RUNNER_TEMP/ccusage-large-fixture" \
+            "$RUNNER_TEMP/ccusage-large-codex-fixture" \
+            1024
 
       - name: Compare fixture performance
         run: |
-          nix develop --command pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts \
+          nix develop ./dev#ci --command pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts \
             --base-package-url "https://pkg.pr.new/${{ github.repository }}/ccusage@${{ github.event.pull_request.base.sha }}" \
             --base-sha "${{ github.event.pull_request.base.sha }}" \
             --head-dir . \
@@ -298,7 +309,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: nix develop --command pnpm exec bun .github/scripts/upsert-pr-comment.ts
+        run: nix develop ./dev#ci --command pnpm exec bun .github/scripts/upsert-pr-comment.ts
 
   ccusage-rust-perf-comment:
     name: ccusage rust perf comment
@@ -322,6 +333,8 @@ jobs:
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
+        with:
+          cache-profile: dev
 
       - name: Resolve PR preview package URL
         env:
@@ -334,14 +347,15 @@ jobs:
 
       - name: Generate large ccusage fixture
         run: |
-          nix develop --command pnpm exec bun apps/ccusage/scripts/generate-large-fixture.ts \
-            --output-dir "$RUNNER_TEMP/ccusage-large-fixture" \
-            --codex-output-dir "$RUNNER_TEMP/ccusage-large-codex-fixture" \
-            --size-mib 1024
+          nix develop ./dev#ci --command just install
+          nix develop ./dev#ci --command just generate-large-fixture \
+            "$RUNNER_TEMP/ccusage-large-fixture" \
+            "$RUNNER_TEMP/ccusage-large-codex-fixture" \
+            1024
 
       - name: Compare Rust performance
         run: |
-          nix develop --command pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts \
+          nix develop ./dev#ci --command pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts \
             --base-package-url "https://pkg.pr.new/${{ github.repository }}/ccusage@${{ github.event.pull_request.base.sha }}" \
             --base-sha "${{ github.event.pull_request.base.sha }}" \
             --head-dir . \
@@ -369,7 +383,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: nix develop --command pnpm exec bun .github/scripts/upsert-pr-comment.ts
+        run: nix develop ./dev#ci --command pnpm exec bun .github/scripts/upsert-pr-comment.ts
 
   action-timeline:
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,7 @@ jobs:
       - uses: ./.github/actions/setup-nix
         with:
           cache-profile: dev
-      - run: nix flake check --print-build-logs
-      - run: nix flake check ./dev --print-build-logs
-      - run: nix develop ./dev#ci --command just install
+      - run: nix develop ./dev#ci --command just flake-check
       - run: nix develop ./dev#ci --command just typecheck
 
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
           - os: macos-15-intel
             platform: darwin
             arch: x64
-            binary: rust/target/release/ccusage
+            binary: result/bin/ccusage
           - os: windows-11-arm
             platform: win32
             arch: arm64
@@ -122,9 +122,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup-nix
-        if: matrix.platform == 'linux' || (matrix.platform == 'darwin' && matrix.arch == 'arm64')
+        if: matrix.platform != 'win32'
       - name: Cache Cargo build
-        if: matrix.platform != 'linux' && !(matrix.platform == 'darwin' && matrix.arch == 'arm64')
+        if: matrix.platform == 'win32'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -142,8 +142,8 @@ jobs:
           else
             nix build .#ccusage-static
           fi
-      - name: Build macOS arm64 binary
-        if: matrix.platform == 'darwin' && matrix.arch == 'arm64'
+      - name: Build macOS binary
+        if: matrix.platform == 'darwin'
         run: nix build .#ccusage
       - name: Verify Linux binary is static
         if: matrix.platform == 'linux'
@@ -158,7 +158,7 @@ jobs:
             grep -Eiq 'not a dynamic executable|statically linked' "$RUNNER_TEMP/ldd.txt"
           fi
       - name: Build Cargo native binary
-        if: matrix.platform != 'linux' && !(matrix.platform == 'darwin' && matrix.arch == 'arm64')
+        if: matrix.platform == 'win32'
         run: cargo build --manifest-path rust/Cargo.toml --release --bin ccusage
       - run: node apps/ccusage/scripts/stage-native-package.mjs --platform "${{ matrix.platform }}" --arch "${{ matrix.arch }}" --binary "${{ matrix.binary }}"
       - name: Archive native package binary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
           - os: macos-latest
             platform: darwin
             arch: arm64
-            binary: rust/target/release/ccusage
+            binary: result/bin/ccusage
           - os: macos-15-intel
             platform: darwin
             arch: x64
@@ -122,9 +122,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup-nix
-        if: matrix.platform == 'linux'
+        if: matrix.platform == 'linux' || (matrix.platform == 'darwin' && matrix.arch == 'arm64')
       - name: Cache Cargo build
-        if: matrix.platform != 'linux'
+        if: matrix.platform != 'linux' && !(matrix.platform == 'darwin' && matrix.arch == 'arm64')
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -142,6 +142,9 @@ jobs:
           else
             nix build .#ccusage-static
           fi
+      - name: Build macOS arm64 binary
+        if: matrix.platform == 'darwin' && matrix.arch == 'arm64'
+        run: nix build .#ccusage
       - name: Verify Linux binary is static
         if: matrix.platform == 'linux'
         shell: bash
@@ -155,7 +158,7 @@ jobs:
             grep -Eiq 'not a dynamic executable|statically linked' "$RUNNER_TEMP/ldd.txt"
           fi
       - name: Build Cargo native binary
-        if: matrix.platform != 'linux'
+        if: matrix.platform != 'linux' && !(matrix.platform == 'darwin' && matrix.arch == 'arm64')
         run: cargo build --manifest-path rust/Cargo.toml --release --bin ccusage
       - run: node apps/ccusage/scripts/stage-native-package.mjs --platform "${{ matrix.platform }}" --arch "${{ matrix.arch }}" --binary "${{ matrix.binary }}"
       - name: Archive native package binary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-nix
+        with:
+          cache-profile: dev
         if: matrix.platform == 'linux'
       - name: Cache Cargo build
         if: matrix.platform != 'linux'
@@ -110,7 +112,8 @@ jobs:
           for archive in "$RUNNER_TEMP"/native-packages/*.tar; do
             tar -xf "$archive"
           done
-      - run: nix develop --command pnpm --filter='./apps/ccusage' --filter='./packages/ccusage-*' publish --provenance --no-git-checks --access public
+      - run: nix develop ./dev#ci --command just install
+      - run: nix develop ./dev#ci --command pnpm --filter='./apps/ccusage' --filter='./packages/ccusage-*' publish --provenance --no-git-checks --access public
 
   release:
     needs:
@@ -123,6 +126,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-nix
-      - run: nix develop --command pnpm changelogithub
+        with:
+          cache-profile: dev
+      - run: nix develop ./dev#ci --command just install
+      - run: nix develop ./dev#ci --command pnpm changelogithub
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,11 +24,11 @@ jobs:
           - os: macos-latest
             platform: darwin
             arch: arm64
-            binary: rust/target/release/ccusage
+            binary: result/bin/ccusage
           - os: macos-15-intel
             platform: darwin
             arch: x64
-            binary: rust/target/release/ccusage
+            binary: result/bin/ccusage
           - os: windows-11-arm
             platform: win32
             arch: arm64
@@ -43,11 +43,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-nix
-        with:
-          cache-profile: dev
-        if: matrix.platform == 'linux'
+        if: matrix.platform != 'win32'
       - name: Cache Cargo build
-        if: matrix.platform != 'linux'
+        if: matrix.platform == 'win32'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -60,6 +58,9 @@ jobs:
       - name: Build Linux static binary
         if: matrix.platform == 'linux'
         run: nix build .#ccusage-static
+      - name: Build macOS binary
+        if: matrix.platform == 'darwin'
+        run: nix build .#ccusage
       - name: Verify Linux binary is static
         if: matrix.platform == 'linux'
         shell: bash
@@ -73,7 +74,7 @@ jobs:
             grep -Eiq 'not a dynamic executable|statically linked' "$RUNNER_TEMP/ldd.txt"
           fi
       - name: Build Cargo native binary
-        if: matrix.platform != 'linux'
+        if: matrix.platform == 'win32'
         run: cargo build --manifest-path rust/Cargo.toml --release --bin ccusage
       - run: node apps/ccusage/scripts/stage-native-package.mjs --platform "${{ matrix.platform }}" --arch "${{ matrix.arch }}" --binary "${{ matrix.binary }}"
       - name: Archive native package binary

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -18,6 +18,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
+        with:
+          cache-profile: dev
       - name: Capture current LiteLLM pricing JSON
         run: |
           rev="$(jq -r '.nodes.litellm.locked.rev' flake.lock)"
@@ -44,7 +46,8 @@ jobs:
             echo "Pricing snapshot is already up to date."
             exit 0
           fi
-          nix develop --command just check
+          nix develop ./dev#ci --command just install
+          nix develop ./dev#ci --command just check
       - name: Create pull request
         env:
           GH_TOKEN: ${{ github.token }}
@@ -88,12 +91,14 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
+        with:
+          cache-profile: dev
       - name: Update models.dev input
         run: |
           nix flake update models-dev
       - name: Regenerate committed models.dev pricing snapshot
         run: |
-          nix develop --command just gen-models-dev-pricing
+          nix develop ./dev#ci --command just gen-models-dev-pricing
       - name: Skip lock-only models.dev updates
         run: |
           # Only the compacted snapshot affects the build; if a models.dev bump
@@ -108,7 +113,8 @@ jobs:
             echo "Pricing snapshot is already up to date."
             exit 0
           fi
-          nix develop --command just check
+          nix develop ./dev#ci --command just install
+          nix develop ./dev#ci --command just check
       - name: Create pull request
         env:
           GH_TOKEN: ${{ github.token }}

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -1,0 +1,315 @@
+{
+  "nodes": {
+    "agent-skills": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780896346,
+        "narHash": "sha256-WC5hQ0GOmFPKrlbit3vjjJMlltwI5vpWXsHj/n5NvVk=",
+        "owner": "Kyure-A",
+        "repo": "agent-skills-nix",
+        "rev": "61d701aa8fffd918d8d8c0ac4784bdbadf6ddd60",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Kyure-A",
+        "repo": "agent-skills-nix",
+        "type": "github"
+      }
+    },
+    "ccusage": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "litellm": "litellm",
+        "models-dev": "models-dev",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "path": "..",
+        "type": "path"
+      },
+      "original": {
+        "path": "..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "agent-skills",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780885330,
+        "narHash": "sha256-aMA5oAq2Iv467U9s8YOb50DYQT9w0WJbyWqwlzHuLMs=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "4fe95527cbe952713318ada8a4d122e1a6ab120f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "litellm": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781061615,
+        "narHash": "sha256-Fs2CA14trAen3nv0rW2lQTHxni/UhvD2EaKFnnHk14c=",
+        "owner": "BerriAI",
+        "repo": "litellm",
+        "rev": "e15b37a18eac240c690763c60ca409d13c7be2e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "BerriAI",
+        "repo": "litellm",
+        "type": "github"
+      }
+    },
+    "models-dev": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781034000,
+        "narHash": "sha256-Q/0ugMpEDw+ACZ3V3FbMdzX+57rhrvXfb/Ycn8t5X/0=",
+        "owner": "anomalyco",
+        "repo": "models.dev",
+        "rev": "fb13347f59fac093d60025d987556f57f9a35427",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anomalyco",
+        "repo": "models.dev",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1757882181,
+        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778794387,
+        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "agent-skills": "agent-skills",
+        "ccusage": "ccusage",
+        "crane": [
+          "ccusage",
+          "crane"
+        ],
+        "flake-parts": [
+          "ccusage",
+          "flake-parts"
+        ],
+        "git-hooks": "git-hooks",
+        "litellm": [
+          "ccusage",
+          "litellm"
+        ],
+        "models-dev": [
+          "ccusage",
+          "models-dev"
+        ],
+        "nix-filter": [
+          "ccusage",
+          "nix-filter"
+        ],
+        "nixpkgs": [
+          "ccusage",
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "ccusage",
+          "rust-overlay"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "ccusage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778555852,
+        "narHash": "sha256-55EmwooVAS4UpA0oWd5wilKPRqCiHD5BAej9QiNwheY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f29b0f7a9f367e0056b716f8aa137cb41e784444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Development environment for ccusage";
+
+  inputs = {
+    ccusage.url = "path:..";
+
+    nixpkgs.follows = "ccusage/nixpkgs";
+    crane.follows = "ccusage/crane";
+    flake-parts.follows = "ccusage/flake-parts";
+    litellm.follows = "ccusage/litellm";
+    models-dev.follows = "ccusage/models-dev";
+    nix-filter.follows = "ccusage/nix-filter";
+    rust-overlay.follows = "ccusage/rust-overlay";
+
+    agent-skills = {
+      url = "github:Kyure-A/agent-skills-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      imports = [
+        inputs.treefmt-nix.flakeModule
+        inputs.git-hooks.flakeModule
+        ../nix/packages.nix
+        ../nix/agent-skills.nix
+        ../nix/treefmt.nix
+        ../nix/git-hooks.nix
+        ../nix/dev-shell.nix
+      ];
+    };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "agent-skills": {
-      "inputs": {
-        "home-manager": "home-manager",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779439121,
-        "narHash": "sha256-GAjLtdB7+eqtrP+3u5jSSHoKvjLRvBzyCevBOLkA12k=",
-        "owner": "Kyure-A",
-        "repo": "agent-skills-nix",
-        "rev": "53b899d6f8377a22f2394d150cc227775980fd09",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Kyure-A",
-        "repo": "agent-skills-nix",
-        "type": "github"
-      }
-    },
     "crane": {
       "locked": {
         "lastModified": 1779130139,
@@ -33,22 +12,6 @@
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
         "type": "github"
       }
     },
@@ -67,70 +30,6 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "agent-skills",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779075347,
-        "narHash": "sha256-ZqttlFPw0meQMdABi8/vgle14OWQ3FkIqUkb4/Mrc+0=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "08c9d01457badce151aa4a983c475042d9dec018",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
         "type": "github"
       }
     },
@@ -214,16 +113,13 @@
     },
     "root": {
       "inputs": {
-        "agent-skills": "agent-skills",
         "crane": "crane",
         "flake-parts": "flake-parts",
-        "git-hooks": "git-hooks",
         "litellm": "litellm",
         "models-dev": "models-dev",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay",
-        "treefmt-nix": "treefmt-nix"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
@@ -243,26 +139,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -5,14 +5,6 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    agent-skills = {
-      url = "github:Kyure-A/agent-skills-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    git-hooks = {
-      url = "github:cachix/git-hooks.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     litellm = {
       url = "github:BerriAI/litellm";
       flake = false;
@@ -24,10 +16,6 @@
     nix-filter.url = "github:numtide/nix-filter";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    treefmt-nix = {
-      url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -43,15 +31,12 @@
       ];
 
       imports = [
-        inputs.treefmt-nix.flakeModule
-        inputs.git-hooks.flakeModule
-        ./nix/agent-skills.nix
-        ./nix/treefmt.nix
-        ./nix/git-hooks.nix
+        inputs.flake-parts.flakeModules.touchup
         ./nix/packages.nix
         ./nix/static-package.nix
         ./nix/checks.nix
-        ./nix/dev-shell.nix
       ];
+
+      touchup.attr.formatter.enable = false;
     };
 }

--- a/justfile
+++ b/justfile
@@ -22,6 +22,10 @@ default:
 # Build every workspace package
 build: ccusage::build docs::build
 
+# Install workspace dependencies exactly as CI and the dev shell expect them
+install:
+    pnpm install --frozen-lockfile
+
 # Type-check every workspace package
 typecheck: ccusage::typecheck docs::typecheck
 
@@ -33,17 +37,22 @@ test: rust::test test-vitest
 test-vitest:
     TZ=UTC pnpm exec vitest run
 
+# Generate a large benchmark fixture for PR performance comparisons
+generate-large-fixture output_dir codex_output_dir size_mib="1024":
+    pnpm exec bun apps/ccusage/scripts/generate-large-fixture.ts --output-dir "{{output_dir}}" --codex-output-dir "{{codex_output_dir}}" --size-mib {{size_mib}}
+
 # Format the whole tree (Nix, Rust, JS/TS, workflows, typos) via treefmt
 fmt:
-    nix fmt
+    nix develop ./dev#ci --command treefmt
 
 # Run package typechecks and every flake check (treefmt, oxlint, clippy, schema drift, gitleaks, build)
 check: typecheck
     nix flake check
+    nix flake check ./dev
 
 # Regenerate apps/ccusage/config-schema.json from the Rust source
 schema:
-    nix run .#generate-schema
+    nix run ./dev#generate-schema
 
 # Update the locked LiteLLM pricing snapshot and validate the result
 update-litellm-pricing:
@@ -54,7 +63,7 @@ update-litellm-pricing:
 gen-models-dev-pricing:
     cp "$(nix build .#models-dev-pricing --no-link --print-out-paths)" rust/crates/ccusage/src/models-dev-pricing.json
     chmod u+w rust/crates/ccusage/src/models-dev-pricing.json
-    nix fmt rust/crates/ccusage/src/models-dev-pricing.json
+    nix develop ./dev#ci --command treefmt rust/crates/ccusage/src/models-dev-pricing.json
 
 # Update the pinned models.dev input, regenerate its pricing snapshot, and validate
 update-models-dev-pricing:

--- a/justfile
+++ b/justfile
@@ -26,8 +26,8 @@ build: ccusage::build docs::build
 install:
     pnpm install --frozen-lockfile
 
-# Type-check every workspace package
-typecheck: ccusage::typecheck docs::typecheck
+# Install dependencies, then type-check every workspace package
+typecheck: install ccusage::typecheck docs::typecheck
 
 # Run the full test suite (Rust workspace + Vitest) in parallel
 [parallel]
@@ -45,10 +45,13 @@ generate-large-fixture output_dir codex_output_dir size_mib="1024":
 fmt:
     nix develop ./dev#ci --command treefmt
 
-# Run package typechecks and every flake check (treefmt, oxlint, clippy, schema drift, gitleaks, build)
-check: typecheck
+# Run root package checks and development tooling checks
+flake-check:
     nix flake check
     nix flake check ./dev
+
+# Run package typechecks and every flake check (treefmt, oxlint, clippy, schema drift, gitleaks, build)
+check: typecheck flake-check
 
 # Regenerate apps/ccusage/config-schema.json from the Rust source
 schema:

--- a/nix/agent-skills.nix
+++ b/nix/agent-skills.nix
@@ -1,4 +1,7 @@
 { inputs, lib, ... }:
+let
+  root = ./..;
+in
 {
   perSystem =
     { system, ... }:
@@ -6,7 +9,7 @@
       pkgs = import inputs.nixpkgs { inherit system; };
       agentLib = inputs.agent-skills.lib.agent-skills;
       localSkills = inputs.nix-filter {
-        root = inputs.self;
+        inherit root;
         include = [ ".agents/skills" ];
       };
       sources = {

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -23,7 +23,7 @@ in
         ;
       nixFilter = inputs.nix-filter.lib;
       repoSrc = nixFilter {
-        root = inputs.self;
+        inherit root;
         exclude = [
           (nixFilter.matchName "node_modules")
           (nixFilter.matchName "target")
@@ -90,7 +90,7 @@ in
 
             if ! diff -u apps/ccusage/config-schema.json generated.json; then
               echo "ERROR: apps/ccusage/config-schema.json is out of sync with the Rust schema source." >&2
-              echo "Run 'nix run .#generate-schema' (or 'pnpm --filter ccusage run generate:schema') and commit the result." >&2
+              echo "Run 'nix run ./dev#generate-schema' (or 'pnpm --filter ccusage run generate:schema') and commit the result." >&2
               exit 1
             fi
 

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -15,51 +15,52 @@ in
         overlays = [ inputs.rust-overlay.overlays.default ];
       };
       rustToolchain = pkgs.rust-bin.fromRustupToolchainFile (root + /rust-toolchain.toml);
+      devShellPackages =
+        (with pkgs; [
+          pnpm_11
+          bun
+
+          rustToolchain
+          cargo-edit
+          cargo-insta
+          cargo-llvm-cov
+          pkg-config
+          openssl
+          config.treefmt.build.wrapper
+          nixfmt
+          deadnix
+          statix
+          typos
+          typos-lsp
+          oxfmt
+          actionlint
+          zizmor
+          oxlint
+          just
+          prek
+          gitleaks
+          renovate
+          typescript-go
+          jq
+          git
+          gh
+          hyperfine
+          similarity
+          ast-grep
+          ripgrep
+          fd
+          fzf
+          delta
+          dust
+        ])
+        ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+          pkgs.apple-sdk_15
+        ]
+        ++ config.pre-commit.settings.enabledPackages;
     in
     {
       devShells.default = pkgs.mkShell {
-        buildInputs =
-          (with pkgs; [
-            pnpm_11
-            bun
-
-            rustToolchain
-            cargo-edit
-            cargo-insta
-            cargo-llvm-cov
-            pkg-config
-            openssl
-            config.treefmt.build.wrapper
-            nixfmt
-            deadnix
-            statix
-            typos
-            typos-lsp
-            oxfmt
-            actionlint
-            zizmor
-            oxlint
-            just
-            prek
-            gitleaks
-            renovate
-            typescript-go
-            jq
-            git
-            gh
-            hyperfine
-            similarity
-            ast-grep
-            ripgrep
-            fd
-            fzf
-            delta
-            dust
-          ])
-          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-            pkgs.apple-sdk_15
-          ]
-          ++ config.pre-commit.settings.enabledPackages;
+        buildInputs = devShellPackages;
 
         shellHook = ''
           # Install dependencies only if node_modules/.pnpm/lock.yaml is older than pnpm-lock.yaml
@@ -70,6 +71,9 @@ in
           ${lib.getExe config.packages.syncAgentSkills}
           ${config.pre-commit.shellHook}
         '';
+      };
+      devShells.ci = pkgs.mkShell {
+        buildInputs = devShellPackages;
       };
     };
 }

--- a/nix/static-package.nix
+++ b/nix/static-package.nix
@@ -41,7 +41,14 @@ in
             ];
             buildInputs = [ ];
           };
-          staticCargoArtifacts = staticCraneLib.buildDepsOnly staticCommonArgs;
+          staticDepsOnlyArgs = config.packages.ccusage.passthru.depsOnlyArgs // {
+            cargoExtraArgs = "-p ccusage --bin ccusage --target ${linuxStaticTarget}";
+            nativeBuildInputs = with staticPkgs; [
+              pkg-config
+            ];
+            buildInputs = [ ];
+          };
+          staticCargoArtifacts = staticCraneLib.buildDepsOnly staticDepsOnlyArgs;
         in
         staticCraneLib.buildPackage (
           staticCommonArgs

--- a/nix/static-package.nix
+++ b/nix/static-package.nix
@@ -41,6 +41,7 @@ in
             ];
             buildInputs = [ ];
           };
+          # Share the same deps-only cache key, then add static target settings.
           staticDepsOnlyArgs = config.packages.ccusage.passthru.depsOnlyArgs // {
             cargoExtraArgs = "-p ccusage --bin ccusage --target ${linuxStaticTarget}";
             nativeBuildInputs = with staticPkgs; [

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -62,6 +62,7 @@ in
     {
       treefmt = {
         inherit pkgs;
+        projectRoot = root;
         projectRootFile = "flake.nix";
 
         programs = {
@@ -146,7 +147,7 @@ in
         };
       };
 
-      # `nix run .#generate-schema` regenerates apps/ccusage/config-schema.json
+      # `nix run ./dev#generate-schema` regenerates apps/ccusage/config-schema.json
       # (and the docs copy) from the current Rust source. It reuses the exact
       # script the treefmt formatter and the config-schema flake check rely on,
       # so the three can never drift apart. Run it from the repo root.

--- a/package.nix
+++ b/package.nix
@@ -35,7 +35,10 @@ let
       libiconv
     ];
   };
-  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+  depsOnlyArgs = builtins.removeAttrs commonArgs [ "CCUSAGE_PRICING_JSON_PATH" ] // {
+    version = "0.0.0";
+  };
+  cargoArtifacts = craneLib.buildDepsOnly depsOnlyArgs;
 in
 craneLib.buildPackage (
   commonArgs
@@ -45,6 +48,7 @@ craneLib.buildPackage (
       inherit
         cargoArtifacts
         commonArgs
+        depsOnlyArgs
         version
         ;
     };

--- a/package.nix
+++ b/package.nix
@@ -35,6 +35,8 @@ let
       libiconv
     ];
   };
+  # Keep the dependency artifact keyed only by inputs that affect Cargo deps.
+  # Pricing snapshots and release versions are embedded by the final package.
   depsOnlyArgs = builtins.removeAttrs commonArgs [ "CCUSAGE_PRICING_JSON_PATH" ] // {
     version = "0.0.0";
   };


### PR DESCRIPTION
## Summary

Stabilises the crane dependency artifact so Rust dependency caching is not invalidated by unrelated release version bumps or LiteLLM pricing input updates.

## What Changed

- Adds deps-only crane arguments that remove \`CCUSAGE_PRICING_JSON_PATH\` and use a stable version.
- Reuses the deps-only arguments for static Linux builds so package variants behave consistently.

## Testing

- \`nix fmt -- package.nix nix/static-package.nix\`
- \`nix build .#ccusage --print-build-logs\`
- \`nix build .#ccusage --dry-run --print-out-paths\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the `crane` dependency cache so Rust deps don’t rebuild on release bumps or pricing snapshot changes, and splits dev tooling into a separate flake to keep packages lean and CI caching predictable. Builds both macOS binaries with Nix and fixes single‑user Nix ownership on non‑Windows cache restores.

- Strips `CCUSAGE_PRICING_JSON_PATH` from deps-only builds and pins the deps artifact `version` to `0.0.0`; exposes `depsOnlyArgs` and reuses it for static builds so both share a stable cache key.
- Adds comments in `package.nix` and `nix/static-package.nix` explaining the stable deps cache key.

- **Refactors**
  - Moves dev-only modules to `dev/flake.nix`; `.envrc` now uses `use flake ./dev`; adds a `./dev#ci` shell.
  - Switches to `nixbuild/nix-quick-install-action`, splits package vs dev cache profiles, and makes dev-shell warming optional.
  - Chowns `/nix/var/log/nix` and `/nix/var/nix` on non‑Windows before builds; stops chown‑ing `/nix/store` to avoid lock permission issues.
  - Builds macOS arm64 and x64 packages via Nix in CI and release (Cargo remains for Windows); updates artifact path to `result/bin/ccusage`.
  - Updates workflows to run flake checks via `just flake-check`, use `nix develop ./dev#ci`, and call shared `just` tasks (`install`, `generate-large-fixture`); `typecheck` now depends on a frozen `pnpm install`.

<sup>Written for commit 615746418881db20e3c51270b6cacaa93bca43eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI recipes: install (pnpm install) and generate-large-fixture for large PR benchmark generation.

* **Chores**
  * Introduced a dedicated dev environment and CI dev shell; CI and release workflows now run under that environment and include an improved cache-profile option and optional warm dev-shell step.
  * Added a macOS native build step and standardized native build outputs.
  * Updated dev reload/watch and formatting/schema commands to target the new dev environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->