### PR TITLE
perf(ci): speed up the check job and make native build cache observable

### DIFF
--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -21,9 +21,9 @@ runs:
         NIX_GITHUB_TOKEN: ${{ inputs.nix-github-token }}
       run: |
         if [ "$NIX_GITHUB_TOKEN" = "false" ]; then
-          NIX_CONFIG="access-tokens =" nix build .#ccusage-static
+          NIX_CONFIG="access-tokens =" nix build .#ccusage-static --print-build-logs
         else
-          nix build .#ccusage-static
+          nix build .#ccusage-static --print-build-logs
         fi
 
     - name: Verify Linux binary is static

--- a/.github/actions/build-macos-nix-native-package/action.yaml
+++ b/.github/actions/build-macos-nix-native-package/action.yaml
@@ -14,7 +14,7 @@ runs:
 
     - name: Build macOS binary
       shell: bash
-      run: nix build .#ccusage
+      run: nix build .#ccusage --print-build-logs
 
     - name: Stage native package
       shell: bash

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -112,9 +112,14 @@ in
           '';
     in
     {
+      # `nix flake check` deliberately omits a full `config.packages.ccusage`
+      # build: ccusage-clippy already compiles the entire workspace with
+      # `--all-targets` (catching any build break), and the build-native-packages
+      # CI job produces and verifies the actual release binary. Building the
+      # optimized native package here too only duplicated a ~70s release compile
+      # on cache-cold runners.
       checks = {
         inherit ccusage-clippy ccusage-fmt config-schema;
-        ccusage = config.packages.ccusage;
         oxlint = mkRepoCheck "oxlint-check" [ pkgs.oxlint ] ''
           oxlint .
         '';

--- a/nix/static-package.nix
+++ b/nix/static-package.nix
@@ -1,3 +1,18 @@
+# Distribution-only Linux build, kept separate from the default `ccusage`
+# package on purpose:
+#
+#   * `ccusage` (package.nix) is the host-native build used for `nix run`,
+#     the dev shell, `nix flake check`, and schema generation. On Linux it is
+#     glibc-dynamic with a runpath into `/nix/store`, so it is fast for local
+#     work but NOT portable to end-user machines.
+#   * `ccusage-static` (this file) cross-compiles to musl and links fully
+#     statically, producing the portable binary that `release.yaml` ships to
+#     npm. The release matrix runs `nix build .#ccusage-static` for Linux;
+#     macOS arm64 uses the native Nix build, while macOS x64 and Windows fall
+#     back to `cargo build` because Nix cannot target those runners.
+#
+# So Linux release artifacts must come from `.#ccusage-static`, never the
+# default `.#ccusage`, which would embed unusable `/nix/store` paths.
 {
   inputs,
   ...


### PR DESCRIPTION
## What

Three small CI changes, motivated by investigating why the native release builds and the `check` job felt slow.

### 1. `perf(ci)`: drop the duplicate `ccusage` package build from `nix flake check`
The `check` job re-realizes the full optimized **native** `ccusage` package on every cache-cold run (~70s), even though:
- `ccusage-clippy` already compiles the entire workspace with `--all-targets` (so any build break is still caught), and
- the `build-native-packages` job already produces *and verifies* the actual release binary.

Removing the redundant `checks.ccusage` entry trims that duplicate release compile from `nix flake check`.

### 2. `ci`: print nix build logs in native package builds
Pass `--print-build-logs` to the Nix builds (`ccusage-static`, `ccusage`) so CI shows whether each build **compiled** the derivation or **restored it from the sticky-disk store** — making cache hits/misses observable.

### 3. `docs(nix)`: explain why `ccusage-static` is separate from `ccusage`
Document the dev/native (`ccusage`) vs distribution (`ccusage-static`) split at the top of the static package definition.

## Why / findings

While investigating, with `--print-build-logs` added:
- **Linux native build** = a clean sticky-disk **store hit** (no compile, ~12s nix). 
- **`check` job** swings between **~2m (warm)** and **~7–8m (cold)**: on cold runs its large (~7.7 GiB) per-job sticky disk gets evicted, so it re-vendors crates from crates.io + recompiles `ccusage-deps` + the package. Nix's caching itself is fine — the CI persistent store just doesn't retain the big closure reliably.

## Follow-up (not in this PR)
The proper "Nix-way" fix for cold-cache `check` runs is a **shared binary cache** (attic / cachix) so any runner can *fetch* the deps/package outputs instead of recompiling them, independent of sticky-disk retention. Happy to do that separately if we want to provision a cache.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783728688&installation_id=139163553&pr_number=1260&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1260&signature=31941ec15b59cb75bb6b20ddffa4c4fc787d4ab67b6cec89a0846404086ec43d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the `check` job by removing a redundant native package build and makes Nix build cache behavior visible in CI. Also documents why `ccusage-static` is separate from `ccusage`.

- **Performance**
  - Remove `checks.ccusage` from `nix flake check` to avoid a duplicate ~70s release compile on cold runners; rely on `ccusage-clippy` and the release job instead.

- **CI and Docs**
  - Pass `--print-build-logs` to `nix build .#ccusage` and `nix build .#ccusage-static` to show compile vs store-restore.
  - Document the `ccusage` (native/dev) vs `ccusage-static` (musl, fully static, release) split in `nix/static-package.nix`.

<sup>Written for commit 68e78e96fd836093d502833eeb9b2a8999ddb6d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to print detailed logs during Linux and macOS native package builds
  * Streamlined build verification configuration by removing a redundant check
  * Enhanced documentation for static package builds to clarify release pipeline behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->