### PR TITLE
fix(codex): date fallback review model pricing

### DIFF
--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -60,7 +60,7 @@ These views support `--json`, `--compact`, `--offline`, and `--speed auto|standa
 | `CODEX_HOME` | Override the root directory, or comma-separated directories, containing Codex homes or saved `codex exec --json` JSONL files |
 | `LOG_LEVEL`  | Adjust log verbosity (0 silent … 5 trace)                                                                                    |
 
-When Codex emits a model alias, the CLI automatically resolves it through the LiteLLM pricing data when possible. For `codex-auto-review`, the CLI uses the newest known Codex/OpenAI model available on the log date. No manual override is needed.
+When Codex emits a model alias, the CLI automatically resolves it through the LiteLLM pricing data when possible. For `codex-auto-review`, the Codex parser maps the label to the newest known Codex/OpenAI model available on the log date before pricing uses the resolved model name. No manual override is needed.
 
 ## Speed Pricing
 

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -47,7 +47,7 @@ These views support `--json`, `--compact`, `--offline`, and `--speed auto|standa
 
 - **Token deltas** – Each `event_msg` with `payload.type === "token_count"` reports cumulative totals. The CLI subtracts the previous totals to recover per-turn token usage (input, cached input, output, reasoning, total).
 - **Per-model grouping** – The `turn_context` metadata specifies the active model. We aggregate tokens per day/month and per model. Sessions lacking model metadata (seen in early September 2025 builds) are skipped.
-- **Pricing** – Rates come from LiteLLM's pricing dataset via the shared `LiteLLMPricingFetcher`. Model aliases such as `gpt-5.5` are resolved through the pricing cache when available.
+- **Pricing** – Rates come from LiteLLM's pricing dataset via the shared `LiteLLMPricingFetcher`. Codex's internal review label is resolved to the newest known model for the log date before pricing is calculated.
 - **Speed pricing** – `--speed auto` is the default. It reads `config.toml` from each `CODEX_HOME` root and applies fast pricing when any Codex config has `service_tier = "priority"` or legacy `service_tier = "fast"` configured. Fast mode uses the model-specific LiteLLM multiplier when available and otherwise falls back to 2x pricing. Pass `--speed fast` or `--speed standard` to override config-based detection.
 - **Legacy fallback** – Early September 2025 logs that never recorded `turn_context` metadata are still included; the CLI assumes `gpt-5` for pricing so you can review the tokens even though the model tag is missing (the JSON output also marks these rows with `"isFallback": true`).
 - **Cost formula** – Non-cached input uses the standard input price; cached input uses the cache-read price (falling back to the input price when missing); and output tokens are billed at the output price. All prices are per million tokens. Reasoning tokens may be shown for reference, but they are part of the output charge and are not billed separately.
@@ -60,7 +60,7 @@ These views support `--json`, `--compact`, `--offline`, and `--speed auto|standa
 | `CODEX_HOME` | Override the root directory, or comma-separated directories, containing Codex homes or saved `codex exec --json` JSONL files |
 | `LOG_LEVEL`  | Adjust log verbosity (0 silent … 5 trace)                                                                                    |
 
-When Codex emits a model alias (for example `gpt-5.5`), the CLI automatically resolves it through the LiteLLM pricing data when possible. No manual override is needed.
+When Codex emits a model alias, the CLI automatically resolves it through the LiteLLM pricing data when possible. For `codex-auto-review`, the CLI uses the newest known Codex/OpenAI model available on the log date. No manual override is needed.
 
 ## Speed Pricing
 

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -60,7 +60,7 @@ These views support `--json`, `--compact`, `--offline`, and `--speed auto|standa
 | `CODEX_HOME` | Override the root directory, or comma-separated directories, containing Codex homes or saved `codex exec --json` JSONL files |
 | `LOG_LEVEL`  | Adjust log verbosity (0 silent … 5 trace)                                                                                    |
 
-When Codex emits a model alias, the CLI automatically resolves it through the LiteLLM pricing data when possible. For `codex-auto-review`, the Codex parser maps the label to the newest known Codex/OpenAI model available on the log date before pricing uses the resolved model name. No manual override is needed.
+When Codex emits a model alias, the CLI automatically resolves it through the LiteLLM pricing data when possible. For `codex-auto-review`, the Codex parser maps the label to the newest known Codex/OpenAI model available on the log date using a pinned models.dev snapshot before pricing uses the resolved model name. No manual override is needed.
 
 ## Speed Pricing
 

--- a/justfile
+++ b/justfile
@@ -54,11 +54,13 @@ update-litellm-pricing:
     nix flake update litellm
     just check
 
-# Regenerate the committed models.dev pricing snapshot from the pinned input
+# Regenerate committed models.dev snapshots from the pinned input
 gen-models-dev-pricing:
-    cp "$(nix build .#models-dev-pricing --no-link --print-out-paths)" rust/crates/ccusage/src/models-dev-pricing.json
+    snapshots="$(nix build .#models-dev-pricing --no-link --print-out-paths)"; cp "$snapshots/models-dev-pricing.json" rust/crates/ccusage/src/models-dev-pricing.json; cp "$snapshots/codex-auto-review-fallbacks.json" rust/crates/ccusage/src/adapter/codex/codex-auto-review-fallbacks.json
     chmod u+w rust/crates/ccusage/src/models-dev-pricing.json
+    chmod u+w rust/crates/ccusage/src/adapter/codex/codex-auto-review-fallbacks.json
     nix fmt rust/crates/ccusage/src/models-dev-pricing.json
+    nix fmt rust/crates/ccusage/src/adapter/codex/codex-auto-review-fallbacks.json
 
 # Update the pinned models.dev input, regenerate its pricing snapshot, and validate
 update-models-dev-pricing:

--- a/justfile
+++ b/justfile
@@ -56,7 +56,7 @@ update-litellm-pricing:
 
 # Regenerate committed models.dev snapshots from the pinned input
 gen-models-dev-pricing:
-    snapshots="$(nix build .#models-dev-pricing --no-link --print-out-paths)"; cp "$snapshots/models-dev-pricing.json" rust/crates/ccusage/src/models-dev-pricing.json; cp "$snapshots/codex-auto-review-fallbacks.json" rust/crates/ccusage/src/adapter/codex/codex-auto-review-fallbacks.json
+    snapshots="$(nix build .#models-dev-pricing --no-link --print-out-paths)" && cp "$snapshots/models-dev-pricing.json" rust/crates/ccusage/src/models-dev-pricing.json && cp "$snapshots/codex-auto-review-fallbacks.json" rust/crates/ccusage/src/adapter/codex/codex-auto-review-fallbacks.json
     chmod u+w rust/crates/ccusage/src/models-dev-pricing.json
     chmod u+w rust/crates/ccusage/src/adapter/codex/codex-auto-review-fallbacks.json
     nix fmt rust/crates/ccusage/src/models-dev-pricing.json

--- a/nix/models-dev-gen.ts
+++ b/nix/models-dev-gen.ts
@@ -128,9 +128,19 @@ function generateCodexAutoReviewFallbacks(
 	);
 
 	return entries
-		.filter(([modelId]) => {
+		.filter(([modelId, model]) => {
 			const version = baseDecimalVersion(openAiModelName(modelId));
-			return version == null || !codexDecimalVersions.has(version);
+			if (version == null || !codexDecimalVersions.has(version)) {
+				return true;
+			}
+			// Drop the base entry only when a `-codex` variant shipped on the same
+			// date. If the codex variant ships later, keep the base so events in
+			// the gap still resolve to the most recent model available then.
+			return !entries.some(
+				([candidateId, candidateModel]) =>
+					codexDecimalVersion(openAiModelName(candidateId)) === version &&
+					candidateModel.release_date === model.release_date,
+			);
 		})
 		.map(([modelId, model]) => ({
 			releasedOn: model.release_date!,

--- a/nix/models-dev-gen.ts
+++ b/nix/models-dev-gen.ts
@@ -7,8 +7,10 @@
  * Anthropic-relevant models and the few pricing fields ccusage consumes. The
  * embedded output is a flat map keyed by runtime model id. The output is
  * committed to the repository and embedded at build time, so every platform
- * ships the identical, pinned data without any build-time network access. Run
- * via `just gen-models-dev-pricing` (see `nix/models-dev-pricing.nix`).
+ * ships the identical, pinned data without any build-time network access. The
+ * same pinned catalog also generates the Codex auto-review fallback metadata
+ * used by the Rust parser. Run via `just gen-models-dev-pricing` (see
+ * `nix/models-dev-pricing.nix`).
  */
 import { generateCatalog } from './packages/core/src/generate.ts';
 import {
@@ -26,13 +28,22 @@ type Cost = {
 	cache_write?: number | null;
 };
 type Model = { id?: string; cost?: Cost; limit?: { context?: number | null } };
+type ModelMetadata = {
+	id?: string;
+	release_date?: string;
+};
 type Provider = { models?: Record<string, Model> };
 type EmbeddedModel = {
 	cost: Cost;
 	limit?: { context: number };
 };
+type CodexAutoReviewFallback = {
+	releasedOn: string;
+	model: string;
+};
 
-const { providers } = (await generateCatalog('.')) as {
+const { models, providers } = (await generateCatalog('.')) as {
+	models: Record<string, ModelMetadata>;
 	providers: Record<string, Provider>;
 };
 
@@ -95,3 +106,61 @@ if (outfile == null || outfile.length === 0) {
 }
 
 await Bun.write(outfile, `${JSON.stringify(sortObject(out), null, 2)}\n`);
+
+const codexFallbacksOutfile = process.env.CODEX_AUTO_REVIEW_FALLBACKS_OUTFILE;
+if (codexFallbacksOutfile != null && codexFallbacksOutfile.length > 0) {
+	await Bun.write(
+		codexFallbacksOutfile,
+		`${JSON.stringify(generateCodexAutoReviewFallbacks(models), null, 2)}\n`,
+	);
+}
+
+function generateCodexAutoReviewFallbacks(
+	models: Record<string, ModelMetadata>,
+): CodexAutoReviewFallback[] {
+	const entries = Object.entries(models).filter(([modelId, model]) =>
+		isCodexAutoReviewFallbackCandidate(modelId, model),
+	);
+	const codexDecimalVersions = new Set(
+		entries
+			.map(([modelId]) => codexDecimalVersion(openAiModelName(modelId)))
+			.filter((version): version is string => version != null),
+	);
+
+	return entries
+		.filter(([modelId]) => {
+			const version = baseDecimalVersion(openAiModelName(modelId));
+			return version == null || !codexDecimalVersions.has(version);
+		})
+		.map(([modelId, model]) => ({
+			releasedOn: model.release_date!,
+			model: openAiModelName(model.id ?? modelId),
+		}))
+		.sort((left, right) => right.releasedOn.localeCompare(left.releasedOn));
+}
+
+function isCodexAutoReviewFallbackCandidate(modelId: string, model: ModelMetadata): boolean {
+	if (model.release_date == null || !/^\d{4}-\d{2}-\d{2}$/.test(model.release_date)) {
+		return false;
+	}
+	const modelName = openAiModelName(modelId);
+	return (
+		modelName === 'gpt-5' ||
+		modelName === 'gpt-5-codex' ||
+		/^gpt-5\.\d+$/.test(modelName) ||
+		/^gpt-5\.\d+-codex$/.test(modelName)
+	);
+}
+
+function baseDecimalVersion(modelId: string): string | undefined {
+	return /^gpt-5\.\d+$/.test(modelId) ? modelId : undefined;
+}
+
+function codexDecimalVersion(modelId: string): string | undefined {
+	const match = /^(gpt-5\.\d+)-codex$/.exec(modelId);
+	return match?.[1];
+}
+
+function openAiModelName(modelId: string): string {
+	return modelId.startsWith('openai/') ? modelId.slice('openai/'.length) : modelId;
+}

--- a/nix/models-dev-pricing.nix
+++ b/nix/models-dev-pricing.nix
@@ -1,14 +1,13 @@
-# Reproducibly regenerate the compacted models.dev pricing snapshot from the
-# pinned `models-dev` flake input. The upstream repository ships per-model TOML
-# sources rather than a prebuilt catalog, so we run their own `generateCatalog`
-# routine (via `nix/models-dev-gen.ts`) with Bun. Its only runtime dependencies
-# are `remeda` and `zod` (both zero-dependency packages), which we vendor
-# directly from the registry using the integrity hashes pinned in upstream
-# `bun.lock`.
+# Reproducibly regenerate compacted models.dev snapshots from the pinned
+# `models-dev` flake input. The upstream repository ships per-model TOML sources
+# rather than a prebuilt catalog, so we run their own `generateCatalog` routine
+# (via `nix/models-dev-gen.ts`) with Bun. Its only runtime dependencies are
+# `remeda` and `zod` (both zero-dependency packages), which we vendor directly
+# from the registry using the integrity hashes pinned in upstream `bun.lock`.
 #
-# The build output is copied into the repository (see `just gen-models-dev-pricing`)
-# and embedded at build time, so every platform ships identical pinned data
-# without build-time network access.
+# The build outputs are copied into the repository (see
+# `just gen-models-dev-pricing`) and embedded at build time, so every platform
+# ships identical pinned data without build-time network access.
 {
   pkgs,
   modelsDevSrc,
@@ -26,7 +25,7 @@ let
     hash = "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==";
   };
 in
-pkgs.runCommand "models-dev-pricing.json"
+pkgs.runCommand "models-dev-snapshots"
   {
     nativeBuildInputs = [ pkgs.bun ];
   }
@@ -52,5 +51,8 @@ pkgs.runCommand "models-dev-pricing.json"
     cp ${./models-dev-compact.ts} work/models-dev-compact.ts
 
     cd work
-    OUTFILE="$out" bun run gen.ts
+    mkdir -p "$out"
+    OUTFILE="$out/models-dev-pricing.json" \
+      CODEX_AUTO_REVIEW_FALLBACKS_OUTFILE="$out/codex-auto-review-fallbacks.json" \
+      bun run gen.ts
   ''

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -27,9 +27,9 @@ in
           ;
       };
       ccusageProgram = pkgs.lib.getExe' ccusage "ccusage";
-      # Regeneration-only output for the committed models.dev pricing snapshot;
-      # `just gen-models-dev-pricing` builds this and copies it into the source
-      # tree. It is not part of the ccusage build, which embeds the committed file.
+      # Regeneration-only output for committed models.dev snapshots;
+      # `just gen-models-dev-pricing` builds this and copies them into the source
+      # tree. It is not part of the ccusage build, which embeds the committed files.
       models-dev-pricing = pkgs.callPackage ../nix/models-dev-pricing.nix {
         modelsDevSrc = inputs.models-dev;
       };

--- a/package.nix
+++ b/package.nix
@@ -18,7 +18,8 @@ let
       || lib.hasSuffix "/cli-help.json" path
       || lib.hasSuffix "/cli-commands.json" path
       || lib.hasSuffix "/fast-multiplier-overrides.json" path
-      || lib.hasSuffix "/models-dev-pricing.json" path;
+      || lib.hasSuffix "/models-dev-pricing.json" path
+      || lib.hasSuffix "/codex-auto-review-fallbacks.json" path;
   };
   commonArgs = {
     pname = "ccusage";

--- a/rust/crates/ccusage/src/adapter/codex/codex-auto-review-fallbacks.json
+++ b/rust/crates/ccusage/src/adapter/codex/codex-auto-review-fallbacks.json
@@ -1,0 +1,30 @@
+[
+	{
+		"releasedOn": "2026-04-23",
+		"model": "gpt-5.5"
+	},
+	{
+		"releasedOn": "2026-03-05",
+		"model": "gpt-5.4"
+	},
+	{
+		"releasedOn": "2026-02-05",
+		"model": "gpt-5.3-codex"
+	},
+	{
+		"releasedOn": "2025-12-11",
+		"model": "gpt-5.2-codex"
+	},
+	{
+		"releasedOn": "2025-11-13",
+		"model": "gpt-5.1-codex"
+	},
+	{
+		"releasedOn": "2025-09-15",
+		"model": "gpt-5-codex"
+	},
+	{
+		"releasedOn": "2025-08-07",
+		"model": "gpt-5"
+	}
+]

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -581,6 +581,42 @@ mod tests {
     }
 
     #[test]
+    fn resolves_codex_auto_review_with_invalid_event_date_to_conservative_model() {
+        let fixture = fs_fixture!({
+            "invalid-month.jsonl": json!({
+                "type": "turn.completed",
+                "timestamp": "2026-99-99T00:00:00.000Z",
+                "model": "codex-auto-review",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "total_tokens": 15,
+                },
+            })
+            .to_string(),
+            "invalid-leap-day.jsonl": json!({
+                "type": "turn.completed",
+                "timestamp": "2026-02-29T00:00:00.000Z",
+                "model": "codex-auto-review",
+                "usage": {
+                    "input_tokens": 20,
+                    "output_tokens": 10,
+                    "total_tokens": 30,
+                },
+            })
+            .to_string(),
+        });
+
+        let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert!(events
+            .iter()
+            .all(|event| event.model.as_deref() == Some("gpt-5")));
+        assert!(events.iter().all(|event| event.is_fallback_model));
+    }
+
+    #[test]
     fn resolves_codex_auto_review_turn_context_for_each_event_date() {
         let fixture = fs_fixture!({
             "session.jsonl": [

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -531,6 +531,110 @@ mod tests {
     }
 
     #[test]
+    fn resolves_codex_auto_review_to_latest_model_for_event_date() {
+        let fixture = fs_fixture!({
+            "run.jsonl": [
+                json!({
+                    "type": "turn.completed",
+                    "timestamp": "2026-02-05T00:00:00.000Z",
+                    "model": "codex-auto-review",
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "total_tokens": 15,
+                    },
+                })
+                .to_string(),
+                json!({
+                    "type": "turn.completed",
+                    "timestamp": "2026-03-05T00:00:00.000Z",
+                    "model": "codex-auto-review",
+                    "usage": {
+                        "input_tokens": 20,
+                        "output_tokens": 10,
+                        "total_tokens": 30,
+                    },
+                })
+                .to_string(),
+                json!({
+                    "type": "turn.completed",
+                    "timestamp": "2026-04-23T00:00:00.000Z",
+                    "model": "codex-auto-review",
+                    "usage": {
+                        "input_tokens": 30,
+                        "output_tokens": 15,
+                        "total_tokens": 45,
+                    },
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        });
+
+        let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
+
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].model.as_deref(), Some("gpt-5.3-codex"));
+        assert_eq!(events[1].model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(events[2].model.as_deref(), Some("gpt-5.5"));
+        assert!(events.iter().all(|event| event.is_fallback_model));
+    }
+
+    #[test]
+    fn resolves_codex_auto_review_turn_context_for_each_event_date() {
+        let fixture = fs_fixture!({
+            "session.jsonl": [
+                json!({
+                    "timestamp": "2025-12-11T00:00:00.000Z",
+                    "type": "turn_context",
+                    "payload": {
+                        "model": "codex-auto-review",
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2025-12-11T00:01:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 10,
+                                "output_tokens": 5,
+                                "total_tokens": 15,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-04-23T00:01:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 20,
+                                "output_tokens": 10,
+                                "total_tokens": 30,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        });
+
+        let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].model.as_deref(), Some("gpt-5.2-codex"));
+        assert_eq!(events[1].model.as_deref(), Some("gpt-5.5"));
+        assert!(events.iter().all(|event| event.is_fallback_model));
+    }
+
+    #[test]
     fn loads_headless_usage_with_token_count_text_content() {
         let fixture = fs_fixture!({
             "run.jsonl":

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -581,7 +581,11 @@ mod tests {
     }
 
     #[test]
-    fn resolves_codex_auto_review_with_invalid_event_date_to_conservative_model() {
+    fn resolves_codex_auto_review_with_invalid_event_date_falls_back_to_file_mtime() {
+        // When the log's own timestamp fields are unparseable AND no alternate
+        // timestamp fields are present, the parser falls back to the file's
+        // modified time so the date-based fallback table still resolves to a
+        // real model rather than locking in a misleading malformed string.
         let fixture = fs_fixture!({
             "invalid-month.jsonl": json!({
                 "type": "turn.completed",
@@ -610,10 +614,41 @@ mod tests {
         let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
 
         assert_eq!(events.len(), 2);
+        // File mtime is "now" at fixture creation, which is on or after every
+        // entry currently in the fallback table, so resolution lands on the
+        // newest known model. The exact value updates when the table grows.
         assert!(events
             .iter()
-            .all(|event| event.model.as_deref() == Some("gpt-5")));
+            .all(|event| event.model.as_deref().is_some_and(|model| model
+                .starts_with("gpt-5"))));
         assert!(events.iter().all(|event| event.is_fallback_model));
+    }
+
+    #[test]
+    fn resolves_codex_auto_review_uses_created_at_when_top_level_timestamp_is_malformed() {
+        // Regression test for the model-date resolution chain short-circuiting
+        // on a malformed top-level `timestamp` and ignoring the `created_at`
+        // fallback field that holds a parseable date.
+        let fixture = fs_fixture!({
+            "run.jsonl": json!({
+                "type": "turn.completed",
+                "timestamp": "not-a-date",
+                "created_at": "2025-12-11T00:00:00.000Z",
+                "model": "codex-auto-review",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "total_tokens": 15,
+                },
+            })
+            .to_string(),
+        });
+
+        let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].model.as_deref(), Some("gpt-5.2-codex"));
+        assert!(events[0].is_fallback_model);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -52,6 +52,11 @@ enum CodexLineKind {
     Headless,
 }
 
+struct CodexExecTimestamps {
+    event: String,
+    model: String,
+}
+
 fn is_codex_subagent_session(path: &Path) -> bool {
     let Ok(mut file) = fs::File::open(path) else {
         return false;
@@ -311,13 +316,16 @@ fn add_codex_exec_event(
         return Ok(());
     };
     let parsed_model = codex_model_from_result(value);
-    let timestamp =
-        codex_timestamp_from_result(value).unwrap_or_else(|| fallback_timestamp.to_string());
+    let timestamps = CodexExecTimestamps {
+        event: codex_timestamp_from_result(value).unwrap_or_else(|| fallback_timestamp.to_string()),
+        model: codex_model_timestamp_from_result(value)
+            .unwrap_or_else(|| fallback_timestamp.to_string()),
+    };
     visit_codex_exec_usage_event(
         session_id,
         raw_usage,
         parsed_model,
-        timestamp,
+        timestamps,
         current_model,
         current_model_is_fallback,
         visit,
@@ -339,13 +347,17 @@ fn add_codex_exec_event_from_value(
         return Ok(());
     };
     let parsed_model = codex_model_from_result_value(&value);
-    let timestamp =
-        codex_timestamp_from_result_value(&value).unwrap_or_else(|| fallback_timestamp.to_string());
+    let timestamps = CodexExecTimestamps {
+        event: codex_timestamp_from_result_value(&value)
+            .unwrap_or_else(|| fallback_timestamp.to_string()),
+        model: codex_model_timestamp_from_result_value(&value)
+            .unwrap_or_else(|| fallback_timestamp.to_string()),
+    };
     visit_codex_exec_usage_event(
         session_id,
         raw_usage,
         parsed_model,
-        timestamp,
+        timestamps,
         current_model,
         current_model_is_fallback,
         visit,
@@ -356,20 +368,20 @@ fn visit_codex_exec_usage_event(
     session_id: &str,
     raw_usage: CodexRawUsage,
     parsed_model: Option<String>,
-    timestamp: String,
+    timestamps: CodexExecTimestamps,
     current_model: &mut Option<String>,
     current_model_is_fallback: &mut bool,
     visit: &mut impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
     let (model, is_fallback_model) = resolve_codex_usage_model(
         parsed_model,
-        &timestamp,
+        &timestamps.model,
         current_model,
         current_model_is_fallback,
     );
     visit(CodexTokenUsageEvent {
         session_id: session_id.to_string(),
-        timestamp,
+        timestamp: timestamps.event,
         model,
         input_tokens: raw_usage.input_tokens,
         cached_input_tokens: raw_usage.cached_input_tokens.min(raw_usage.input_tokens),
@@ -515,13 +527,41 @@ fn codex_log_model_fallback(model: &str, timestamp: &str) -> Option<&'static str
 fn codex_timestamp_date(timestamp: &str) -> Option<&str> {
     let date = timestamp.get(..10)?;
     let bytes = date.as_bytes();
-    (bytes.len() == 10
+    if !(bytes.len() == 10
         && bytes[0..4].iter().all(u8::is_ascii_digit)
         && bytes[4] == b'-'
         && bytes[5..7].iter().all(u8::is_ascii_digit)
         && bytes[7] == b'-'
         && bytes[8..10].iter().all(u8::is_ascii_digit))
-    .then_some(date)
+    {
+        return None;
+    }
+    let year = codex_date_part(&bytes[0..4])?;
+    let month = codex_date_part(&bytes[5..7])?;
+    let day = codex_date_part(&bytes[8..10])?;
+    let max_day = codex_days_in_month(year, month)?;
+    (day >= 1 && day <= max_day).then_some(date)
+}
+
+fn codex_date_part(bytes: &[u8]) -> Option<u16> {
+    bytes.iter().try_fold(0u16, |value, byte| {
+        let digit = byte.checked_sub(b'0')?;
+        (digit <= 9).then_some(value * 10 + u16::from(digit))
+    })
+}
+
+fn codex_days_in_month(year: u16, month: u16) -> Option<u16> {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => Some(31),
+        4 | 6 | 9 | 11 => Some(30),
+        2 if codex_is_leap_year(year) => Some(29),
+        2 => Some(28),
+        _ => None,
+    }
+}
+
+fn codex_is_leap_year(year: u16) -> bool {
+    year % 4 == 0 && year % 100 != 0 || year % 400 == 0
 }
 
 fn codex_session_id(sessions_dir: &Path, path: &Path) -> String {
@@ -704,6 +744,30 @@ fn codex_timestamp_from_result(value: &CodexLogEntry<'_>) -> Option<String> {
         })
 }
 
+fn codex_model_timestamp_from_result(value: &CodexLogEntry<'_>) -> Option<String> {
+    raw_or_normalized_codex_timestamp(value.timestamp.as_ref())
+        .or_else(|| raw_or_normalized_codex_timestamp(value.created_at.as_ref()))
+        .or_else(|| raw_or_normalized_codex_timestamp(value.created_at_camel.as_ref()))
+        .or_else(|| {
+            value
+                .data
+                .as_ref()
+                .and_then(raw_or_normalized_result_fields_timestamp)
+        })
+        .or_else(|| {
+            value
+                .result
+                .as_ref()
+                .and_then(raw_or_normalized_result_fields_timestamp)
+        })
+        .or_else(|| {
+            value
+                .response
+                .as_ref()
+                .and_then(raw_or_normalized_result_fields_timestamp)
+        })
+}
+
 fn codex_timestamp_from_result_value(value: &Value) -> Option<String> {
     normalize_value_fields_timestamp(value)
         .or_else(|| value.get("data").and_then(normalize_value_fields_timestamp))
@@ -719,16 +783,57 @@ fn codex_timestamp_from_result_value(value: &Value) -> Option<String> {
         })
 }
 
+fn codex_model_timestamp_from_result_value(value: &Value) -> Option<String> {
+    raw_or_normalized_value_fields_timestamp(value)
+        .or_else(|| {
+            value
+                .get("data")
+                .and_then(raw_or_normalized_value_fields_timestamp)
+        })
+        .or_else(|| {
+            value
+                .get("result")
+                .and_then(raw_or_normalized_value_fields_timestamp)
+        })
+        .or_else(|| {
+            value
+                .get("response")
+                .and_then(raw_or_normalized_value_fields_timestamp)
+        })
+}
+
 fn normalize_result_fields_timestamp(value: &CodexResultFields<'_>) -> Option<String> {
     normalize_codex_timestamp(value.timestamp.as_ref())
         .or_else(|| normalize_codex_timestamp(value.created_at.as_ref()))
         .or_else(|| normalize_codex_timestamp(value.created_at_camel.as_ref()))
 }
 
+fn raw_or_normalized_result_fields_timestamp(value: &CodexResultFields<'_>) -> Option<String> {
+    raw_or_normalized_codex_timestamp(value.timestamp.as_ref())
+        .or_else(|| raw_or_normalized_codex_timestamp(value.created_at.as_ref()))
+        .or_else(|| raw_or_normalized_codex_timestamp(value.created_at_camel.as_ref()))
+}
+
 fn normalize_value_fields_timestamp(value: &Value) -> Option<String> {
     normalize_value_timestamp(value.get("timestamp"))
         .or_else(|| normalize_value_timestamp(value.get("created_at")))
         .or_else(|| normalize_value_timestamp(value.get("createdAt")))
+}
+
+fn raw_or_normalized_value_fields_timestamp(value: &Value) -> Option<String> {
+    raw_or_normalized_value_timestamp(value.get("timestamp"))
+        .or_else(|| raw_or_normalized_value_timestamp(value.get("created_at")))
+        .or_else(|| raw_or_normalized_value_timestamp(value.get("createdAt")))
+}
+
+fn raw_or_normalized_codex_timestamp(value: Option<&CodexTimestamp<'_>>) -> Option<String> {
+    match value? {
+        CodexTimestamp::String(text) => {
+            let text = text.trim();
+            (!text.is_empty()).then(|| text.to_string())
+        }
+        CodexTimestamp::Number(_) => normalize_codex_timestamp(value),
+    }
 }
 
 fn normalize_codex_timestamp(value: Option<&CodexTimestamp<'_>>) -> Option<String> {
@@ -751,6 +856,18 @@ fn normalize_codex_timestamp(value: Option<&CodexTimestamp<'_>>) -> Option<Strin
             )))
         }
     }
+}
+
+fn raw_or_normalized_value_timestamp(value: Option<&Value>) -> Option<String> {
+    let value = value?;
+    if let Some(text) = value.as_str() {
+        let text = text.trim();
+        if text.is_empty() {
+            return None;
+        }
+        return Some(text.to_string());
+    }
+    normalize_value_timestamp(Some(value))
 }
 
 fn normalize_value_timestamp(value: Option<&Value>) -> Option<String> {

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -839,7 +839,17 @@ fn raw_or_normalized_codex_timestamp(value: Option<&CodexTimestamp<'_>>) -> Opti
     match value? {
         CodexTimestamp::String(text) => {
             let text = text.trim();
-            (!text.is_empty()).then(|| text.to_string())
+            if text.is_empty() {
+                return None;
+            }
+            if codex_timestamp_date(text).is_some() {
+                return Some(text.to_string());
+            }
+            // Malformed string: try parsing-based normalization. If that also
+            // fails, return None so the caller's `or_else` chain can try the
+            // next available timestamp field instead of locking in a string
+            // that downstream date resolution will reject.
+            normalize_codex_timestamp(value)
         }
         CodexTimestamp::Number(_) => normalize_codex_timestamp(value),
     }
@@ -874,7 +884,14 @@ fn raw_or_normalized_value_timestamp(value: Option<&Value>) -> Option<String> {
         if text.is_empty() {
             return None;
         }
-        return Some(text.to_string());
+        if codex_timestamp_date(text).is_some() {
+            return Some(text.to_string());
+        }
+        // Malformed string: try parsing-based normalization. If that also
+        // fails, return None so the caller's `or_else` chain can try the
+        // next available timestamp field instead of locking in a string
+        // that downstream date resolution will reject.
+        return normalize_value_timestamp(Some(value));
     }
     normalize_value_timestamp(Some(value))
 }

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -35,6 +35,7 @@ static THREAD_SPAWN_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(b"thread_spawn"));
 
 const CODEX_AUTO_REVIEW_MODEL: &str = "codex-auto-review";
+// New entries must be inserted in descending release-date order.
 const CODEX_AUTO_REVIEW_FALLBACK_MODELS: [(&str, &str); 7] = [
     ("2026-04-23", "gpt-5.5"),
     ("2026-03-05", "gpt-5.4"),
@@ -501,7 +502,7 @@ fn codex_log_model_fallback(model: &str, timestamp: &str) -> Option<&'static str
         return None;
     }
     let Some(date) = codex_timestamp_date(timestamp) else {
-        return Some("gpt-5.5");
+        return Some("gpt-5");
     };
     Some(
         CODEX_AUTO_REVIEW_FALLBACK_MODELS

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use memchr::memmem::Finder;
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{CodexRawUsage, CodexTokenUsageEvent, Result, TimestampMs};
@@ -35,16 +36,20 @@ static THREAD_SPAWN_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(b"thread_spawn"));
 
 const CODEX_AUTO_REVIEW_MODEL: &str = "codex-auto-review";
-// New entries must be inserted in descending release-date order.
-const CODEX_AUTO_REVIEW_FALLBACK_MODELS: [(&str, &str); 7] = [
-    ("2026-04-23", "gpt-5.5"),
-    ("2026-03-05", "gpt-5.4"),
-    ("2026-02-05", "gpt-5.3-codex"),
-    ("2025-12-11", "gpt-5.2-codex"),
-    ("2025-11-13", "gpt-5.1-codex"),
-    ("2025-09-15", "gpt-5-codex"),
-    ("2025-08-07", "gpt-5"),
-];
+const CODEX_AUTO_REVIEW_FALLBACKS_JSON: &str = include_str!("codex-auto-review-fallbacks.json");
+
+static CODEX_AUTO_REVIEW_FALLBACK_MODELS: LazyLock<Vec<CodexAutoReviewFallback<'static>>> =
+    LazyLock::new(|| {
+        serde_json::from_str(CODEX_AUTO_REVIEW_FALLBACKS_JSON)
+            .expect("embedded codex-auto-review fallback snapshot must parse")
+    });
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexAutoReviewFallback<'a> {
+    released_on: &'a str,
+    model: &'a str,
+}
 
 #[derive(Clone, Copy)]
 enum CodexLineKind {
@@ -517,11 +522,15 @@ fn codex_log_model_fallback(model: &str, timestamp: &str) -> Option<&'static str
         return Some("gpt-5");
     };
     Some(
-        CODEX_AUTO_REVIEW_FALLBACK_MODELS
+        codex_auto_review_fallback_models()
             .iter()
-            .find_map(|(released_on, fallback)| (date >= *released_on).then_some(*fallback))
+            .find_map(|fallback| (date >= fallback.released_on).then_some(fallback.model))
             .unwrap_or("gpt-5"),
     )
+}
+
+fn codex_auto_review_fallback_models() -> &'static [CodexAutoReviewFallback<'static>] {
+    CODEX_AUTO_REVIEW_FALLBACK_MODELS.as_slice()
 }
 
 fn codex_timestamp_date(timestamp: &str) -> Option<&str> {
@@ -949,5 +958,24 @@ fn subtract_codex_raw_usage(
         total_tokens: current
             .total_tokens
             .saturating_sub(previous.map_or(0, |usage| usage.total_tokens)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_codex_auto_review_fallbacks_from_models_dev_snapshot() {
+        let fallbacks = codex_auto_review_fallback_models();
+
+        assert_eq!(fallbacks.len(), 7);
+        assert_eq!(fallbacks[0].released_on, "2026-04-23");
+        assert_eq!(fallbacks[0].model, "gpt-5.5");
+        assert_eq!(fallbacks[6].released_on, "2025-08-07");
+        assert_eq!(fallbacks[6].model, "gpt-5");
+        assert!(fallbacks
+            .windows(2)
+            .all(|window| window[0].released_on > window[1].released_on));
     }
 }

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -34,6 +34,17 @@ static PROMPT_TOKENS_FIELD_FINDER: LazyLock<Finder<'static>> =
 static THREAD_SPAWN_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(b"thread_spawn"));
 
+const CODEX_AUTO_REVIEW_MODEL: &str = "codex-auto-review";
+const CODEX_AUTO_REVIEW_FALLBACK_MODELS: [(&str, &str); 7] = [
+    ("2026-04-23", "gpt-5.5"),
+    ("2026-03-05", "gpt-5.4"),
+    ("2026-02-05", "gpt-5.3-codex"),
+    ("2025-12-11", "gpt-5.2-codex"),
+    ("2025-11-13", "gpt-5.1-codex"),
+    ("2025-09-15", "gpt-5-codex"),
+    ("2025-08-07", "gpt-5"),
+];
+
 #[derive(Clone, Copy)]
 enum CodexLineKind {
     Session,
@@ -267,20 +278,12 @@ fn visit_codex_session_entry(
 
     let parsed_model =
         codex_model_from_payload(payload).or_else(|| info.and_then(codex_model_from_info));
-    if let Some(model) = parsed_model.clone() {
-        *current_model = Some(model);
-        *current_model_is_fallback = false;
-    }
-    let mut is_fallback_model = false;
-    let model = parsed_model.or_else(|| current_model.clone()).or_else(|| {
-        is_fallback_model = true;
-        *current_model_is_fallback = true;
-        *current_model = Some("gpt-5".to_string());
-        current_model.clone()
-    });
-    if parsed_model_is_missing(&model, current_model, *current_model_is_fallback) {
-        is_fallback_model = true;
-    }
+    let (model, is_fallback_model) = resolve_codex_usage_model(
+        parsed_model,
+        &timestamp,
+        current_model,
+        current_model_is_fallback,
+    );
 
     visit(CodexTokenUsageEvent {
         session_id: session_id.to_string(),
@@ -357,20 +360,12 @@ fn visit_codex_exec_usage_event(
     current_model_is_fallback: &mut bool,
     visit: &mut impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
-    if let Some(model) = parsed_model.clone() {
-        *current_model = Some(model);
-        *current_model_is_fallback = false;
-    }
-    let mut is_fallback_model = false;
-    let model = parsed_model.or_else(|| current_model.clone()).or_else(|| {
-        is_fallback_model = true;
-        *current_model_is_fallback = true;
-        *current_model = Some("gpt-5".to_string());
-        current_model.clone()
-    });
-    if parsed_model_is_missing(&model, current_model, *current_model_is_fallback) {
-        is_fallback_model = true;
-    }
+    let (model, is_fallback_model) = resolve_codex_usage_model(
+        parsed_model,
+        &timestamp,
+        current_model,
+        current_model_is_fallback,
+    );
     visit(CodexTokenUsageEvent {
         session_id: session_id.to_string(),
         timestamp,
@@ -468,6 +463,64 @@ fn parsed_model_is_missing(
     current_model_is_fallback: bool,
 ) -> bool {
     model.is_some() && current_model.is_some() && current_model_is_fallback
+}
+
+fn resolve_codex_usage_model(
+    parsed_model: Option<String>,
+    timestamp: &str,
+    current_model: &mut Option<String>,
+    current_model_is_fallback: &mut bool,
+) -> (Option<String>, bool) {
+    if let Some(model) = parsed_model.as_ref() {
+        *current_model = Some(model.clone());
+        *current_model_is_fallback = false;
+    }
+    let mut is_fallback_model = false;
+    let model = parsed_model.or_else(|| current_model.clone()).or_else(|| {
+        is_fallback_model = true;
+        *current_model_is_fallback = true;
+        *current_model = Some("gpt-5".to_string());
+        current_model.clone()
+    });
+    if parsed_model_is_missing(&model, current_model, *current_model_is_fallback) {
+        is_fallback_model = true;
+    }
+    let model = model.map(|model| {
+        codex_log_model_fallback(&model, timestamp)
+            .map(|fallback| {
+                is_fallback_model = true;
+                fallback.to_string()
+            })
+            .unwrap_or(model)
+    });
+    (model, is_fallback_model)
+}
+
+fn codex_log_model_fallback(model: &str, timestamp: &str) -> Option<&'static str> {
+    if model != CODEX_AUTO_REVIEW_MODEL {
+        return None;
+    }
+    let Some(date) = codex_timestamp_date(timestamp) else {
+        return Some("gpt-5.5");
+    };
+    Some(
+        CODEX_AUTO_REVIEW_FALLBACK_MODELS
+            .iter()
+            .find_map(|(released_on, fallback)| (date >= *released_on).then_some(*fallback))
+            .unwrap_or("gpt-5"),
+    )
+}
+
+fn codex_timestamp_date(timestamp: &str) -> Option<&str> {
+    let date = timestamp.get(..10)?;
+    let bytes = date.as_bytes();
+    (bytes.len() == 10
+        && bytes[0..4].iter().all(u8::is_ascii_digit)
+        && bytes[4] == b'-'
+        && bytes[5..7].iter().all(u8::is_ascii_digit)
+        && bytes[7] == b'-'
+        && bytes[8..10].iter().all(u8::is_ascii_digit))
+    .then_some(date)
 }
 
 fn codex_session_id(sessions_dir: &Path, path: &Path) -> String {

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1135,7 +1135,6 @@ fn normalized_pricing_key(value: &str) -> Cow<'_, str> {
 /// canonical pricing keys.
 fn pricing_alias(model: &str) -> Option<&'static str> {
     match model {
-        "codex-auto-review" => Some("gpt-5.5"),
         "gpt-5.3-spark" => Some("gpt-5.3-codex-spark"),
         _ => None,
     }
@@ -1796,23 +1795,11 @@ mod tests {
     }
 
     #[test]
-    fn embedded_pricing_resolves_codex_auto_review_model() {
+    fn embedded_pricing_does_not_resolve_undated_codex_auto_review_model() {
         let pricing = PricingMap::load_embedded();
-        let auto_review = pricing
-            .find("codex-auto-review")
-            .expect("codex-auto-review should resolve via model alias");
-        let latest_codex = pricing
-            .find("gpt-5.5")
-            .expect("canonical latest Codex pricing should exist");
 
-        assert_eq!(auto_review.input, latest_codex.input);
-        assert_eq!(auto_review.output, latest_codex.output);
-        assert_eq!(auto_review.cache_read, latest_codex.cache_read);
-        assert_eq!(auto_review.fast_multiplier, latest_codex.fast_multiplier);
-        assert_eq!(
-            pricing.context_limit("codex-auto-review"),
-            pricing.context_limit("gpt-5.5")
-        );
+        assert!(pricing.find("codex-auto-review").is_none());
+        assert!(pricing.context_limit("codex-auto-review").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Resolve Codex \`codex-auto-review\` log labels to the newest known Codex/OpenAI model available on each event date.
- Move that behavior out of the undated pricing alias path so older review logs no longer price as \`gpt-5.5\` unconditionally.
- Document the date-aware fallback behavior in the Codex guide.

Testing:
- just fmt
- cargo test --manifest-path rust/Cargo.toml -p ccusage resolves_codex_auto_review
- cargo test --manifest-path rust/Cargo.toml -p ccusage embedded_pricing_
- cargo test --manifest-path rust/Cargo.toml -p ccusage codex
- pre-push hooks via nix develop --command git push

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Codex review pricing by resolving `codex-auto-review` to the newest available model per log date during parsing, using an embedded `models.dev` snapshot. Invalid or missing dates fall back to `gpt-5`, and the embedded snapshot is now included in Nix builds.

- **Bug Fixes**
  - Generate and embed the Codex review fallback table from pinned `models.dev`, with correct base vs `-codex` same-day handling; parse once at runtime (no extra I/O). `just gen-models-dev-pricing` now refreshes both snapshots.
  - Resolve from the raw log timestamp, trying `created_at`/`createdAt` and nested fields when the top-level value is malformed; validate YYYY-MM-DD, month lengths, and leap years; invalid/pre-table/missing dates map to `gpt-5`.
  - Remove the undated alias in `pricing` so `codex-auto-review` doesn’t resolve globally or set a context limit.
  - Update the Codex guide to note parser-side mapping from the pinned snapshot; add tests for per-date mapping, malformed timestamps with fallback fields, file mtime fallback, ordering, and `turn_context`.
  - Include the embedded fallback JSON in Nix cleanSource so native packages build correctly.
  - Make `just gen-models-dev-pricing` fail fast by chaining build and copy with `&&`.

<sup>Written for commit 01b690bfe767799d9ca67a28dff517d60715b8b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Codex guide: internal review aliases resolve to the newest known model as of an event's log date and explained alias mapping behavior.

* **Behavior**
  * Undated `codex-auto-review` no longer maps to a fixed model and is treated as not found (no context limit); dated aliases resolve to the newest model for the event date.

* **Tests**
  * Added unit tests for alias resolution across event dates, invalid dates, and contextual scenarios.

* **Chores**
  * Vendored a dated fallback snapshot and updated generation tooling to produce and include it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->