### PR TITLE
docs(readme): lift sponsor placement

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -23,6 +23,32 @@
 
 > Analyze coding (agent) CLI token usage and costs from local data.
 
+## Major Sponsors
+
+<table>
+    <tr>
+        <td align="center" width="50%">
+            <a href="https://coderabbit.link/ryoppippi">
+                <picture>
+                    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/coderabbit-logo-dark.svg">
+                    <img src="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/coderabbit-logo.svg" alt="CodeRabbit" width="320">
+                </picture>
+            </a>
+        </td>
+        <td align="center" width="50%">
+            <a href="https://blacksmith.sh">
+                <img src="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/blacksmith.png" alt="Blacksmith" width="320">
+            </a>
+        </td>
+    </tr>
+</table>
+
+## Quick Start
+
+```bash
+npx ccusage@latest
+```
+
 ## Supported Sources
 
 ccusage reads local usage data from coding agent CLIs and turns it into daily, weekly, monthly, and session reports.
@@ -49,21 +75,21 @@ Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` t
 
 ## Installation
 
-### Quick Start (Recommended)
+### Package Runners
 
 You can run ccusage directly without a global installation:
 
 ```bash
-# Recommended
-bunx ccusage
+# npm
+npx ccusage@latest
 
 # Nix
 nix run github:ccusage/ccusage -- daily
 
 # Alternative package runners
+bunx ccusage
 pnpm dlx ccusage
 pnpx ccusage
-npx ccusage@latest
 
 # PR preview builds
 bunx -p https://pkg.pr.new/ccusage/ccusage@<pr-number> ccusage --offline
@@ -198,26 +224,7 @@ The scheduled `update pricing` workflow runs the same update and validation, the
 
 </details>
 
-## Sponsors
-
-<p align="center">
-    <strong>Sponsored by</strong>
-</p>
-
-<p align="center">
-    <a href="https://coderabbit.link/ryoppippi">
-        <picture>
-            <source media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/coderabbit-logo-dark.svg">
-            <img src="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/coderabbit-logo.svg" alt="CodeRabbit" width="320">
-        </picture>
-    </a>
-</p>
-
-<p align="center">
-    <a href="https://blacksmith.sh">
-        <img src="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/blacksmith.png" alt="Blacksmith" width="320">
-    </a>
-</p>
+## GitHub Sponsors
 
 <p align="center">
     <a href="https://github.com/sponsors/ryoppippi">

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -25,23 +25,18 @@
 
 ## Major Sponsors
 
-<table>
-    <tr>
-        <td align="center" width="50%">
-            <a href="https://coderabbit.link/ryoppippi">
-                <picture>
-                    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/coderabbit-logo-dark.svg">
-                    <img src="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/coderabbit-logo.svg" alt="CodeRabbit" width="320">
-                </picture>
-            </a>
-        </td>
-        <td align="center" width="50%">
-            <a href="https://blacksmith.sh">
-                <img src="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/blacksmith.png" alt="Blacksmith" width="320">
-            </a>
-        </td>
-    </tr>
-</table>
+<p align="center">
+    <a href="https://coderabbit.link/ryoppippi">
+        <picture>
+            <source media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/coderabbit-logo-dark.svg">
+            <img src="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/coderabbit-logo.svg" alt="CodeRabbit" width="320">
+        </picture>
+    </a>
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <a href="https://blacksmith.sh">
+        <img src="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/blacksmith.png" alt="Blacksmith" width="320">
+    </a>
+</p>
 
 ## Quick Start
 


### PR DESCRIPTION
Moves the two major sponsor logos directly below the README screenshot, using a GitHub-compatible table layout instead of flex styling. Adds a short npx quick start before the detailed reference sections while keeping package runner details later in the README. Validated with git diff --check and the local Browser preview at http://localhost:3333/.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the two major sponsor logos directly below the README screenshot and center them with inline HTML for reliable GitHub rendering. Add a one-line Quick Start (`npx ccusage@latest`), keep other runners under Installation (now “Package Runners”), and focus the bottom section on GitHub Sponsors.

<sup>Written for commit a1b07831804620e76214d7aa2dcaa1084430ca61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Major Sponsors" block with sponsor logos and clarified sponsor recognition (renamed to "GitHub Sponsors" and removed duplicate logos)
  * Simplified Quick Start snippet for faster onboarding
  * Reorganized installation guidance into a "Package Runners" section and adjusted example commands (including an npx example)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->