### PR TITLE
ci: add manual gate-close workflow for missed PRs

### DIFF
--- a/.github/workflows/gate-close-pr.yaml
+++ b/.github/workflows/gate-close-pr.yaml
@@ -1,0 +1,53 @@
+name: Gate Close PR
+
+# Manually close a PR that the PR Gate did not auto-close (for example a PR
+# opened while the gate was misconfigured). Runs from a workflow_dispatch so the
+# comment and close are attributed to github-actions[bot], matching the gate.
+# It posts the same message as .github/workflows/pr-gate.yaml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to close
+        required: true
+        type: number
+
+jobs:
+  close:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Close PR with the contribution-gate message
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const prNumber = Number(context.payload.inputs.pr_number);
+            const defaultBranch = context.payload.repository.default_branch;
+
+            const message = [
+              'This PR was auto-closed. Only contributors approved with `lgtm` can open PRs. Open an issue first.',
+              '',
+              `Maintainers review auto-closed issues and reopen worthwhile ones. Issues that do not meet the quality bar in [CONTRIBUTING.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/CONTRIBUTING.md) may not be reopened or receive a reply.`,
+              '',
+              'If a maintainer replies `lgtmi`, your future issues will stay open. If a maintainer replies `lgtm`, your future issues and PRs will stay open.',
+              '',
+              `See [CONTRIBUTING.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/CONTRIBUTING.md).`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: message,
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              state: 'closed',
+            });


### PR DESCRIPTION
## What

Add a `workflow_dispatch` workflow that closes a given PR number with the same message the PR Gate posts, attributed to `github-actions[bot]`.

## Why

The PR Gate only fires on `pull_request_target` `opened`. PRs opened while the gate was misconfigured (e.g. #1281) cannot be retroactively auto-closed, and closing them from a local `gh` would be attributed to a maintainer rather than the bot. This workflow lets a maintainer dispatch a bot-attributed close for any PR the gate missed.

## Safety

Same posture as the PR Gate: no `actions/checkout`, only GitHub API calls via `github-script`, scoped token permissions (`issues: write`, `pull-requests: write`). The PR number comes from a trusted `workflow_dispatch` input.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual workflow to close PRs the gate missed, attributed to `github-actions[bot]`. Lets maintainers retro-close PRs opened while the gate was misconfigured.

- **New Features**
  - Adds `.github/workflows/gate-close-pr.yaml`; runs on `workflow_dispatch` with input `pr_number`.
  - Posts the same contribution-gate message as the PR Gate, then closes the PR via API.
  - Uses `actions/github-script@v9`; no checkout; scoped permissions (`issues: write`, `pull-requests: write`).

<sup>Written for commit 5bbe8b5e15421155e4725edd973949c5d518dc88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new GitHub Actions workflow for automated pull request management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->