### PR TITLE
ci: simplify pnpm version resolution for the sticky disk key

### DIFF
--- a/.github/actions/setup-linux-blacksmith-sticky-disk/action.yaml
+++ b/.github/actions/setup-linux-blacksmith-sticky-disk/action.yaml
@@ -17,12 +17,7 @@ runs:
       id: pnpm
       if: steps.blacksmith.outputs.enabled == 'true'
       shell: bash
-      run: |
-        package_manager="$(node -p "require('./package.json').packageManager ?? ''")"
-        case "$package_manager" in
-          pnpm@*) echo "version=${package_manager#pnpm@}" >> "$GITHUB_OUTPUT" ;;
-          *) echo "version=unknown" >> "$GITHUB_OUTPUT" ;;
-        esac
+      run: echo "version=$(jq -r '.packageManager | ltrimstr("pnpm@")' package.json)" >> "$GITHUB_OUTPUT"
 
     - name: Prepare Nix store mount point
       if: steps.blacksmith.outputs.enabled == 'true'


### PR DESCRIPTION
Reads the `packageManager` pin with a jq one-liner instead of a node -p invocation plus a case statement, following the same pattern used elsewhere. The resolved version only feeds the node_modules sticky disk cache key; the pnpm that actually runs self-resolves to the pinned version via `manage-package-manager-versions`, regardless of which binary starts it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783716376&installation_id=139163553&pr_number=1255&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1255&signature=3216bb01086ff50ee56f9012e894aaa1655fcb28bd758a0d85ce27b492bfda93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `jq` to read the `packageManager` pin from package.json when computing the `node_modules` sticky disk cache key, replacing the previous `node -p` + case logic. This simplifies the CI step and doesn’t change which `pnpm` version runs, since `manage-package-manager-versions` still resolves the pinned version.

<sup>Written for commit fb344f18a91d3b670b9b0a561d33c2480e7a54d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pnpm version detection in Linux build setup for improved CI/CD efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->