### PR TITLE
perf(ci): pin Rust deps with a GC root so the sticky disk keeps them

### DIFF
--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -26,6 +26,23 @@ runs:
           nix build .#ccusage-static --print-build-logs
         fi
 
+    # Pin the deps-only artifacts with a GC root that lives on the mounted Nix
+    # store (the Blacksmith sticky disk). Without a root the crane cargoArtifacts
+    # path is unreferenced once the binary is built, so the sticky disk drops it
+    # and the next run rebuilds all dependencies (~190s). The root persists with
+    # the disk, keeping the deps warm across runs.
+    - name: Pin dependency cache root
+      shell: bash
+      env:
+        NIX_GITHUB_TOKEN: ${{ inputs.nix-github-token }}
+      run: |
+        mkdir -p /nix/ccusage-ci-gcroots
+        if [ "$NIX_GITHUB_TOKEN" = "false" ]; then
+          NIX_CONFIG="access-tokens =" nix build '.#ccusage-static.cargoArtifacts' --out-link /nix/ccusage-ci-gcroots/deps
+        else
+          nix build '.#ccusage-static.cargoArtifacts' --out-link /nix/ccusage-ci-gcroots/deps
+        fi
+
     - name: Verify Linux binary is static
       shell: bash
       env:

--- a/nix/static-package.nix
+++ b/nix/static-package.nix
@@ -72,6 +72,13 @@ in
           staticCommonArgs
           // {
             cargoArtifacts = staticCargoArtifacts;
+            # Expose the deps-only artifacts so CI can pin them with a GC root and
+            # keep them on the Blacksmith sticky disk across runs; otherwise the
+            # store path is unreferenced once the binary is built and gets pruned,
+            # forcing a full ~190s dependency rebuild on every run.
+            passthru = {
+              cargoArtifacts = staticCargoArtifacts;
+            };
             # A PT_INTERP header means the binary requests a dynamic loader,
             # so it would not run on end-user machines without the build-time
             # loader path. READELF is exported by the cross bintools wrapper.


### PR DESCRIPTION
## Summary

The linux native build rebuilds the entire crate dependency set (~190s) on
**every** run — including on `main` — even though the `ccusage-deps` derivation
hash is identical across runs (verified from the build logs). So the deps are
deterministic but never served from cache.

## Root cause

crane's `cargoArtifacts` (deps-only) store path has no GC root once the final
binary is built. The Blacksmith sticky disk appears to drop unreferenced paths
on commit, so the deps are gone by the next run and get fully recompiled.

## Fix (hypothesis to validate in CI)

- Expose the static build's `cargoArtifacts` via `passthru`.
- After `nix build .#ccusage-static`, pin the deps with a GC root on the mounted
  Nix store (`/nix/ccusage-ci-gcroots/deps`). The root lives on the sticky disk,
  so the deps survive the commit and the next run reuses them.

## How to verify

After this merges, the **second** `build-linux-*` run on `main` should drop from
~190s to ~40s (deps reused, only the final binary recompiles). If it does not,
the sticky disk is dropping paths for a different reason (e.g. not committing the
full store) and we'll need to look at the Blacksmith disk config instead.

Same root cause affects the test job's `cargoTest` (#1273) and macOS; if this
works, I'll roll the GC-root pin out to those too.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Rust dependency artifacts with a Nix GC root so the Linux native build reuses `crane` `cargoArtifacts` across runs instead of rebuilding. Exposes `ccusage-static`’s `cargoArtifacts` via `passthru` and in CI links them to `/nix/ccusage-ci-gcroots/deps` with `nix build '.#ccusage-static.cargoArtifacts'`, targeting ~190s → ~40s on the second run.

<sup>Written for commit c766768089595305aff80fae7593f0b1d78505c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783785360&installation_id=139163553&pr_number=1274&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1274&signature=c33e9d8ad4072cd22e1cf281c3cccf8128b1e884467a8a2c85f905b4d150bf81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* **Build Pipeline**: Optimized dependency caching mechanisms in Linux native package builds to enhance build performance and reliability across continuous integration runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->