### PR TITLE
perf(ci): scope coverage source to its real inputs

### DIFF
--- a/nix/coverage.nix
+++ b/nix/coverage.nix
@@ -23,13 +23,20 @@ in
       craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
       inherit (config.packages.ccusage.passthru) cargoArtifacts commonArgs;
       nixFilter = inputs.nix-filter.lib;
-      repoSrc = nixFilter {
+      # Scope the source to the Rust tree plus the few out-of-tree files the
+      # build and tests pull in at compile time, so the derivation only rebuilds
+      # when something it actually depends on changes — not on every docs, TS, or
+      # config edit elsewhere in the repo:
+      #   * rust/build.rs           reads ../../../flake.lock
+      #   * config_schema.rs tests  include_str! ../../../../ccusage.example.json
+      #   * ccusage-cli tests       include_str! ../../../../apps/ccusage/package.json
+      coverageSrc = nixFilter {
         inherit root;
-        exclude = [
-          (nixFilter.matchName "node_modules")
-          (nixFilter.matchName "target")
-          (nixFilter.matchName "dist")
-          (nixFilter.matchName "coverage")
+        include = [
+          "rust"
+          "flake.lock"
+          "ccusage.example.json"
+          "apps/ccusage/package.json"
         ];
       };
     in
@@ -37,7 +44,7 @@ in
       packages.ccusage-coverage = craneLib.cargoLlvmCov (
         commonArgs
         // {
-          src = repoSrc;
+          src = coverageSrc;
           sourceRoot = "source/rust";
           cargoLock = root + /rust/Cargo.lock;
           inherit cargoArtifacts;


### PR DESCRIPTION
## Summary

The `ccusage-coverage` derivation used the **whole repository** as its source,
so any edit anywhere (docs, a TS file, package.json) invalidated it and forced a
full instrumented Rust rebuild — ~230–250s on the arm runner — even when no Rust
code changed.

## What changed

Narrow the source to the Rust tree plus the only out-of-tree files the build and
tests pull in at compile time:

- `flake.lock` — read by `rust/crates/ccusage/build.rs`
- `ccusage.example.json` — `include_str!` in `config_schema.rs` tests
- `apps/ccusage/package.json` — `include_str!` in `ccusage-cli` tests

Now the derivation is cache-stable across unrelated edits and only recompiles
when its actual inputs change.

## Verification (local)

- Editing `README.md` → coverage `drvPath` unchanged (cache preserved).
- Editing a Rust file → `drvPath` changes (rebuilds correctly).
- Scoped build still passes all workspace tests (253 + 10 + 51 + 16 + 2) and
  emits valid cobertura XML.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783784428&installation_id=139163553&pr_number=1272&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1272&signature=48de68e2e64ab6b548fdfb7b3682f2db166ee80f717941f98ff98c0b52465652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped the `ccusage-coverage` Nix derivation to the Rust tree and the few compile-time inputs, so coverage builds only rebuild when real inputs change. This removes unnecessary instrumented Rust rebuilds from unrelated repo edits and speeds up CI.

- **Performance**
  - Source narrowed via `nix-filter` to: `rust/`, `flake.lock`, `ccusage.example.json`, `apps/ccusage/package.json`.
  - `cargoLlvmCov` now uses the new `coverageSrc`; `sourceRoot` remains `"source/rust"`.
  - Verified: non-Rust edits keep the `drvPath` stable; Rust edits rebuild; tests pass and Cobertura XML is still produced.

<sup>Written for commit a3d27254c655d3a7030a5714c2f2f133d89966fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the coverage build configuration to selectively include only necessary source files, reducing unnecessary rebuild triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->