### PR TITLE
perf(ci): run CI once per change instead of twice

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,17 +48,19 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
-      # Realize the dev shell (and run its pnpm install hook) up front so the
-      # setup time lands in this dedicated step instead of bleeding into the
-      # first timed step below and adding noise to action-timeline.
-      - name: Warm Nix dev shell
-        run: nix develop --command true
+      # Vitest is the only step that needs the JS toolchain (the coverage step
+      # builds via `nix build`), so install just pnpm/bun/just instead of
+      # realizing the full dev shell, which drags in every linter, formatter,
+      # and the pre-commit hook closure and dominated this job's wall time.
+      - name: Install JS tooling
+        run: nix profile install --inputs-from . nixpkgs#pnpm_11 nixpkgs#bun nixpkgs#just
+      - run: pnpm install --frozen-lockfile
       - name: Create default Claude directories for tests
         run: |
           mkdir -p "$HOME/.claude/projects"
           mkdir -p "$HOME/.config/claude/projects"
       - name: Run Vitest tests
-        run: nix develop --command just test-vitest
+        run: just test-vitest
       - name: Generate Rust coverage report
         run: |
           mkdir -p coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions: read-all
@@ -56,20 +57,15 @@ jobs:
         run: |
           mkdir -p "$HOME/.claude/projects"
           mkdir -p "$HOME/.config/claude/projects"
-      - name: Run test suite
-        if: github.event_name != 'pull_request' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
-        run: nix develop --command just test
       - name: Run Vitest tests
-        if: github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: nix develop --command just test-vitest
       - name: Generate Rust coverage report
-        if: github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           mkdir -p coverage
           nix build .#ccusage-coverage --print-build-logs --out-link "$RUNNER_TEMP/coverage-report"
           cp "$RUNNER_TEMP/coverage-report" coverage/cobertura.xml
       - name: Upload Rust coverage report
-        if: (github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
         with:
           file: coverage/cobertura.xml


### PR DESCRIPTION
## Summary

Every commit on a PR branch triggered the full CI workflow **twice** — once for
the `push` event and once for `pull_request` — duplicating the `check`, `test`,
and the entire native-build matrix.

## What changed

- Restrict `push` to the `main` branch. Branch commits are now validated once
  via the `pull_request` event; `main` keeps its post-merge run.
- Remove the dead `Run test suite` step (it only fired on pushes to non-default
  branches, which no longer happen).
- Drop the now-always-true event guards on the Vitest and coverage steps.

## Why / safety

Rust tests stay fully covered: the coverage step runs `cargo llvm-cov` over the
whole workspace on both remaining triggers, so the removed `just test` path is
redundant. The upload step keeps its fork guard.

**Tradeoff:** pushing a branch *without* an open PR no longer runs CI. Opening
the PR runs it. This is the intended cost saving — it roughly halves CI minutes
spent per PR.

## Verify

This very PR should show a single CI run (the `pull_request` run); the `push`
run for the branch is suppressed by the new `on.push.branches` filter on the
branch's own workflow file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783782053&installation_id=139163553&pr_number=1268&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1268&signature=5f5708152b570291a5f0b348b939eace2143940b5e082b7c75a7e5f136ceb45d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run CI once per change by limiting `push` to `main` and relying on `pull_request` for branches; branch pushes without an open PR no longer run CI. Speed up the test job by installing only `pnpm`, `bun`, and `just` instead of realizing the full Nix dev shell.

- **Refactors**
  - Removed the unused "Run test suite" step (it only ran on non-default branch pushes).
  - Dropped always-true event guards for Vitest and Rust coverage; kept and simplified the fork guard on `actions/upload-code-coverage`.
  - Replaced Nix dev shell warmup with direct JS tooling install and `just test-vitest`; coverage stays a `nix build` derivation.

<sup>Written for commit 6d4ea6568421c4196a1c3de7ea41033c5783b6cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now only triggers on the main branch.
  * Simplified test execution and coverage reporting flow.
  * Streamlined logic for uploading coverage artifacts so reports are uploaded for non-PRs and for PRs originating from the main repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->