### PR TITLE
fix(ci): restore pull_request_target trigger for PR gate

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -1,7 +1,13 @@
 name: PR Gate
 
+# Must be pull_request_target, NOT pull_request: only the target variant runs
+# with the base repo's write permissions for forked/outside-contributor PRs.
+# With plain `pull_request`, outside-contributor runs are gated as
+# `action_required` and never execute, so the auto-close gate silently no-ops.
+# This workflow never checks out PR code (it only calls the GitHub API via
+# github-script), so the usual pull_request_target injection risk does not apply.
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
## What

Restore the PR Gate workflow trigger from `pull_request` back to `pull_request_target`.

## Why

The Blacksmith migration (#1249) intentionally moved the gate away from `pull_request_target` to avoid a privileged target workflow. That had an unintended side effect: for PRs opened by **outside contributors**, plain `pull_request` workflows are held as `action_required` and never run without a maintainer manually approving them. As a result the auto-close gate silently stopped firing — e.g. #1281 was opened by a non-approved contributor but stayed open instead of being auto-closed.

```diff
-  pull_request_target:
+  pull_request:
```

`pull_request_target` runs with the base repository write permissions, so the gate can close unapproved PRs automatically again.

## Safety

This is the canonical safe use of `pull_request_target`:

- It **never checks out PR code** — there is no `actions/checkout`, and it only calls the GitHub API via `github-script`.
- It reads `APPROVED_CONTRIBUTORS` from the **default branch**, not the PR head, so the PR cannot tamper with the allowlist.
- Untrusted payload values (e.g. the PR author login) are passed as API parameters via the `context` object, not interpolated into shell/script strings, so there is no script-injection vector.
- Token permissions are scoped to `contents: read`, `issues: write`, `pull-requests: write`.

The classic `pull_request_target` token-theft / "pwn request" attacks require executing attacker-controlled PR code in the privileged context, which this workflow does not do. An inline comment was added documenting this requirement so a future edit that adds `actions/checkout` does not silently reintroduce the risk.

Closes the gap that left #1281 open.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the PR Gate workflow to `pull_request_target` so it runs on forked/outside-contributor PRs and auto-closes unapproved PRs. Fixes the regression where `pull_request` jobs stayed `action_required` and never ran.

- **Bug Fixes**
  - Switched trigger back to `pull_request_target` and documented safe use (no checkout; uses `github-script`; reads allowlist from default branch; scoped permissions).

<sup>Written for commit 67ae53ef18c3b612083ae1b968266b011ec60991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow configuration for pull request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->