### PR TITLE
perf(ci): try Intel runners for non-native jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
   check:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true'
-    runs-on: blacksmith-32vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-32vcpu-ubuntu-2404
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -35,7 +35,7 @@ jobs:
   test:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true'
-    runs-on: blacksmith-32vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -131,7 +131,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    runs-on: blacksmith-32vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     outputs:
       urls: ${{ steps.publish.outputs.urls }}
       preview-url: ${{ steps.preview-url.outputs.url }}
@@ -313,7 +313,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    runs-on: blacksmith-32vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -582,7 +582,7 @@ mod tests {
 
     #[test]
     fn resolves_codex_auto_review_with_invalid_event_date_falls_back_to_file_mtime() {
-        // When the log's own timestamp fields are unparseable AND no alternate
+        // When the log's own timestamp fields are unparsable AND no alternate
         // timestamp fields are present, the parser falls back to the file's
         // modified time so the date-based fallback table still resolves to a
         // real model rather than locking in a misleading malformed string.
@@ -617,10 +617,10 @@ mod tests {
         // File mtime is "now" at fixture creation, which is on or after every
         // entry currently in the fallback table, so resolution lands on the
         // newest known model. The exact value updates when the table grows.
-        assert!(events
-            .iter()
-            .all(|event| event.model.as_deref().is_some_and(|model| model
-                .starts_with("gpt-5"))));
+        assert!(events.iter().all(|event| event
+            .model
+            .as_deref()
+            .is_some_and(|model| model.starts_with("gpt-5"))));
         assert!(events.iter().all(|event| event.is_fallback_model));
     }
 


### PR DESCRIPTION
Switches CI jobs that do not build native packages from the ARM Blacksmith Ubuntu runner to the matching Intel runner for a timing comparison.

The native package build matrix and Linux arm64 preview E2E coverage remain unchanged, so architecture coverage is preserved while check, test, packaging, and perf-comment jobs run on Intel.

A separate formatter-only commit is included because the repository pre-push hook required current treefmt output before publishing the branch.

Testing:
- git diff --check
- nix develop --command just fmt
- pre-push hook: clippy, treefmt, gitleaks, cargo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch non-native CI jobs from the ARM Blacksmith Ubuntu runner to the equivalent Intel runner to compare queue and wall-clock time. Native package builds and Linux arm64 preview E2E stay on ARM, so architecture coverage is unchanged.

- **Refactors**
  - Moved `check`, `test`, packaging/publish, and performance-comment jobs to `blacksmith-32vcpu-ubuntu-2404`.
  - Applied `treefmt` to the Codex loader test file; formatting-only change.

<sup>Written for commit 43fc7cb757632a047bc90bc72080fd32dce67f2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow runner configurations.

* **Tests**
  * Adjusted test assertion formatting and comment wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->