### PR TITLE
ci: action cache for build-native (do not merge)

### DIFF
--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: ./.github/actions/setup-nix
+    - uses: ./.github/actions/setup-linux-nix-action-cache
 
     - name: Build Linux static binary
       shell: bash

--- a/.github/actions/setup-linux-nix-action-cache/action.yaml
+++ b/.github/actions/setup-linux-nix-action-cache/action.yaml
@@ -1,0 +1,22 @@
+name: Setup Linux Nix (action cache experiment)
+description: Install Nix and restore/save the store via cache-nix-action instead of the Blacksmith sticky disk
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+      with:
+        github_access_token: ${{ github.token }}
+        nix_conf: |
+          access-tokens = github.com=${{ github.token }}
+
+    - name: Cache Linux Nix store
+      uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      with:
+        primary-key: nix-actioncache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'package.nix', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock') }}
+        restore-prefixes-first-match: nix-actioncache-${{ runner.os }}-${{ runner.arch }}-
+        gc-max-store-size-linux: 8000000000
+        purge: true
+        purge-prefixes: nix-actioncache-${{ runner.os }}-${{ runner.arch }}-
+        purge-created: 172800
+        purge-primary-key: never

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -20,6 +20,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            exp
           ignoreLabels: |
             autorelease: pending
             dependencies


### PR DESCRIPTION
Experiment: swap the Linux native build from the Blacksmith sticky disk to cache-nix-action (store bounded to 8GB), to compare deps-cache reliability/speed against the sticky disk. Throwaway.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Linux native builds from the Blacksmith sticky disk to a Nix store cached via `nix-community/cache-nix-action` (8GB cap) to compare reliability and speed.

- **Refactors**
  - Added `./.github/actions/setup-linux-nix-action-cache` to install Nix via `nixbuild/nix-quick-install-action` and cache the store; updated `./.github/actions/build-linux-native-package` to use it.
  - Cache key scoped by OS/arch and Nix/Rust lockfile hashes; purges stale caches after 2 days.
  - PR title validation now allows the `exp` type.

<sup>Written for commit 6af31c59eeb0d67f2639c0058e4a7c499a1821f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

