### PR TITLE
perf(build): use mold for Linux Rust linking

### DIFF
--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -27,7 +27,6 @@ in
             cargo-edit
             cargo-insta
             cargo-llvm-cov
-            mold
             pkg-config
             openssl
             config.treefmt.build.wrapper
@@ -57,6 +56,9 @@ in
             delta
             dust
           ])
+          ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            pkgs.mold
+          ]
           ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
             pkgs.apple-sdk_15
           ]

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -27,6 +27,7 @@ in
             cargo-edit
             cargo-insta
             cargo-llvm-cov
+            mold
             pkg-config
             openssl
             config.treefmt.build.wrapper
@@ -62,6 +63,9 @@ in
           ++ config.pre-commit.settings.enabledPackages;
 
         shellHook = ''
+          if [ "$(uname -s)" = "Linux" ]; then
+            export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-fuse-ld=mold"
+          fi
           if [ ! -f node_modules/.pnpm/lock.yaml ] || [ pnpm-lock.yaml -nt node_modules/.pnpm/lock.yaml ]; then
             echo "📦 Installing dependencies..."
             pnpm install --frozen-lockfile

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -66,7 +66,10 @@ in
 
         shellHook = ''
           if [ "$(uname -s)" = "Linux" ]; then
-            export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-fuse-ld=mold"
+            case " ''${RUSTFLAGS:-} " in
+              *" -C link-arg=-fuse-ld=mold "*) ;;
+              *) export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-fuse-ld=mold" ;;
+            esac
           fi
           if [ ! -f node_modules/.pnpm/lock.yaml ] || [ pnpm-lock.yaml -nt node_modules/.pnpm/lock.yaml ]; then
             echo "📦 Installing dependencies..."

--- a/nix/static-package.nix
+++ b/nix/static-package.nix
@@ -37,6 +37,7 @@ in
           staticCommonArgs = config.packages.ccusage.passthru.commonArgs // {
             cargoExtraArgs = "-p ccusage --bin ccusage --target ${linuxStaticTarget}";
             nativeBuildInputs = with staticPkgs; [
+              mold
               pkg-config
             ];
             buildInputs = [ ];
@@ -45,6 +46,7 @@ in
           staticDepsOnlyArgs = config.packages.ccusage.passthru.depsOnlyArgs // {
             cargoExtraArgs = "-p ccusage --bin ccusage --target ${linuxStaticTarget}";
             nativeBuildInputs = with staticPkgs; [
+              mold
               pkg-config
             ];
             buildInputs = [ ];

--- a/package.nix
+++ b/package.nix
@@ -2,6 +2,7 @@
   craneLib,
   inputs,
   lib,
+  mold,
   pkg-config,
   root ? ./.,
   stdenv,
@@ -27,9 +28,11 @@ let
     doCheck = false;
     cargoExtraArgs = "-p ccusage --bin ccusage";
     CCUSAGE_PRICING_JSON_PATH = "${inputs.litellm}/model_prices_and_context_window.json";
+    RUSTFLAGS = lib.optionalString stdenv.isLinux "-C link-arg=-fuse-ld=mold";
     nativeBuildInputs = [
       pkg-config
-    ];
+    ]
+    ++ lib.optionals stdenv.isLinux [ mold ];
     buildInputs = lib.optionals stdenv.isDarwin [
       apple-sdk_15
       libiconv


### PR DESCRIPTION
Uses mold for Linux Rust linking in the Nix package, static package, and Linux dev shell paths so CI can show whether linker time improves.

The change is intentionally small and Linux-only. macOS and Windows build paths are left unchanged.

Testing:
- nix fmt package.nix nix/static-package.nix nix/dev-shell.nix
- nix build .#ccusage
- nix eval --raw .#packages.aarch64-linux.ccusage-static.name
- nix eval --raw .#packages.x86_64-linux.ccusage-static.name

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783725814&installation_id=139163553&pr_number=1259&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1259&signature=99113ed9288657ed9432d6a18ed6edda12c887f3a20286dc31d8587574989b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `mold` as the Rust linker on Linux in the Nix package, static package, and Linux dev shell to speed up linking and let CI measure the impact. On Linux, add `mold` to native build inputs and set RUSTFLAGS (-C link-arg=-fuse-ld=mold) with an idempotent dev-shell append; macOS/Windows dev shells and builds are unchanged.

<sup>Written for commit 23e457332cde7351c1b7571827476d463da144d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development shell and packaging now use the Mold linker on Linux to produce builds.
  * Build environments and static package builds set the Mold linker flag on Linux while preserving any existing Rust build flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->