### PR TITLE
chore: pin deps in nix profile (do not merge)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,15 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup-nix
       - run: nix flake check --print-build-logs
+      # EXPERIMENT: pin the crane deps in a nix profile so they survive the
+      # sticky disk's GC-root-respecting trim (profiles were the only roots that
+      # persisted in testing); unrooted intermediate deps were dropped and
+      # rebuilt every run.
+      - name: Pin Rust deps cache (experiment)
+        run: |
+          nix build .#ccusage.cargoArtifacts --no-link --print-build-logs
+          nix-env --profile /nix/var/nix/profiles/ccusage-deps --set "$(nix eval --raw .#ccusage.cargoArtifacts.outPath)"
+          ls -la /nix/var/nix/profiles/ | grep ccusage || true
       - run: nix develop --command just typecheck
 
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           nix build .#ccusage.cargoArtifacts --no-link --print-build-logs
           nix-env --profile /nix/var/nix/profiles/ccusage-deps --set "$(nix eval --raw .#ccusage.cargoArtifacts.outPath)"
-          ls -la /nix/var/nix/profiles/ | grep ccusage || true
+          readlink -f /nix/var/nix/profiles/ccusage-deps || true
       - run: nix develop --command just typecheck
 
   test:


### PR DESCRIPTION
Experiment: after nix flake check, pin .#ccusage.cargoArtifacts into /nix/var/nix/profiles/ccusage-deps so it survives the sticky disk trim. If the next check run reuses deps (flake-check drops from ~184s), profile-rooting is the fix; roll out to build + test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an experimental CI step to build `.#ccusage.cargoArtifacts` and pin its outPath to `/nix/var/nix/profiles/ccusage-deps` so Rust deps survive sticky-disk trims and speed up later `nix flake check` runs. Fixes actionlint (SC2010), prints the resolved profile path, and triggers a warm run to verify reuse.

<sup>Written for commit 39ec7d3142710b6512dd80d0be51fd1f0f48efec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

