### PR TITLE
build(rust): update toolchain to 1.96.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778555852,
-        "narHash": "sha256-55EmwooVAS4UpA0oWd5wilKPRqCiHD5BAej9QiNwheY=",
+        "lastModified": 1781234414,
+        "narHash": "sha256-HdA+P4fKRGOomkewnI/Tww5Wz4xK1O7+hDO90YAsPB4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f29b0f7a9f367e0056b716f8aa137cb41e784444",
+        "rev": "1d18bfe3de6244c641ca4e8011186d0981b81d76",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.96.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]

--- a/rust/crates/ccusage-cli/src/help_codegen.rs
+++ b/rust/crates/ccusage-cli/src/help_codegen.rs
@@ -23,7 +23,7 @@ fn generate_option_functions(
 ) -> BTreeMap<String, String> {
     let mut rendered_options = BTreeMap::new();
     let mut option_sets = option_sets.iter().collect::<Vec<_>>();
-    option_sets.sort_by(|(left, _), (right, _)| left.cmp(right));
+    option_sets.sort_by_key(|(left, _)| *left);
     for (function_name, options) in option_sets {
         let rendered = render_options(options);
         rendered_options.insert(function_name.to_string(), rendered.clone());
@@ -32,7 +32,7 @@ fn generate_option_functions(
 
     let combined_options = object_field(command_spec, "combinedOptions");
     let mut combined_options = combined_options.iter().collect::<Vec<_>>();
-    combined_options.sort_by(|(left, _), (right, _)| left.cmp(right));
+    combined_options.sort_by_key(|(left, _)| *left);
     for (function_name, parts) in combined_options {
         let Value::Array(parts) = parts else {
             panic!("combined option parts must be an array");

--- a/rust/crates/ccusage-test-support/src/lib.rs
+++ b/rust/crates/ccusage-test-support/src/lib.rs
@@ -73,8 +73,6 @@ macro_rules! fs_fixture {
 
 #[cfg(test)]
 mod tests {
-    use crate::fs_fixture;
-
     #[test]
     fn creates_inline_fixture_tree() {
         let fixture = fs_fixture!({

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -570,7 +570,7 @@ fn codex_days_in_month(year: u16, month: u16) -> Option<u16> {
 }
 
 fn codex_is_leap_year(year: u16) -> bool {
-    year % 4 == 0 && year % 100 != 0 || year % 400 == 0
+    year.is_multiple_of(4) && !year.is_multiple_of(100) || year.is_multiple_of(400)
 }
 
 fn codex_session_id(sessions_dir: &Path, path: &Path) -> String {

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -469,16 +469,16 @@ impl PricingMap {
             1.0
         };
 
-        let cache_create = if override_value.cache_creation_input_token_cost.is_some() {
-            override_value.cache_creation_input_token_cost.unwrap()
+        let cache_create = if let Some(value) = override_value.cache_creation_input_token_cost {
+            value
         } else if should_scale && base.cache_create > 0.0 {
             base.cache_create * scale
         } else {
             base.cache_create
         };
 
-        let cache_read = if override_value.cache_read_input_token_cost.is_some() {
-            override_value.cache_read_input_token_cost.unwrap()
+        let cache_read = if let Some(value) = override_value.cache_read_input_token_cost {
+            value
         } else if should_scale && base.cache_read > 0.0 {
             base.cache_read * scale
         } else {


### PR DESCRIPTION
## Summary

Updates the pinned Rust toolchain from 1.85.1 to 1.96.0 and refreshes the rust-overlay flake input so Nix can resolve that stable release.

This keeps the Rust compiler, clippy, rustfmt, and llvm-tools current, and unblocks Rust crates that require 1.95 or newer. This PR is not framed as a runtime performance optimization because local benchmark results were mixed.

## Validation

- Pre-commit hook on commit: treefmt, gitleaks
- Pre-push hook on push: treefmt, gitleaks; clippy/cargo/vitest hooks skipped because no matching files
- Built release binaries for Rust 1.85.1 and 1.96.0 in separate target dirs
- Verified JSON parity for claude daily, claude session, claude blocks, codex daily, and codex session

## Local measurements

- arm64 macOS release binary: 2,812,944 bytes -> 2,730,592 bytes (-82,352 bytes, -2.93%)
- Claude 129 MiB fixture: daily improved, session/blocks were slightly slower/noisy
- Codex 1.0 GiB fixture: session improved, daily was slower in the rerun

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Rust toolchain to 1.96.0 and refresh the Nix `rust-overlay` pin so local and CI builds use the current stable compiler. Also fixes new `clippy` 1.96 lints to keep `-D warnings` green, keeps `rustfmt` and `llvm-tools-preview` in sync, and unblocks crates requiring 1.95+.

- **Dependencies**
  - Updated `rust-overlay` flake input to resolve Rust 1.96.0.

<sup>Written for commit d7e76ba7bbddaf82fb4c801cfb63547c7ad190fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain to version 1.96.0

* **Refactor**
  * Internal improvements to option sorting and leap-year checks
  * Simplified pricing override handling for more consistent behavior

* **Tests**
  * Removed redundant test imports and relied on exported test helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->