### PR TITLE
fix(ci): repair the failing update-pricing workflow

### DIFF
--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -62,7 +62,7 @@ jobs:
           git checkout -B "$branch"
           git add flake.lock
           git commit -m "chore(pricing): update LiteLLM snapshot"
-          git push --force-with-lease origin "$branch"
+          git push --force origin "$branch"
 
           body="$(printf '%s\n' \
             'Updates the locked LiteLLM pricing input used by Nix builds.' \
@@ -126,7 +126,7 @@ jobs:
           git checkout -B "$branch"
           git add flake.lock rust/crates/ccusage/src/models-dev-pricing.json
           git commit -m "chore(pricing): update models.dev snapshot"
-          git push --force-with-lease origin "$branch"
+          git push --force origin "$branch"
 
           body="$(printf '%s\n' \
             'Updates the pinned models.dev input and its committed pricing snapshot.' \

--- a/nix/models-dev-pricing.nix
+++ b/nix/models-dev-pricing.nix
@@ -45,8 +45,11 @@ pkgs.runCommand "models-dev-pricing.json"
     tar -xzf ${zod} -C work/node_modules/zod --strip-components=1
 
     # The generator imports `./packages/core/src/generate.ts`, so it must run
-    # from inside the workspace next to the vendored node_modules.
+    # from inside the workspace next to the vendored node_modules. It also
+    # imports its sibling `./models-dev-compact.ts`, so copy that alongside it
+    # under the same relative name the import expects.
     cp ${./models-dev-gen.ts} work/gen.ts
+    cp ${./models-dev-compact.ts} work/models-dev-compact.ts
 
     cd work
     OUTFILE="$out" bun run gen.ts


### PR DESCRIPTION
## Summary

Both jobs of the scheduled **update pricing** workflow have been failing on every run. This PR fixes the two independent root causes.

## What changed

- **`nix/models-dev-pricing.nix`** — also copy `models-dev-compact.ts` into the writable Bun workspace. #1244 split the generator so `models-dev-gen.ts` imports its sibling `./models-dev-compact.ts`, but the derivation only copied `gen.ts`, so the sandboxed Bun run failed with `Cannot find module './models-dev-compact.ts'`. This broke the `update-models-dev-pricing` job and any manual `just gen-models-dev-pricing`.
- **`.github/workflows/update-pricing.yaml`** — push the automation branches with `git push --force` instead of `--force-with-lease`. The job checks out `main` at `fetch-depth: 1` and never fetches the bot branch, so there is no remote-tracking ref and the lease check rejects the push with `stale info`. These branches are written only by this workflow, so a plain force-push is safe.

## Why

The hourly cron has been red since the #1244 refactor (models.dev job) and on every run that already had an open automation branch (force-with-lease push). Restoring both keeps the LiteLLM and models.dev pricing snapshots updating automatically.

## Testing

- `nix build .#models-dev-pricing` now succeeds locally, and the regenerated snapshot is byte-identical to the committed `rust/crates/ccusage/src/models-dev-pricing.json`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783762214&installation_id=139163553&pr_number=1262&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1262&signature=a8a4f876d6a29fb130b4d6605994212b7027f92b7d89a177ab3b8a7bedd4e1ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the scheduled update-pricing workflow by addressing failures in the Nix build and CI push step. Restores automatic LiteLLM and models.dev pricing snapshot updates.

- **Bug Fixes**
  - In `nix/models-dev-pricing.nix`, copy `models-dev-compact.ts` alongside `gen.ts` so Bun can resolve the sibling import.
  - In `.github/workflows/update-pricing.yaml`, push automation branches with `git push --force` instead of `--force-with-lease` to avoid lease errors on shallow checkouts.

<sup>Written for commit 94a62cbdc997a761942157e8c5994f96ada01a2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined internal automation workflows for pricing update operations.
  * Improved build system configuration to ensure reliable dependency resolution during deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->