### PR TITLE
ci: pin survival on build-native disk (do not merge)

### DIFF
--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -36,7 +36,6 @@ runs:
         echo "::group::surviving gc roots"
         nix-store --gc --print-roots 2>/dev/null | grep -Ev '/proc/|/run/' | head -40 || true
         echo "::endgroup::"
-        exit 1
 
     - name: Build Linux static binary
       shell: bash

--- a/.github/actions/build-linux-native-package/action.yaml
+++ b/.github/actions/build-linux-native-package/action.yaml
@@ -15,6 +15,29 @@ runs:
   steps:
     - uses: ./.github/actions/setup-nix
 
+    - name: DEBUG did the pin survive on the build-native disk
+      shell: bash
+      run: |
+        echo "::group::profiles on restored disk"
+        ls -la /nix/var/nix/profiles/ 2>&1 || true
+        echo "ccusage-deps profile -> $(readlink -f /nix/var/nix/profiles/ccusage-deps 2>&1 || echo NONE)"
+        echo "::endgroup::"
+        echo "::group::musl deps presence"
+        OUT="$(NIX_CONFIG='access-tokens =' nix eval --raw '.#ccusage-static.cargoArtifacts.outPath' 2>/dev/null || true)"
+        echo "musl deps outPath: $OUT"
+        if [ -n "$OUT" ]; then
+          if nix-store --query --valid-paths "$OUT" >/dev/null 2>&1; then
+            echo "RESULT: musl deps PRESENT on restored disk (pin worked)"
+          else
+            echo "RESULT: musl deps MISSING on restored disk (pin did NOT survive)"
+          fi
+        fi
+        echo "::endgroup::"
+        echo "::group::surviving gc roots"
+        nix-store --gc --print-roots 2>/dev/null | grep -Ev '/proc/|/run/' | head -40 || true
+        echo "::endgroup::"
+        exit 1
+
     - name: Build Linux static binary
       shell: bash
       env:


### PR DESCRIPTION
Throwaway: after setup-nix (disk restored, before build) on the build-native job, check whether the pinned ccusage-deps profile and the musl deps path survived the sticky-disk trim. Determines if the profile pin actually works for the large build-native store or only worked for check by luck (small store, no trim).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a debug step to the `build-linux-native-package` action to verify the pinned `ccusage-deps` profile and musl deps survive the build-native disk restore/trim, without failing CI (no exit 1).
It lists `/nix/var/nix/profiles`, resolves the pin, checks `.#ccusage-static.cargoArtifacts.outPath` via `nix eval`/`nix-store`, and prints surviving GC roots.

<sup>Written for commit 17f937528f5204aee5437b953c170d75a27947ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

