### PR TITLE
fix(ci): download E2E fixture via gh REST to dodge Blacksmith cold-start ECONNREFUSED

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,14 +224,26 @@ jobs:
         if: matrix.runner == 'bun'
         with:
           bun-version: latest
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ccusage-e2e-fixture
-          path: ${{ runner.temp }}/e2e-fixture
-      - name: Point CLAUDE_CONFIG_DIR at the fixture
+      - name: Download E2E fixture
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          "CLAUDE_CONFIG_DIR=$env:RUNNER_TEMP/e2e-fixture" >> $env:GITHUB_ENV
+          # actions/download-artifact talks to the artifact backend through the
+          # Blacksmith-proxied results-receiver endpoint, whose local agent is
+          # not yet listening in the first seconds after a macOS VM boots — the
+          # download runs ~2s in and intermittently hits ECONNREFUSED on
+          # ListArtifacts (re-running the job, once the agent is warm, succeeds).
+          # gh run download uses the api.github.com REST API directly, sidestepping
+          # that proxy, and we retry with backoff to ride out any transient hiccup.
+          $dir = "$env:RUNNER_TEMP/e2e-fixture"
+          for ($i = 1; $i -le 5; $i++) {
+            gh run download $env:GITHUB_RUN_ID --name ccusage-e2e-fixture --dir $dir
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($i -eq 5) { throw "failed to download the E2E fixture after 5 attempts" }
+            Start-Sleep -Seconds ($i * 5)
+          }
+          "CLAUDE_CONFIG_DIR=$dir" >> $env:GITHUB_ENV
       - name: Run preview E2E
         shell: pwsh
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,17 +228,20 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           # actions/download-artifact talks to the artifact backend through the
           # Blacksmith-proxied results-receiver endpoint, whose local agent is
-          # not yet listening in the first seconds after a macOS VM boots — the
+          # not yet listening in the first seconds after a macOS VM boots: the
           # download runs ~2s in and intermittently hits ECONNREFUSED on
           # ListArtifacts (re-running the job, once the agent is warm, succeeds).
           # gh run download uses the api.github.com REST API directly, sidestepping
           # that proxy, and we retry with backoff to ride out any transient hiccup.
+          # This job intentionally skips actions/checkout, so we bind the repo
+          # explicitly via GH_REPO/--repo to give the CLI repository context.
           $dir = "$env:RUNNER_TEMP/e2e-fixture"
           for ($i = 1; $i -le 5; $i++) {
-            gh run download $env:GITHUB_RUN_ID --name ccusage-e2e-fixture --dir $dir
+            gh run download $env:GITHUB_RUN_ID --repo $env:GH_REPO --name ccusage-e2e-fixture --dir $dir
             if ($LASTEXITCODE -eq 0) { break }
             if ($i -eq 5) { throw "failed to download the E2E fixture after 5 attempts" }
             Start-Sleep -Seconds ($i * 5)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,7 +228,6 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
         run: |
           # actions/download-artifact talks to the artifact backend through the
           # Blacksmith-proxied results-receiver endpoint, whose local agent is
@@ -237,11 +236,20 @@ jobs:
           # ListArtifacts (re-running the job, once the agent is warm, succeeds).
           # gh run download uses the api.github.com REST API directly, sidestepping
           # that proxy, and we retry with backoff to ride out any transient hiccup.
-          # This job intentionally skips actions/checkout, so we bind the repo
-          # explicitly via GH_REPO/--repo to give the CLI repository context.
+          # These jobs skip actions/checkout, so create a minimal git context
+          # for gh instead of relying on --repo (which some gh versions still
+          # follow with a local git probe).
+          $gitDir = "$env:RUNNER_TEMP/gh-context"
+          New-Item -ItemType Directory -Force -Path $gitDir | Out-Null
+          Push-Location $gitDir
+          git init -q
+          git remote add origin "https://github.com/$env:GITHUB_REPOSITORY.git"
+          Pop-Location
           $dir = "$env:RUNNER_TEMP/e2e-fixture"
           for ($i = 1; $i -le 5; $i++) {
-            gh run download $env:GITHUB_RUN_ID --repo $env:GH_REPO --name ccusage-e2e-fixture --dir $dir
+            Push-Location $gitDir
+            gh run download $env:GITHUB_RUN_ID --name ccusage-e2e-fixture --dir $dir
+            Pop-Location
             if ($LASTEXITCODE -eq 0) { break }
             if ($i -eq 5) { throw "failed to download the E2E fixture after 5 attempts" }
             Start-Sleep -Seconds ($i * 5)


### PR DESCRIPTION
## Problem

The checkout-less E2E jobs intermittently fail at the fixture download with:

```
Unable to download artifact(s): Failed to ListArtifacts: Unable to make request: ECONNREFUSED
```

Re-running the job succeeds, so it is transient.

## Root cause

On Blacksmith **macOS** runners the artifact backend is reached through a Blacksmith-proxied endpoint (`BLACKSMITH_ACTIONS_RESULTS_URL=https://results-receiver.actions.githubusercontent.com/`). Its local agent is **not yet listening in the first ~2 s after the macOS VM boots**. The download step runs almost immediately after boot (only setup-node/pnpm/bun precede it), so `actions/download-artifact` hits `ECONNREFUSED` on `ListArtifacts` — a *connection refused*, i.e. nothing listening, not a timeout or DNS error. Once the VM/agent is warm (on re-run) it works.

## Fix

- Replace `actions/download-artifact` with **`gh run download`**, which uses the `api.github.com` REST API directly and sidesteps the Blacksmith results-receiver proxy that is the actual failure path.
- Wrap it in a 5-attempt retry with linear backoff to absorb any remaining transient hiccup.

The E2E jobs stay **pure**: still no repo checkout, the fixture is still produced only by the publish job and consumed via the run's artifact. Only the transport changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch E2E fixture download to `gh run download` to bypass the Blacksmith results-receiver cold-start on macOS that caused intermittent `ECONNREFUSED`. Add retry and a minimal git context so checkout-less jobs resolve the repo.

- **Bug Fixes**
  - Replace `actions/download-artifact` with `gh run download` (uses `api.github.com`, bypasses the Blacksmith proxy) and create a temporary git repo with `origin` set to `${GITHUB_REPOSITORY}` to give `gh` repo context.
  - Add 5-attempt linear backoff, export `GH_TOKEN`, and set `CLAUDE_CONFIG_DIR` to the downloaded path.

<sup>Written for commit 8befc936404b77794e08a01157237225a3944998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability for end-to-end testing by adding a retry loop with incremental backoff for fixture downloads on Windows and macOS runners.
  * Ensures the test fixture is placed reliably and the configuration directory is exported to the job environment for downstream steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->