### PR TITLE
ci: run the preview E2E on main pushes too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,7 +168,10 @@ jobs:
         run: pnpm pkg-pr-new publish --pnpm --bin './apps/ccusage' './packages/ccusage-linux-arm64' './packages/ccusage-linux-x64' './packages/ccusage-darwin-arm64' './packages/ccusage-darwin-x64' './packages/ccusage-win32-x64'
 
   ccusage-preview-e2e:
-    if: github.event_name == 'pull_request' && needs.changes.outputs.code-changed == 'true'
+    # Run on PRs and on pushes to the default branch. `push` only fires on main
+    # (see on.push.branches), so this validates the published preview package
+    # post-merge too, not just on PRs.
+    if: needs.changes.outputs.code-changed == 'true'
     needs:
       - changes
       - npm-publish-dry-run-and-upload-pkg-pr-now


### PR DESCRIPTION
## Summary

The `ccusage-preview-e2e` job only ran on `pull_request`. Run it on pushes to
`main` as well so the published preview package (including the cross-built
binaries) is validated post-merge, not just on PRs.

`push` only fires on `main` (see `on.push.branches`), so dropping the
`github.event_name == 'pull_request'` guard runs the E2E on PRs and main pushes
exactly. `npm-publish-dry-run-and-upload-pkg-pr-now` (the dependency) already
runs on both events, and the E2E steps don't reference any pull_request-only
context.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `ccusage-preview-e2e` on pull requests and on pushes to `main` so the published preview package (including cross-built binaries) is validated post-merge too. Removes the `github.event_name == 'pull_request'` guard; `push` only fires on `main`, aligning behavior across PRs and main pushes.

<sup>Written for commit 8b61bef5111eabdb34b08c01451285128d468a01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to execute preview environment tests on all code changes, including direct commits to the default branch, expanding testing coverage beyond pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->