### PR TITLE
chore: provision node and bun via nix instead of pnpm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,11 +49,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
       # Vitest is the only step that needs the JS toolchain (the coverage step
-      # builds via `nix build`), so install just pnpm/bun/just instead of
+      # builds via `nix build`), so install just pnpm/node/just instead of
       # realizing the full dev shell, which drags in every linter, formatter,
       # and the pre-commit hook closure and dominated this job's wall time.
       - name: Install JS tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm_11 nixpkgs#bun nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm_11 nixpkgs#nodejs_24 nixpkgs#just
       - run: pnpm install --frozen-lockfile
       - name: Create default Claude directories for tests
         run: |
@@ -145,9 +145,9 @@ jobs:
       - uses: ./.github/actions/setup-nix
       # Packing only repackages the native binaries restored from the build
       # matrix below (no Rust build happens here), so the full `nix develop` dev
-      # shell is unnecessary. Provision just pnpm; bun is fetched via the
-      # engines.runtime entry during `pnpm install` for the prepack scripts.
-      - run: nix profile install --inputs-from . nixpkgs#pnpm
+      # shell is unnecessary. The prepack scripts run tsdown (node) and
+      # ensure-native-binary (bun), so provision those runtimes explicitly.
+      - run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -231,7 +231,7 @@ jobs:
       # `nix develop` dev shell is unnecessary. Install just the tools the perf
       # scripts invoke, pinned to the flake's nixpkgs via `--inputs-from .`.
       - name: Install perf tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve PR preview package URL
@@ -309,7 +309,7 @@ jobs:
       # `nix develop` dev shell is unnecessary. Install just the tools the perf
       # scripts invoke, pinned to the flake's nixpkgs via `--inputs-from .`.
       - name: Install perf tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve PR preview package URL

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
       # realizing the full dev shell, which drags in every linter, formatter,
       # and the pre-commit hook closure and dominated this job's wall time.
       - name: Install JS tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm_11 nixpkgs#nodejs_24 nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#just
       - run: pnpm install --frozen-lockfile
       - name: Create default Claude directories for tests
         run: |
@@ -147,7 +147,7 @@ jobs:
       # matrix below (no Rust build happens here), so the full `nix develop` dev
       # shell is unnecessary. The prepack scripts run tsdown (node) and
       # ensure-native-binary (bun), so provision those runtimes explicitly.
-      - run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun
+      - run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#bun
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -231,7 +231,7 @@ jobs:
       # `nix develop` dev shell is unnecessary. Install just the tools the perf
       # scripts invoke, pinned to the flake's nixpkgs via `--inputs-from .`.
       - name: Install perf tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve PR preview package URL
@@ -309,7 +309,7 @@ jobs:
       # `nix develop` dev shell is unnecessary. Install just the tools the perf
       # scripts invoke, pinned to the flake's nixpkgs via `--inputs-from .`.
       - name: Install perf tooling
-        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs_24 nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#bun nixpkgs#hyperfine nixpkgs#just
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve PR preview package URL

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           node-version: lts/*
           package-manager-cache: false
-      - run: nix profile install --inputs-from . nixpkgs#pnpm
+      # node comes from setup-node above (needed for the npm registry auth);
+      # bun is required by the ensure-native-binary prepack script.
+      - run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#bun
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -20,6 +20,7 @@ in
       devShells.default = pkgs.mkShell {
         buildInputs =
           (with pkgs; [
+            nodejs_24
             pnpm_11
             bun
 

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -20,8 +20,8 @@ in
       devShells.default = pkgs.mkShell {
         buildInputs =
           (with pkgs; [
-            nodejs_24
-            pnpm_11
+            nodejs
+            pnpm
             bun
 
             rustToolchain

--- a/package.json
+++ b/package.json
@@ -18,19 +18,5 @@
 		"pkg-pr-new": "catalog:release",
 		"vitest": "catalog:testing"
 	},
-	"engines": {
-		"runtime": [
-			{
-				"name": "node",
-				"version": "^24.15.0",
-				"onFail": "download"
-			},
-			{
-				"name": "bun",
-				"version": "^1.3.13",
-				"onFail": "download"
-			}
-		]
-	},
 	"packageManager": "pnpm@11.1.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,13 +67,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      bun:
-        specifier: runtime:^1.3.13
-        version: runtime:1.3.14
-      node:
-        specifier: runtime:^24.15.0
-        version: runtime:24.15.0
     devDependencies:
       bumpp:
         specifier: catalog:release
@@ -1077,115 +1070,6 @@ packages:
   bun-types@1.3.5:
     resolution: {integrity: sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw==}
 
-  bun@runtime:1.3.14:
-    resolution:
-      type: variations
-      variants:
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-2LliIYKK1vl6x6wKt+lYcjQa92MAHogD6CZ2UsJlJiA=
-            prefix: bun-darwin-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: darwin
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-QYPfM3RiPlurMVxUfPoJdFM81FfYa3O2OfeoeXTNZjM=
-            prefix: bun-darwin-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-x64.zip
-          targets:
-            - cpu: x64
-              os: darwin
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-c8XBkFn95AkTf8bLq1kF/Hxa+ljOYOQaQaUhwj//Zrs=
-            prefix: bun-freebsd-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-freebsd-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: freebsd
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-uIHcTdvWjHmjW9NUkIi9HXADtWLOw8t5VMDKi29SiKU=
-            prefix: bun-freebsd-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-freebsd-x64.zip
-          targets:
-            - cpu: x64
-              os: freebsd
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-uY4K02JcXADR1bX/VWBcet3b+uFRhh5oreV7LTuHA7s=
-            prefix: bun-linux-aarch64-musl
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64-musl.zip
-          targets:
-            - cpu: arm64
-              os: linux
-              libc: musl
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-on/7Y6gxA3WDbg1vZorhf6jY0YuIw3yCHGUzGXOhmjs=
-            prefix: bun-linux-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-FL2a7e6/Hbpn6N75UxyJvJiez98d5C5b/K8bjNkpRxk=
-            prefix: bun-linux-x64-musl
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64-musl.zip
-          targets:
-            - cpu: x64
-              os: linux
-              libc: musl
-        - resolution:
-            archive: zip
-            bin: bun
-            integrity: sha256-lR7iruhV8IWVruxiJSJqKY0/6oOj3NZGXAnLzN9+hI8=
-            prefix: bun-linux-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip
-          targets:
-            - cpu: x64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: bun.exe
-            integrity: sha256-iYQfWlfyNItn7Ag5txj0v06n0Hw3HJukt3tseQ+RiVM=
-            prefix: bun-windows-aarch64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-aarch64.zip
-          targets:
-            - cpu: arm64
-              os: win32
-        - resolution:
-            archive: zip
-            bin: bun.exe
-            integrity: sha256-CgYgkwtmdde6RA6B9ODgDTz74JbEsUDT//AiBenhiSI=
-            prefix: bun-windows-x64
-            type: binary
-            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-x64.zip
-          targets:
-            - cpu: x64
-              os: win32
-    version: 1.3.14
-    hasBin: true
-
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -1826,96 +1710,6 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
-
-  node@runtime:24.15.0:
-    resolution:
-      type: variations
-      variants:
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-3UvHfctfTJoslkNzm7WTUAzLCUE+xCyqD47w5e8RYJU=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-aix-ppc64.tar.gz
-          targets:
-            - cpu: ppc64
-              os: aix
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-NyMxuWl3mrXRW5SYhPxur4jVr+h73ouogdZAC5EA/8Q=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-/9XuKTRnkn8+5zGlU+uI/R9Iz3TuvC10prq+SvIoZzs=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-c6/CNNVYwkkZh19RwtHqACoq2k6m+DYBo4OGn++mTu0=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-sfiJAKSxY2XqulYmkwT8Edp1gdvwNVLUSV+azh/AX20=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-ppc64le.tar.gz
-          targets:
-            - cpu: ppc64le
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-+YVFVDnVL+m43mqPbQe/7MxzbepSfofqyv5ajXUWo4A=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-s390x.tar.gz
-          targets:
-            - cpu: s390x
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-RINoctmuxJ8ea1KpqSKHLbmisC0jWmFqVoG2qF/sjYk=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-yet0Au2ibiun5EtnJ/yFqN5WxQlbH3Hr0wYokiEaoRY=
-            prefix: node-v24.15.0-win-arm64
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-arm64.zip
-          targets:
-            - cpu: arm64
-              os: win32
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-zFFJ6r1Td5zh573FQBZDYi0MfmgAreGJKKdn6UC7DmI=
-            prefix: node-v24.15.0-win-x64
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-x64.zip
-          targets:
-            - cpu: x64
-              os: win32
-    version: 24.15.0
-    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -3204,8 +2998,6 @@ snapshots:
     dependencies:
       '@types/node': 24.5.1
 
-  bun@runtime:1.3.14: {}
-
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -3924,8 +3716,6 @@ snapshots:
   nanoid@3.3.11: {}
 
   node-fetch-native@1.6.7: {}
-
-  node@runtime:24.15.0: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Summary

Recreated from #1270 (which was auto-closed when its stacked base branch was
deleted on merge). Now targets `main` directly with #1268/#1269 already landed.

`package.json` declared `engines.runtime` for node and bun with
`onFail: download`, so pnpm fetched and managed those runtimes itself rather
than using the pinned Nix toolchain. This removes that and provisions both
runtimes via Nix.

## What changed

- **package.json**: drop `engines.runtime`; **pnpm-lock.yaml** resynced (managed runtimes removed).
- **flake dev shell**: add `nodejs` (bun already present).
- **CI `test`**: install `nodejs` for Vitest.
- **CI `pkg-pr-new`**: add `nodejs` + `bun` for the tsdown / ensure-native-binary prepack scripts.
- **CI perf jobs**: add `nodejs` alongside bun.
- **release.yaml**: add `bun`; node still comes from `setup-node` (kept for npm registry auth / provenance).
- Use the default `pnpm` / `nodejs` nixpkgs attributes (pnpm 11.1.1, node LTS 24.x).

## Verification

With a clean pnpm state, after removing `engines.runtime`:
- `pnpm install --frozen-lockfile` no longer manages/downloads node or bun.
- `pnpm exec vitest run` runs on the PATH Nix node; 34 tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783783180&installation_id=139163553&pr_number=1271&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1271&signature=f97136839c66654e71016ab9a51c6388b96e262d37266aaf42406b0a2b0041bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provision Node and Bun via Nix instead of `pnpm` runtime downloads. Removes `engines.runtime` and updates dev shell and CI to use Nix-pinned `nodejs` and `bun` for reproducible builds.

- **Refactors**
  - Dev shell: add `nodejs`; switch to nixpkgs defaults (`pnpm`, `nodejs`); keep `bun`.
  - CI test job: install `pnpm`/`nodejs`/`just` via Nix for Vitest.
  - CI `pkg-pr-new`: install `pnpm`/`nodejs`/`bun` for `tsdown` and `ensure-native-binary` prepack scripts.
  - CI perf jobs: add `nodejs` alongside `bun`.
  - Release: keep `setup-node` for npm auth/provenance; install `pnpm` and `bun` via Nix.

- **Dependencies**
  - Remove `engines.runtime` from `package.json` to stop `pnpm`-managed runtime downloads.
  - Regenerate `pnpm-lock.yaml` to drop `runtime:` entries for Node and Bun.

<sup>Written for commit 52e788746518348aa54b426d307ef632b84b8809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and release workflow configurations to adjust tooling dependencies and installation steps.
  * Updated development environment setup to use updated package manager versions.
  * Removed runtime version requirements from package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->