### PR TITLE
fix(pricing): resolve Codex log model aliases

### DIFF
--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -733,23 +733,23 @@ impl PricingMap {
                 fast_multiplier: 1.0,
             },
         );
-        self.entries.insert(
-            "gpt-5.5".to_string(),
-            Pricing {
-                input: 5e-6,
-                output: 30e-6,
-                cache_create: 5e-6,
-                cache_read: 0.5e-6,
-                cache_read_explicit: true,
-                input_above_200k: None,
-                output_above_200k: None,
-                cache_create_above_200k: None,
-                cache_read_above_200k: None,
-                fast_multiplier: fast_multiplier_overrides
-                    .multiplier_for("gpt-5.5")
-                    .unwrap_or(1.0),
-            },
-        );
+        let gpt_5_5_pricing = Pricing {
+            input: 5e-6,
+            output: 30e-6,
+            cache_create: 5e-6,
+            cache_read: 0.5e-6,
+            cache_read_explicit: true,
+            input_above_200k: None,
+            output_above_200k: None,
+            cache_create_above_200k: None,
+            cache_read_above_200k: None,
+            fast_multiplier: fast_multiplier_overrides
+                .multiplier_for("gpt-5.5")
+                .unwrap_or(1.0),
+        };
+        self.entries.insert("gpt-5.5".to_string(), gpt_5_5_pricing);
+        self.entries
+            .insert("codex-auto-review".to_string(), gpt_5_5_pricing);
         self.entries.insert(
             "grok-4.3".to_string(),
             Pricing {
@@ -826,15 +826,14 @@ impl PricingMap {
         };
         self.entries
             .insert("gpt-5.2-codex".to_string(), gpt_5_codex_pricing);
-        self.entries.insert(
-            "gpt-5.3-codex".to_string(),
-            Pricing {
-                fast_multiplier: fast_multiplier_overrides
-                    .multiplier_for("gpt-5.3-codex")
-                    .unwrap_or(1.0),
-                ..gpt_5_codex_pricing
-            },
-        );
+        let gpt_5_3_codex_pricing = Pricing {
+            fast_multiplier: fast_multiplier_overrides
+                .multiplier_for("gpt-5.3-codex")
+                .unwrap_or(1.0),
+            ..gpt_5_codex_pricing
+        };
+        self.entries
+            .insert("gpt-5.3-codex".to_string(), gpt_5_3_codex_pricing);
         self.entries
             .insert("gpt-5.2".to_string(), gpt_5_codex_pricing);
         self.entries.insert(
@@ -1770,6 +1769,18 @@ mod tests {
         assert_eq!(pricing.find("gpt-5.5").unwrap().fast_multiplier, 2.5);
         assert_eq!(pricing.find("gpt-5.4").unwrap().fast_multiplier, 2.0);
         assert_eq!(pricing.find("gpt-5.3-codex").unwrap().fast_multiplier, 2.0);
+    }
+
+    #[test]
+    fn embedded_pricing_resolves_codex_auto_review_model() {
+        let pricing = PricingMap::load_embedded();
+        let auto_review = pricing.find("codex-auto-review").unwrap();
+        let latest_codex = pricing.find("gpt-5.5").unwrap();
+
+        assert_eq!(auto_review.input, latest_codex.input);
+        assert_eq!(auto_review.output, latest_codex.output);
+        assert_eq!(auto_review.cache_read, latest_codex.cache_read);
+        assert_eq!(auto_review.fast_multiplier, latest_codex.fast_multiplier);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -361,10 +361,12 @@ impl PricingMap {
     }
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
-        self.find_entry(model)
+        self.find_entry_or_alias(model)
             .or_else(|| {
                 self.enable_models_dev_fallback
-                    .then(|| models_dev_pricing().and_then(|pricing| pricing.find_entry(model)))
+                    .then(|| {
+                        models_dev_pricing().and_then(|pricing| pricing.find_entry_or_alias(model))
+                    })
                     .flatten()
             })
             // The embedded models.dev snapshot is a separate map, so it only
@@ -372,9 +374,14 @@ impl PricingMap {
             // fuzzy alias matching. It works offline, unlike the network source.
             .or_else(|| {
                 self.enable_embedded_models_dev_fallback
-                    .then(|| embedded_models_dev_pricing().find_entry(model))
+                    .then(|| embedded_models_dev_pricing().find_entry_or_alias(model))
                     .flatten()
             })
+    }
+
+    fn find_entry_or_alias(&self, model: &str) -> Option<Pricing> {
+        self.find_entry(model)
+            .or_else(|| pricing_alias(model).and_then(|alias| self.find_entry(alias)))
     }
 
     fn find_entry(&self, model: &str) -> Option<Pricing> {
@@ -733,23 +740,23 @@ impl PricingMap {
                 fast_multiplier: 1.0,
             },
         );
-        let gpt_5_5_pricing = Pricing {
-            input: 5e-6,
-            output: 30e-6,
-            cache_create: 5e-6,
-            cache_read: 0.5e-6,
-            cache_read_explicit: true,
-            input_above_200k: None,
-            output_above_200k: None,
-            cache_create_above_200k: None,
-            cache_read_above_200k: None,
-            fast_multiplier: fast_multiplier_overrides
-                .multiplier_for("gpt-5.5")
-                .unwrap_or(1.0),
-        };
-        self.entries.insert("gpt-5.5".to_string(), gpt_5_5_pricing);
-        self.entries
-            .insert("codex-auto-review".to_string(), gpt_5_5_pricing);
+        self.entries.insert(
+            "gpt-5.5".to_string(),
+            Pricing {
+                input: 5e-6,
+                output: 30e-6,
+                cache_create: 5e-6,
+                cache_read: 0.5e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: fast_multiplier_overrides
+                    .multiplier_for("gpt-5.5")
+                    .unwrap_or(1.0),
+            },
+        );
         self.entries.insert(
             "grok-4.3".to_string(),
             Pricing {
@@ -826,14 +833,15 @@ impl PricingMap {
         };
         self.entries
             .insert("gpt-5.2-codex".to_string(), gpt_5_codex_pricing);
-        let gpt_5_3_codex_pricing = Pricing {
-            fast_multiplier: fast_multiplier_overrides
-                .multiplier_for("gpt-5.3-codex")
-                .unwrap_or(1.0),
-            ..gpt_5_codex_pricing
-        };
-        self.entries
-            .insert("gpt-5.3-codex".to_string(), gpt_5_3_codex_pricing);
+        self.entries.insert(
+            "gpt-5.3-codex".to_string(),
+            Pricing {
+                fast_multiplier: fast_multiplier_overrides
+                    .multiplier_for("gpt-5.3-codex")
+                    .unwrap_or(1.0),
+                ..gpt_5_codex_pricing
+            },
+        );
         self.entries
             .insert("gpt-5.2".to_string(), gpt_5_codex_pricing);
         self.entries.insert(
@@ -1114,6 +1122,14 @@ fn normalized_pricing_key(value: &str) -> Cow<'_, str> {
         Cow::Owned(value.replace(['.', '@'], "-"))
     } else {
         Cow::Borrowed(value)
+    }
+}
+
+fn pricing_alias(model: &str) -> Option<&'static str> {
+    match model {
+        "codex-auto-review" => Some("gpt-5.5"),
+        "gpt-5.3-spark" => Some("gpt-5.3-codex-spark"),
+        _ => None,
     }
 }
 
@@ -1781,6 +1797,18 @@ mod tests {
         assert_eq!(auto_review.output, latest_codex.output);
         assert_eq!(auto_review.cache_read, latest_codex.cache_read);
         assert_eq!(auto_review.fast_multiplier, latest_codex.fast_multiplier);
+    }
+
+    #[test]
+    fn embedded_pricing_resolves_codex_spark_short_model() {
+        let pricing = PricingMap::load_embedded();
+        let short_spark = pricing.find("gpt-5.3-spark").unwrap();
+        let codex_spark = pricing.find("gpt-5.3-codex-spark").unwrap();
+
+        assert_eq!(short_spark.input, codex_spark.input);
+        assert_eq!(short_spark.output, codex_spark.output);
+        assert_eq!(short_spark.cache_read, codex_spark.cache_read);
+        assert_eq!(short_spark.fast_multiplier, codex_spark.fast_multiplier);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -400,19 +400,25 @@ impl PricingMap {
     }
 
     pub(crate) fn context_limit(&self, model: &str) -> Option<u64> {
-        self.context_limit_entry(model)
+        self.context_limit_entry_or_alias(model)
             .or_else(|| {
                 self.enable_models_dev_fallback
                     .then(|| {
-                        models_dev_pricing().and_then(|pricing| pricing.context_limit_entry(model))
+                        models_dev_pricing()
+                            .and_then(|pricing| pricing.context_limit_entry_or_alias(model))
                     })
                     .flatten()
             })
             .or_else(|| {
                 self.enable_embedded_models_dev_fallback
-                    .then(|| embedded_models_dev_pricing().context_limit_entry(model))
+                    .then(|| embedded_models_dev_pricing().context_limit_entry_or_alias(model))
                     .flatten()
             })
+    }
+
+    fn context_limit_entry_or_alias(&self, model: &str) -> Option<u64> {
+        self.context_limit_entry(model)
+            .or_else(|| pricing_alias(model).and_then(|alias| self.context_limit_entry(alias)))
     }
 
     fn context_limit_entry(&self, model: &str) -> Option<u64> {
@@ -1125,6 +1131,8 @@ fn normalized_pricing_key(value: &str) -> Cow<'_, str> {
     }
 }
 
+/// Maps Codex log labels that upstream pricing sources do not publish to
+/// canonical pricing keys.
 fn pricing_alias(model: &str) -> Option<&'static str> {
     match model {
         "codex-auto-review" => Some("gpt-5.5"),
@@ -1790,20 +1798,32 @@ mod tests {
     #[test]
     fn embedded_pricing_resolves_codex_auto_review_model() {
         let pricing = PricingMap::load_embedded();
-        let auto_review = pricing.find("codex-auto-review").unwrap();
-        let latest_codex = pricing.find("gpt-5.5").unwrap();
+        let auto_review = pricing
+            .find("codex-auto-review")
+            .expect("codex-auto-review should resolve via model alias");
+        let latest_codex = pricing
+            .find("gpt-5.5")
+            .expect("canonical latest Codex pricing should exist");
 
         assert_eq!(auto_review.input, latest_codex.input);
         assert_eq!(auto_review.output, latest_codex.output);
         assert_eq!(auto_review.cache_read, latest_codex.cache_read);
         assert_eq!(auto_review.fast_multiplier, latest_codex.fast_multiplier);
+        assert_eq!(
+            pricing.context_limit("codex-auto-review"),
+            pricing.context_limit("gpt-5.5")
+        );
     }
 
     #[test]
-    fn embedded_pricing_resolves_codex_spark_short_model() {
+    fn embedded_pricing_resolves_codex_spark_short_model_alias() {
         let pricing = PricingMap::load_embedded();
-        let short_spark = pricing.find("gpt-5.3-spark").unwrap();
-        let codex_spark = pricing.find("gpt-5.3-codex-spark").unwrap();
+        let short_spark = pricing
+            .find("gpt-5.3-spark")
+            .expect("gpt-5.3-spark should resolve via model alias");
+        let codex_spark = pricing
+            .find("gpt-5.3-codex-spark")
+            .expect("canonical Codex Spark pricing should exist");
 
         assert_eq!(short_spark.input, codex_spark.input);
         assert_eq!(short_spark.output, codex_spark.output);


### PR DESCRIPTION
Adds pricing fallback aliases for Codex log model names that are not published directly by upstream pricing sources.

Codex reports now preserve raw log labels such as `codex-auto-review` and `gpt-5.3-spark` while resolving their costs through canonical model pricing keys.

Testing:
- `nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage embedded_pricing_resolves_codex`
- `nix develop --command cargo fmt --manifest-path rust/crates/ccusage/Cargo.toml --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model aliases are now correctly resolved to their canonical versions when looking up pricing information
  * Context limit retrieval for model aliases now works properly through automatic canonical name mapping
  * Previously unrecognized model alias names are now fully supported in pricing queries

* **Tests**
  * Added test cases to validate that model aliases correctly map to their pricing entries and context limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->