### PR TITLE
fix(ci): correct UK spelling that broke the treefmt check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
     # Each native build shares one per-job, per-arch Blacksmith sticky disk
     # across every run. Overlapping runs clone the same snapshot and re-commit
     # wholesale, so a later run overwrites the deps another run just pinned and
-    # both rebuild from scratch. Serialise runs of the same matrix entry (queue,
+    # both rebuild from scratch. Serialize runs of the same matrix entry (queue,
     # don't cancel) so the pinned deps survive and stay warm. The key is per
     # matrix.name because each entry already has its own disk.
     concurrency:


### PR DESCRIPTION
The concurrency comment added in #1279 used "Serialise" (UK spelling), which
the repo's typos/treefmt check rewrites to "Serialize". It was pushed with
`--no-verify`, bypassing the pre-push hook, so `nix flake check` (treefmt
--fail-on-change) now fails on main. One-character fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a UK spelling in `.github/workflows/ci.yaml` that triggered `treefmt` changes and broke CI. Replaces "Serialise" with "Serialize" so `nix flake check` passes again.

<sup>Written for commit 41c2f2888073ad3ea582fe903b44c0d04bbde9d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated comment formatting in CI workflow for consistency with American English conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->