### PR TITLE
ci: run perf-comment and pkg-pr-new jobs without the full Nix dev shell

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,12 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup-nix
+      # Packing only repackages the native binaries restored from the build
+      # matrix below (no Rust build happens here), so the full `nix develop` dev
+      # shell is unnecessary. Provision just pnpm; bun is fetched via the
+      # engines.runtime entry during `pnpm install` for the prepack scripts.
+      - run: nix profile install --inputs-from . nixpkgs#pnpm
+      - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ccusage-native-*
@@ -154,7 +160,7 @@ jobs:
             tar -xf "$archive"
           done
       - id: publish
-        run: nix develop --command pnpm pkg-pr-new publish --pnpm --bin './apps/ccusage' './packages/ccusage-linux-arm64' './packages/ccusage-linux-x64' './packages/ccusage-darwin-arm64' './packages/ccusage-win32-x64'
+        run: pnpm pkg-pr-new publish --pnpm --bin './apps/ccusage' './packages/ccusage-linux-arm64' './packages/ccusage-linux-x64' './packages/ccusage-darwin-arm64' './packages/ccusage-win32-x64'
 
   ccusage-preview-e2e:
     if: github.event_name == 'pull_request' && needs.changes.outputs.code-changed == 'true'
@@ -220,6 +226,10 @@ jobs:
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
+      # This job only benchmarks the prebuilt ccusage binary bundled in the
+      # installed pkg.pr.new package (no Rust build happens here), so the full
+      # `nix develop` dev shell is unnecessary. Install just the tools the perf
+      # scripts invoke, pinned to the flake's nixpkgs via `--inputs-from .`.
       - name: Install perf tooling
         run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
       - run: pnpm install --frozen-lockfile
@@ -294,6 +304,10 @@ jobs:
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
+      # This job only benchmarks the prebuilt ccusage binary bundled in the
+      # installed pkg.pr.new package (no Rust build happens here), so the full
+      # `nix develop` dev shell is unnecessary. Install just the tools the perf
+      # scripts invoke, pinned to the flake's nixpkgs via `--inputs-from .`.
       - name: Install perf tooling
         run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - id: detect
         uses: ./.github/actions/detect-code-changes
 
-  lint-check:
+  check:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true'
     runs-on: blacksmith-32vcpu-ubuntu-2404-arm
@@ -47,6 +47,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
+      # Realize the dev shell (and run its pnpm install hook) up front so the
+      # setup time lands in this dedicated step instead of bleeding into the
+      # first timed step below and adding noise to action-timeline.
+      - name: Warm Nix dev shell
+        run: nix develop --command true
       - name: Create default Claude directories for tests
         run: |
           mkdir -p "$HOME/.claude/projects"
@@ -364,7 +369,7 @@ jobs:
   action-timeline:
     needs:
       - changes
-      - lint-check
+      - check
       - test
       - build-native-packages
       - npm-publish-dry-run-and-upload-pkg-pr-now

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,6 +220,9 @@ jobs:
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
+      - name: Install perf tooling
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
+      - run: pnpm install --frozen-lockfile
 
       - name: Resolve PR preview package URL
         env:
@@ -233,14 +236,14 @@ jobs:
 
       - name: Generate large ccusage fixture
         run: |
-          nix develop --command just generate-large-fixture \
+          just generate-large-fixture \
             "$RUNNER_TEMP/ccusage-large-fixture" \
             "$RUNNER_TEMP/ccusage-large-codex-fixture" \
             1024
 
       - name: Compare fixture performance
         run: |
-          nix develop --command pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts \
+          pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts \
             --base-package-url "https://pkg.pr.new/${{ github.repository }}/ccusage@${{ github.event.pull_request.base.sha }}" \
             --base-sha "${{ github.event.pull_request.base.sha }}" \
             --head-dir . \
@@ -267,7 +270,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: nix develop --command pnpm exec bun .github/scripts/upsert-pr-comment.ts
+        run: pnpm exec bun .github/scripts/upsert-pr-comment.ts
 
   ccusage-rust-perf-comment:
     name: ccusage rust perf comment
@@ -291,6 +294,9 @@ jobs:
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
+      - name: Install perf tooling
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
+      - run: pnpm install --frozen-lockfile
 
       - name: Resolve PR preview package URL
         env:
@@ -304,14 +310,14 @@ jobs:
 
       - name: Generate large ccusage fixture
         run: |
-          nix develop --command just generate-large-fixture \
+          just generate-large-fixture \
             "$RUNNER_TEMP/ccusage-large-fixture" \
             "$RUNNER_TEMP/ccusage-large-codex-fixture" \
             1024
 
       - name: Compare Rust performance
         run: |
-          nix develop --command pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts \
+          pnpm exec bun apps/ccusage/scripts/compare-pr-performance.ts \
             --base-package-url "https://pkg.pr.new/${{ github.repository }}/ccusage@${{ github.event.pull_request.base.sha }}" \
             --base-sha "${{ github.event.pull_request.base.sha }}" \
             --head-dir . \
@@ -339,7 +345,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: nix develop --command pnpm exec bun .github/scripts/upsert-pr-comment.ts
+        run: pnpm exec bun .github/scripts/upsert-pr-comment.ts
 
   action-timeline:
     needs:


### PR DESCRIPTION
## Summary

Several CI jobs entered the full `nix develop` dev shell (Rust toolchain, litellm, typescript-go, …) just to run a few bun/pnpm scripts that never touch Rust. This slims the `ccusage perf comment`, `ccusage rust perf comment`, and `npm-publish-dry-run-and-upload-pkg-pr-now` jobs down to the tools they actually use, provisioned with `nix profile install --inputs-from . …` (pinned to the flake's locked nixpkgs).

Follows up #1257 (release publish off the dev shell + per-`github.job` sticky-disk keys). With per-job sticky disks, each job warms its own store; provisioning only what it needs keeps that store tiny instead of caching the whole dev shell.

## What changed

**perf-comment jobs** (`ccusage perf comment`, `ccusage rust perf comment`)
- `compare-pr-performance.ts` already benchmarks the native binary bundled in the installed pkg.pr.new package (`installedNativePackageBinEntry` → `node_modules/@ccusage/ccusage-<plat>-<arch>/bin/ccusage`) — no local Rust build, confirmed by job logs (package installs + "Installed native binary" benchmark, zero `cargo`/`Compiling`).
- Replace `nix develop` with `nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun nixpkgs#hyperfine nixpkgs#just` + `pnpm install --frozen-lockfile`, then run the scripts directly. No change to `compare-pr-performance.ts`.

**pkg-pr-new dry-run job**
- Packing only repackages the native binaries restored from the build matrix, so no Rust toolchain is needed (bun is fetched via `engines.runtime` during `pnpm install`).
- Replace `nix develop --command pnpm pkg-pr-new publish` with `nix profile install --inputs-from . nixpkgs#pnpm` + `pnpm install --frozen-lockfile` + a direct `pnpm pkg-pr-new publish`.

**Comments** added to all three jobs explaining why the dev shell is unnecessary (prebuilt binaries, no cargo).

`node` continues to come from the runner image. The `typecheck` and `test` jobs keep `nix develop` — they genuinely need the full toolchain (cargo, clippy, cargo-llvm-cov, tsgo, vitest). The build matrix is untouched: linux/mac-arm use targeted `nix build .#ccusage[-static]`, and Intel mac / Windows already `cargo build` with the runner's system Rust (pinned by `rust-toolchain.toml`) — none use the dev shell.

## Why

Pulling the entire Rust dev shell to run a benchmarking or packaging script is pure overhead; on a cold sticky-disk miss it is ~4.5 min of download. The minimal tool set is a small closure (cold ~tens of seconds, instant when warm).

## Testing / validation

- `actionlint` clean on `ci.yaml`; `zizmor` findings identical before/after; pre-commit hooks pass.
- Verified the perf script's head-binary resolution comes from the installed package (the `rust/target/release/ccusage` path is only a fallback / size-table entry, absent in CI).
- Confirmed each script's external deps: `compare-pr-performance.ts` spawns `hyperfine` and imports `gunshi`/`fs-fixture`; `generate-large-fixture.ts` imports `gunshi`; `upsert-pr-comment.ts` uses `fetch` only — all covered by the installed tools + `pnpm install`.

All three jobs run on PR CI, so this PR exercises the changes directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated: a job key and dependency were adjusted, and test jobs now warm the dev shell before timed steps.
  * Tooling is now provisioned via profiles and installed up front; packaging, fixture generation, and performance-comparison steps invoke tools directly rather than through the previous wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->