### PR TITLE
perf(ci): build Rust coverage as a Nix derivation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,11 +66,8 @@ jobs:
         if: github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           mkdir -p coverage
-          env -u CFLAGS -u CXXFLAGS nix develop --command cargo llvm-cov \
-            --manifest-path rust/Cargo.toml \
-            --workspace \
-            --cobertura \
-            --output-path coverage/cobertura.xml
+          nix build .#ccusage-coverage --print-build-logs --out-link "$RUNNER_TEMP/coverage-report"
+          cp "$RUNNER_TEMP/coverage-report" coverage/cobertura.xml
       - name: Upload Rust coverage report
         if: (github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
         ./nix/git-hooks.nix
         ./nix/packages.nix
         ./nix/static-package.nix
+        ./nix/coverage.nix
         ./nix/checks.nix
         ./nix/dev-shell.nix
       ];

--- a/nix/coverage.nix
+++ b/nix/coverage.nix
@@ -1,0 +1,56 @@
+# Rust coverage report built as a Nix derivation so it shares the crane
+# `cargoArtifacts` cache (warm on the per-job Blacksmith sticky disk) instead of
+# the dev-shell's `cargo llvm-cov`, which recompiled the whole workspace into an
+# uncached `rust/target` on every CI run. Output is the cobertura XML file at
+# `$out`, consumed by the coverage upload step in CI via `nix build`.
+{ inputs, ... }:
+let
+  root = ./..;
+in
+{
+  perSystem =
+    {
+      config,
+      system,
+      ...
+    }:
+    let
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [ inputs.rust-overlay.overlays.default ];
+      };
+      rustToolchain = pkgs.rust-bin.fromRustupToolchainFile (root + /rust-toolchain.toml);
+      craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+      inherit (config.packages.ccusage.passthru) cargoArtifacts commonArgs;
+      nixFilter = inputs.nix-filter.lib;
+      repoSrc = nixFilter {
+        inherit root;
+        exclude = [
+          (nixFilter.matchName "node_modules")
+          (nixFilter.matchName "target")
+          (nixFilter.matchName "dist")
+          (nixFilter.matchName "coverage")
+        ];
+      };
+    in
+    {
+      packages.ccusage-coverage = craneLib.cargoLlvmCov (
+        commonArgs
+        // {
+          src = repoSrc;
+          sourceRoot = "source/rust";
+          cargoLock = root + /rust/Cargo.lock;
+          inherit cargoArtifacts;
+          cargoExtraArgs = "--workspace";
+          cargoLlvmCovExtraArgs = "--cobertura --output-path $out";
+          # The workspace tests resolve default Claude data directories from
+          # $HOME; the sandbox has none, so seed a writable HOME with the same
+          # empty directory layout the CI test job creates before running tests.
+          preBuild = ''
+            export HOME=$(mktemp -d)
+            mkdir -p "$HOME/.claude/projects" "$HOME/.config/claude/projects"
+          '';
+        }
+      );
+    };
+}

--- a/nix/coverage.nix
+++ b/nix/coverage.nix
@@ -43,6 +43,12 @@ in
           inherit cargoArtifacts;
           cargoExtraArgs = "--workspace";
           cargoLlvmCovExtraArgs = "--cobertura --output-path $out";
+          # jiff resolves named time zones (e.g. Asia/Tokyo) from the system
+          # zoneinfo database, which the hermetic build sandbox lacks, so it
+          # would fall back to UTC and shift the timezone-dependent tests by a
+          # day. Point it at the nixpkgs tzdata; referencing the store path here
+          # also pulls it into the sandbox as a build input.
+          TZDIR = "${pkgs.tzdata}/share/zoneinfo";
           # The workspace tests resolve default Claude data directories from
           # $HOME; the sandbox has none, so seed a writable HOME with the same
           # empty directory layout the CI test job creates before running tests.


### PR DESCRIPTION
## Summary

Moves the Rust coverage report from a dev-shell `cargo llvm-cov` invocation
to a crane `cargoLlvmCov` Nix package, so it shares the warm `cargoArtifacts`
cache instead of recompiling the whole workspace cold on every CI run.

## What changed

- **`nix/coverage.nix`** (new): a `ccusage-coverage` package built with crane's
  `cargoLlvmCov`, reusing the shared `cargoArtifacts` closure and emitting the
  cobertura report directly at `$out`. A `preBuild` seeds the empty Claude data
  directories under a writable `$HOME`, since the build sandbox has none.
- **`flake.nix`**: import the new module.
- **`.github/workflows/ci.yaml`**: the coverage step now `nix build`s the
  package and copies its report, replacing the `nix develop --command
  cargo llvm-cov` call.

## Why

`cargo llvm-cov` compiled the entire workspace into `rust/target`, but only
`/nix` is persisted on the per-job Blacksmith sticky disk, so that target dir
was never cached. It was the one Rust compile that stayed cold on every run.
As a Nix derivation the dependencies stay warm on the sticky disk, and an
unchanged source tree returns the cached report instantly — bringing coverage
onto the same crane caching path as the rest of the Rust builds.

## Testing

- `nix build .#ccusage-coverage` locally (aarch64-darwin): all workspace tests
  pass in the sandbox and a valid cobertura XML is produced (line-rate 77.4%).
- Re-build with unchanged sources is a cache hit (~0.4s, no recompile).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783779955&installation_id=139163553&pr_number=1266&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1266&signature=70c45b0fb8ad7d619e6510e4bd7a3183f71b3444e14e617e8f0f3138e1ca903c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build Rust coverage as a Nix derivation using crane to reuse the shared `cargoArtifacts` cache, eliminating cold rebuilds and speeding up CI. CI now builds `ccusage-coverage` and uploads its Cobertura report.

- **Refactors**
  - Added `nix/coverage.nix` defining `ccusage-coverage` via `crane.cargoLlvmCov`; reuses `cargoArtifacts`, writes Cobertura to `$out`, and seeds a writable `$HOME` for tests.
  - Imported the module in `flake.nix`.
  - CI: replaced dev-shell `cargo llvm-cov` with `nix build .#ccusage-coverage` and copy the report.

- **Bug Fixes**
  - Provided `TZDIR` from nixpkgs `tzdata` in the coverage build so timezone-dependent tests resolve real offsets in the hermetic sandbox.

<sup>Written for commit 16f8a74fe08c38ef6cdc5fe60f41d4c5b8f8344b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched CI coverage generation to a Nix-built coverage package for more consistent, reproducible coverage artifacts.
  * Added a Nix coverage module to produce Cobertura XML and integrated it into the project’s Nix configuration.
  * Improved build/test stability (avoids timezone-dependent shifts and ensures predictable build environment) to reduce flaky coverage results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->