### PR TITLE
perf(pricing): shrink embedded snapshots 58% and binary 2.9%

### DIFF
--- a/.agents/skills/rust-binary-size/SKILL.md
+++ b/.agents/skills/rust-binary-size/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: rust-binary-size
+description: Guides Rust binary size reduction for ccusage. Use when changing release profiles, dependency features, native packaging size, or investigating Rust executable bloat.
+paths:
+  - 'rust/Cargo.toml'
+  - 'rust/**/*.rs'
+  - 'rust/**/*.toml'
+  - 'apps/ccusage/scripts/**'
+globs: 'rust/**/*.rs,rust/**/*.toml,apps/ccusage/scripts/**'
+---
+
+# Rust Binary Size
+
+Use this skill when applying binary-size guidance to the Rust-first `ccusage`
+CLI, release profiles, native package binaries, dependency features, or size
+regression investigations.
+
+Primary external reference: <https://github.com/johnthagen/min-sized-rust>
+
+## Baseline
+
+Start by checking the existing release profile before adding new size settings:
+
+```sh
+sed -n '1,120p' rust/Cargo.toml
+```
+
+This workspace should keep stable release settings aligned with
+`min-sized-rust` unless a measured tradeoff argues otherwise:
+
+- `opt-level = "z"` for workspace crates unless benchmarking shows `"s"` is smaller.
+- `lto = "fat"` for maximum cross-crate dead-code elimination in release builds.
+- `codegen-units = 1` for better release optimization.
+- `panic = "abort"` only for binaries where stack unwinding is not required.
+- `strip = "symbols"` or an equivalent stable strip setting for packaged binaries.
+
+## Investigation
+
+Prefer measurement before changing code or dependencies:
+
+```sh
+direnv exec . cargo build --manifest-path rust/Cargo.toml --release --bin ccusage
+ls -lh rust/target/release/ccusage
+```
+
+When a size regression is not explained by the release profile, inspect
+dependency features and large symbols before editing:
+
+```sh
+direnv exec . cargo tree --manifest-path rust/Cargo.toml -e features -p ccusage
+direnv exec . cargo bloat --manifest-path rust/Cargo.toml --release --bin ccusage --crates
+```
+
+If `cargo bloat` is unavailable, use the `missing-tools` skill or run it through
+the Nix/dev-shell path preferred by the repository. Do not add a new tool to the
+flake unless repeated project work needs it.
+
+## Safe Changes
+
+Prefer stable, low-risk changes first:
+
+- Disable unnecessary dependency default features when tests prove the disabled
+  features are not required.
+- Narrow optional dependency features instead of replacing a well-fitting crate.
+- Remove unused code paths, generated assets, or format-heavy diagnostics from
+  release-only paths only when behavior remains correct.
+- Keep `ccusage` functionality, JSON output, table output, and packaging
+  semantics unchanged unless the user explicitly asks for a behavior change.
+
+## Risky Changes
+
+Treat these as opt-in only unless the user explicitly asks for an aggressive
+minimum-size experiment:
+
+- Nightly-only flags such as `-Zlocation-detail`, `-Zfmt-debug`,
+  `panic=immediate-abort`, or `build-std`.
+- `#![no_std]`, `#![no_main]`, C entry points, or manual stdio.
+- UPX or other binary packers, especially for distributed CLI artifacts.
+- Dynamic Rust linking through `prefer-dynamic`, because deployment and ABI
+  constraints make it unsuitable for ordinary CLI releases.
+
+## Validation
+
+After changes, run formatting and the relevant behavioral checks:
+
+```sh
+direnv exec . just fmt
+direnv exec . just test
+```
+
+For release-profile or packaging changes, also build the native CLI and compare
+the binary size with the previous measurement. Record the command and result in
+the PR body or review reply.

--- a/.github/scripts/upsert-pr-comment.ts
+++ b/.github/scripts/upsert-pr-comment.ts
@@ -52,23 +52,18 @@ async function githubRequest<T>(path: string, options: RequestInit = {}): Promis
 	return response.json() as Promise<T>;
 }
 
-const repository = requiredEnv('GITHUB_REPOSITORY');
-const prNumber = requiredEnv('PR_NUMBER');
-const marker = requiredEnv('COMMENT_MARKER');
-const body = await Bun.file(requiredEnv('COMMENT_FILE')).text();
-
-async function createComment(): Promise<void> {
+async function createComment(repository: string, prNumber: string, body: string): Promise<void> {
 	await githubRequest(`/repos/${repository}/issues/${prNumber}/comments`, {
 		method: 'POST',
 		body: JSON.stringify({ body }),
 	});
 }
 
-async function tryCreateComment(): Promise<void> {
+async function tryCreateComment(repository: string, prNumber: string, body: string): Promise<void> {
 	try {
-		await createComment();
+		await createComment(repository, prNumber, body);
 	} catch (error) {
-		if (error instanceof GitHubRequestError && error.status === 403) {
+		if (isCommentWriteAuthFailure(error)) {
 			console.warn(
 				`Skipping PR comment because GitHub token cannot write comments: ${error.message}`,
 			);
@@ -78,24 +73,52 @@ async function tryCreateComment(): Promise<void> {
 	}
 }
 
-const comments = await githubRequest<GitHubComment[]>(
-	`/repos/${repository}/issues/${prNumber}/comments?per_page=100`,
-);
-const existing = comments.find(
-	(comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
-);
+function isCommentWriteAuthFailure(error: unknown): error is GitHubRequestError {
+	return error instanceof GitHubRequestError && (error.status === 401 || error.status === 403);
+}
 
-if (existing == null) {
-	await tryCreateComment();
-} else {
-	try {
-		await githubRequest(`/repos/${repository}/issues/comments/${existing.id}`, {
-			method: 'PATCH',
-			body: JSON.stringify({ body }),
-		});
-	} catch (error) {
-		console.warn(`Failed to update existing PR comment; creating a new comment instead.`);
-		console.warn(error);
-		await tryCreateComment();
+async function main(): Promise<void> {
+	const repository = requiredEnv('GITHUB_REPOSITORY');
+	const prNumber = requiredEnv('PR_NUMBER');
+	const marker = requiredEnv('COMMENT_MARKER');
+	const body = await Bun.file(requiredEnv('COMMENT_FILE')).text();
+	const comments = await githubRequest<GitHubComment[]>(
+		`/repos/${repository}/issues/${prNumber}/comments?per_page=100`,
+	);
+	const existing = comments.find(
+		(comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
+	);
+
+	if (existing == null) {
+		await tryCreateComment(repository, prNumber, body);
+	} else {
+		try {
+			await githubRequest(`/repos/${repository}/issues/comments/${existing.id}`, {
+				method: 'PATCH',
+				body: JSON.stringify({ body }),
+			});
+		} catch (error) {
+			console.warn(`Failed to update existing PR comment; creating a new comment instead.`);
+			console.warn(error);
+			await tryCreateComment(repository, prNumber, body);
+		}
 	}
+}
+
+if (import.meta.vitest != null) {
+	describe(isCommentWriteAuthFailure, () => {
+		it('treats unauthenticated comment writes as skippable', () => {
+			expect(isCommentWriteAuthFailure(new GitHubRequestError('unauthenticated', 401))).toBe(true);
+		});
+
+		it('treats forbidden comment writes as skippable', () => {
+			expect(isCommentWriteAuthFailure(new GitHubRequestError('forbidden', 403))).toBe(true);
+		});
+
+		it('keeps other GitHub errors fatal', () => {
+			expect(isCommentWriteAuthFailure(new GitHubRequestError('server error', 500))).toBe(false);
+		});
+	});
+} else {
+	await main();
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -296,7 +296,7 @@ jobs:
             --large-codex-fixture-dir "$RUNNER_TEMP/ccusage-large-codex-fixture" \
             --large-warmup 0 \
             --large-runs 1 \
-            --package-runner-timeout-ms 1800000 \
+            --package-runner-timeout-ms 300000 \
             --output "$RUNNER_TEMP/ccusage-perf-comment.md"
 
       - name: Write job summary
@@ -370,7 +370,7 @@ jobs:
             --large-codex-fixture-dir "$RUNNER_TEMP/ccusage-large-codex-fixture" \
             --large-warmup 0 \
             --large-runs 1 \
-            --package-runner-timeout-ms 1800000 \
+            --package-runner-timeout-ms 300000 \
             --output "$RUNNER_TEMP/ccusage-rust-perf-comment.md"
 
       - name: Write job summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Use these skills before working in this repository:
 - `skill-creator` - repo-local skill creation, SKILL.md frontmatter, description trigger quality, and reference layout.
 - `ast-grep` - structural code searches in Rust or TypeScript and AST-based migration verification with the dev-shell `ast-grep` CLI.
 - `bun-api-reference` - local Bun runtime API docs and type references under `node_modules/bun-types`.
+- `rust-binary-size` - Rust release profile, dependency feature, native packaging size, and executable bloat reduction guidance based on min-sized-rust.
 - `tdd` - Red-Green-Refactor workflow for logic changes.
 - `reduce-similarities` - AST-based duplicate Rust code detection with similarity-rs; TypeScript duplication checks use `typescript` and `ast-grep`.
 - `cmux-debug` - terminal UI and responsive table verification in cmux.

--- a/apps/ccusage/scripts/compare-pr-performance.ts
+++ b/apps/ccusage/scripts/compare-pr-performance.ts
@@ -54,6 +54,11 @@ type PackageRunnerComparison = {
 	head?: PackageRunnerMeasurement;
 };
 
+type PackageInstall = {
+	acquisition: number;
+	binEntry: string;
+};
+
 type SampleOptions = {
 	runs: number;
 	warmup: number;
@@ -402,10 +407,11 @@ async function installPackageUrl({
 	label: string;
 	packageUrl: string;
 	timeoutMs: number;
-}): Promise<{ acquisition: number; binEntry: string }> {
+}): Promise<PackageInstall | undefined> {
 	await writeProgress(`${label} package install waiting for package URL`);
 	if (!(await waitForPackageUrl(packageUrl, timeoutMs))) {
-		throw new Error(`${label} package URL was not ready: ${packageUrl}`);
+		await writeProgress(`${label} package install skipped because package URL was not ready`);
+		return undefined;
 	}
 	await mkdir(installDir, { recursive: true });
 	await Bun.write(
@@ -1695,6 +1701,38 @@ function renderMarkdown(
 	return `${lines.join('\n')}\n`;
 }
 
+function renderSkippedMarkdown(options: {
+	basePackageUrl?: string;
+	baseSha?: string;
+	headRuntime: HeadRuntime;
+	headSha?: string;
+	reason: string;
+}): string {
+	const markerName =
+		options.headRuntime === 'rust' ? 'ccusage-rust-perf-comment' : 'ccusage-perf-comment';
+	const lines = [
+		`<!-- ${markerName} -->`,
+		...(options.headSha == null ? [] : [`<!-- ${markerName}:${options.headSha} -->`]),
+		'## ccusage performance comparison',
+		'',
+		...(options.headSha == null
+			? []
+			: [
+					`PR SHA: \`${formatSha(options.headSha)}\``,
+					...(options.baseSha == null ? [] : [`Base SHA: \`${formatSha(options.baseSha)}\``]),
+					'',
+				]),
+		'Performance comparison skipped.',
+		'',
+		options.reason,
+		...(options.basePackageUrl == null
+			? []
+			: ['', `Base package: \`${packageUrlSha(options.basePackageUrl)}\``]),
+		'',
+	];
+	return `${lines.join('\n')}\n`;
+}
+
 if (import.meta.vitest != null) {
 	describe(createCcusageCommandFromBin, () => {
 		it('builds hyperfine command text that benchmarks the published ccusage bin with both Claude and Codex fixture environment variables', () => {
@@ -1777,6 +1815,26 @@ if (import.meta.vitest != null) {
 	});
 
 	describe(createHeadCcusageCommand, () => {
+		describe(installPackageUrl, () => {
+			it('skips package installation when the package URL is not ready before the timeout', async () => {
+				await using fixture = await createFixture({});
+				vi.stubGlobal('Bun', {
+					sleep: vi.fn(),
+					stderr: {},
+					write: vi.fn(async () => undefined),
+				});
+
+				await expect(
+					installPackageUrl({
+						installDir: join(fixture.path, 'package'),
+						label: 'base',
+						packageUrl: 'https://pkg.pr.new/ryoppippi/ccusage/ccusage@missing',
+						timeoutMs: 0,
+					}),
+				).resolves.toBeUndefined();
+			});
+		});
+
 		it('resolves the installed package published bin instead of the package manager shim', async () => {
 			await using fixture = await createFixture({});
 			const packageDir = join(fixture.path, 'node_modules', 'ccusage');
@@ -2191,6 +2249,22 @@ if (import.meta.vitest != null) {
 				'| installed native package binary | 2.00 KiB | 1.00 KiB | -1.00 KiB | 2.00x |',
 			);
 		});
+
+		it('renders a commit-specific skip comment when the base package URL is unavailable', () => {
+			const markdown = renderSkippedMarkdown({
+				basePackageUrl: 'https://pkg.pr.new/ryoppippi/ccusage/ccusage@0123456789abcdef',
+				baseSha: '0123456789abcdef',
+				headRuntime: 'rust',
+				headSha: 'abcdef0123456789',
+				reason: 'Base package URL was not ready before the timeout.',
+			});
+
+			expect(markdown).toContain('<!-- ccusage-rust-perf-comment:abcdef0123456789 -->');
+			expect(markdown).toContain('PR SHA: `abcdef012345`');
+			expect(markdown).toContain('Base SHA: `0123456789ab`');
+			expect(markdown).toContain('Base package: `0123456789ab`');
+			expect(markdown).toContain('Base package URL was not ready before the timeout.');
+		});
 	});
 
 	describe(parsePeakRssBytes, () => {
@@ -2348,6 +2422,21 @@ const command = define({
 						packageUrl: headPackageUrl,
 						timeoutMs: ctx.values.packageRunnerTimeoutMs,
 					});
+		if (basePackageUrl != null && basePackageInstall == null && baseDir == null) {
+			const markdown = renderSkippedMarkdown({
+				basePackageUrl,
+				baseSha: ctx.values.baseSha,
+				headRuntime,
+				headSha: gitSha(resolve(ctx.values.headDir)),
+				reason: `Base package URL was not ready before ${formatDuration(ctx.values.packageRunnerTimeoutMs)}. Fixture performance comparison requires a base package when --base-dir is not provided.`,
+			});
+			if (ctx.values.output == null) {
+				await Bun.write(Bun.stdout, markdown);
+			} else {
+				await Bun.write(resolve(ctx.values.output), markdown);
+			}
+			return;
+		}
 		const headNativeBinEntry =
 			headPackageInstall == null
 				? undefined

--- a/apps/ccusage/scripts/stage-native-package.mjs
+++ b/apps/ccusage/scripts/stage-native-package.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { chmodSync, copyFileSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import process from 'node:process';
@@ -24,6 +25,21 @@ function readOption(name, fallback) {
 	return value;
 }
 
+function rewriteDarwinSystemLibraries(binaryPath) {
+	const linkedLibraries = execFileSync('otool', ['-L', binaryPath], { encoding: 'utf8' });
+	for (const line of linkedLibraries.split('\n')) {
+		const library = line.trim().split(/\s+/)[0];
+		if (/^\/nix\/store\/[^/]+-libiconv-[^/]+\/lib\/libiconv\.2\.dylib$/.test(library)) {
+			execFileSync('install_name_tool', [
+				'-change',
+				library,
+				'/usr/lib/libiconv.2.dylib',
+				binaryPath,
+			]);
+		}
+	}
+}
+
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, '../../..');
 const platform = readOption('platform', process.platform);
@@ -44,6 +60,9 @@ mkdirSync(targetDir, { recursive: true });
 copyFileSync(source, target);
 if (platform !== 'win32') {
 	chmodSync(target, 0o755);
+}
+if (platform === 'darwin') {
+	rewriteDarwinSystemLibraries(target);
 }
 
 process.stdout.write(`${target}\n`);

--- a/nix/models-dev-compact.test.ts
+++ b/nix/models-dev-compact.test.ts
@@ -5,3 +5,15 @@ it('falls back to the source model id when the catalog id is empty', () => {
 		'anthropic/claude-sonnet-4',
 	);
 });
+
+it('falls back to the source model id when the catalog id is undefined', () => {
+	expect(selectModelsDevPricingKey('anthropic/claude-sonnet-4', undefined)).toBe(
+		'anthropic/claude-sonnet-4',
+	);
+});
+
+it('uses the catalog id when it is non-empty', () => {
+	expect(selectModelsDevPricingKey('anthropic/claude-sonnet-4', 'catalog-id-123')).toBe(
+		'catalog-id-123',
+	);
+});

--- a/nix/models-dev-compact.test.ts
+++ b/nix/models-dev-compact.test.ts
@@ -1,4 +1,7 @@
-import { selectModelsDevPricingKey } from './models-dev-compact.ts';
+import {
+	formatDuplicateModelsDevPricingKeyWarning,
+	selectModelsDevPricingKey,
+} from './models-dev-compact.ts';
 
 it('falls back to the source model id when the catalog id is empty', () => {
 	expect(selectModelsDevPricingKey('anthropic/claude-sonnet-4', '')).toBe(
@@ -15,5 +18,16 @@ it('falls back to the source model id when the catalog id is undefined', () => {
 it('uses the catalog id when it is non-empty', () => {
 	expect(selectModelsDevPricingKey('anthropic/claude-sonnet-4', 'catalog-id-123')).toBe(
 		'catalog-id-123',
+	);
+});
+
+it('formats duplicate pricing key warnings with the skipped source id', () => {
+	expect(
+		formatDuplicateModelsDevPricingKeyWarning({
+			pricingKey: 'claude-sonnet-4',
+			sourceModelId: 'anthropic/claude-sonnet-4',
+		}),
+	).toBe(
+		'models.dev pricing key "claude-sonnet-4" already exists; skipping duplicate source model "anthropic/claude-sonnet-4".',
 	);
 });

--- a/nix/models-dev-compact.test.ts
+++ b/nix/models-dev-compact.test.ts
@@ -1,0 +1,7 @@
+import { selectModelsDevPricingKey } from './models-dev-compact.ts';
+
+it('falls back to the source model id when the catalog id is empty', () => {
+	expect(selectModelsDevPricingKey('anthropic/claude-sonnet-4', '')).toBe(
+		'anthropic/claude-sonnet-4',
+	);
+});

--- a/nix/models-dev-compact.ts
+++ b/nix/models-dev-compact.ts
@@ -1,3 +1,13 @@
 export function selectModelsDevPricingKey(modelId: string, catalogId: string | undefined): string {
 	return catalogId != null && catalogId.length > 0 ? catalogId : modelId;
 }
+
+export function formatDuplicateModelsDevPricingKeyWarning({
+	pricingKey,
+	sourceModelId,
+}: {
+	pricingKey: string;
+	sourceModelId: string;
+}): string {
+	return `models.dev pricing key "${pricingKey}" already exists; skipping duplicate source model "${sourceModelId}".`;
+}

--- a/nix/models-dev-compact.ts
+++ b/nix/models-dev-compact.ts
@@ -1,0 +1,3 @@
+export function selectModelsDevPricingKey(modelId: string, catalogId: string | undefined): string {
+	return catalogId != null && catalogId.length > 0 ? catalogId : modelId;
+}

--- a/nix/models-dev-gen.ts
+++ b/nix/models-dev-gen.ts
@@ -11,7 +11,10 @@
  * via `just gen-models-dev-pricing` (see `nix/models-dev-pricing.nix`).
  */
 import { generateCatalog } from './packages/core/src/generate.ts';
-import { selectModelsDevPricingKey } from './models-dev-compact.ts';
+import {
+	formatDuplicateModelsDevPricingKeyWarning,
+	selectModelsDevPricingKey,
+} from './models-dev-compact.ts';
 
 /** Model ids/keys we keep; ccusage is Claude-first, so we embed Anthropic models. */
 const KEEP = /claude|anthropic/i;
@@ -48,6 +51,12 @@ for (const provider of Object.values(providers)) {
 		}
 		const pricingKey = selectModelsDevPricingKey(modelId, model.id);
 		if (out[pricingKey] != null) {
+			console.warn(
+				formatDuplicateModelsDevPricingKeyWarning({
+					pricingKey,
+					sourceModelId: modelId,
+				}),
+			);
 			continue;
 		}
 		const entry: EmbeddedModel = {

--- a/nix/models-dev-gen.ts
+++ b/nix/models-dev-gen.ts
@@ -5,9 +5,10 @@
  * reuse its own `generateCatalog` routine (the same code that backs
  * https://models.dev/api.json) and then compact the result down to the
  * Anthropic-relevant models and the few pricing fields ccusage consumes. The
- * output is committed to the repository and embedded at build time, so every
- * platform ships the identical, pinned data without any build-time network
- * access. Run via `just gen-models-dev-pricing` (see `nix/models-dev-pricing.nix`).
+ * embedded output is a flat map keyed by runtime model id. The output is
+ * committed to the repository and embedded at build time, so every platform
+ * ships the identical, pinned data without any build-time network access. Run
+ * via `just gen-models-dev-pricing` (see `nix/models-dev-pricing.nix`).
  */
 import { generateCatalog } from './packages/core/src/generate.ts';
 
@@ -22,14 +23,17 @@ type Cost = {
 };
 type Model = { id?: string; cost?: Cost; limit?: { context?: number | null } };
 type Provider = { models?: Record<string, Model> };
+type EmbeddedModel = {
+	cost: Cost;
+	limit?: { context: number };
+};
 
 const { providers } = (await generateCatalog('.')) as {
 	providers: Record<string, Provider>;
 };
 
-const out: Record<string, { models: Record<string, unknown> }> = {};
-for (const [providerId, provider] of Object.entries(providers)) {
-	const models: Record<string, unknown> = {};
+const out: Record<string, EmbeddedModel> = {};
+for (const provider of Object.values(providers)) {
 	for (const [modelId, model] of Object.entries(provider.models ?? {})) {
 		// models.dev also exposes the canonical id under `id`; match either so
 		// provider-prefixed aliases (e.g. us.anthropic.*) are kept too.
@@ -41,23 +45,22 @@ for (const [providerId, provider] of Object.entries(providers)) {
 		if (cost.input == null || cost.output == null) {
 			continue;
 		}
-		const entry: Record<string, unknown> = {};
-		if (model.id != null) {
-			entry.id = model.id;
+		const pricingKey = model.id ?? modelId;
+		if (out[pricingKey] != null) {
+			continue;
 		}
-		entry.cost = {
-			input: cost.input,
-			output: cost.output,
-			...(cost.cache_read != null ? { cache_read: cost.cache_read } : {}),
-			...(cost.cache_write != null ? { cache_write: cost.cache_write } : {}),
+		const entry: EmbeddedModel = {
+			cost: {
+				input: cost.input,
+				output: cost.output,
+				...(cost.cache_read != null ? { cache_read: cost.cache_read } : {}),
+				...(cost.cache_write != null ? { cache_write: cost.cache_write } : {}),
+			},
 		};
 		if (model.limit?.context != null) {
 			entry.limit = { context: model.limit.context };
 		}
-		models[modelId] = entry;
-	}
-	if (Object.keys(models).length > 0) {
-		out[providerId] = { models };
+		out[pricingKey] = entry;
 	}
 }
 

--- a/nix/models-dev-gen.ts
+++ b/nix/models-dev-gen.ts
@@ -11,6 +11,7 @@
  * via `just gen-models-dev-pricing` (see `nix/models-dev-pricing.nix`).
  */
 import { generateCatalog } from './packages/core/src/generate.ts';
+import { selectModelsDevPricingKey } from './models-dev-compact.ts';
 
 /** Model ids/keys we keep; ccusage is Claude-first, so we embed Anthropic models. */
 const KEEP = /claude|anthropic/i;
@@ -45,7 +46,7 @@ for (const provider of Object.values(providers)) {
 		if (cost.input == null || cost.output == null) {
 			continue;
 		}
-		const pricingKey = model.id ?? modelId;
+		const pricingKey = selectModelsDevPricingKey(modelId, model.id);
 		if (out[pricingKey] != null) {
 			continue;
 		}

--- a/rust/crates/ccusage/build.rs
+++ b/rust/crates/ccusage/build.rs
@@ -105,28 +105,33 @@ fn compact_pricing_json(json: &str) -> Option<String> {
             continue;
         };
         let mut fields = Map::new();
-        for field in [
-            "input_cost_per_token",
-            "output_cost_per_token",
-            "cache_creation_input_token_cost",
-            "cache_read_input_token_cost",
-            "input_cost_per_token_above_200k_tokens",
-            "output_cost_per_token_above_200k_tokens",
-            "cache_creation_input_token_cost_above_200k_tokens",
-            "cache_read_input_token_cost_above_200k_tokens",
-            "max_input_tokens",
-            "provider_specific_entry",
+        for (source, target) in [
+            ("input_cost_per_token", "i"),
+            ("output_cost_per_token", "o"),
+            ("cache_creation_input_token_cost", "cc"),
+            ("cache_read_input_token_cost", "cr"),
+            ("input_cost_per_token_above_200k_tokens", "ia"),
+            ("output_cost_per_token_above_200k_tokens", "oa"),
+            ("cache_creation_input_token_cost_above_200k_tokens", "cca"),
+            ("cache_read_input_token_cost_above_200k_tokens", "cra"),
+            ("max_input_tokens", "ctx"),
         ] {
-            let Some(value) = pricing.get(field) else {
+            let Some(value) = pricing.get(source) else {
                 continue;
             };
             if !value.is_null() {
-                fields.insert(field.to_string(), value.clone());
+                fields.insert(target.to_string(), value.clone());
             }
         }
-        if fields.contains_key("input_cost_per_token")
-            && fields.contains_key("output_cost_per_token")
+        if let Some(fast) = pricing
+            .get("provider_specific_entry")
+            .and_then(Value::as_object)
+            .and_then(|entry| entry.get("fast"))
+            .filter(|value| !value.is_null())
         {
+            fields.insert("fast".to_string(), fast.clone());
+        }
+        if fields.contains_key("i") && fields.contains_key("o") {
             compact.insert(model, Value::Object(fields));
         }
     }

--- a/rust/crates/ccusage/src/models-dev-pricing.json
+++ b/rust/crates/ccusage/src/models-dev-pricing.json
@@ -1,5195 +1,2394 @@
 {
-	"302ai": {
-		"models": {
-			"claude-3-5-haiku-20241022": {
-				"cost": {
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "claude-3-5-haiku-20241022",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-5-haiku-latest": {
-				"cost": {
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "claude-3-5-haiku-latest",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5": {
-				"cost": {
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5-20251001": {
-				"cost": {
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5-20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-20250805": {
-				"cost": {
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1-20250805",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-20250805-thinking": {
-				"cost": {
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1-20250805-thinking",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-20250514": {
-				"cost": {
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5": {
-				"cost": {
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5-20251101": {
-				"cost": {
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5-20251101",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5-20251101-thinking": {
-				"cost": {
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5-20251101-thinking",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-6-thinking": {
-				"cost": {
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6-thinking",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-20250514": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5-20250929": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5-20250929",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5-20250929-thinking": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5-20250929-thinking",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-6-thinking": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6-thinking",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled": {
+		"cost": {
+			"cache_read": 0.0306,
+			"input": 0.306,
+			"output": 0.306
+		},
+		"limit": {
+			"context": 262144
 		}
 	},
-	"abacus": {
-		"models": {
-			"claude-3-7-sonnet-20250219": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-3-7-sonnet-20250219",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5-20251001": {
-				"cost": {
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5-20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-20250805": {
-				"cost": {
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1-20250805",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-20250514": {
-				"cost": {
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5-20251101": {
-				"cost": {
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5-20251101",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-20250514": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5-20250929": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5-20250929",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic--claude-3-haiku": {
+		"cost": {
+			"cache_read": 0.03,
+			"cache_write": 0.3,
+			"input": 0.25,
+			"output": 1.25
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"aihubmix": {
-		"models": {
-			"claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-6-think": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6-think",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7-think": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7-think",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-6-think": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6-think",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic--claude-3-opus": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"amazon-bedrock": {
-		"models": {
-			"anthropic.claude-haiku-4-5-20251001-v1:0": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic.claude-haiku-4-5-20251001-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic.claude-opus-4-1-20250805-v1:0": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic.claude-opus-4-1-20250805-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic.claude-opus-4-5-20251101-v1:0": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic.claude-opus-4-5-20251101-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic.claude-opus-4-6-v1": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic.claude-opus-4-6-v1",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic.claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic.claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic.claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic.claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic.claude-sonnet-4-5-20250929-v1:0": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic.claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic.claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"au.anthropic.claude-opus-4-6-v1": {
-				"cost": {
-					"cache_read": 1.65,
-					"cache_write": 20.625,
-					"input": 16.5,
-					"output": 82.5
-				},
-				"id": "au.anthropic.claude-opus-4-6-v1",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"au.anthropic.claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "au.anthropic.claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"au.anthropic.claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.33,
-					"cache_write": 4.125,
-					"input": 3.3,
-					"output": 16.5
-				},
-				"id": "au.anthropic.claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"eu.anthropic.claude-fable-5": {
-				"cost": {
-					"cache_read": 1.1,
-					"cache_write": 13.75,
-					"input": 11,
-					"output": 55
-				},
-				"id": "eu.anthropic.claude-fable-5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"eu.anthropic.claude-opus-4-5-20251101-v1:0": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"eu.anthropic.claude-opus-4-6-v1": {
-				"cost": {
-					"cache_read": 0.55,
-					"cache_write": 6.875,
-					"input": 5.5,
-					"output": 27.5
-				},
-				"id": "eu.anthropic.claude-opus-4-6-v1",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"eu.anthropic.claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.55,
-					"cache_write": 6.875,
-					"input": 5.5,
-					"output": 27.5
-				},
-				"id": "eu.anthropic.claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"eu.anthropic.claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.55,
-					"cache_write": 6.875,
-					"input": 5.5,
-					"output": 27.5
-				},
-				"id": "eu.anthropic.claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
-				"cost": {
-					"cache_read": 0.33,
-					"cache_write": 4.125,
-					"input": 3.3,
-					"output": 16.5
-				},
-				"id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"eu.anthropic.claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.33,
-					"cache_write": 4.125,
-					"input": 3.3,
-					"output": 16.5
-				},
-				"id": "eu.anthropic.claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"global.anthropic.claude-fable-5": {
-				"cost": {
-					"cache_read": 1,
-					"cache_write": 12.5,
-					"input": 10,
-					"output": 50
-				},
-				"id": "global.anthropic.claude-fable-5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"global.anthropic.claude-opus-4-5-20251101-v1:0": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"global.anthropic.claude-opus-4-6-v1": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "global.anthropic.claude-opus-4-6-v1",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"global.anthropic.claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "global.anthropic.claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"global.anthropic.claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "global.anthropic.claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"global.anthropic.claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "global.anthropic.claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"jp.anthropic.claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "jp.anthropic.claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"jp.anthropic.claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "jp.anthropic.claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"jp.anthropic.claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "jp.anthropic.claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"us.anthropic.claude-fable-5": {
-				"cost": {
-					"cache_read": 1,
-					"cache_write": 12.5,
-					"input": 10,
-					"output": 50
-				},
-				"id": "us.anthropic.claude-fable-5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"us.anthropic.claude-haiku-4-5-20251001-v1:0": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"us.anthropic.claude-opus-4-1-20250805-v1:0": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"us.anthropic.claude-opus-4-5-20251101-v1:0": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"us.anthropic.claude-opus-4-6-v1": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "us.anthropic.claude-opus-4-6-v1",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"us.anthropic.claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "us.anthropic.claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"us.anthropic.claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "us.anthropic.claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"us.anthropic.claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "us.anthropic.claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic--claude-3-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"anthropic": {
-		"models": {
-			"claude-3-5-haiku-20241022": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "claude-3-5-haiku-20241022",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-5-haiku-latest": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "claude-3-5-haiku-latest",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-5-sonnet-20240620": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-3-5-sonnet-20240620",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-5-sonnet-20241022": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-3-5-sonnet-20241022",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-7-sonnet-20250219": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-3-7-sonnet-20250219",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-haiku-20240307": {
-				"cost": {
-					"cache_read": 0.03,
-					"cache_write": 0.3,
-					"input": 0.25,
-					"output": 1.25
-				},
-				"id": "claude-3-haiku-20240307",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-opus-20240229": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-3-opus-20240229",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-sonnet-20240229": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 0.3,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-3-sonnet-20240229",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-fable-5": {
-				"cost": {
-					"cache_read": 1,
-					"cache_write": 12.5,
-					"input": 10,
-					"output": 50
-				},
-				"id": "claude-fable-5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5-20251001": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5-20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-0": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-20250805": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1-20250805",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-20250514": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5-20251101": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5-20251101",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-0": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-0",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-20250514": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5-20250929": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5-20250929",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic--claude-3.5-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"auriko": {
-		"models": {
-			"claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic--claude-3.7-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"azure": {
-		"models": {
-			"claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic--claude-4-opus": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"azure-cognitive-services": {
-		"models": {
-			"claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic--claude-4-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"cloudflare-ai-gateway": {
-		"models": {
-			"anthropic/claude-3-5-haiku": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "anthropic/claude-3-5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-3-haiku": {
-				"cost": {
-					"cache_read": 0.03,
-					"cache_write": 0.3,
-					"input": 0.25,
-					"output": 1.25
-				},
-				"id": "anthropic/claude-3-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-3-opus": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-3-opus",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-3-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 0.3,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-3-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-3.5-haiku": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "anthropic/claude-3.5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-3.5-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-3.5-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-fable-5": {
-				"cost": {
-					"cache_read": 1,
-					"cache_write": 12.5,
-					"input": 10,
-					"output": 50
-				},
-				"id": "anthropic/claude-fable-5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4-1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic--claude-4.5-haiku": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"cortecs": {
-		"models": {
-			"claude-4-5-sonnet": {
-				"cost": {
-					"input": 3.259,
-					"output": 16.296
-				},
-				"id": "claude-4-5-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-4-6-sonnet": {
-				"cost": {
-					"input": 3.59,
-					"output": 17.92
-				},
-				"id": "claude-4-6-sonnet",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-haiku-4-5": {
-				"cost": {
-					"input": 1.09,
-					"output": 5.43
-				},
-				"id": "claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus4-5": {
-				"cost": {
-					"input": 5.98,
-					"output": 29.89
-				},
-				"id": "claude-opus4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus4-6": {
-				"cost": {
-					"input": 5.98,
-					"output": 29.89
-				},
-				"id": "claude-opus4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus4-7": {
-				"cost": {
-					"cache_read": 0.56,
-					"cache_write": 6.99,
-					"input": 5.6,
-					"output": 27.99
-				},
-				"id": "claude-opus4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4": {
-				"cost": {
-					"input": 3.307,
-					"output": 16.536
-				},
-				"id": "claude-sonnet-4",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic--claude-4.5-opus": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"databricks": {
-		"models": {
-			"databricks-claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "databricks-claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"databricks-claude-opus-4-1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "databricks-claude-opus-4-1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"databricks-claude-opus-4-5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "databricks-claude-opus-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"databricks-claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "databricks-claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"databricks-claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "databricks-claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"databricks-claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "databricks-claude-sonnet-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"databricks-claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "databricks-claude-sonnet-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"databricks-claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "databricks-claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic--claude-4.5-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"digitalocean": {
-		"models": {
-			"anthropic-claude-3-opus": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic-claude-3-opus",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic-claude-3.5-haiku": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "anthropic-claude-3.5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic-claude-3.5-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic-claude-3.5-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic-claude-3.7-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic-claude-3.7-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic-claude-4.1-opus": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic-claude-4.1-opus",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic-claude-4.5-haiku": {
-				"cost": {
-					"cache_read": 1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic-claude-4.5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic-claude-4.5-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic-claude-4.5-sonnet",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic-claude-4.6-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic-claude-4.6-sonnet",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic-claude-haiku-4.5": {
-				"cost": {
-					"cache_read": 1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic-claude-haiku-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic-claude-opus-4": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic-claude-opus-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic-claude-opus-4.5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic-claude-opus-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic-claude-opus-4.6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic-claude-opus-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic-claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic-claude-opus-4.7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic-claude-opus-4.8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic-claude-opus-4.8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic-claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic-claude-sonnet-4",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic--claude-4.6-opus": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"fastrouter": {
-		"models": {
-			"anthropic/claude-opus-4.1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4.1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic--claude-4.6-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"freemodel": {
-		"models": {
-			"claude-haiku-4-5-20251001": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5-20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic--claude-4.7-opus": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"frogbot": {
-		"models": {
-			"claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic-claude-3-opus": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"github-copilot": {
-		"models": {
-			"claude-haiku-4.5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4.5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4.6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4.6",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4.7",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4.8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4.8",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4",
-				"limit": {
-					"context": 216000
-				}
-			},
-			"claude-sonnet-4.5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4.6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4.6",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic-claude-3.5-haiku": {
+		"cost": {
+			"cache_read": 0.08,
+			"cache_write": 1,
+			"input": 0.8,
+			"output": 4
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"gmicloud": {
-		"models": {
-			"anthropic/claude-opus-4.6": {
-				"cost": {
-					"cache_read": 0.5,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.6",
-				"limit": {
-					"context": 409600
-				}
-			},
-			"anthropic/claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.45,
-					"input": 4.5,
-					"output": 22.5
-				},
-				"id": "anthropic/claude-opus-4.7",
-				"limit": {
-					"context": 409600
-				}
-			},
-			"anthropic/claude-sonnet-4.6": {
-				"cost": {
-					"cache_read": 0.3,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.6",
-				"limit": {
-					"context": 409600
-				}
-			}
+	"anthropic-claude-3.5-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"google-vertex": {
-		"models": {
-			"claude-3-5-haiku@20241022": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "claude-3-5-haiku@20241022",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5@20251001": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5@20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1@20250805": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1@20250805",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5@20251101": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5@20251101",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6@default": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6@default",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7@default": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7@default",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-8@default": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-8@default",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4@20250514": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4@20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5@20250929": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5@20250929",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-6@default": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6@default",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4@20250514": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4@20250514",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic-claude-3.7-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"google-vertex-anthropic": {
-		"models": {
-			"claude-3-5-haiku@20241022": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "claude-3-5-haiku@20241022",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5@20251001": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5@20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1@20250805": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1@20250805",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5@20251101": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5@20251101",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6@default": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6@default",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7@default": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7@default",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-8@default": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-8@default",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4@20250514": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4@20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5@20250929": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5@20250929",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-6@default": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6@default",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4@20250514": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4@20250514",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic-claude-4.1-opus": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"helicone": {
-		"models": {
-			"claude-3-haiku-20240307": {
-				"cost": {
-					"cache_read": 0.03,
-					"cache_write": 0.3,
-					"input": 0.25,
-					"output": 1.25
-				},
-				"id": "claude-3-haiku-20240307",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3.5-haiku": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.7999999999999999,
-					"output": 4
-				},
-				"id": "claude-3.5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3.5-sonnet-v2": {
-				"cost": {
-					"cache_read": 0.30000000000000004,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-3.5-sonnet-v2",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3.7-sonnet": {
-				"cost": {
-					"cache_read": 0.30000000000000004,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-3.7-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-4.5-haiku": {
-				"cost": {
-					"cache_read": 0.09999999999999999,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-4.5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-4.5-opus": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-4.5-opus",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-4.5-sonnet": {
-				"cost": {
-					"cache_read": 0.30000000000000004,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-4.5-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5-20251001": {
-				"cost": {
-					"cache_read": 0.09999999999999999,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5-20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-20250805": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1-20250805",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.30000000000000004,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5-20250929": {
-				"cost": {
-					"cache_read": 0.30000000000000004,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5-20250929",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic-claude-4.5-haiku": {
+		"cost": {
+			"cache_read": 1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"jiekou": {
-		"models": {
-			"claude-haiku-4-5-20251001": {
-				"cost": {
-					"input": 0.9,
-					"output": 4.5
-				},
-				"id": "claude-haiku-4-5-20251001",
-				"limit": {
-					"context": 20000
-				}
-			},
-			"claude-opus-4-1-20250805": {
-				"cost": {
-					"input": 13.5,
-					"output": 67.5
-				},
-				"id": "claude-opus-4-1-20250805",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-20250514": {
-				"cost": {
-					"input": 13.5,
-					"output": 67.5
-				},
-				"id": "claude-opus-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5-20251101": {
-				"cost": {
-					"input": 4.5,
-					"output": 22.5
-				},
-				"id": "claude-opus-4-5-20251101",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-20250514": {
-				"cost": {
-					"input": 2.7,
-					"output": 13.5
-				},
-				"id": "claude-sonnet-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5-20250929": {
-				"cost": {
-					"input": 2.7,
-					"output": 13.5
-				},
-				"id": "claude-sonnet-4-5-20250929",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic-claude-4.5-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"kilo": {
-		"models": {
-			"anthropic/claude-3-haiku": {
-				"cost": {
-					"cache_read": 0.03,
-					"cache_write": 0.3,
-					"input": 0.25,
-					"output": 1.25
-				},
-				"id": "anthropic/claude-3-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-3.5-haiku": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "anthropic/claude-3.5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-haiku-4.5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4.1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.6-fast": {
-				"cost": {
-					"cache_read": 3,
-					"cache_write": 37.5,
-					"input": 30,
-					"output": 150
-				},
-				"id": "anthropic/claude-opus-4.6-fast",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.7-fast": {
-				"cost": {
-					"cache_read": 3,
-					"cache_write": 37.5,
-					"input": 30,
-					"output": 150
-				},
-				"id": "anthropic/claude-opus-4.7-fast",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4.5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4.6": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"stealth/claude-opus-4.6": {
-				"cost": {
-					"cache_read": 0.4,
-					"cache_write": 5,
-					"input": 4,
-					"output": 20
-				},
-				"id": "stealth/claude-opus-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"stealth/claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.4,
-					"cache_write": 5,
-					"input": 4,
-					"output": 20
-				},
-				"id": "stealth/claude-opus-4.7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"stealth/claude-sonnet-4.6": {
-				"cost": {
-					"cache_read": 0.24,
-					"cache_write": 3,
-					"input": 2.4,
-					"output": 12
-				},
-				"id": "stealth/claude-sonnet-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"~anthropic/claude-haiku-latest": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "~anthropic/claude-haiku-latest",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"~anthropic/claude-opus-latest": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "~anthropic/claude-opus-latest",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"~anthropic/claude-sonnet-latest": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "~anthropic/claude-sonnet-latest",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic-claude-4.6-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"llmgateway": {
-		"models": {
-			"claude-3-5-haiku": {
-				"cost": {
-					"cache_read": 0.08,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "claude-3-5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-5-sonnet-20241022": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-3-5-sonnet-20241022",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-7-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-3-7-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-7-sonnet-20250219": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-3-7-sonnet-20250219",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-3-opus": {
-				"cost": {
-					"cache_read": 1.5,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-3-opus",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5-20251001": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5-20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-20250805": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1-20250805",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-20250514": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5-20251101": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5-20251101",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-20250514": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5-20250929": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5-20250929",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic-claude-haiku-4.5": {
+		"cost": {
+			"cache_read": 1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"merge-gateway": {
-		"models": {
-			"anthropic/claude-haiku-4-5-20251001": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-4-5-20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-1-20250805": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4-1-20250805",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-20250514": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-5-20251101": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-5-20251101",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4-20250514": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4-5-20250929": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4-5-20250929",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic-claude-opus-4": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"nano-gpt": {
-		"models": {
-			"Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled": {
-				"cost": {
-					"cache_read": 0.0306,
-					"input": 0.306,
-					"output": 0.306
-				},
-				"id": "Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled",
-				"limit": {
-					"context": 262144
-				}
-			},
-			"anthropic/claude-haiku-latest": {
-				"cost": {
-					"cache_read": 0.1,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-latest",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.6": {
-				"cost": {
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "anthropic/claude-opus-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.6:thinking": {
-				"cost": {
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "anthropic/claude-opus-4.6:thinking",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.6:thinking:low": {
-				"cost": {
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "anthropic/claude-opus-4.6:thinking:low",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.6:thinking:max": {
-				"cost": {
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "anthropic/claude-opus-4.6:thinking:max",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.6:thinking:medium": {
-				"cost": {
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "anthropic/claude-opus-4.6:thinking:medium",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.4998,
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "anthropic/claude-opus-4.7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.7:thinking": {
-				"cost": {
-					"cache_read": 0.4998,
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "anthropic/claude-opus-4.7:thinking",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.8": {
-				"cost": {
-					"cache_read": 0.4998,
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "anthropic/claude-opus-4.8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.8:thinking": {
-				"cost": {
-					"cache_read": 0.4998,
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "anthropic/claude-opus-4.8:thinking",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-latest": {
-				"cost": {
-					"cache_read": 0.4998,
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "anthropic/claude-opus-latest",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4.6": {
-				"cost": {
-					"input": 2.992,
-					"output": 14.993999999999998
-				},
-				"id": "anthropic/claude-sonnet-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4.6:thinking": {
-				"cost": {
-					"input": 2.992,
-					"output": 14.993999999999998
-				},
-				"id": "anthropic/claude-sonnet-4.6:thinking",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-latest": {
-				"cost": {
-					"cache_read": 0.2992,
-					"input": 2.992,
-					"output": 14.994
-				},
-				"id": "anthropic/claude-sonnet-latest",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-3-5-haiku-20241022": {
-				"cost": {
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "claude-3-5-haiku-20241022",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5-20251001": {
-				"cost": {
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5-20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-haiku-4-5-20251001-thinking": {
-				"cost": {
-					"cache_read": 0.1,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5-20251001-thinking",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-20250805": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-1-20250805",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-thinking": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-1-thinking",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-thinking:1024": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-1-thinking:1024",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-thinking:32000": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-1-thinking:32000",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-thinking:32768": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-1-thinking:32768",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1-thinking:8192": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-1-thinking:8192",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-20250514": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5-20251101": {
-				"cost": {
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "claude-opus-4-5-20251101",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5-20251101:thinking": {
-				"cost": {
-					"input": 4.998,
-					"output": 25.007
-				},
-				"id": "claude-opus-4-5-20251101:thinking",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-thinking": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-thinking",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-thinking:1024": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-thinking:1024",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-thinking:32000": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-thinking:32000",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-thinking:32768": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-thinking:32768",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-thinking:8192": {
-				"cost": {
-					"input": 14.994,
-					"output": 75.004
-				},
-				"id": "claude-opus-4-thinking:8192",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-20250514": {
-				"cost": {
-					"input": 2.992,
-					"output": 14.994
-				},
-				"id": "claude-sonnet-4-20250514",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5-20250929": {
-				"cost": {
-					"input": 2.992,
-					"output": 14.994
-				},
-				"id": "claude-sonnet-4-5-20250929",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-5-20250929-thinking": {
-				"cost": {
-					"input": 2.992,
-					"output": 14.994
-				},
-				"id": "claude-sonnet-4-5-20250929-thinking",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-thinking": {
-				"cost": {
-					"input": 2.992,
-					"output": 14.994
-				},
-				"id": "claude-sonnet-4-thinking",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-thinking:1024": {
-				"cost": {
-					"input": 2.992,
-					"output": 14.994
-				},
-				"id": "claude-sonnet-4-thinking:1024",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-thinking:32768": {
-				"cost": {
-					"input": 2.992,
-					"output": 14.994
-				},
-				"id": "claude-sonnet-4-thinking:32768",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-thinking:64000": {
-				"cost": {
-					"input": 2.992,
-					"output": 14.994
-				},
-				"id": "claude-sonnet-4-thinking:64000",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-thinking:8192": {
-				"cost": {
-					"input": 2.992,
-					"output": 14.994
-				},
-				"id": "claude-sonnet-4-thinking:8192",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"deepclaude": {
-				"cost": {
-					"input": 3,
-					"output": 15
-				},
-				"id": "deepclaude",
-				"limit": {
-					"context": 128000
-				}
-			}
+	"anthropic-claude-opus-4.5": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"nearai": {
-		"models": {
-			"anthropic/claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-6",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15.5
-				},
-				"id": "anthropic/claude-sonnet-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic-claude-opus-4.6": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"opencode": {
-		"models": {
-			"claude-3-5-haiku": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "claude-3-5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-fable-5": {
-				"cost": {
-					"cache_read": 1,
-					"cache_write": 12.5,
-					"input": 10,
-					"output": 50
-				},
-				"id": "claude-fable-5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "claude-opus-4-1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic-claude-opus-4.7": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"openrouter": {
-		"models": {
-			"anthropic/claude-3-haiku": {
-				"cost": {
-					"cache_read": 0.03,
-					"cache_write": 0.3,
-					"input": 0.25,
-					"output": 1.25
-				},
-				"id": "anthropic/claude-3-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-3.5-haiku": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "anthropic/claude-3.5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-haiku-4.5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4.1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.6-fast": {
-				"cost": {
-					"cache_read": 3,
-					"cache_write": 37.5,
-					"input": 30,
-					"output": 150
-				},
-				"id": "anthropic/claude-opus-4.6-fast",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.7-fast": {
-				"cost": {
-					"cache_read": 3,
-					"cache_write": 37.5,
-					"input": 30,
-					"output": 150
-				},
-				"id": "anthropic/claude-opus-4.7-fast",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.8-fast": {
-				"cost": {
-					"cache_read": 1,
-					"cache_write": 12.5,
-					"input": 10,
-					"output": 50
-				},
-				"id": "anthropic/claude-opus-4.8-fast",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4.5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4.6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"~anthropic/claude-haiku-latest": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "~anthropic/claude-haiku-latest",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"~anthropic/claude-opus-latest": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "~anthropic/claude-opus-latest",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"~anthropic/claude-sonnet-latest": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "~anthropic/claude-sonnet-latest",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic-claude-opus-4.8": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"orcarouter": {
-		"models": {
-			"anthropic/claude-haiku-4.5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4.1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4.5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4.6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic-claude-sonnet-4": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"perplexity-agent": {
-		"models": {
-			"anthropic/claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-5": {
-				"cost": {
-					"cache_read": 0.5,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-6",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.5,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.3,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4-6",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic.claude-haiku-4-5-20251001-v1:0": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"poe": {
-		"models": {
-			"anthropic/claude-haiku-3": {
-				"cost": {
-					"cache_read": 0.021,
-					"cache_write": 0.26,
-					"input": 0.21,
-					"output": 1.1
-				},
-				"id": "anthropic/claude-haiku-3",
-				"limit": {
-					"context": 189096
-				}
-			},
-			"anthropic/claude-haiku-3.5": {
-				"cost": {
-					"cache_read": 0.068,
-					"cache_write": 0.85,
-					"input": 0.68,
-					"output": 3.4
-				},
-				"id": "anthropic/claude-haiku-3.5",
-				"limit": {
-					"context": 189096
-				}
-			},
-			"anthropic/claude-haiku-4.5": {
-				"cost": {
-					"cache_read": 0.085,
-					"cache_write": 1.1,
-					"input": 0.85,
-					"output": 4.3
-				},
-				"id": "anthropic/claude-haiku-4.5",
-				"limit": {
-					"context": 192000
-				}
-			},
-			"anthropic/claude-opus-4": {
-				"cost": {
-					"cache_read": 1.3,
-					"cache_write": 16,
-					"input": 13,
-					"output": 64
-				},
-				"id": "anthropic/claude-opus-4",
-				"limit": {
-					"context": 192512
-				}
-			},
-			"anthropic/claude-opus-4.1": {
-				"cost": {
-					"cache_read": 1.3,
-					"cache_write": 16,
-					"input": 13,
-					"output": 64
-				},
-				"id": "anthropic/claude-opus-4.1",
-				"limit": {
-					"context": 196608
-				}
-			},
-			"anthropic/claude-opus-4.5": {
-				"cost": {
-					"cache_read": 0.43,
-					"cache_write": 5.3,
-					"input": 4.3,
-					"output": 21
-				},
-				"id": "anthropic/claude-opus-4.5",
-				"limit": {
-					"context": 196608
-				}
-			},
-			"anthropic/claude-opus-4.6": {
-				"cost": {
-					"cache_read": 0.43,
-					"cache_write": 5.3,
-					"input": 4.3,
-					"output": 21
-				},
-				"id": "anthropic/claude-opus-4.6",
-				"limit": {
-					"context": 983040
-				}
-			},
-			"anthropic/claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.43,
-					"cache_write": 5.4,
-					"input": 4.3,
-					"output": 21
-				},
-				"id": "anthropic/claude-opus-4.7",
-				"limit": {
-					"context": 1048576
-				}
-			},
-			"anthropic/claude-opus-4.8": {
-				"cost": {
-					"input": 4.2929,
-					"output": 21.4646
-				},
-				"id": "anthropic/claude-opus-4.8",
-				"limit": {
-					"context": 1048576
-				}
-			},
-			"anthropic/claude-sonnet-3.5": {
-				"cost": {
-					"cache_read": 0.26,
-					"cache_write": 3.2,
-					"input": 2.6,
-					"output": 13
-				},
-				"id": "anthropic/claude-sonnet-3.5",
-				"limit": {
-					"context": 189096
-				}
-			},
-			"anthropic/claude-sonnet-3.5-june": {
-				"cost": {
-					"cache_read": 0.26,
-					"cache_write": 3.2,
-					"input": 2.6,
-					"output": 13
-				},
-				"id": "anthropic/claude-sonnet-3.5-june",
-				"limit": {
-					"context": 189096
-				}
-			},
-			"anthropic/claude-sonnet-3.7": {
-				"cost": {
-					"cache_read": 0.26,
-					"cache_write": 3.2,
-					"input": 2.6,
-					"output": 13
-				},
-				"id": "anthropic/claude-sonnet-3.7",
-				"limit": {
-					"context": 196608
-				}
-			},
-			"anthropic/claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.26,
-					"cache_write": 3.2,
-					"input": 2.6,
-					"output": 13
-				},
-				"id": "anthropic/claude-sonnet-4",
-				"limit": {
-					"context": 983040
-				}
-			},
-			"anthropic/claude-sonnet-4.5": {
-				"cost": {
-					"cache_read": 0.26,
-					"cache_write": 3.2,
-					"input": 2.6,
-					"output": 13
-				},
-				"id": "anthropic/claude-sonnet-4.5",
-				"limit": {
-					"context": 983040
-				}
-			},
-			"anthropic/claude-sonnet-4.6": {
-				"cost": {
-					"cache_read": 0.26,
-					"cache_write": 3.2,
-					"input": 2.6,
-					"output": 13
-				},
-				"id": "anthropic/claude-sonnet-4.6",
-				"limit": {
-					"context": 983040
-				}
-			}
+	"anthropic.claude-opus-4-1-20250805-v1:0": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"qihang-ai": {
-		"models": {
-			"claude-haiku-4-5-20251001": {
-				"cost": {
-					"input": 0.14,
-					"output": 0.71
-				},
-				"id": "claude-haiku-4-5-20251001",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-opus-4-5-20251101": {
-				"cost": {
-					"input": 0.71,
-					"output": 3.57
-				},
-				"id": "claude-opus-4-5-20251101",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"claude-sonnet-4-5-20250929": {
-				"cost": {
-					"input": 0.43,
-					"output": 2.14
-				},
-				"id": "claude-sonnet-4-5-20250929",
-				"limit": {
-					"context": 200000
-				}
-			}
+	"anthropic.claude-opus-4-5-20251101-v1:0": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"requesty": {
-		"models": {
-			"anthropic/claude-3-7-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-3-7-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-haiku-4-5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4-1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4-5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic.claude-opus-4-6-v1": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"sap-ai-core": {
-		"models": {
-			"anthropic--claude-3-haiku": {
-				"cost": {
-					"cache_read": 0.03,
-					"cache_write": 0.3,
-					"input": 0.25,
-					"output": 1.25
-				},
-				"id": "anthropic--claude-3-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic--claude-3-opus": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic--claude-3-opus",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic--claude-3-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic--claude-3-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic--claude-3.5-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic--claude-3.5-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic--claude-3.7-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic--claude-3.7-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic--claude-4-opus": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic--claude-4-opus",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic--claude-4-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic--claude-4-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic--claude-4.5-haiku": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic--claude-4.5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic--claude-4.5-opus": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic--claude-4.5-opus",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic--claude-4.5-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic--claude-4.5-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic--claude-4.6-opus": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic--claude-4.6-opus",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic--claude-4.6-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic--claude-4.6-sonnet",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic--claude-4.7-opus": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic--claude-4.7-opus",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic.claude-opus-4-7": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"venice": {
-		"models": {
-			"claude-opus-4-5": {
-				"cost": {
-					"cache_read": 0.6,
-					"cache_write": 7.5,
-					"input": 6,
-					"output": 30
-				},
-				"id": "claude-opus-4-5",
-				"limit": {
-					"context": 198000
-				}
-			},
-			"claude-opus-4-6": {
-				"cost": {
-					"cache_read": 0.6,
-					"cache_write": 7.5,
-					"input": 6,
-					"output": 30
-				},
-				"id": "claude-opus-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-6-fast": {
-				"cost": {
-					"cache_read": 3.6,
-					"cache_write": 45,
-					"input": 36,
-					"output": 180
-				},
-				"id": "claude-opus-4-6-fast",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7": {
-				"cost": {
-					"cache_read": 0.6,
-					"cache_write": 7.5,
-					"input": 6,
-					"output": 30
-				},
-				"id": "claude-opus-4-7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-7-fast": {
-				"cost": {
-					"cache_read": 3.6,
-					"cache_write": 45,
-					"input": 36,
-					"output": 180
-				},
-				"id": "claude-opus-4-7-fast",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-8": {
-				"cost": {
-					"cache_read": 0.6,
-					"cache_write": 7.5,
-					"input": 6,
-					"output": 30
-				},
-				"id": "claude-opus-4-8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-opus-4-8-fast": {
-				"cost": {
-					"cache_read": 1.2,
-					"cache_write": 15,
-					"input": 12,
-					"output": 60
-				},
-				"id": "claude-opus-4-8-fast",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"claude-sonnet-4-5": {
-				"cost": {
-					"cache_read": 0.375,
-					"cache_write": 4.69,
-					"input": 3.75,
-					"output": 18.75
-				},
-				"id": "claude-sonnet-4-5",
-				"limit": {
-					"context": 198000
-				}
-			},
-			"claude-sonnet-4-6": {
-				"cost": {
-					"cache_read": 0.36,
-					"cache_write": 4.5,
-					"input": 3.6,
-					"output": 18
-				},
-				"id": "claude-sonnet-4-6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic.claude-opus-4-8": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
 		}
 	},
-	"vercel": {
-		"models": {
-			"anthropic/claude-3-haiku": {
-				"cost": {
-					"cache_read": 0.03,
-					"cache_write": 0.3,
-					"input": 0.25,
-					"output": 1.25
-				},
-				"id": "anthropic/claude-3-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-3.5-haiku": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "anthropic/claude-3.5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-fable-5": {
-				"cost": {
-					"cache_read": 1,
-					"cache_write": 12.5,
-					"input": 10,
-					"output": 50
-				},
-				"id": "anthropic/claude-fable-5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-haiku-4.5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4.1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4.5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-sonnet-4.6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic.claude-sonnet-4-5-20250929-v1:0": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
 		}
 	},
-	"zenmux": {
-		"models": {
-			"anthropic/claude-3.5-haiku": {
-				"cost": {
-					"cache_read": 0.08,
-					"cache_write": 1,
-					"input": 0.8,
-					"output": 4
-				},
-				"id": "anthropic/claude-3.5-haiku",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-3.7-sonnet": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-3.7-sonnet",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-haiku-4.5": {
-				"cost": {
-					"cache_read": 0.1,
-					"cache_write": 1.25,
-					"input": 1,
-					"output": 5
-				},
-				"id": "anthropic/claude-haiku-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.1": {
-				"cost": {
-					"cache_read": 1.5,
-					"cache_write": 18.75,
-					"input": 15,
-					"output": 75
-				},
-				"id": "anthropic/claude-opus-4.1",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.5": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.5",
-				"limit": {
-					"context": 200000
-				}
-			},
-			"anthropic/claude-opus-4.6": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.7": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.7",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-opus-4.8": {
-				"cost": {
-					"cache_read": 0.5,
-					"cache_write": 6.25,
-					"input": 5,
-					"output": 25
-				},
-				"id": "anthropic/claude-opus-4.8",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4.5": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.5",
-				"limit": {
-					"context": 1000000
-				}
-			},
-			"anthropic/claude-sonnet-4.6": {
-				"cost": {
-					"cache_read": 0.3,
-					"cache_write": 3.75,
-					"input": 3,
-					"output": 15
-				},
-				"id": "anthropic/claude-sonnet-4.6",
-				"limit": {
-					"context": 1000000
-				}
-			}
+	"anthropic.claude-sonnet-4-6": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-3-5-haiku": {
+		"cost": {
+			"cache_read": 0.08,
+			"cache_write": 1,
+			"input": 0.8,
+			"output": 4
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-3-7-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-3-haiku": {
+		"cost": {
+			"cache_read": 0.03,
+			"cache_write": 0.3,
+			"input": 0.25,
+			"output": 1.25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-3-opus": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-3-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 0.3,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-3.5-haiku": {
+		"cost": {
+			"cache_read": 0.08,
+			"cache_write": 1,
+			"input": 0.8,
+			"output": 4
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-3.5-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-3.7-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-fable-5": {
+		"cost": {
+			"cache_read": 1,
+			"cache_write": 12.5,
+			"input": 10,
+			"output": 50
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-haiku-3": {
+		"cost": {
+			"cache_read": 0.021,
+			"cache_write": 0.26,
+			"input": 0.21,
+			"output": 1.1
+		},
+		"limit": {
+			"context": 189096
+		}
+	},
+	"anthropic/claude-haiku-3.5": {
+		"cost": {
+			"cache_read": 0.068,
+			"cache_write": 0.85,
+			"input": 0.68,
+			"output": 3.4
+		},
+		"limit": {
+			"context": 189096
+		}
+	},
+	"anthropic/claude-haiku-4-5": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-haiku-4-5-20251001": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-haiku-4.5": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-haiku-latest": {
+		"cost": {
+			"cache_read": 0.1,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-opus-4": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-opus-4-1": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-opus-4-1-20250805": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-opus-4-20250514": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-opus-4-5": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-opus-4-5-20251101": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-opus-4-6": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-opus-4-7": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4-8": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.1": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-opus-4.5": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-opus-4.6": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.6-fast": {
+		"cost": {
+			"cache_read": 3,
+			"cache_write": 37.5,
+			"input": 30,
+			"output": 150
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.6:thinking": {
+		"cost": {
+			"input": 4.998,
+			"output": 25.007
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.6:thinking:low": {
+		"cost": {
+			"input": 4.998,
+			"output": 25.007
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.6:thinking:max": {
+		"cost": {
+			"input": 4.998,
+			"output": 25.007
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.6:thinking:medium": {
+		"cost": {
+			"input": 4.998,
+			"output": 25.007
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.7": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.7-fast": {
+		"cost": {
+			"cache_read": 3,
+			"cache_write": 37.5,
+			"input": 30,
+			"output": 150
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.7:thinking": {
+		"cost": {
+			"cache_read": 0.4998,
+			"input": 4.998,
+			"output": 25.007
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.8": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.8-fast": {
+		"cost": {
+			"cache_read": 1,
+			"cache_write": 12.5,
+			"input": 10,
+			"output": 50
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-4.8:thinking": {
+		"cost": {
+			"cache_read": 0.4998,
+			"input": 4.998,
+			"output": 25.007
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-opus-latest": {
+		"cost": {
+			"cache_read": 0.4998,
+			"input": 4.998,
+			"output": 25.007
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-sonnet-3.5": {
+		"cost": {
+			"cache_read": 0.26,
+			"cache_write": 3.2,
+			"input": 2.6,
+			"output": 13
+		},
+		"limit": {
+			"context": 189096
+		}
+	},
+	"anthropic/claude-sonnet-3.5-june": {
+		"cost": {
+			"cache_read": 0.26,
+			"cache_write": 3.2,
+			"input": 2.6,
+			"output": 13
+		},
+		"limit": {
+			"context": 189096
+		}
+	},
+	"anthropic/claude-sonnet-3.7": {
+		"cost": {
+			"cache_read": 0.26,
+			"cache_write": 3.2,
+			"input": 2.6,
+			"output": 13
+		},
+		"limit": {
+			"context": 196608
+		}
+	},
+	"anthropic/claude-sonnet-4": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-sonnet-4-20250514": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-sonnet-4-5": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15.5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-sonnet-4-5-20250929": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"anthropic/claude-sonnet-4-6": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-sonnet-4.5": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-sonnet-4.6": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-sonnet-4.6:thinking": {
+		"cost": {
+			"input": 2.992,
+			"output": 14.993999999999998
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"anthropic/claude-sonnet-latest": {
+		"cost": {
+			"cache_read": 0.2992,
+			"input": 2.992,
+			"output": 14.994
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"au.anthropic.claude-opus-4-6-v1": {
+		"cost": {
+			"cache_read": 1.65,
+			"cache_write": 20.625,
+			"input": 16.5,
+			"output": 82.5
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"au.anthropic.claude-opus-4-8": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"au.anthropic.claude-sonnet-4-6": {
+		"cost": {
+			"cache_read": 0.33,
+			"cache_write": 4.125,
+			"input": 3.3,
+			"output": 16.5
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-3-5-haiku": {
+		"cost": {
+			"cache_read": 0.08,
+			"input": 0.8,
+			"output": 4
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-5-haiku-20241022": {
+		"cost": {
+			"cache_read": 0.08,
+			"cache_write": 1,
+			"input": 0.8,
+			"output": 4
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-5-haiku-latest": {
+		"cost": {
+			"cache_read": 0.08,
+			"cache_write": 1,
+			"input": 0.8,
+			"output": 4
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-5-haiku@20241022": {
+		"cost": {
+			"cache_read": 0.08,
+			"cache_write": 1,
+			"input": 0.8,
+			"output": 4
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-5-sonnet-20240620": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-5-sonnet-20241022": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-7-sonnet": {
+		"cost": {
+			"cache_read": 0.3,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-7-sonnet-20250219": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-haiku-20240307": {
+		"cost": {
+			"cache_read": 0.03,
+			"cache_write": 0.3,
+			"input": 0.25,
+			"output": 1.25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-opus": {
+		"cost": {
+			"cache_read": 1.5,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-opus-20240229": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3-sonnet-20240229": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 0.3,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3.5-haiku": {
+		"cost": {
+			"cache_read": 0.08,
+			"cache_write": 1,
+			"input": 0.7999999999999999,
+			"output": 4
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3.5-sonnet-v2": {
+		"cost": {
+			"cache_read": 0.30000000000000004,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-3.7-sonnet": {
+		"cost": {
+			"cache_read": 0.30000000000000004,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-4-5-sonnet": {
+		"cost": {
+			"input": 3.259,
+			"output": 16.296
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-4-6-sonnet": {
+		"cost": {
+			"input": 3.59,
+			"output": 17.92
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-4.5-haiku": {
+		"cost": {
+			"cache_read": 0.09999999999999999,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-4.5-opus": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-4.5-sonnet": {
+		"cost": {
+			"cache_read": 0.30000000000000004,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-fable-5": {
+		"cost": {
+			"cache_read": 1,
+			"cache_write": 12.5,
+			"input": 10,
+			"output": 50
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-haiku-4-5": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-haiku-4-5-20251001": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-haiku-4-5-20251001-thinking": {
+		"cost": {
+			"cache_read": 0.1,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-haiku-4-5@20251001": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-haiku-4.5": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-0": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-1": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-1-20250805": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-1-20250805-thinking": {
+		"cost": {
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-1-thinking": {
+		"cost": {
+			"input": 14.994,
+			"output": 75.004
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-1-thinking:1024": {
+		"cost": {
+			"input": 14.994,
+			"output": 75.004
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-1-thinking:32000": {
+		"cost": {
+			"input": 14.994,
+			"output": 75.004
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-1-thinking:32768": {
+		"cost": {
+			"input": 14.994,
+			"output": 75.004
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-1-thinking:8192": {
+		"cost": {
+			"input": 14.994,
+			"output": 75.004
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-1@20250805": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-20250514": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-5": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-5-20251101": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-5-20251101-thinking": {
+		"cost": {
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-5-20251101:thinking": {
+		"cost": {
+			"input": 4.998,
+			"output": 25.007
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-5@20251101": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-6": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-6-fast": {
+		"cost": {
+			"cache_read": 3.6,
+			"cache_write": 45,
+			"input": 36,
+			"output": 180
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-6-think": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-6-thinking": {
+		"cost": {
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-6@default": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-7": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-7-fast": {
+		"cost": {
+			"cache_read": 3.6,
+			"cache_write": 45,
+			"input": 36,
+			"output": 180
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-7-think": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-7@default": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-8": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-8-fast": {
+		"cost": {
+			"cache_read": 1.2,
+			"cache_write": 15,
+			"input": 12,
+			"output": 60
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-8@default": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus-4-thinking": {
+		"cost": {
+			"input": 14.994,
+			"output": 75.004
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-thinking:1024": {
+		"cost": {
+			"input": 14.994,
+			"output": 75.004
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-thinking:32000": {
+		"cost": {
+			"input": 14.994,
+			"output": 75.004
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-thinking:32768": {
+		"cost": {
+			"input": 14.994,
+			"output": 75.004
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4-thinking:8192": {
+		"cost": {
+			"input": 14.994,
+			"output": 75.004
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4.5": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4.6": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4.7": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4.8": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus-4@20250514": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus4-5": {
+		"cost": {
+			"input": 5.98,
+			"output": 29.89
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-opus4-6": {
+		"cost": {
+			"input": 5.98,
+			"output": 29.89
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-opus4-7": {
+		"cost": {
+			"cache_read": 0.56,
+			"cache_write": 6.99,
+			"input": 5.6,
+			"output": 27.99
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4-0": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-sonnet-4-20250514": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-sonnet-4-5": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-sonnet-4-5-20250929": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-sonnet-4-5-20250929-thinking": {
+		"cost": {
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-sonnet-4-5@20250929": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-sonnet-4-6": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4-6-think": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4-6-thinking": {
+		"cost": {
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4-6@default": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4-thinking": {
+		"cost": {
+			"input": 2.992,
+			"output": 14.994
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4-thinking:1024": {
+		"cost": {
+			"input": 2.992,
+			"output": 14.994
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4-thinking:32768": {
+		"cost": {
+			"input": 2.992,
+			"output": 14.994
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4-thinking:64000": {
+		"cost": {
+			"input": 2.992,
+			"output": 14.994
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4-thinking:8192": {
+		"cost": {
+			"input": 2.992,
+			"output": 14.994
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"claude-sonnet-4.5": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-sonnet-4.6": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"claude-sonnet-4@20250514": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"databricks-claude-haiku-4-5": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"databricks-claude-opus-4-1": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"databricks-claude-opus-4-5": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"databricks-claude-opus-4-6": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"databricks-claude-opus-4-7": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"databricks-claude-sonnet-4": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"databricks-claude-sonnet-4-5": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"databricks-claude-sonnet-4-6": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"deepclaude": {
+		"cost": {
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 128000
+		}
+	},
+	"eu.anthropic.claude-fable-5": {
+		"cost": {
+			"cache_read": 1.1,
+			"cache_write": 13.75,
+			"input": 11,
+			"output": 55
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"eu.anthropic.claude-opus-4-6-v1": {
+		"cost": {
+			"cache_read": 0.55,
+			"cache_write": 6.875,
+			"input": 5.5,
+			"output": 27.5
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"eu.anthropic.claude-opus-4-7": {
+		"cost": {
+			"cache_read": 0.55,
+			"cache_write": 6.875,
+			"input": 5.5,
+			"output": 27.5
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"eu.anthropic.claude-opus-4-8": {
+		"cost": {
+			"cache_read": 0.55,
+			"cache_write": 6.875,
+			"input": 5.5,
+			"output": 27.5
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+		"cost": {
+			"cache_read": 0.33,
+			"cache_write": 4.125,
+			"input": 3.3,
+			"output": 16.5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"eu.anthropic.claude-sonnet-4-6": {
+		"cost": {
+			"cache_read": 0.33,
+			"cache_write": 4.125,
+			"input": 3.3,
+			"output": 16.5
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"global.anthropic.claude-fable-5": {
+		"cost": {
+			"cache_read": 1,
+			"cache_write": 12.5,
+			"input": 10,
+			"output": 50
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"global.anthropic.claude-opus-4-5-20251101-v1:0": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"global.anthropic.claude-opus-4-6-v1": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"global.anthropic.claude-opus-4-7": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"global.anthropic.claude-opus-4-8": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"global.anthropic.claude-sonnet-4-6": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"jp.anthropic.claude-opus-4-7": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"jp.anthropic.claude-opus-4-8": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"jp.anthropic.claude-sonnet-4-6": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"stealth/claude-opus-4.6": {
+		"cost": {
+			"cache_read": 0.4,
+			"cache_write": 5,
+			"input": 4,
+			"output": 20
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"stealth/claude-opus-4.7": {
+		"cost": {
+			"cache_read": 0.4,
+			"cache_write": 5,
+			"input": 4,
+			"output": 20
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"stealth/claude-sonnet-4.6": {
+		"cost": {
+			"cache_read": 0.24,
+			"cache_write": 3,
+			"input": 2.4,
+			"output": 12
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"us.anthropic.claude-fable-5": {
+		"cost": {
+			"cache_read": 1,
+			"cache_write": 12.5,
+			"input": 10,
+			"output": 50
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"us.anthropic.claude-opus-4-1-20250805-v1:0": {
+		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
+			"input": 15,
+			"output": 75
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"us.anthropic.claude-opus-4-5-20251101-v1:0": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"us.anthropic.claude-opus-4-6-v1": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"us.anthropic.claude-opus-4-7": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"us.anthropic.claude-opus-4-8": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"us.anthropic.claude-sonnet-4-6": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"~anthropic/claude-haiku-latest": {
+		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
+			"input": 1,
+			"output": 5
+		},
+		"limit": {
+			"context": 200000
+		}
+	},
+	"~anthropic/claude-opus-latest": {
+		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
+		},
+		"limit": {
+			"context": 1000000
+		}
+	},
+	"~anthropic/claude-sonnet-latest": {
+		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
+			"input": 3,
+			"output": 15
+		},
+		"limit": {
+			"context": 1000000
 		}
 	}
 }

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -87,6 +87,13 @@ struct ModelsDevProvider {
     models: FxHashMap<String, ModelsDevModel>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ModelsDevJson {
+    Providers(FxHashMap<String, ModelsDevProvider>),
+    Models(FxHashMap<String, ModelsDevModel>),
+}
+
 struct ModelsDevPricingCache {
     pricing: OnceLock<PricingMap>,
     last_failure: Mutex<Option<Instant>>,
@@ -281,56 +288,64 @@ impl PricingMap {
     }
 
     fn load_models_dev_json_missing(&mut self, json: &str) -> Option<usize> {
-        let Ok(raw) = serde_json::from_str::<FxHashMap<String, ModelsDevProvider>>(json) else {
+        let Ok(raw) = serde_json::from_str::<ModelsDevJson>(json) else {
             return None;
         };
+        Some(match raw {
+            ModelsDevJson::Providers(providers) => providers
+                .into_values()
+                .map(|provider| self.load_models_dev_models(provider.models))
+                .sum(),
+            ModelsDevJson::Models(models) => self.load_models_dev_models(models),
+        })
+    }
+
+    fn load_models_dev_models(&mut self, models: FxHashMap<String, ModelsDevModel>) -> usize {
         let mut loaded_count = 0;
-        for provider in raw.into_values() {
-            for (model_key, model) in provider.models {
-                let model_id = model.id.unwrap_or(model_key);
-                if self.entries.contains_key(&model_id) {
-                    continue;
-                }
-                let Some(cost) = model.cost else {
-                    continue;
-                };
-                let Some(input) = cost.input else {
-                    continue;
-                };
-                let Some(output) = cost.output else {
-                    continue;
-                };
-                let input = input / 1_000_000.0;
-                let output = output / 1_000_000.0;
-                let cache_read_explicit = cost.cache_read.is_some();
-                self.entries.insert(
-                    model_id.clone(),
-                    Pricing {
-                        input,
-                        output,
-                        cache_create: cost
-                            .cache_write
-                            .map(|value| value / 1_000_000.0)
-                            .unwrap_or(input * 1.25),
-                        cache_read: cost
-                            .cache_read
-                            .map(|value| value / 1_000_000.0)
-                            .unwrap_or(input * 0.1),
-                        cache_read_explicit,
-                        input_above_200k: None,
-                        output_above_200k: None,
-                        cache_create_above_200k: None,
-                        cache_read_above_200k: None,
-                        fast_multiplier: 1.0,
-                    },
-                );
-                if let Some(context_limit) = model.limit.and_then(|limit| limit.context) {
-                    self.context_limits.insert(model_id, context_limit);
-                }
-                loaded_count += 1;
+        for (model_key, model) in models {
+            let model_id = model.id.unwrap_or(model_key);
+            if self.entries.contains_key(&model_id) {
+                continue;
             }
+            let Some(cost) = model.cost else {
+                continue;
+            };
+            let Some(input) = cost.input else {
+                continue;
+            };
+            let Some(output) = cost.output else {
+                continue;
+            };
+            let input = input / 1_000_000.0;
+            let output = output / 1_000_000.0;
+            let cache_read_explicit = cost.cache_read.is_some();
+            self.entries.insert(
+                model_id.clone(),
+                Pricing {
+                    input,
+                    output,
+                    cache_create: cost
+                        .cache_write
+                        .map(|value| value / 1_000_000.0)
+                        .unwrap_or(input * 1.25),
+                    cache_read: cost
+                        .cache_read
+                        .map(|value| value / 1_000_000.0)
+                        .unwrap_or(input * 0.1),
+                    cache_read_explicit,
+                    input_above_200k: None,
+                    output_above_200k: None,
+                    cache_create_above_200k: None,
+                    cache_read_above_200k: None,
+                    fast_multiplier: 1.0,
+                },
+            );
+            if let Some(context_limit) = model.limit.and_then(|limit| limit.context) {
+                self.context_limits.insert(model_id, context_limit);
+            }
+            loaded_count += 1;
         }
-        Some(loaded_count)
+        loaded_count
     }
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
@@ -1466,6 +1481,36 @@ mod tests {
         assert_eq!(pricing.context_limit("gpt-fallback"), Some(456));
         assert!((alias.input - 4e-6).abs() < f64::EPSILON);
         assert_eq!(pricing.context_limits.get("gpt-alias"), Some(&654));
+    }
+
+    #[test]
+    fn loads_flat_models_dev_pricing_snapshot() {
+        let mut pricing = PricingMap::default();
+        let models_dev_json = r#"{
+                "claude-fallback": {
+                    "cost": {
+                        "input": 3.0,
+                        "output": 15.0,
+                        "cache_read": 0.3,
+                        "cache_write": 3.75
+                    },
+                    "limit": {
+                        "context": 200000
+                    }
+                }
+            }"#;
+
+        assert_eq!(
+            pricing.load_models_dev_json_missing(models_dev_json),
+            Some(1)
+        );
+
+        let fallback = pricing.find("claude-fallback").unwrap();
+        assert!((fallback.input - 3e-6).abs() < f64::EPSILON);
+        assert!((fallback.output - 15e-6).abs() < f64::EPSILON);
+        assert!((fallback.cache_create - 3.75e-6).abs() < f64::EPSILON);
+        assert!((fallback.cache_read - 0.3e-6).abs() < f64::EPSILON);
+        assert_eq!(pricing.context_limit("claude-fallback"), Some(200000));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -987,23 +987,24 @@ impl PricingMap {
 fn parse_litellm_pricing(value: Value) -> Option<LiteLlmPricing> {
     if value
         .as_object()
-        .is_some_and(|entry| entry.contains_key("i"))
+        .is_some_and(|entry| entry.contains_key("i") && entry.contains_key("o"))
     {
-        let compact = serde_json::from_value::<CompactLiteLlmPricing>(value).ok()?;
-        return Some(LiteLlmPricing {
-            input_cost_per_token: Some(compact.i),
-            output_cost_per_token: Some(compact.o),
-            cache_creation_input_token_cost: compact.cc,
-            cache_read_input_token_cost: compact.cr,
-            input_cost_per_token_above_200k_tokens: compact.ia,
-            output_cost_per_token_above_200k_tokens: compact.oa,
-            cache_creation_input_token_cost_above_200k_tokens: compact.cca,
-            cache_read_input_token_cost_above_200k_tokens: compact.cra,
-            max_input_tokens: compact.ctx,
-            provider_specific_entry: compact
-                .fast
-                .map(|fast| ProviderSpecificEntry { fast: Some(fast) }),
-        });
+        if let Ok(compact) = serde_json::from_value::<CompactLiteLlmPricing>(value.clone()) {
+            return Some(LiteLlmPricing {
+                input_cost_per_token: Some(compact.i),
+                output_cost_per_token: Some(compact.o),
+                cache_creation_input_token_cost: compact.cc,
+                cache_read_input_token_cost: compact.cr,
+                input_cost_per_token_above_200k_tokens: compact.ia,
+                output_cost_per_token_above_200k_tokens: compact.oa,
+                cache_creation_input_token_cost_above_200k_tokens: compact.cca,
+                cache_read_input_token_cost_above_200k_tokens: compact.cra,
+                max_input_tokens: compact.ctx,
+                provider_specific_entry: compact
+                    .fast
+                    .map(|fast| ProviderSpecificEntry { fast: Some(fast) }),
+            });
+        }
     }
     let pricing = serde_json::from_value::<LiteLlmPricing>(value).ok()?;
     pricing
@@ -1409,6 +1410,25 @@ mod tests {
         assert_eq!(compact.cache_read_above_200k, Some(0.2e-6));
         assert_eq!(compact.fast_multiplier, 1.5);
         assert_eq!(pricing.context_limit("gpt-compact"), Some(123456));
+    }
+
+    #[test]
+    fn falls_back_to_full_litellm_pricing_when_compact_shape_is_incomplete() {
+        let mut pricing = PricingMap::default();
+        let loaded = pricing.load_json(
+            r#"{
+                "gpt-full-with-extra-i": {
+                    "i": "provider metadata",
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000010
+                }
+            }"#,
+        );
+
+        assert_eq!(loaded, 1);
+        let full = pricing.find("gpt-full-with-extra-i").unwrap();
+        assert_eq!(full.input, 1e-6);
+        assert_eq!(full.output, 10e-6);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -84,6 +84,20 @@ struct ProviderSpecificEntry {
 }
 
 #[derive(Debug, Deserialize)]
+struct CompactLiteLlmPricing {
+    i: f64,
+    o: f64,
+    cc: Option<f64>,
+    cr: Option<f64>,
+    ia: Option<f64>,
+    oa: Option<f64>,
+    cca: Option<f64>,
+    cra: Option<f64>,
+    ctx: Option<u64>,
+    fast: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
 struct ModelsDevProvider {
     models: FxHashMap<String, ModelsDevModel>,
 }
@@ -245,7 +259,7 @@ impl PricingMap {
         };
         let mut loaded_count = 0;
         for (model, value) in raw {
-            let Ok(pricing) = serde_json::from_value::<LiteLlmPricing>(value) else {
+            let Some(pricing) = parse_litellm_pricing(value) else {
                 continue;
             };
             let Some(input) = pricing.input_cost_per_token else {
@@ -970,6 +984,34 @@ impl PricingMap {
     }
 }
 
+fn parse_litellm_pricing(value: Value) -> Option<LiteLlmPricing> {
+    if value
+        .as_object()
+        .is_some_and(|entry| entry.contains_key("i"))
+    {
+        let compact = serde_json::from_value::<CompactLiteLlmPricing>(value).ok()?;
+        return Some(LiteLlmPricing {
+            input_cost_per_token: Some(compact.i),
+            output_cost_per_token: Some(compact.o),
+            cache_creation_input_token_cost: compact.cc,
+            cache_read_input_token_cost: compact.cr,
+            input_cost_per_token_above_200k_tokens: compact.ia,
+            output_cost_per_token_above_200k_tokens: compact.oa,
+            cache_creation_input_token_cost_above_200k_tokens: compact.cca,
+            cache_read_input_token_cost_above_200k_tokens: compact.cra,
+            max_input_tokens: compact.ctx,
+            provider_specific_entry: compact
+                .fast
+                .map(|fast| ProviderSpecificEntry { fast: Some(fast) }),
+        });
+    }
+    let pricing = serde_json::from_value::<LiteLlmPricing>(value).ok()?;
+    pricing
+        .input_cost_per_token
+        .zip(pricing.output_cost_per_token)
+        .map(|_| pricing)
+}
+
 fn parse_models_dev_json(json: &str) -> Option<ModelsDevJson> {
     let value = serde_json::from_str::<Value>(json).ok()?;
     let Value::Object(entries) = &value else {
@@ -1332,6 +1374,41 @@ mod tests {
         assert_eq!(loaded, 1);
         assert!(pricing.find("gpt-valid").is_some());
         assert_eq!(pricing.context_limit("gpt-valid"), Some(123));
+    }
+
+    #[test]
+    fn loads_compact_litellm_pricing_json() {
+        let mut pricing = PricingMap::default();
+        let loaded = pricing.load_json(
+            r#"{
+                "gpt-compact": {
+                    "i": 0.000001,
+                    "o": 0.000010,
+                    "cc": 0.00000125,
+                    "cr": 0.0000001,
+                    "ia": 0.000002,
+                    "oa": 0.000020,
+                    "cca": 0.0000025,
+                    "cra": 0.0000002,
+                    "ctx": 123456,
+                    "fast": 1.5
+                }
+            }"#,
+        );
+
+        assert_eq!(loaded, 1);
+        let compact = pricing.find("gpt-compact").unwrap();
+        assert_eq!(compact.input, 1e-6);
+        assert_eq!(compact.output, 10e-6);
+        assert_eq!(compact.cache_create, 1.25e-6);
+        assert_eq!(compact.cache_read, 0.1e-6);
+        assert!(compact.cache_read_explicit);
+        assert_eq!(compact.input_above_200k, Some(2e-6));
+        assert_eq!(compact.output_above_200k, Some(20e-6));
+        assert_eq!(compact.cache_create_above_200k, Some(2.5e-6));
+        assert_eq!(compact.cache_read_above_200k, Some(0.2e-6));
+        assert_eq!(compact.fast_multiplier, 1.5);
+        assert_eq!(pricing.context_limit("gpt-compact"), Some(123456));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1419,6 +1419,7 @@ mod tests {
             r#"{
                 "gpt-full-with-extra-i": {
                     "i": "provider metadata",
+                    "o": "provider metadata",
                     "input_cost_per_token": 0.000001,
                     "output_cost_per_token": 0.000010
                 }

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -7,6 +7,7 @@ use std::{
 use ccusage_cli::PricingOverride;
 
 use serde::Deserialize;
+use serde_json::Value;
 
 use crate::fast::FxHashMap;
 
@@ -87,8 +88,7 @@ struct ModelsDevProvider {
     models: FxHashMap<String, ModelsDevModel>,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
+#[derive(Debug)]
 enum ModelsDevJson {
     Providers(FxHashMap<String, ModelsDevProvider>),
     Models(FxHashMap<String, ModelsDevModel>),
@@ -288,9 +288,7 @@ impl PricingMap {
     }
 
     fn load_models_dev_json_missing(&mut self, json: &str) -> Option<usize> {
-        let Ok(raw) = serde_json::from_str::<ModelsDevJson>(json) else {
-            return None;
-        };
+        let raw = parse_models_dev_json(json)?;
         Some(match raw {
             ModelsDevJson::Providers(providers) => providers
                 .into_values()
@@ -972,6 +970,44 @@ impl PricingMap {
     }
 }
 
+fn parse_models_dev_json(json: &str) -> Option<ModelsDevJson> {
+    let value = serde_json::from_str::<Value>(json).ok()?;
+    let Value::Object(entries) = &value else {
+        return None;
+    };
+    if entries.values().any(models_dev_entry_has_models_field) {
+        if !entries.values().all(models_dev_entry_has_models_field) {
+            return None;
+        }
+        return serde_json::from_value::<FxHashMap<String, ModelsDevProvider>>(value)
+            .ok()
+            .map(ModelsDevJson::Providers);
+    }
+    if !entries.values().all(models_dev_entry_has_required_cost) {
+        return None;
+    }
+    serde_json::from_value::<FxHashMap<String, ModelsDevModel>>(value)
+        .ok()
+        .map(ModelsDevJson::Models)
+}
+
+fn models_dev_entry_has_models_field(value: &Value) -> bool {
+    value
+        .as_object()
+        .is_some_and(|entry| entry.get("models").is_some_and(Value::is_object))
+}
+
+fn models_dev_entry_has_required_cost(value: &Value) -> bool {
+    value
+        .as_object()
+        .and_then(|entry| entry.get("cost"))
+        .and_then(Value::as_object)
+        .is_some_and(|cost| {
+            cost.get("input").is_some_and(Value::is_number)
+                && cost.get("output").is_some_and(Value::is_number)
+        })
+}
+
 /// Matches pricing keys across provider/model aliases while preserving version boundaries.
 fn pricing_key_matches(candidate: &str, model: &str, normalized_model: &str) -> bool {
     if contains_pricing_key(model, candidate) || contains_pricing_key(candidate, model) {
@@ -1134,6 +1170,7 @@ mod tests {
         embedded_models_dev_pricing, Pricing, PricingMap, BUILD_TIME_MODELS_DEV_JSON,
         BUILD_TIME_PRICING_JSON,
     };
+    use ccusage_test_support::fs_fixture;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
@@ -1481,6 +1518,32 @@ mod tests {
         assert_eq!(pricing.context_limit("gpt-fallback"), Some(456));
         assert!((alias.input - 4e-6).abs() < f64::EPSILON);
         assert_eq!(pricing.context_limits.get("gpt-alias"), Some(&654));
+    }
+
+    #[test]
+    fn rejects_malformed_models_dev_provider_payload() {
+        let fixture = fs_fixture!({
+            "models-dev.json": r#"{
+                "openai": {
+                    "models": {
+                        "gpt-fallback": {
+                            "cost": {
+                                "input": 2.0,
+                                "output": 8.0
+                            }
+                        }
+                    }
+                },
+                "broken-provider": {
+                    "name": "Broken Provider"
+                }
+            }"#,
+        });
+        let json = std::fs::read_to_string(fixture.path("models-dev.json")).unwrap();
+        let mut pricing = PricingMap::default();
+
+        assert_eq!(pricing.load_models_dev_json_missing(&json), None);
+        assert_eq!(pricing.len(), 0);
     }
 
     #[test]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,16 @@ export default defineConfig({
 		passWithNoTests: true,
 		watch: false,
 		reporters: isGitHubActions ? ['default', 'github-actions'] : ['default'],
-		projects: ['apps/*/vitest.config.ts', 'packages/*/vitest.config.ts'],
+		projects: [
+			'apps/*/vitest.config.ts',
+			'packages/*/vitest.config.ts',
+			{
+				test: {
+					name: 'nix',
+					include: ['nix/**/*.test.ts'],
+					globals: true,
+				},
+			},
+		],
 	},
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,15 @@ export default defineConfig({
 					globals: true,
 				},
 			},
+			{
+				test: {
+					name: 'github-scripts',
+					include: [],
+					includeSource: ['.github/scripts/upsert-pr-comment.ts'],
+					exclude: ['**/node_modules/**', '**/.git/**', '.direnv/**'],
+					globals: true,
+				},
+			},
 		],
 	},
 });


### PR DESCRIPTION
Adds a repo-local Rust binary-size skill based on min-sized-rust and registers it in AGENTS.md.

Applies that guidance by compacting embedded pricing snapshots so the release binary ships less unused JSON structure while keeping runtime parsing compatible with live upstream response shapes.

Impact:
- models.dev snapshot: 97,159 bytes -> 36,871 bytes (-60,288 bytes, -62.05%)
- LiteLLM snapshot: 66,046 bytes -> 31,949 bytes (-34,097 bytes, -51.63%)
- combined embedded pricing snapshots: 163,205 bytes -> 68,820 bytes (-94,385 bytes, -57.83%)
- release binary: 2,895,424 bytes -> 2,812,880 bytes (-82,544 bytes, -2.85%)

Data integrity:
- models.dev: compared old snapshot flattened with the old loader key rule (id ?? model key) against the new snapshot.
- models.dev model ids: 224 -> 224; missing keys: 0; extra keys: 0; cost/limit mismatches: 0
- LiteLLM: compared old long-form generated snapshot against the new short-key snapshot after expanding runtime-relevant fields.
- LiteLLM model ids: 401 -> 401; missing keys: 0; extra keys: 0; runtime-relevant value mismatches: 0

Testing:
- direnv exec . just fmt
- direnv exec . just typecheck
- direnv exec . just test
- direnv exec . cargo test --manifest-path rust/Cargo.toml -p ccusage pricing::tests:: -- --nocapture
- direnv exec . cargo build --manifest-path rust/Cargo.toml --release --bin ccusage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Rust binary-size skill guide and listed the skill in the recommended agents section.

* **Improvements**
  * Pricing ingestion accepts additional snapshot shapes, better validates inputs, deduplicates keys, and uses a more compact on-disk format.
  * Test discovery refined with targeted project configs; PR-comment script refactored for more robust handling.

* **Bug Fixes**
  * macOS packaging now rewrites a bundled libiconv to the system library for compatibility.

* **CI / Tooling**
  * Performance comparisons timeout faster and can skip gracefully when artifacts are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
