### PR TITLE
perf(release): publish without the Nix dev shell

### DIFF
--- a/.github/actions/setup-linux-blacksmith-sticky-disk/action.yaml
+++ b/.github/actions/setup-linux-blacksmith-sticky-disk/action.yaml
@@ -24,7 +24,12 @@ runs:
       if: steps.blacksmith.outputs.enabled == 'true'
       uses: useblacksmith/stickydisk@2b7a836cbb2b48f4780ae76a7b6fd79d545fb54a # v1.3.0
       with:
-        key: ${{ github.repository }}-nix-${{ runner.os }}-${{ runner.arch }}
+        # Scope the disk per job: a sticky disk clones the last committed
+        # snapshot and re-commits on completion, so jobs that realize different
+        # Nix closures (e.g. a full dev shell vs. a single `nix build`) would
+        # otherwise overwrite each other's store on a shared key and force cold
+        # re-downloads. Keying by job keeps each closure warm independently.
+        key: ${{ github.repository }}-nix-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}
         path: /nix
 
     - name: Prepare mounted Nix store ownership

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,12 +84,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: ./.github/actions/setup-nix
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           registry-url: 'https://registry.npmjs.org'
           node-version: lts/*
           package-manager-cache: false
+      - run: nix profile install --inputs-from . nixpkgs#pnpm
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,12 +84,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: ./.github/actions/setup-nix
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           registry-url: 'https://registry.npmjs.org'
           node-version: lts/*
           package-manager-cache: false
+      - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ccusage-native-*
@@ -100,7 +101,7 @@ jobs:
           for archive in "$RUNNER_TEMP"/native-packages/*.tar; do
             tar -xf "$archive"
           done
-      - run: nix develop --command pnpm --filter='./apps/ccusage' --filter='./packages/ccusage-*' publish --provenance --no-git-checks --access public
+      - run: pnpm --filter='./apps/ccusage' --filter='./packages/ccusage-*' publish --provenance --no-git-checks --access public
 
   release:
     needs:

--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -29,7 +29,7 @@
 	},
 	"scripts": {
 		"bench": "node scripts/bench.mjs",
-		"build": "pnpm run generate:schema && tsdown && pnpm run ensure:native-binary",
+		"build": "tsdown && pnpm run ensure:native-binary",
 		"build:rust": "cargo build --manifest-path ../../rust/Cargo.toml --release --bin ccusage",
 		"ensure:native-binary": "bun scripts/ensure-native-binary.ts",
 		"generate:schema": "cargo run --quiet --manifest-path ../../rust/Cargo.toml --bin generate-config-schema -- config-schema.json && oxfmt --write config-schema.json && cp config-schema.json ../../docs/public/config-schema.json",


### PR DESCRIPTION
## Summary

The `npm publish` release job took ~7m, of which ~5m was `nix develop` re-downloading the entire dev shell (Rust toolchain, litellm, typescript-go, …) from cache.nixos.org just to run `pnpm publish`. That job runs on a GitHub-hosted runner — required for npm provenance, which rejects self-hosted/Blacksmith runners — so it can never get the Blacksmith sticky-disk Nix cache and pays the full download every release. This PR removes the dev shell from the publish path and fixes a sticky-disk key collision that caused the same cold re-downloads (and large variance) on the Blacksmith `pkg-pr-new` job.

## What changed

- **Drop schema regeneration from the publish build** (`apps/ccusage/package.json`). `build` no longer runs `generate:schema`, which compiled and ran the Rust `generate-config-schema` binary on every publish / pkg-pr-new pack. The committed `config-schema.json` is already kept in sync with the Rust source by the `nix flake check` schema-drift check, so regenerating it during packaging is redundant — and it was the only Rust dependency left in the publish path. `build` now runs only `tsdown` and `ensure:native-binary`; the `generate:schema` script stays for local use (`just schema`).
- **Publish without the dev shell** (`.github/workflows/release.yaml`). Instead of `nix develop --command pnpm … publish` (full dev shell), keep the lightweight `setup-nix` (Nix install only) and provision just pnpm with `nix profile install --inputs-from . nixpkgs#pnpm` — pinned to the flake's locked nixpkgs (11.1.1, same as the dev shell). `setup-node` stays **only** for the npm publish configuration (registry + OIDC provenance `.npmrc` wiring): the locked nixpkgs node is below the `engines` floor, so node is sourced from `setup-node`. `bun` is not installed explicitly — `pnpm install` downloads it via `engines.runtime` into `node_modules/.bin`, where the prepack `ensure:native-binary` script resolves it.
- **Scope the Blacksmith sticky-disk key per job** (`.github/actions/setup-linux-blacksmith-sticky-disk/action.yaml`). The key was shared across every Linux job of the same arch; a sticky disk clones the last committed snapshot and re-commits on completion, so jobs with different Nix closures overwrote each other's store, forcing cold re-downloads. This was the source of the `pkg-pr-new` run-to-run variance (149s vs 388s). Keying by `github.job` keeps each closure warm independently. `pkg-pr-new` keeps its Nix dev shell but no longer recompiles Rust during prepack (first change) and gets a stable warm cache.

## Why

`pnpm publish` only needs node, pnpm and bun. Pulling a full Rust dev shell — or recompiling the config schema — on the publish path was pure overhead, and no caching backend helps because the cost is the *size* of the closure on a cold miss, not where it's cached. A minimal `nix profile install nixpkgs#pnpm` keeps the version pinned to the same nixpkgs as the dev shell while making the job consistently fast.

## Testing / validation

- `actionlint` and `zizmor` clean on `release.yaml` (only the 2 pre-existing `excessive-permissions` warnings remain); `treefmt` clean; pre-commit hooks pass.
- Verified locally that `nix profile install`-style provisioning resolves against the locked nixpkgs: `nixpkgs#pnpm` → 11.1.1 (== `pnpm_11`), `nixpkgs#bun` → 1.3.13, `nixpkgs#nodejs_24` → 24.14.1 (below `engines` ^24.15.0 — hence node stays on `setup-node`).
- Confirmed via the actual release run logs that `ensure:native-binary` exits before its cargo fallback when the native artifacts are restored (linux-arm64 binary present, correct version, static) — so the publish path needs no cargo.

> [!NOTE]
> `release.yaml` only runs on tag push, so this path is not exercised by PR CI — it will be validated on the next release. The sticky-disk key change makes all Blacksmith jobs cold once (one-time re-warm).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI stability by scoping job-level cache/keying to avoid cross-job store conflicts and redundant downloads.
  * Streamlined publishing workflow by installing the package manager in the runtime environment and running publish commands directly.
  * Simplified the build script to remove an earlier generation step, reducing build steps and improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->