### PR TITLE
perf(ci): drop the full dev shell from the test job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,17 +48,19 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
-      # Realize the dev shell (and run its pnpm install hook) up front so the
-      # setup time lands in this dedicated step instead of bleeding into the
-      # first timed step below and adding noise to action-timeline.
-      - name: Warm Nix dev shell
-        run: nix develop --command true
+      # Vitest is the only step that needs the JS toolchain (the coverage step
+      # builds via `nix build`), so install just pnpm/bun/just instead of
+      # realizing the full dev shell, which drags in every linter, formatter,
+      # and the pre-commit hook closure and dominated this job's wall time.
+      - name: Install JS tooling
+        run: nix profile install --inputs-from . nixpkgs#pnpm_11 nixpkgs#bun nixpkgs#just
+      - run: pnpm install --frozen-lockfile
       - name: Create default Claude directories for tests
         run: |
           mkdir -p "$HOME/.claude/projects"
           mkdir -p "$HOME/.config/claude/projects"
       - name: Run Vitest tests
-        run: nix develop --command just test-vitest
+        run: just test-vitest
       - name: Generate Rust coverage report
         run: |
           mkdir -p coverage


### PR DESCRIPTION
## Summary

The `test` job spent **~73s** on "Warm Nix dev shell" realizing the complete
development shell (every linter, formatter, renovate, and the pre-commit hook
closure) while `pnpm install` itself was only ~7s.

Now that coverage is a `nix build` derivation (#1266), Vitest is the only step
that needs a JS toolchain. This replaces `nix develop` with
`nix profile install pnpm_11 bun just` — the same pattern already used by the
perf-comment and pkg-pr-new jobs — and runs `just test-vitest` directly.

## Why

The full dev shell pulls in tooling the test job never uses. Installing only
pnpm/bun/just skips that closure entirely.

## Notes

- Stacked on #1268; retarget to `main` once that merges.
- Coverage is unchanged (`nix build .#ccusage-coverage`).
- Verify: compare the new "Install JS tooling" + Vitest timing against the old
  ~73s "Warm Nix dev shell" step.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783782347&installation_id=139163553&pr_number=1269&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1269&signature=73094ace98d719de5c43b691d87bb9a17441d3869cee37fd224dc7bd954a3d89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop the full Nix dev shell from the test job to cut ~73s of shell warmup. Install only `pnpm_11`, `bun`, and `just`, run `Vitest` directly, and keep coverage via `nix build`.

- **Refactors**
  - Replace `nix develop` with `nix profile install nixpkgs#pnpm_11 nixpkgs#bun nixpkgs#just`.
  - Add `pnpm install --frozen-lockfile`; run tests with `just test-vitest`.
  - Coverage unchanged (`nix build .#ccusage-coverage`).

<sup>Written for commit 0a3391e302b2175807c5037d00f3971e7e9e75ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

