### PR TITLE
fix(build): verify native release binaries are portable

### DIFF
--- a/.github/actions/build-macos-cargo-native-package/action.yaml
+++ b/.github/actions/build-macos-cargo-native-package/action.yaml
@@ -14,6 +14,19 @@ runs:
       shell: bash
       run: cargo build --manifest-path rust/Cargo.toml --release --bin ccusage
 
+    - name: Verify macOS binary links only system dylibs
+      shell: bash
+      env:
+        BINARY: ${{ inputs.binary }}
+      run: |
+        otool -L "$BINARY"
+        violations=$(otool -L "$BINARY" | tail -n +2 | awk '{print $1}' | grep -Ev '^(/usr/lib/|/System/Library/)' || true)
+        if [ -n "$violations" ]; then
+          echo "Found dylib dependencies that do not exist on end-user machines:" >&2
+          echo "$violations" >&2
+          exit 1
+        fi
+
     - name: Stage native package
       shell: bash
       env:

--- a/apps/ccusage/scripts/ensure-native-binary.ts
+++ b/apps/ccusage/scripts/ensure-native-binary.ts
@@ -53,6 +53,57 @@ async function nativePackageIncludesBinary(packageRoot: string | undefined): Pro
 	return Array.isArray(files) && files.includes(`bin/${binaryName}`);
 }
 
+/**
+ * Dylib prefixes that exist on every macOS installation. Anything else
+ * (such as /nix/store paths) only exists on the build machine and crashes
+ * the binary for end users with a missing dynamic library error.
+ */
+const systemDylibPrefixes = ['/usr/lib/', '/System/Library/'];
+
+/**
+ * Checks that a binary can run on end-user machines without dynamic
+ * libraries that only exist on the build machine.
+ *
+ * - Linux: the binary must be fully static (the release pipeline builds
+ *   against musl), because a glibc or Nix-linked binary fails outside the
+ *   build environment.
+ * - macOS: fully static linking is not supported, so the binary must link
+ *   only system dylibs under {@link systemDylibPrefixes}.
+ * - Windows: not checked; MSVC builds link only system DLLs by default.
+ *
+ * @param binary - Path to the binary to inspect
+ * @returns Whether the binary is safe to ship to end users
+ */
+async function isPortableBinary(binary: string | undefined): Promise<boolean> {
+	if (binary == null) {
+		return false;
+	}
+	if (platform === 'linux') {
+		// ldd exits non-zero for static executables, so inspect the combined
+		// output instead of the exit code (mirrors the release CI check).
+		const result = await Bun.$`ldd ${binary}`.quiet().nothrow();
+		const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+		return /not a dynamic executable|statically linked/i.test(output);
+	}
+	if (platform === 'darwin') {
+		const result = await Bun.$`otool -L ${binary}`.quiet().nothrow();
+		if (result.exitCode !== 0) {
+			return false;
+		}
+		// otool -L prints the binary path on the first line, then one indented
+		// line per linked dylib: "\t/usr/lib/libSystem.B.dylib (compatibility ...)".
+		const dylibs = result.stdout
+			.toString()
+			.split('\n')
+			.slice(1)
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0)
+			.map((line) => line.split(/\s+/).at(0) ?? '');
+		return dylibs.every((dylib) => systemDylibPrefixes.some((prefix) => dylib.startsWith(prefix)));
+	}
+	return true;
+}
+
 async function hasExpectedVersion(binary: string | undefined, version: string): Promise<boolean> {
 	if (binary == null) {
 		return false;
@@ -71,6 +122,11 @@ if (
 	(await nativePackageIncludesBinary(nativePackageRoot)) &&
 	(await hasExpectedVersion(nativeBinary, version))
 ) {
+	if (!(await isPortableBinary(nativeBinary))) {
+		throw new Error(
+			`${nativeBinary} depends on dynamic libraries that do not exist on end-user machines; rebuild it (Linux packages must be static, macOS packages may only link system dylibs)`,
+		);
+	}
 	process.exit(0);
 }
 

--- a/nix/static-package.nix
+++ b/nix/static-package.nix
@@ -55,6 +55,15 @@ in
           staticCommonArgs
           // {
             cargoArtifacts = staticCargoArtifacts;
+            # A PT_INTERP header means the binary requests a dynamic loader,
+            # so it would not run on end-user machines without the build-time
+            # loader path. READELF is exported by the cross bintools wrapper.
+            postInstall = ''
+              if "''${READELF:-readelf}" -l $out/bin/ccusage | grep -q INTERP; then
+                echo "error: ccusage-static is not statically linked" >&2
+                exit 1
+              fi
+            '';
             meta = config.packages.ccusage.meta // {
               description = "Static Linux build of ccusage";
             };

--- a/package.nix
+++ b/package.nix
@@ -48,6 +48,13 @@ craneLib.buildPackage (
     inherit cargoArtifacts;
     postInstall = lib.optionalString stdenv.isDarwin ''
       install_name_tool -change ${libiconv}/lib/libiconv.2.dylib /usr/lib/libiconv.2.dylib $out/bin/ccusage
+      # End-user machines have no /nix/store, so any dylib outside the macOS
+      # system paths would crash the published binary with a missing dynamic
+      # library error. grep prints the offending entries when it matches.
+      if otool -L $out/bin/ccusage | tail -n +2 | awk '{print $1}' | grep -Ev '^(/usr/lib/|/System/Library/)'; then
+        echo "error: ccusage links dylibs that do not exist on end-user machines" >&2
+        exit 1
+      fi
     '';
     passthru = {
       inherit


### PR DESCRIPTION
## Summary

v20.0.10 shipped a macOS binary that was dynamically linked against `/nix/store/.../libiconv.2.dylib`, which crashed for every user without Nix with a missing dynamic library error. #1249 fixed the linkage with `install_name_tool`, but nothing guarded against the same class of regression. This PR adds verification at three layers so a non-portable binary can no longer ship silently.

## What Changed

- `package.nix`: the darwin build now fails in `postInstall` if any linked dylib lives outside `/usr/lib` or `/System/Library`, printing the offending paths. `install_name_tool -change` is a silent no-op when the old path does not match, so the rewrite alone is not a guarantee. Runs on every `nix build .#ccusage` and via `nix flake check` (which builds the package as a check).
- `nix/static-package.nix`: `ccusage-static` now fails in `postInstall` if the binary has a `PT_INTERP` program header, i.e. it is not actually static. This moves the primary gate into the build itself, complementing the existing `ldd` step in the CI action.
- `apps/ccusage/scripts/ensure-native-binary.ts`: staged package binaries are only accepted if they are portable (Linux: fully static via `ldd`; macOS: only system dylibs via `otool -L`; Windows: skipped). A version-matched but non-portable binary throws instead of being silently accepted.

## Testing

- darwin positive: `nix build .#ccusage` passes and `otool -L` shows only `/usr/lib` dylibs.
- darwin negative: temporarily removing the `install_name_tool` line makes the build fail with the offending `/nix/store` path in the log.
- `ensure-native-binary.ts` verified in both directions: accepts the fixed staged binary (exit 0) and throws on a version-matched Nix-linked binary.
- Linux assertion cannot be built on this machine; `nix eval .#packages.aarch64-linux.ccusage-static.drvPath` confirms the derivation evaluates. The release CI build exercises it, with the existing `ldd` action step as a second net.
- `just fmt` and `just typecheck` pass.

## Related Issues

Follow-up hardening to #1249.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783719095&installation_id=139163553&pr_number=1256&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1256&signature=3a62b92f6161b5d8e9e442cee997d2346f045d55dfccd296df89d55c18680b75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add build, CI, and packaging checks to ensure native release binaries are portable. macOS links only system dylibs, Linux is fully static, and non‑portable staged binaries are rejected to prevent regressions like the Nix‑linked `libiconv` crash.

- **Bug Fixes**
  - `package.nix` (darwin): fail if any dylib outside `/usr/lib` or `/System/Library`; print offenders.
  - `nix/static-package.nix` (linux-static): fail if `PT_INTERP` exists (not fully static).
  - `apps/ccusage/scripts/ensure-native-binary.ts`: only accept portable staged binaries (Linux static; macOS system dylibs).
  - `.github/actions/build-macos-cargo-native-package`: fail macOS x64 cargo build if non‑system dylibs; show offenders.

<sup>Written for commit fb1127f162af93f421f0a3eda4f2d73b282309bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added binary portability validation and build-time checks to ensure the native ccusage executable is compatible across platforms—verifies static linking on Linux and that macOS builds only use system-provided dynamic libraries. Build/CI now fail with clearer errors when validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->