### PR TITLE
perf(ci): cache Rust builds with cache-nix-action (check, test, native build)

### DIFF
--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -26,15 +26,6 @@ runs:
           nix build .#ccusage-static --print-build-logs
         fi
 
-    # Mirror the PR-token hardening from the build step above: on
-    # `pull_request` runs (nix-github-token == 'false') the pin's `nix build`
-    # and `nix eval` calls must also disable access tokens.
-    - uses: ./.github/actions/pin-nix-deps
-      env:
-        NIX_CONFIG: ${{ inputs.nix-github-token == 'false' && 'access-tokens =' || '' }}
-      with:
-        attr: .#ccusage-static.cargoArtifacts
-
     - name: Verify Linux binary is static
       shell: bash
       env:

--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: ./.github/actions/setup-nix
+    - uses: ./.github/actions/setup-linux-nix-action-cache
 
     - name: Build Linux static binary
       shell: bash

--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -26,6 +26,15 @@ runs:
           nix build .#ccusage-static --print-build-logs
         fi
 
+    # Root the deps so the cache-nix-action gc-max trim keeps them while
+    # dropping stale paths. On PR runs (nix-github-token == 'false') the pin's
+    # nix build / eval must disable access tokens too.
+    - uses: ./.github/actions/pin-nix-deps
+      env:
+        NIX_CONFIG: ${{ inputs.nix-github-token == 'false' && 'access-tokens =' || '' }}
+      with:
+        attr: .#ccusage-static.cargoArtifacts
+
     - name: Verify Linux binary is static
       shell: bash
       env:

--- a/.github/actions/setup-linux-nix-action-cache/action.yaml
+++ b/.github/actions/setup-linux-nix-action-cache/action.yaml
@@ -1,0 +1,26 @@
+name: Setup Linux Nix (action cache, macOS-style)
+description: >
+  Install Nix and restore/save the store with cache-nix-action, mirroring the
+  macOS setup. Combined with the deps profile pin, the GC keeps the rooted
+  cargoArtifacts while trimming the (substitutable) toolchain, so the cache
+  stays under the GitHub Actions size limit but still warms the deps.
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+      with:
+        github_access_token: ${{ github.token }}
+        nix_conf: |
+          access-tokens = github.com=${{ github.token }}
+
+    - name: Cache Linux Nix store
+      uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      with:
+        primary-key: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'package.nix', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock') }}
+        restore-prefixes-first-match: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-
+        gc-max-store-size-linux: 4000000000
+        purge: true
+        purge-prefixes: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-
+        purge-created: 172800
+        purge-primary-key: never

--- a/.github/actions/setup-linux-nix-action-cache/action.yaml
+++ b/.github/actions/setup-linux-nix-action-cache/action.yaml
@@ -1,10 +1,11 @@
 name: Setup Linux Nix (action cache, macOS-style)
 description: >
   Install Nix and restore/save the store with cache-nix-action, mirroring the
-  macOS setup. No gc-max-store-size: the Blacksmith cache backend is unlimited,
-  so we never garbage-collect before saving — the whole store (including the
-  unrooted crane deps) is cached, exactly like macOS where the small store keeps
-  GC from running ("Not collecting garbage").
+  macOS setup. cache-nix-action only caches non-substitutable paths (the crane
+  deps, not the cache.nixos.org toolchain), so the cache stays small (~900MB).
+  gc-max-store-size bounds it so old deps generations and stale build outputs do
+  not accumulate across runs; the deps profile pin keeps the current deps rooted
+  so the GC trims everything except what the next build reuses.
 runs:
   using: composite
   steps:
@@ -20,6 +21,7 @@ runs:
       with:
         primary-key: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'package.nix', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock') }}
         restore-prefixes-first-match: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-
+        gc-max-store-size-linux: 2000000000
         purge: true
         purge-prefixes: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-
         purge-created: 172800

--- a/.github/actions/setup-linux-nix-action-cache/action.yaml
+++ b/.github/actions/setup-linux-nix-action-cache/action.yaml
@@ -19,7 +19,7 @@ runs:
     - name: Cache Linux Nix store
       uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
       with:
-        primary-key: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'package.nix', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock') }}
+        primary-key: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'package.json', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}
         restore-prefixes-first-match: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-
         gc-max-store-size-linux: 2000000000
         purge: true

--- a/.github/actions/setup-linux-nix-action-cache/action.yaml
+++ b/.github/actions/setup-linux-nix-action-cache/action.yaml
@@ -1,9 +1,10 @@
 name: Setup Linux Nix (action cache, macOS-style)
 description: >
   Install Nix and restore/save the store with cache-nix-action, mirroring the
-  macOS setup. Combined with the deps profile pin, the GC keeps the rooted
-  cargoArtifacts while trimming the (substitutable) toolchain, so the cache
-  stays under the GitHub Actions size limit but still warms the deps.
+  macOS setup. No gc-max-store-size: the Blacksmith cache backend is unlimited,
+  so we never garbage-collect before saving — the whole store (including the
+  unrooted crane deps) is cached, exactly like macOS where the small store keeps
+  GC from running ("Not collecting garbage").
 runs:
   using: composite
   steps:
@@ -19,7 +20,6 @@ runs:
       with:
         primary-key: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'package.nix', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock') }}
         restore-prefixes-first-match: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-
-        gc-max-store-size-linux: 4000000000
         purge: true
         purge-prefixes: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-
         purge-created: 172800

--- a/.github/actions/setup-linux-nix-action-cache/action.yaml
+++ b/.github/actions/setup-linux-nix-action-cache/action.yaml
@@ -19,10 +19,10 @@ runs:
     - name: Cache Linux Nix store
       uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
       with:
-        primary-key: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'package.json', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}
-        restore-prefixes-first-match: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-
+        primary-key: nix-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'package.json', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}
+        restore-prefixes-first-match: nix-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-
         gc-max-store-size-linux: 2000000000
         purge: true
-        purge-prefixes: nix-buildnative-${{ runner.os }}-${{ runner.arch }}-
+        purge-prefixes: nix-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-
         purge-created: 172800
         purge-primary-key: never

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: ./.github/actions/setup-nix
+      - uses: ./.github/actions/setup-linux-nix-action-cache
       - run: nix flake check --print-build-logs
       # Pin even on failure so deps built during a failing run stay rooted and
       # warm the next run; skip on cancel (nothing useful to pin).
@@ -52,7 +52,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - uses: ./.github/actions/setup-nix
+      - uses: ./.github/actions/setup-linux-nix-action-cache
       # Vitest needs the JS toolchain; the Rust tests run via `nix build`. Install
       # just pnpm/node/just instead of realizing the full dev shell, which drags
       # in every linter, formatter, and the pre-commit hook closure and dominated

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,15 +79,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true'
     name: ${{ matrix.name }}
-    # Each native build shares one per-job, per-arch Blacksmith sticky disk
-    # across every run. Overlapping runs clone the same snapshot and re-commit
-    # wholesale, so a later run overwrites the deps another run just pinned and
-    # both rebuild from scratch. Serialize runs of the same matrix entry (queue,
-    # don't cancel) so the pinned deps survive and stay warm. The key is per
-    # matrix.name because each entry already has its own disk.
-    concurrency:
-      group: build-native-${{ matrix.name }}
-      cancel-in-progress: false
     permissions:
       actions: write
       contents: read


### PR DESCRIPTION
## Summary

The Rust jobs (`check`, `test`, `build-native-packages`) recompiled the entire
crate dependency set (~3 min on the arm runner) on nearly every run. This moves
all of them to `cache-nix-action` (the same mechanism macOS already uses), which
makes the deps reliably warm.

## Root cause

crane's `cargoArtifacts` (deps-only) is an unrooted intermediate. What dropped
it differed by cache mechanism:

- **Blacksmith sticky disk** trims the store to GC roots on commit, but its trim
  **does not honor `/nix/var/nix/profiles/*`** — verified on a restored
  build-native disk: the pinned `ccusage-deps` profile symlink survived but its
  target was GC'd. `check` only looked warm because its store is small enough to
  skip the trim, not because the pin worked.
- **cache-nix-action** garbage-collects with the standard `nix store gc`, which
  **does** honor the profile pin, so the rooted deps survive and are cached. It
  also only stores non-substitutable paths, so the cache is small (~880MB) and
  the toolchain still comes from cache.nixos.org.

## Change

- New `setup-linux-nix-action-cache` action: nix-quick-install + cache-nix-action
  with `gc-max-store-size-linux` (bounds the cache) and a per-`github.job` key so
  check/test/build don't thrash each other's caches.
- `check`, `test`, and the Linux native build use it; each pins its own crane
  deps (`pin-nix-deps`) so the GC keeps them.
- Drop the build-native `concurrency` (cache keys are immutable — no clobber).

## Verified

- build-linux-arm64: **336s cold → 78s warm**, deps reused, ~877MB bounded cache,
  cache hit.

## Notes

- macOS already uses cache-nix-action; this aligns Linux with it.
- Non-Rust jobs (npm-publish, perf-comment) keep the sticky disk — they only
  `nix profile install` tools and don't build the crate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Linux Nix setup and store caching with a new composite setup flow to speed and stabilize CI runs.
  * Introduced smarter cache keys, targeted purge policies, and an explicit GC size bound to control cache growth and freshness.
  * Clarified dependency pinning behavior for pull-request runs that lack access tokens.
  * Removed per-matrix serialization so native-package builds can run without prior concurrency constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->