### PR TITLE
ci(cache): scope macOS Nix cache key by target arch

### DIFF
--- a/.github/actions/build-macos-nix-native-package/action.yaml
+++ b/.github/actions/build-macos-nix-native-package/action.yaml
@@ -11,6 +11,10 @@ runs:
   using: composite
   steps:
     - uses: ./.github/actions/setup-nix
+      with:
+        # arm64 and x64 both run on the same arm64 runner, so scope the macOS
+        # Nix cache by target arch to stop the two builds clobbering one store.
+        cache-key-suffix: ${{ inputs.arch }}
 
     - name: Build macOS binary
       shell: bash

--- a/.github/actions/setup-macos-nix-cache/action.yaml
+++ b/.github/actions/setup-macos-nix-cache/action.yaml
@@ -1,15 +1,22 @@
 name: Setup macOS Nix cache
 description: Restore and save the macOS Nix store with the original Nix cache action
+inputs:
+  key-suffix:
+    description: >
+      Extra suffix to scope the cache key. The arm64 and x64 macOS builds run on
+      the same arm64 runner (same runner.os/runner.arch), so without this they
+      would share one key and clobber each other's store.
+    default: ''
 runs:
   using: composite
   steps:
     - name: Cache macOS Nix store
       uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
       with:
-        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'package.json', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}
-        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ inputs.key-suffix }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'package.json', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-${{ inputs.key-suffix }}-
         gc-max-store-size-macos: 3500000000
         purge: true
-        purge-prefixes: nix-${{ runner.os }}-${{ runner.arch }}-
+        purge-prefixes: nix-${{ runner.os }}-${{ runner.arch }}-${{ inputs.key-suffix }}-
         purge-created: 172800
         purge-primary-key: never

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -1,5 +1,9 @@
 name: Setup Nix
 description: Install Nix with platform-specific cache setup
+inputs:
+  cache-key-suffix:
+    description: Extra suffix to scope the macOS Nix cache key (e.g. cross target arch)
+    default: ''
 runs:
   using: composite
   steps:

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -19,6 +19,8 @@ runs:
 
     - uses: ./.github/actions/setup-macos-nix-cache
       if: runner.os == 'macOS'
+      with:
+        key-suffix: ${{ inputs.cache-key-suffix }}
 
     - name: Fix single-user Nix store ownership
       if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary

The arm64 and x64 macOS native packages both build on the same arm64 Blacksmith runner (x64 cross-compiles via the multi-arch Apple SDK), so `runner.os`/`runner.arch` are identical for both. They shared one `cache-nix-action` key (`nix-macOS-ARM64-<hash>`) and clobbered each other's restored Nix store every run — leaving the Intel build effectively uncached and cold.

## What changed

- Added a `key-suffix` input to `setup-macos-nix-cache` that is appended to the primary key, restore prefix, and purge prefix.
- Added a `cache-key-suffix` input to `setup-nix` that forwards to the macOS cache action.
- `build-macos-nix-native-package` now passes the target `arch` as the suffix.

Result: `build-mac-arm64` → `nix-macOS-ARM64-arm64-<hash>`, `build-mac-x64` → `nix-macOS-ARM64-x64-<hash>`. Independent caches, no clobber. Both keys re-warm once on first run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope the macOS Nix cache key by target arch so arm64 and x64 builds get separate caches on the shared arm64 runner. Stops cache clobbering and keeps both builds warm.

- **Bug Fixes**
  - Added `key-suffix` to `setup-macos-nix-cache` and applied it to primary, restore, and purge keys.
  - Added `cache-key-suffix` to `setup-nix` and forwarded it to `setup-macos-nix-cache`.
  - `build-macos-nix-native-package` passes the target `arch` as the suffix (e.g., `nix-macOS-ARM64-arm64-<hash>` and `...-x64-<hash>`).

<sup>Written for commit c9be5a0adc61e599a051c1d770f2619079c46e31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Scoped macOS Nix build cache by adding architecture-specific cache keys and configurable key suffixes, preventing arm64/x64 cache clobbering on shared runners. Also updated cache purge/restore behaviors to target scoped entries, resulting in more reliable, isolated macOS builds and reduced cache-related failures across architectures and CI run stability. No functional changes to build outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->