### PR TITLE
chore: inspect sticky disk (do not merge)

### DIFF
--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -15,6 +15,33 @@ runs:
   steps:
     - uses: ./.github/actions/setup-nix
 
+    - name: DEBUG inspect restored sticky disk
+      shell: bash
+      run: |
+        echo "::group::deps presence"
+        OUT="$(nix eval --raw '.#ccusage-static.cargoArtifacts.outPath' 2>/dev/null || true)"
+        echo "deps outPath: $OUT"
+        if [ -n "$OUT" ]; then
+          if nix-store --query --valid-paths "$OUT" >/dev/null 2>&1; then
+            echo "RESULT: DEPS PRESENT on restored disk"
+          else
+            echo "RESULT: DEPS MISSING on restored disk"
+          fi
+        fi
+        echo "::endgroup::"
+        echo "::group::gc roots"
+        nix-store --gc --print-roots 2>/dev/null | grep -Ev '/proc/|/run/' | head -50 || true
+        echo "::endgroup::"
+        echo "::group::store stats"
+        du -sh /nix/store 2>/dev/null || true
+        ls -la /nix 2>/dev/null || true
+        echo "::endgroup::"
+        echo "::group::what gc would delete"
+        nix-collect-garbage --dry-run 2>&1 | tail -8 || true
+        echo "::endgroup::"
+        # Stop before the expensive build; this run only inspects the disk.
+        exit 1
+
     - name: Build Linux static binary
       shell: bash
       env:


### PR DESCRIPTION
Throwaway: dumps whether the deps output path is present on the restored build-native sticky disk, plus gc roots / store stats, then exits before the build. For diagnosing the deps cache miss.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a debug step in `build-linux-native-package` to inspect the restored sticky disk and diagnose the deps cache miss. It checks the presence of `ccusage-static.cargoArtifacts.outPath` in the Nix store, prints GC roots and store stats, shows what GC would delete, and exits early to skip the build.

<sup>Written for commit 4210df0814576f87bc7c93f7e10931680827318d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

