### PR TITLE
perf(ci): replace coverage report with a plain Rust test run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      code-quality: write
       pull-requests: read
 
     steps:
@@ -48,10 +47,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
-      # Vitest is the only step that needs the JS toolchain (the coverage step
-      # builds via `nix build`), so install just pnpm/node/just instead of
-      # realizing the full dev shell, which drags in every linter, formatter,
-      # and the pre-commit hook closure and dominated this job's wall time.
+      # Vitest needs the JS toolchain; the Rust tests run via `nix build`. Install
+      # just pnpm/node/just instead of realizing the full dev shell, which drags
+      # in every linter, formatter, and the pre-commit hook closure and dominated
+      # this job's wall time.
       - name: Install JS tooling
         run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#just
       - run: pnpm install --frozen-lockfile
@@ -61,19 +60,8 @@ jobs:
           mkdir -p "$HOME/.config/claude/projects"
       - name: Run Vitest tests
         run: just test-vitest
-      - name: Generate Rust coverage report
-        run: |
-          mkdir -p coverage
-          nix build .#ccusage-coverage --print-build-logs --out-link "$RUNNER_TEMP/coverage-report"
-          cp "$RUNNER_TEMP/coverage-report" coverage/cobertura.xml
-      - name: Upload Rust coverage report
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
-        with:
-          file: coverage/cobertura.xml
-          language: Rust
-          label: code-coverage/cargo-llvm-cov
-          fail-on-error: false
+      - name: Run Rust tests
+        run: nix build .#ccusage-tests --print-build-logs
 
   build-native-packages:
     needs: changes

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
         ./nix/git-hooks.nix
         ./nix/packages.nix
         ./nix/static-package.nix
-        ./nix/coverage.nix
+        ./nix/tests.nix
         ./nix/checks.nix
         ./nix/dev-shell.nix
       ];

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -1,8 +1,8 @@
-# Rust coverage report built as a Nix derivation so it shares the crane
+# Rust workspace test run as a Nix derivation so it shares the crane
 # `cargoArtifacts` cache (warm on the per-job Blacksmith sticky disk) instead of
-# the dev-shell's `cargo llvm-cov`, which recompiled the whole workspace into an
-# uncached `rust/target` on every CI run. Output is the cobertura XML file at
-# `$out`, consumed by the coverage upload step in CI via `nix build`.
+# recompiling into an uncached `rust/target` on every CI run. Built by the CI
+# test job via `nix build .#ccusage-tests`; the derivation succeeds only when
+# `cargo test --workspace` passes.
 { inputs, ... }:
 let
   root = ./..;
@@ -23,26 +23,35 @@ in
       craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
       inherit (config.packages.ccusage.passthru) cargoArtifacts commonArgs;
       nixFilter = inputs.nix-filter.lib;
-      repoSrc = nixFilter {
+      # Scope the source to the Rust tree plus the few out-of-tree files the
+      # build and tests pull in at compile time, so the derivation only rebuilds
+      # when something it actually depends on changes — not on every docs, TS, or
+      # config edit elsewhere in the repo:
+      #   * rust/build.rs           reads ../../../flake.lock
+      #   * config_schema.rs tests  include_str! ../../../../ccusage.example.json
+      #   * ccusage-cli tests       include_str! ../../../../apps/ccusage/package.json
+      testSrc = nixFilter {
         inherit root;
-        exclude = [
-          (nixFilter.matchName "node_modules")
-          (nixFilter.matchName "target")
-          (nixFilter.matchName "dist")
-          (nixFilter.matchName "coverage")
+        include = [
+          "rust"
+          "flake.lock"
+          "ccusage.example.json"
+          "apps/ccusage/package.json"
         ];
       };
     in
     {
-      packages.ccusage-coverage = craneLib.cargoLlvmCov (
+      packages.ccusage-tests = craneLib.cargoTest (
         commonArgs
         // {
-          src = repoSrc;
+          src = testSrc;
           sourceRoot = "source/rust";
           cargoLock = root + /rust/Cargo.lock;
           inherit cargoArtifacts;
+          # commonArgs disables checks for the release build; re-enable here so
+          # cargoTest actually runs the test suite rather than skipping it.
+          doCheck = true;
           cargoExtraArgs = "--workspace";
-          cargoLlvmCovExtraArgs = "--cobertura --output-path $out";
           # jiff resolves named time zones (e.g. Asia/Tokyo) from the system
           # zoneinfo database, which the hermetic build sandbox lacks, so it
           # would fall back to UTC and shift the timezone-dependent tests by a


### PR DESCRIPTION
## Summary

The nixified `cargo llvm-cov` coverage build recompiled the whole workspace with
instrumentation (~230s on the arm runner) and produced a cobertura report that
nothing consumes (no badge, no docs reference). Drop coverage entirely and run
the workspace tests instead via crane's `cargoTest`, which reuses the shared,
non-instrumented `cargoArtifacts` and only compiles the test binaries.

## What changed

- **nix/coverage.nix → nix/tests.nix**: `ccusage-tests` package built with
  `cargoTest` (`doCheck` enabled). Source scoped to the Rust tree plus the few
  out-of-tree files the build/tests `include_str!` (flake.lock,
  ccusage.example.json, apps/ccusage/package.json) so unrelated edits don't bust
  the cache.
- **CI test job**: replace the coverage generate + upload steps with
  `nix build .#ccusage-tests`; drop the now-unused `code-quality` permission and
  the `upload-code-coverage` action.

## Notes

- No coverage badge / docs reference exists, so nothing is orphaned.
- Verified locally: the derivation runs the suite (253 + 10 + 51 + 16 + 2 tests
  pass) rather than skipping it.
- Cache warmth still depends on the sticky disk retaining `cargoArtifacts`; a
  follow-up will add a GC root so the deps persist across runs (the same reason
  the native build currently recompiles deps every run).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783785162&installation_id=139163553&pr_number=1273&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1273&signature=df462ea8205ada25a2b1e11ac7e6c99ac2401b374128d8a6615ffd32170879a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the Rust coverage step with a plain test run in CI to speed up builds and remove an unused Cobertura report. Tests now run via `nix build .#ccusage-tests` using `crane`’s `cargoTest`, reusing `cargoArtifacts`.

- **Refactors**
  - Replace `ccusage-coverage` with `ccusage-tests` in nix/tests.nix, built with `cargoTest` (`doCheck` enabled); workspace tests must pass.
  - CI: drop coverage generation/upload and the `code-quality` permission; run `nix build .#ccusage-tests`.
  - Limit the test source to `rust` plus `flake.lock`, `ccusage.example.json`, and `apps/ccusage/package.json` to avoid cache busts from unrelated edits.

<sup>Written for commit fccf571d96b6773fe3863b1a844b3c2e09bf175f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to run tests via dedicated build steps
  * Removed coverage reporting infrastructure
  * Refactored test build configuration to use optimized test-focused dependencies
  * Reduced repository permissions in CI pipeline for improved security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->