### PR TITLE
fix(pricing): stabilise models.dev snapshot generation

### DIFF
--- a/nix/models-dev-compact.test.ts
+++ b/nix/models-dev-compact.test.ts
@@ -1,5 +1,6 @@
 import {
 	formatDuplicateModelsDevPricingKeyWarning,
+	shouldReplaceModelsDevPricingCandidate,
 	selectModelsDevPricingKey,
 } from './models-dev-compact.ts';
 
@@ -30,4 +31,50 @@ it('formats duplicate pricing key warnings with the skipped source id', () => {
 	).toBe(
 		'models.dev pricing key "claude-sonnet-4" already exists; skipping duplicate source model "anthropic/claude-sonnet-4".',
 	);
+});
+
+it('prefers Anthropic provider pricing over duplicate aliases', () => {
+	expect(
+		shouldReplaceModelsDevPricingCandidate(
+			{
+				pricingKey: 'claude-sonnet-4-6',
+				sourceProviderId: 'github-copilot',
+				sourceModelId: 'claude-sonnet-4-6',
+				hasContextLimit: true,
+				hasExplicitCacheRead: true,
+				hasExplicitCacheWrite: true,
+			},
+			{
+				pricingKey: 'claude-sonnet-4-6',
+				sourceProviderId: 'anthropic',
+				sourceModelId: 'claude-sonnet-4-6',
+				hasContextLimit: true,
+				hasExplicitCacheRead: true,
+				hasExplicitCacheWrite: true,
+			},
+		),
+	).toBe(true);
+});
+
+it('uses a stable source ordering tie-break for duplicate aliases', () => {
+	expect(
+		shouldReplaceModelsDevPricingCandidate(
+			{
+				pricingKey: 'claude-sonnet-4',
+				sourceProviderId: 'nano-gpt',
+				sourceModelId: 'claude-sonnet-4',
+				hasContextLimit: true,
+				hasExplicitCacheRead: true,
+				hasExplicitCacheWrite: true,
+			},
+			{
+				pricingKey: 'claude-sonnet-4',
+				sourceProviderId: 'github-copilot',
+				sourceModelId: 'claude-sonnet-4',
+				hasContextLimit: true,
+				hasExplicitCacheRead: true,
+				hasExplicitCacheWrite: true,
+			},
+		),
+	).toBe(true);
 });

--- a/nix/models-dev-compact.test.ts
+++ b/nix/models-dev-compact.test.ts
@@ -37,7 +37,6 @@ it('prefers Anthropic provider pricing over duplicate aliases', () => {
 	expect(
 		shouldReplaceModelsDevPricingCandidate(
 			{
-				pricingKey: 'claude-sonnet-4-6',
 				sourceProviderId: 'github-copilot',
 				sourceModelId: 'claude-sonnet-4-6',
 				hasContextLimit: true,
@@ -45,7 +44,6 @@ it('prefers Anthropic provider pricing over duplicate aliases', () => {
 				hasExplicitCacheWrite: true,
 			},
 			{
-				pricingKey: 'claude-sonnet-4-6',
 				sourceProviderId: 'anthropic',
 				sourceModelId: 'claude-sonnet-4-6',
 				hasContextLimit: true,
@@ -60,7 +58,6 @@ it('uses a stable source ordering tie-break for duplicate aliases', () => {
 	expect(
 		shouldReplaceModelsDevPricingCandidate(
 			{
-				pricingKey: 'claude-sonnet-4',
 				sourceProviderId: 'nano-gpt',
 				sourceModelId: 'claude-sonnet-4',
 				hasContextLimit: true,
@@ -68,7 +65,6 @@ it('uses a stable source ordering tie-break for duplicate aliases', () => {
 				hasExplicitCacheWrite: true,
 			},
 			{
-				pricingKey: 'claude-sonnet-4',
 				sourceProviderId: 'github-copilot',
 				sourceModelId: 'claude-sonnet-4',
 				hasContextLimit: true,

--- a/nix/models-dev-compact.ts
+++ b/nix/models-dev-compact.ts
@@ -2,6 +2,22 @@ export function selectModelsDevPricingKey(modelId: string, catalogId: string | u
 	return catalogId != null && catalogId.length > 0 ? catalogId : modelId;
 }
 
+export type ModelsDevPricingCandidate = {
+	pricingKey: string;
+	sourceProviderId: string;
+	sourceModelId: string;
+	hasContextLimit: boolean;
+	hasExplicitCacheRead: boolean;
+	hasExplicitCacheWrite: boolean;
+};
+
+export function shouldReplaceModelsDevPricingCandidate(
+	existing: ModelsDevPricingCandidate,
+	candidate: ModelsDevPricingCandidate,
+): boolean {
+	return compareModelsDevPricingCandidates(candidate, existing) > 0;
+}
+
 export function formatDuplicateModelsDevPricingKeyWarning({
 	pricingKey,
 	sourceModelId,
@@ -10,4 +26,37 @@ export function formatDuplicateModelsDevPricingKeyWarning({
 	sourceModelId: string;
 }): string {
 	return `models.dev pricing key "${pricingKey}" already exists; skipping duplicate source model "${sourceModelId}".`;
+}
+
+function compareModelsDevPricingCandidates(
+	left: ModelsDevPricingCandidate,
+	right: ModelsDevPricingCandidate,
+): number {
+	return (
+		compareNumber(candidateProviderPriority(left), candidateProviderPriority(right)) ||
+		compareBoolean(left.hasExplicitCacheRead, right.hasExplicitCacheRead) ||
+		compareBoolean(left.hasExplicitCacheWrite, right.hasExplicitCacheWrite) ||
+		compareBoolean(left.hasContextLimit, right.hasContextLimit) ||
+		compareStringAscending(left.sourceProviderId, right.sourceProviderId) ||
+		compareStringAscending(left.sourceModelId, right.sourceModelId)
+	);
+}
+
+function candidateProviderPriority(candidate: ModelsDevPricingCandidate): number {
+	if (candidate.sourceProviderId === 'anthropic') {
+		return 2;
+	}
+	return candidate.sourceModelId.includes('anthropic') ? 1 : 0;
+}
+
+function compareNumber(left: number, right: number): number {
+	return left === right ? 0 : left > right ? 1 : -1;
+}
+
+function compareBoolean(left: boolean, right: boolean): number {
+	return compareNumber(left ? 1 : 0, right ? 1 : 0);
+}
+
+function compareStringAscending(left: string, right: string): number {
+	return left === right ? 0 : left < right ? 1 : -1;
 }

--- a/nix/models-dev-compact.ts
+++ b/nix/models-dev-compact.ts
@@ -36,8 +36,8 @@ function compareModelsDevPricingCandidates(
 		compareBoolean(left.hasExplicitCacheRead, right.hasExplicitCacheRead) ||
 		compareBoolean(left.hasExplicitCacheWrite, right.hasExplicitCacheWrite) ||
 		compareBoolean(left.hasContextLimit, right.hasContextLimit) ||
-		compareStringAscending(left.sourceProviderId, right.sourceProviderId) ||
-		compareStringAscending(left.sourceModelId, right.sourceModelId)
+		compareStringPreferSmaller(left.sourceProviderId, right.sourceProviderId) ||
+		compareStringPreferSmaller(left.sourceModelId, right.sourceModelId)
 	);
 }
 
@@ -56,6 +56,6 @@ function compareBoolean(left: boolean, right: boolean): number {
 	return compareNumber(left ? 1 : 0, right ? 1 : 0);
 }
 
-function compareStringAscending(left: string, right: string): number {
+function compareStringPreferSmaller(left: string, right: string): number {
 	return left === right ? 0 : left < right ? 1 : -1;
 }

--- a/nix/models-dev-compact.ts
+++ b/nix/models-dev-compact.ts
@@ -3,7 +3,6 @@ export function selectModelsDevPricingKey(modelId: string, catalogId: string | u
 }
 
 export type ModelsDevPricingCandidate = {
-	pricingKey: string;
 	sourceProviderId: string;
 	sourceModelId: string;
 	hasContextLimit: boolean;

--- a/nix/models-dev-gen.ts
+++ b/nix/models-dev-gen.ts
@@ -15,7 +15,9 @@
 import { generateCatalog } from './packages/core/src/generate.ts';
 import {
 	formatDuplicateModelsDevPricingKeyWarning,
+	type ModelsDevPricingCandidate,
 	selectModelsDevPricingKey,
+	shouldReplaceModelsDevPricingCandidate,
 } from './models-dev-compact.ts';
 
 /** Model ids/keys we keep; ccusage is Claude-first, so we embed Anthropic models. */
@@ -32,7 +34,7 @@ type ModelMetadata = {
 	id?: string;
 	release_date?: string;
 };
-type Provider = { models?: Record<string, Model> };
+type Provider = { id?: string; models?: Record<string, Model> };
 type EmbeddedModel = {
 	cost: Cost;
 	limit?: { context: number };
@@ -47,9 +49,9 @@ const { models, providers } = (await generateCatalog('.')) as {
 	providers: Record<string, Provider>;
 };
 
-const out: Record<string, EmbeddedModel> = {};
-for (const provider of Object.values(providers)) {
-	for (const [modelId, model] of Object.entries(provider.models ?? {})) {
+const selected: Record<string, { candidate: ModelsDevPricingCandidate; entry: EmbeddedModel }> = {};
+for (const [providerId, provider] of sortedEntries(providers)) {
+	for (const [modelId, model] of sortedEntries(provider.models ?? {})) {
 		// models.dev also exposes the canonical id under `id`; match either so
 		// provider-prefixed aliases (e.g. us.anthropic.*) are kept too.
 		if (!(KEEP.test(modelId) || KEEP.test(model.id ?? ''))) {
@@ -61,15 +63,6 @@ for (const provider of Object.values(providers)) {
 			continue;
 		}
 		const pricingKey = selectModelsDevPricingKey(modelId, model.id);
-		if (out[pricingKey] != null) {
-			console.warn(
-				formatDuplicateModelsDevPricingKeyWarning({
-					pricingKey,
-					sourceModelId: modelId,
-				}),
-			);
-			continue;
-		}
 		const entry: EmbeddedModel = {
 			cost: {
 				input: cost.input,
@@ -81,9 +74,34 @@ for (const provider of Object.values(providers)) {
 		if (model.limit?.context != null) {
 			entry.limit = { context: model.limit.context };
 		}
-		out[pricingKey] = entry;
+		const candidate: ModelsDevPricingCandidate = {
+			pricingKey,
+			sourceProviderId: provider.id ?? providerId,
+			sourceModelId: modelId,
+			hasContextLimit: entry.limit != null,
+			hasExplicitCacheRead: cost.cache_read != null,
+			hasExplicitCacheWrite: cost.cache_write != null,
+		};
+		const existing = selected[pricingKey];
+		if (existing != null) {
+			const replacement = shouldReplaceModelsDevPricingCandidate(existing.candidate, candidate);
+			console.warn(
+				formatDuplicateModelsDevPricingKeyWarning({
+					pricingKey,
+					sourceModelId: replacement ? existing.candidate.sourceModelId : candidate.sourceModelId,
+				}),
+			);
+			if (!replacement) {
+				continue;
+			}
+		}
+		selected[pricingKey] = { candidate, entry };
 	}
 }
+
+const out = Object.fromEntries(
+	Object.entries(selected).map(([pricingKey, { entry }]) => [pricingKey, entry]),
+);
 
 // Stable key ordering keeps the committed snapshot's diffs minimal across regenerations.
 const sortObject = (value: unknown): unknown => {
@@ -99,6 +117,10 @@ const sortObject = (value: unknown): unknown => {
 	}
 	return value;
 };
+
+function sortedEntries<T>(value: Record<string, T>): Array<[string, T]> {
+	return Object.entries(value).sort(([left], [right]) => left.localeCompare(right));
+}
 
 const outfile = process.env.OUTFILE;
 if (outfile == null || outfile.length === 0) {

--- a/nix/models-dev-gen.ts
+++ b/nix/models-dev-gen.ts
@@ -75,7 +75,6 @@ for (const [providerId, provider] of sortedEntries(providers)) {
 			entry.limit = { context: model.limit.context };
 		}
 		const candidate: ModelsDevPricingCandidate = {
-			pricingKey,
 			sourceProviderId: provider.id ?? providerId,
 			sourceModelId: modelId,
 			hasContextLimit: entry.limit != null,
@@ -119,7 +118,7 @@ const sortObject = (value: unknown): unknown => {
 };
 
 function sortedEntries<T>(value: Record<string, T>): Array<[string, T]> {
-	return Object.entries(value).sort(([left], [right]) => left.localeCompare(right));
+	return Object.entries(value).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
 }
 
 const outfile = process.env.OUTFILE;

--- a/nix/models-dev-gen.ts
+++ b/nix/models-dev-gen.ts
@@ -118,7 +118,9 @@ const sortObject = (value: unknown): unknown => {
 };
 
 function sortedEntries<T>(value: Record<string, T>): Array<[string, T]> {
-	return Object.entries(value).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+	return Object.entries(value).sort(([left], [right]) =>
+		left < right ? -1 : left > right ? 1 : 0,
+	);
 }
 
 const outfile = process.env.OUTFILE;

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -582,7 +582,7 @@ mod tests {
 
     #[test]
     fn resolves_codex_auto_review_with_invalid_event_date_falls_back_to_file_mtime() {
-        // When the log's own timestamp fields are unparseable AND no alternate
+        // When the log's own timestamp fields are unparsable AND no alternate
         // timestamp fields are present, the parser falls back to the file's
         // modified time so the date-based fallback table still resolves to a
         // real model rather than locking in a misleading malformed string.
@@ -617,10 +617,10 @@ mod tests {
         // File mtime is "now" at fixture creation, which is on or after every
         // entry currently in the fallback table, so resolution lands on the
         // newest known model. The exact value updates when the table grows.
-        assert!(events
-            .iter()
-            .all(|event| event.model.as_deref().is_some_and(|model| model
-                .starts_with("gpt-5"))));
+        assert!(events.iter().all(|event| event
+            .model
+            .as_deref()
+            .is_some_and(|model| model.starts_with("gpt-5"))));
         assert!(events.iter().all(|event| event.is_fallback_model));
     }
 

--- a/rust/crates/ccusage/src/models-dev-pricing.json
+++ b/rust/crates/ccusage/src/models-dev-pricing.json
@@ -643,7 +643,7 @@
 			"output": 25
 		},
 		"limit": {
-			"context": 200000
+			"context": 1000000
 		}
 	},
 	"anthropic/claude-opus-4-7": {
@@ -782,11 +782,13 @@
 	},
 	"anthropic/claude-opus-4.8": {
 		"cost": {
-			"input": 4.2929,
-			"output": 21.4646
+			"cache_read": 0.5,
+			"cache_write": 6.25,
+			"input": 5,
+			"output": 25
 		},
 		"limit": {
-			"context": 1048576
+			"context": 1000000
 		}
 	},
 	"anthropic/claude-opus-4.8-fast": {
@@ -880,7 +882,7 @@
 			"cache_read": 0.3,
 			"cache_write": 3.75,
 			"input": 3,
-			"output": 15.5
+			"output": 15
 		},
 		"limit": {
 			"context": 200000
@@ -921,6 +923,8 @@
 	},
 	"anthropic/claude-sonnet-4.6": {
 		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
 			"input": 3,
 			"output": 15
 		},
@@ -1015,6 +1019,8 @@
 	},
 	"claude-3-5-haiku-20241022": {
 		"cost": {
+			"cache_read": 0.08,
+			"cache_write": 1,
 			"input": 0.8,
 			"output": 4
 		},
@@ -1078,6 +1084,8 @@
 	},
 	"claude-3-7-sonnet-20250219": {
 		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
 			"input": 3,
 			"output": 15
 		},
@@ -1236,6 +1244,8 @@
 	},
 	"claude-haiku-4-5-20251001": {
 		"cost": {
+			"cache_read": 0.1,
+			"cache_write": 1.25,
 			"input": 1,
 			"output": 5
 		},
@@ -1310,6 +1320,8 @@
 	},
 	"claude-opus-4-1-20250805": {
 		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
 			"input": 15,
 			"output": 75
 		},
@@ -1384,6 +1396,8 @@
 	},
 	"claude-opus-4-20250514": {
 		"cost": {
+			"cache_read": 1.5,
+			"cache_write": 18.75,
 			"input": 15,
 			"output": 75
 		},
@@ -1404,6 +1418,8 @@
 	},
 	"claude-opus-4-5-20251101": {
 		"cost": {
+			"cache_read": 0.5,
+			"cache_write": 6.25,
 			"input": 5,
 			"output": 25
 		},
@@ -1734,6 +1750,8 @@
 	},
 	"claude-sonnet-4-20250514": {
 		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
 			"input": 3,
 			"output": 15
 		},
@@ -1754,6 +1772,8 @@
 	},
 	"claude-sonnet-4-5-20250929": {
 		"cost": {
+			"cache_read": 0.3,
+			"cache_write": 3.75,
 			"input": 3,
 			"output": 15
 		},
@@ -1763,11 +1783,11 @@
 	},
 	"claude-sonnet-4-5-20250929-thinking": {
 		"cost": {
-			"input": 2.992,
-			"output": 14.994
+			"input": 3,
+			"output": 15
 		},
 		"limit": {
-			"context": 1000000
+			"context": 200000
 		}
 	},
 	"claude-sonnet-4-5@20250929": {


### PR DESCRIPTION
## Summary

Stabilises the models.dev pricing snapshot generator so duplicate pricing keys no longer depend on upstream provider iteration order.

The generator now sorts provider/model entries and ranks duplicate candidates, preferring Anthropic provider rows and complete cache/context metadata before falling back to deterministic source ids. The committed snapshot was regenerated with the fixed generator.

## Testing

- pnpm exec vitest run nix/models-dev-compact.test.ts
- direnv exec . cargo test --manifest-path rust/Cargo.toml -p ccusage pricing::tests::
- direnv exec . just gen-models-dev-pricing
- direnv exec . just test-vitest
- pre-push hook via direnv exec . git push -u origin codex/fix-models-dev-pricing-determinism

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes models.dev pricing snapshot generation with bytewise string sorting and deterministic duplicate resolution, so output no longer varies by provider order or locale. Regenerates the snapshot to restore canonical Anthropic cache/context values, including cache_read/write and context limits.

- **Bug Fixes**
  - Sort provider and model entries using bytewise comparison; resolve duplicate keys by preferring `anthropic`, then entries with explicit cache read/write and context, then stable provider/model id tie-break.
  - Remove unused candidate field; add tests for Anthropic-priority selection and stable alias tie-breaks; regenerate snapshot and apply treefmt formatting in Nix/Rust tests.

<sup>Written for commit a41584ec32a4431b84e1a2c8f8e8eddac54ee38f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pricing and context limits for several Claude and Anthropic models; normalized cache-related cost values.

* **Tests**
  * Added unit tests ensuring deterministic and preferred-provider selection when duplicate pricing entries occur.

* **Chores**
  * Improved duplicate-entry resolution to produce more stable, predictable pricing snapshots.

* **Style**
  * Minor test comment and formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->