### PR TITLE
chore: provision node and bun via nix instead of pnpm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,11 +49,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
       # Vitest is the only step that needs the JS toolchain (the coverage step
-      # builds via `nix build`), so install just pnpm/bun/just instead of
+      # builds via `nix build`), so install just pnpm/node/just instead of
       # realizing the full dev shell, which drags in every linter, formatter,
       # and the pre-commit hook closure and dominated this job's wall time.
       - name: Install JS tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm_11 nixpkgs#bun nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm_11 nixpkgs#nodejs_24 nixpkgs#just
       - run: pnpm install --frozen-lockfile
       - name: Create default Claude directories for tests
         run: |
@@ -145,9 +145,9 @@ jobs:
       - uses: ./.github/actions/setup-nix
       # Packing only repackages the native binaries restored from the build
       # matrix below (no Rust build happens here), so the full `nix develop` dev
-      # shell is unnecessary. Provision just pnpm; bun is fetched via the
-      # engines.runtime entry during `pnpm install` for the prepack scripts.
-      - run: nix profile install --inputs-from . nixpkgs#pnpm
+      # shell is unnecessary. The prepack scripts run tsdown (node) and
+      # ensure-native-binary (bun), so provision those runtimes explicitly.
+      - run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -231,7 +231,7 @@ jobs:
       # `nix develop` dev shell is unnecessary. Install just the tools the perf
       # scripts invoke, pinned to the flake's nixpkgs via `--inputs-from .`.
       - name: Install perf tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve PR preview package URL
@@ -309,7 +309,7 @@ jobs:
       # `nix develop` dev shell is unnecessary. Install just the tools the perf
       # scripts invoke, pinned to the flake's nixpkgs via `--inputs-from .`.
       - name: Install perf tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve PR preview package URL

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,17 +48,19 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
-      # Realize the dev shell (and run its pnpm install hook) up front so the
-      # setup time lands in this dedicated step instead of bleeding into the
-      # first timed step below and adding noise to action-timeline.
-      - name: Warm Nix dev shell
-        run: nix develop --command true
+      # Vitest is the only step that needs the JS toolchain (the coverage step
+      # builds via `nix build`), so install just pnpm/bun/just instead of
+      # realizing the full dev shell, which drags in every linter, formatter,
+      # and the pre-commit hook closure and dominated this job's wall time.
+      - name: Install JS tooling
+        run: nix profile install --inputs-from . nixpkgs#pnpm_11 nixpkgs#bun nixpkgs#just
+      - run: pnpm install --frozen-lockfile
       - name: Create default Claude directories for tests
         run: |
           mkdir -p "$HOME/.claude/projects"
           mkdir -p "$HOME/.config/claude/projects"
       - name: Run Vitest tests
-        run: nix develop --command just test-vitest
+        run: just test-vitest
       - name: Generate Rust coverage report
         run: |
           mkdir -p coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
       # realizing the full dev shell, which drags in every linter, formatter,
       # and the pre-commit hook closure and dominated this job's wall time.
       - name: Install JS tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm_11 nixpkgs#nodejs_24 nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#just
       - run: pnpm install --frozen-lockfile
       - name: Create default Claude directories for tests
         run: |
@@ -147,7 +147,7 @@ jobs:
       # matrix below (no Rust build happens here), so the full `nix develop` dev
       # shell is unnecessary. The prepack scripts run tsdown (node) and
       # ensure-native-binary (bun), so provision those runtimes explicitly.
-      - run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun
+      - run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#bun
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -231,7 +231,7 @@ jobs:
       # `nix develop` dev shell is unnecessary. Install just the tools the perf
       # scripts invoke, pinned to the flake's nixpkgs via `--inputs-from .`.
       - name: Install perf tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve PR preview package URL
@@ -309,7 +309,7 @@ jobs:
       # `nix develop` dev shell is unnecessary. Install just the tools the perf
       # scripts invoke, pinned to the flake's nixpkgs via `--inputs-from .`.
       - name: Install perf tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve PR preview package URL

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           node-version: lts/*
           package-manager-cache: false
-      - run: nix profile install --inputs-from . nixpkgs#pnpm
+      # node comes from setup-node above (needed for the npm registry auth);
+      # bun is required by the ensure-native-binary prepack script.
+      - run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -20,6 +20,7 @@ in
       devShells.default = pkgs.mkShell {
         buildInputs =
           (with pkgs; [
+            nodejs_24
             pnpm_11
             bun
 

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -20,8 +20,8 @@ in
       devShells.default = pkgs.mkShell {
         buildInputs =
           (with pkgs; [
-            nodejs_24
-            pnpm_11
+            nodejs
+            pnpm
             bun
 
             rustToolchain

--- a/package.json
+++ b/package.json
@@ -18,19 +18,5 @@
 		"pkg-pr-new": "catalog:release",
 		"vitest": "catalog:testing"
 	},
-	"engines": {
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.15.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.13",
-				"onFail": "download"
-			}
-		]
-	},
 	"packageManager": "pnpm@11.1.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,13 +67,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      bun:
-        specifier: runtime:^1.3.13
-        version: runtime:1.3.14
-      node:
-        specifier: runtime:^24.15.0
-        version: runtime:24.15.0
     devDependencies:
       bumpp:
         specifier: catalog:release
@@ -1077,115 +1070,6 @@ packages:
   bun-types@1.3.5:
     resolution: {integrity: sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw==}
 
-  bun@runtime:1.3.14:
-    resolution:
-      type: variations
-      variants:
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-2LliIYKK1vl6x6wKt+lYcjQa92MAHogD6CZ2UsJlJiA=
-            prefix: bun-darwin-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: darwin
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-QYPfM3RiPlurMVxUfPoJdFM81FfYa3O2OfeoeXTNZjM=
-            prefix: bun-darwin-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-x64.zip
-          targets:
-            - cpu: x64
-              os: darwin
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-c8XBkFn95AkTf8bLq1kF/Hxa+ljOYOQaQaUhwj//Zrs=
-            prefix: bun-freebsd-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-freebsd-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: freebsd
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-uIHcTdvWjHmjW9NUkIi9HXADtWLOw8t5VMDKi29SiKU=
-            prefix: bun-freebsd-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-freebsd-x64.zip
-          targets:
-            - cpu: x64
-              os: freebsd
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-uY4K02JcXADR1bX/VWBcet3b+uFRhh5oreV7LTuHA7s=
-            prefix: bun-linux-aarch64-musl
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64-musl.zip
-          targets:
-            - cpu: arm64
-              os: linux
-              libc: musl
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-on/7Y6gxA3WDbg1vZorhf6jY0YuIw3yCHGUzGXOhmjs=
-            prefix: bun-linux-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-FL2a7e6/Hbpn6N75UxyJvJiez98d5C5b/K8bjNkpRxk=
-            prefix: bun-linux-x64-musl
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64-musl.zip
-          targets:
-            - cpu: x64
-              os: linux
-              libc: musl
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-lR7iruhV8IWVruxiJSJqKY0/6oOj3NZGXAnLzN9+hI8=
-            prefix: bun-linux-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip
-          targets:
-            - cpu: x64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: bun.exe
-            integrity: sha256-iYQfWlfyNItn7Ag5txj0v06n0Hw3HJukt3tseQ+RiVM=
-            prefix: bun-windows-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: win32
-        - resolution:
-            archive: zip
-            bin: bun.exe
-            integrity: sha256-CgYgkwtmdde6RA6B9ODgDTz74JbEsUDT//AiBenhiSI=
-            prefix: bun-windows-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-x64.zip
-          targets:
-            - cpu: x64
-              os: win32
-    version: 1.3.14
-    hasBin: true
-
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -1826,96 +1710,6 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
-
-  node@runtime:24.15.0:
-    resolution:
-      type: variations
-      variants:
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-3UvHfctfTJoslkNzm7WTUAzLCUE+xCyqD47w5e8RYJU=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-aix-ppc64.tar.gz
-          targets:
-            - cpu: ppc64
-              os: aix
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-NyMxuWl3mrXRW5SYhPxur4jVr+h73ouogdZAC5EA/8Q=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-/9XuKTRnkn8+5zGlU+uI/R9Iz3TuvC10prq+SvIoZzs=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-c6/CNNVYwkkZh19RwtHqACoq2k6m+DYBo4OGn++mTu0=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-sfiJAKSxY2XqulYmkwT8Edp1gdvwNVLUSV+azh/AX20=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-ppc64le.tar.gz
-          targets:
-            - cpu: ppc64le
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-+YVFVDnVL+m43mqPbQe/7MxzbepSfofqyv5ajXUWo4A=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-s390x.tar.gz
-          targets:
-            - cpu: s390x
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-RINoctmuxJ8ea1KpqSKHLbmisC0jWmFqVoG2qF/sjYk=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-yet0Au2ibiun5EtnJ/yFqN5WxQlbH3Hr0wYokiEaoRY=
-            prefix: node-v24.15.0-win-arm64
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-arm64.zip
-          targets:
-            - cpu: arm64
-              os: win32
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-zFFJ6r1Td5zh573FQBZDYi0MfmgAreGJKKdn6UC7DmI=
-            prefix: node-v24.15.0-win-x64
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-x64.zip
-          targets:
-            - cpu: x64
-              os: win32
-    version: 24.15.0
-    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -3204,8 +2998,6 @@ snapshots:
     dependencies:
       '@types/node': 24.5.1
 
-  bun@runtime:1.3.14: {}
-
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -3924,8 +3716,6 @@ snapshots:
   nanoid@3.3.11: {}
 
   node-fetch-native@1.6.7: {}
-
-  node@runtime:24.15.0: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Summary

`package.json` declared `engines.runtime` for node and bun with
`onFail: download`, so pnpm fetched and managed those runtimes itself rather
than using the pinned Nix toolchain. This removes that and provisions both
runtimes explicitly via Nix.

## What changed

- **package.json**: drop `engines.runtime`.
- **flake.nix dev shell**: add `nodejs_24` (bun already present).
- **CI `test`**: install `nodejs_24` for Vitest (drop the unused bun).
- **CI `pkg-pr-new`**: add `nodejs_24` + `bun` for the tsdown / ensure-native-binary prepack scripts.
- **CI perf jobs**: add `nodejs_24` alongside bun.
- **release.yaml**: add `bun`; node still comes from `setup-node` (kept — needed for npm registry auth / provenance).

## Verification

With a clean pnpm state (`PNPM_HOME`/XDG dirs in a tempdir), after removing
`engines.runtime`:
- `pnpm install --frozen-lockfile` no longer manages/downloads node or bun.
- `pnpm exec vitest run` runs on the PATH Nix node (v24.14.1); 34 tests pass.

## Notes

- Stacked on #1269 → #1268; retarget to `main` as those merge.
- `setup-node` in release.yaml and preview-e2e is intentionally retained.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783782796&installation_id=139163553&pr_number=1270&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1270&signature=9e81f69dfac6701084de06d1dde219fcb744860f4d4f0bc590621259590ef5dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provision Node and Bun via Nix (using default `nodejs`/`pnpm`) so dev and CI run on consistent, pinned runtimes without downloads. Also speeds up tests by installing only the JS tools instead of realizing the full dev shell.

- **Refactors**
  - Removed `engines.runtime` from `package.json`; regenerated `pnpm-lock.yaml` to drop `runtime:` Node/Bun entries.
  - Dev shell: include `nodejs` and `pnpm` (replaces `nodejs_24`/`pnpm_11`); `bun` unchanged.
  - CI: use `nix profile` installs. Tests install `pnpm`/`nodejs`/`just` and run `just test-vitest` (no `nix develop`). `pkg-pr-new` and perf install `nodejs` + `bun`. Release installs `bun` via Nix; keep `setup-node` for npm auth/provenance.

<sup>Written for commit 509f5dfa7a2a324bb9923ce8710cfde9ad2a5144. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

