### PR TITLE
perf(ci): pin crane deps in a Nix profile to persist across runs

### DIFF
--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -26,7 +26,12 @@ runs:
           nix build .#ccusage-static --print-build-logs
         fi
 
+    # Mirror the PR-token hardening from the build step above: on
+    # `pull_request` runs (nix-github-token == 'false') the pin's `nix build`
+    # and `nix eval` calls must also disable access tokens.
     - uses: ./.github/actions/pin-nix-deps
+      env:
+        NIX_CONFIG: ${{ inputs.nix-github-token == 'false' && 'access-tokens =' || '' }}
       with:
         attr: .#ccusage-static.cargoArtifacts
 

--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -26,6 +26,10 @@ runs:
           nix build .#ccusage-static --print-build-logs
         fi
 
+    - uses: ./.github/actions/pin-nix-deps
+      with:
+        attr: .#ccusage-static.cargoArtifacts
+
     - name: Verify Linux binary is static
       shell: bash
       env:

--- a/.github/actions/pin-nix-deps/action.yaml
+++ b/.github/actions/pin-nix-deps/action.yaml
@@ -1,0 +1,22 @@
+name: Pin Nix deps cache
+description: >
+  Pin a crane cargoArtifacts derivation into a Nix profile so it survives the
+  Blacksmith sticky disk's GC-root-respecting trim. The deps are an unrooted
+  intermediate, so without a profile root they are dropped on commit and
+  recompiled (~3min) on every run; a profile is the one root that persists.
+inputs:
+  attr:
+    description: Flake attribute of the cargoArtifacts derivation to pin
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Pin Rust deps in a Nix profile
+      shell: bash
+      env:
+        DEPS_ATTR: ${{ inputs.attr }}
+      run: |
+        # The deps were already realized by the preceding build/check, so this
+        # only ensures the path and roots it; it does not recompile.
+        nix build "$DEPS_ATTR" --no-link --print-build-logs
+        nix-env --profile /nix/var/nix/profiles/ccusage-deps --set "$(nix eval --raw "$DEPS_ATTR.outPath")"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup-nix
       - run: nix flake check --print-build-logs
+      - uses: ./.github/actions/pin-nix-deps
+        with:
+          attr: .#ccusage.cargoArtifacts
       - run: nix develop --command just typecheck
 
   test:
@@ -62,6 +65,9 @@ jobs:
         run: just test-vitest
       - name: Run Rust tests
         run: nix build .#ccusage-tests --print-build-logs
+      - uses: ./.github/actions/pin-nix-deps
+        with:
+          attr: .#ccusage.cargoArtifacts
 
   build-native-packages:
     needs: changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup-nix
       - run: nix flake check --print-build-logs
-      - uses: ./.github/actions/pin-nix-deps
+      # Pin even on failure so deps built during a failing run stay rooted and
+      # warm the next run; skip on cancel (nothing useful to pin).
+      - if: ${{ !cancelled() }}
+        uses: ./.github/actions/pin-nix-deps
         with:
           attr: .#ccusage.cargoArtifacts
       - run: nix develop --command just typecheck
@@ -65,7 +68,10 @@ jobs:
         run: just test-vitest
       - name: Run Rust tests
         run: nix build .#ccusage-tests --print-build-logs
-      - uses: ./.github/actions/pin-nix-deps
+      # Pin even on failure so deps built during a failing run stay rooted and
+      # warm the next run; skip on cancel (nothing useful to pin).
+      - if: ${{ !cancelled() }}
+        uses: ./.github/actions/pin-nix-deps
         with:
           attr: .#ccusage.cargoArtifacts
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true'
     name: ${{ matrix.name }}
+    # Each native build shares one per-job, per-arch Blacksmith sticky disk
+    # across every run. Overlapping runs clone the same snapshot and re-commit
+    # wholesale, so a later run overwrites the deps another run just pinned and
+    # both rebuild from scratch. Serialise runs of the same matrix entry (queue,
+    # don't cancel) so the pinned deps survive and stay warm. The key is per
+    # matrix.name because each entry already has its own disk.
+    concurrency:
+      group: build-native-${{ matrix.name }}
+      cancel-in-progress: false
     permissions:
       actions: write
       contents: read

--- a/nix/static-package.nix
+++ b/nix/static-package.nix
@@ -72,6 +72,13 @@ in
           staticCommonArgs
           // {
             cargoArtifacts = staticCargoArtifacts;
+            # Exposed so CI can pin the deps-only artifacts with a Nix profile
+            # root and keep them on the sticky disk across runs; otherwise the
+            # store path is unreferenced once the binary is built and the disk's
+            # GC-root-respecting trim drops it, forcing a full dependency rebuild.
+            passthru = {
+              cargoArtifacts = staticCargoArtifacts;
+            };
             # A PT_INTERP header means the binary requests a dynamic loader,
             # so it would not run on end-user machines without the build-time
             # loader path. READELF is exported by the cross bintools wrapper.


### PR DESCRIPTION
## Summary

`check`, `test`, and the native build jobs recompiled the **entire crate
dependency set** (~3 min on the arm runner) on nearly every run, even though the
deps derivation is deterministic.

## Root cause (confirmed by inspection + A/B)

The Blacksmith sticky disk persists the Nix store but **trims it to GC roots on
commit**. crane's `cargoArtifacts` (deps-only) is an unrooted intermediate —
referenced only at build time — so it was dropped on every commit and rebuilt.

I confirmed this by attaching the build-native sticky disk and finding the deps
output path **missing** on restore while ~7GB of other paths persisted, and the
only surviving GC root was a Nix profile. An A/B on the `check` job then showed
`nix flake check` drop from **~184s → ~38s** with **zero** dependency
recompilation once the deps were pinned in a profile.

(Notes from the investigation: the GHA action-cache approach used on macOS does
*not* help here — even on a cache hit the deps rebuilt, because `gc-max-store-size`
trims unrooted paths before saving, the same failure mode. A binary cache would
also fix it but needs extra infra; this keeps the fast Blacksmith disk.)

## Change

- New `pin-nix-deps` composite action: `nix-env --set` the cargoArtifacts path
  into `/nix/var/nix/profiles/ccusage-deps` (profiles survive the trim).
- `check` + `test` pin the glibc deps (`.#ccusage.cargoArtifacts`).
- The Linux native build pins the musl deps (`.#ccusage-static.cargoArtifacts`);
  re-exposed via `passthru`.

Each job has its own sticky disk, so each pins its own deps.

## Expected effect

Warm runs: `check` ~184s→~38s, Linux native build deps reused (no ~190s rebuild),
`test` Rust deps reused. First run after merge pins; the run after that benefits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now pins and persists Rust/Nix dependency artifacts produced by static builds so cached artifacts are reused across runs.
  * Added a reusable action to record dependency outputs into a persistent Nix profile and invoked it in check and test jobs.
  * Exposed dependency-artifact outputs for CI to reference.
  * Hardened token handling for the pinning step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Rust dependency artifacts from `crane` into a Nix profile in CI so the Blacksmith sticky disk keeps them across runs, removing repeated recompiles and speeding `check`, `test`, and native builds. Native builds are now serialized to protect the pinned cache across overlapping runs; warm `nix flake check` runs dropped from ~184s to ~38s and the native musl build avoids ~190s of dep rebuilds.

- **Performance**
  - Added `./.github/actions/pin-nix-deps` to root `cargoArtifacts` in `/nix/var/nix/profiles/ccusage-deps` via `nix-env --set`; first run pins, later runs reuse.
  - Pin `.#ccusage.cargoArtifacts` in `check` and `test` (runs on failure; skips on cancel).
  - Pin `.#ccusage-static.cargoArtifacts` in the Linux native build; exposed via `passthru` on `.#ccusage-static` and hardened on PRs with `NIX_CONFIG="access-tokens ="` when `nix-github-token` is `false`.
  - Serialized `build-native-packages` per matrix entry with `concurrency` so overlapping runs don’t overwrite each other’s pinned deps.

<sup>Written for commit cd795c821f56a2007f96a1c8e02e2ad42081c853. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->