### PR TITLE
fix(ci): use PAT for pricing automation pull requests

### DIFF
--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -47,11 +47,16 @@ jobs:
           nix develop --command just check
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PRICING_AUTOMATION_TOKEN }}
         run: |
           if git diff --quiet; then
             echo "Pricing snapshot is already up to date."
             exit 0
+          fi
+
+          if [ -z "$GH_TOKEN" ]; then
+            echo "PRICING_AUTOMATION_TOKEN is required because the ccusage org blocks GITHUB_TOKEN from creating pull requests."
+            exit 1
           fi
 
           git config user.name "github-actions[bot]"
@@ -111,11 +116,16 @@ jobs:
           nix develop --command just check
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PRICING_AUTOMATION_TOKEN }}
         run: |
           if git diff --quiet; then
             echo "Pricing snapshot is already up to date."
             exit 0
+          fi
+
+          if [ -z "$GH_TOKEN" ]; then
+            echo "PRICING_AUTOMATION_TOKEN is required because the ccusage org blocks GITHUB_TOKEN from creating pull requests."
+            exit 1
           fi
 
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Problem

The scheduled `update pricing` workflow still fails at **Create pull request** even after #1262:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

The ccusage org policy blocks `GITHUB_TOKEN` from opening PRs. Branch pushes succeed, but `gh pr create` does not.

## Fix

- Use the `PRICING_AUTOMATION_TOKEN` repository secret for the PR creation steps instead of `github.token`.
- Fail fast with a clear message if the secret is missing.

## Immediate unblock

Opened the pending automation PRs manually:
- #1263 — LiteLLM pricing
- #1264 — models.dev pricing

## Follow-up

Longer term, either keep a dedicated automation PAT in `PRICING_AUTOMATION_TOKEN`, or enable **Allow GitHub Actions to create and approve pull requests** in the ccusage org Actions settings so `GITHUB_TOKEN` can be used again.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783772870&installation_id=139163553&pr_number=1265&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1265&signature=30aa88b09af0d9f40084a18f4f19a272872cdeb9ff5086a9001c28519727c9b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch PR creation in the `update-pricing` workflow to use the `PRICING_AUTOMATION_TOKEN` PAT so automation can open pull requests in orgs that block `GITHUB_TOKEN`. Adds a fail-fast check when the secret is missing to surface misconfiguration quickly.

- **Bug Fixes**
  - Use `PRICING_AUTOMATION_TOKEN` for PR creation instead of `github.token`.
  - Exit early with a clear error if the secret is not set.

<sup>Written for commit f7580384969f85849dcfd216aaadf88a491219b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security configuration for automated pricing updates by enforcing explicit token authentication in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->