### PR TITLE
fix: bundle the tz database on platforms without a system one

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -378,6 +378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
@@ -394,6 +395,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -19,6 +19,7 @@ jiff = { version = "0.2.24", default-features = false, features = [
 	"std",
 	"tz-system",
 	"tzdb-zoneinfo",
+	"tzdb-bundle-platform",
 ] }
 memchr = "2"
 compact_str = "0.9"


### PR DESCRIPTION
## Summary

Enables jiff's `tzdb-bundle-platform` feature so named time zones resolve on
platforms that ship no system zoneinfo database (notably Windows).

## Why

With only `tzdb-zoneinfo`, jiff reads the IANA database from the system
(`/usr/share/zoneinfo`). On Windows there is no such database, so named-zone
lookups (e.g. `Asia/Tokyo`) fail and jiff falls back to UTC — producing
off-by-one-day results for date bucketing and the `--timezone` option for
Windows users.

`tzdb-bundle-platform` embeds the IANA database only on platforms that lack a
reliable system one (Windows, wasm) and keeps preferring the system tzdb where
it exists, so Linux and macOS binaries are unchanged in size.

## Testing

- `cargo check -p ccusage` passes; lockfile gains only `jiff-tzdb` /
  `jiff-tzdb-platform`.
- CI Windows build job exercises the bundled path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783780907&installation_id=139163553&pr_number=1267&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1267&signature=808a1f7923faf4659e435f2e26efaff50649e6c0d0a1523feb72f38b84803a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundle the IANA time zone database for platforms without a system tzdb (e.g., Windows) so named zones resolve correctly. Fixes UTC fallback causing off-by-one-day date bucketing and incorrect `--timezone` results; Linux/macOS binaries unchanged.

- **Bug Fixes**
  - Enabled `jiff` feature `tzdb-bundle-platform` alongside `tzdb-zoneinfo` and `tz-system`.
  - Added `jiff-tzdb` and `jiff-tzdb-platform`; bundles tzdb only on Windows/wasm, prefers system tzdb elsewhere.

<sup>Written for commit 4750c5052c4e1a4da1f37e3a166a9597bc4cdf93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

