### PR TITLE
Revert "perf(ci): pin Rust deps with a GC root"

### DIFF
--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -26,23 +26,6 @@ runs:
           nix build .#ccusage-static --print-build-logs
         fi
 
-    # Pin the deps-only artifacts with a GC root that lives on the mounted Nix
-    # store (the Blacksmith sticky disk). Without a root the crane cargoArtifacts
-    # path is unreferenced once the binary is built, so the sticky disk drops it
-    # and the next run rebuilds all dependencies (~190s). The root persists with
-    # the disk, keeping the deps warm across runs.
-    - name: Pin dependency cache root
-      shell: bash
-      env:
-        NIX_GITHUB_TOKEN: ${{ inputs.nix-github-token }}
-      run: |
-        mkdir -p /nix/ccusage-ci-gcroots
-        if [ "$NIX_GITHUB_TOKEN" = "false" ]; then
-          NIX_CONFIG="access-tokens =" nix build '.#ccusage-static.cargoArtifacts' --out-link /nix/ccusage-ci-gcroots/deps
-        else
-          nix build '.#ccusage-static.cargoArtifacts' --out-link /nix/ccusage-ci-gcroots/deps
-        fi
-
     - name: Verify Linux binary is static
       shell: bash
       env:

--- a/nix/static-package.nix
+++ b/nix/static-package.nix
@@ -72,13 +72,6 @@ in
           staticCommonArgs
           // {
             cargoArtifacts = staticCargoArtifacts;
-            # Expose the deps-only artifacts so CI can pin them with a GC root and
-            # keep them on the Blacksmith sticky disk across runs; otherwise the
-            # store path is unreferenced once the binary is built and gets pruned,
-            # forcing a full ~190s dependency rebuild on every run.
-            passthru = {
-              cargoArtifacts = staticCargoArtifacts;
-            };
             # A PT_INTERP header means the binary requests a dynamic loader,
             # so it would not run on end-user machines without the build-time
             # loader path. READELF is exported by the cross bintools wrapper.


### PR DESCRIPTION
Reverts #1274.

The GC-root pin did not fix the dependency rebuild: a rerun of `build-linux-arm64`
still rebuilt all deps (~234s) with the root in place. The sticky disk persists
~24GB for this job (confirmed in the Blacksmith dashboard), so the store is being
retained but the `cargoArtifacts` path is still missing on restore — the root
didn't prevent it. Reverting the no-op change while we inspect the disk directly
via a Blacksmith testbox.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783787605&installation_id=139163553&pr_number=1275&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1275&signature=102f856a999000fea17b8a5c79eda7c09bb68c145298c22e34689988fcb804fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the CI GC-root pin for Rust dependency artifacts and removes the `cargoArtifacts` passthru in Nix, since the change didn’t reduce rebuilds. This returns the Linux build to previous behavior while we debug the sticky disk separately.

- **Refactors**
  - Removed “Pin dependency cache root” step from `.github/actions/build-linux-native-package/action.yaml`.
  - Dropped `passthru.cargoArtifacts` from `nix/static-package.nix`.

<sup>Written for commit fa9b08b7ef9a87fa3a6cb35a6abcec2b1d4646a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the Linux native package build workflow by removing internal dependency cache pinning logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->