### PR TITLE
build(rust): migrate crates to edition 2024

### DIFF
--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -70,7 +70,7 @@ in
           nixfmt.enable = true;
           rustfmt = {
             enable = true;
-            edition = "2021";
+            edition = "2024";
             package = rustToolchain;
           };
           statix.enable = true;

--- a/rust/crates/ccusage-cli/Cargo.toml
+++ b/rust/crates/ccusage-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccusage-cli"
 version = "20.0.11"
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 [dependencies]

--- a/rust/crates/ccusage-cli/src/help_codegen.rs
+++ b/rust/crates/ccusage-cli/src/help_codegen.rs
@@ -130,10 +130,10 @@ fn generate_command_spec(
         let usage = string_field(page, "usage");
         let commands = optional_array_field(page, "commands");
         let option_set = optional_string_field(page, "options");
-        if let Some(option_set) = option_set.as_deref() {
-            if !rendered_options.contains_key(option_set) {
-                panic!("missing option set {option_set}");
-            }
+        if let Some(option_set) = option_set.as_deref()
+            && !rendered_options.contains_key(option_set)
+        {
+            panic!("missing option set {option_set}");
         }
         output.push_str("    HelpPage {\n");
         output.push_str("        path: &");

--- a/rust/crates/ccusage-cli/src/lib.rs
+++ b/rust/crates/ccusage-cli/src/lib.rs
@@ -4,9 +4,9 @@ mod parser;
 mod types;
 
 pub use types::{
-    normalize_date_bound, AgentCommandArgs, AgentReportKind, BlocksArgs, Cli, CliConfig,
-    CodexSpeed, Command, CostMode, CostSource, DailyArgs, NoConfig, PricingOverride, SessionArgs,
-    SharedArgs, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs,
+    AgentCommandArgs, AgentReportKind, BlocksArgs, Cli, CliConfig, CodexSpeed, Command, CostMode,
+    CostSource, DailyArgs, NoConfig, PricingOverride, SessionArgs, SharedArgs, SortOrder,
+    StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs, normalize_date_bound,
 };
 
 #[cfg(test)]

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -4,9 +4,9 @@ use crate::arg_parser::ArgParser;
 use crate::help::{print_help_and_exit, print_version_and_exit};
 use crate::types::{OPENCODE_AGENT_REPORTS, STANDARD_AGENT_REPORTS};
 use crate::{
-    normalize_date_bound, AgentCommandArgs, AgentReportKind, BlocksArgs, Cli, CliConfig,
-    CodexSpeed, Command, CostMode, CostSource, DailyArgs, NoConfig, SessionArgs, SharedArgs,
-    SortOrder, StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs,
+    AgentCommandArgs, AgentReportKind, BlocksArgs, Cli, CliConfig, CodexSpeed, Command, CostMode,
+    CostSource, DailyArgs, NoConfig, SessionArgs, SharedArgs, SortOrder, StatuslineArgs,
+    VisualBurnRate, WeekDay, WeeklyArgs, normalize_date_bound,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::help::{help_text, help_text_for_args};
 use crate::*;

--- a/rust/crates/ccusage-terminal/Cargo.toml
+++ b/rust/crates/ccusage-terminal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccusage-terminal"
 version = "20.0.11"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 terminal_size = "0.4.4"

--- a/rust/crates/ccusage-terminal/src/lib.rs
+++ b/rust/crates/ccusage-terminal/src/lib.rs
@@ -4,7 +4,7 @@ mod terminal;
 mod title;
 mod width;
 
-pub use style::{color, Color, TerminalStyle};
+pub use style::{Color, TerminalStyle, color};
 pub use table::{Align, SimpleTable};
 pub use terminal::terminal_width;
 pub use title::print_box_title;

--- a/rust/crates/ccusage-terminal/src/table.rs
+++ b/rust/crates/ccusage-terminal/src/table.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 
 use crate::{
-    style::{color, Color, TerminalStyle},
+    style::{Color, TerminalStyle, color},
     terminal::DEFAULT_TERMINAL_WIDTH,
     width::{char_display_width, contains_ansi, visible_width, visible_width_max_line},
 };
@@ -139,10 +139,10 @@ impl SimpleTable {
             return row.to_vec();
         }
         let mut row = row.to_vec();
-        if let Some(first) = row.first_mut() {
-            if let Some(compact) = compact_date_cell(first) {
-                *first = compact;
-            }
+        if let Some(first) = row.first_mut()
+            && let Some(compact) = compact_date_cell(first)
+        {
+            *first = compact;
         }
         row
     }

--- a/rust/crates/ccusage-terminal/src/title.rs
+++ b/rust/crates/ccusage-terminal/src/title.rs
@@ -1,5 +1,5 @@
 use crate::{
-    style::{color, Color, TerminalStyle},
+    style::{Color, TerminalStyle, color},
     width::visible_width,
 };
 
@@ -57,12 +57,16 @@ mod tests {
             },
         );
 
-        assert!(lines
-            .iter()
-            .any(|line| line.contains("Coding (Agent) CLI Usage Report - Daily")));
-        assert!(lines
-            .iter()
-            .any(|line| line.contains("Detected: Claude, Codex")));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("Coding (Agent) CLI Usage Report - Daily"))
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("Detected: Claude, Codex"))
+        );
         assert_eq!(lines.iter().filter(|line| line.starts_with('╭')).count(), 1);
         assert_eq!(lines.iter().filter(|line| line.starts_with('╰')).count(), 1);
     }

--- a/rust/crates/ccusage-test-support/Cargo.toml
+++ b/rust/crates/ccusage-test-support/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccusage-test-support"
 version = "20.0.11"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/rust/crates/ccusage-test-support/src/lib.rs
+++ b/rust/crates/ccusage-test-support/src/lib.rs
@@ -1,12 +1,48 @@
 use std::{
+    ffi::{OsStr, OsString},
     fs,
     path::{Path, PathBuf},
+    sync::{Mutex, MutexGuard},
 };
 
 use assert_fs::{
     TempDir,
     fixture::{ChildPath, FileWriteStr, PathChild, PathCreateDir},
 };
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn env_lock() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap()
+}
+
+pub struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl EnvVarGuard {
+    pub fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let guard = env_lock();
+        let previous = std::env::var_os(key);
+        unsafe { std::env::set_var(key, value) };
+        Self {
+            key,
+            previous,
+            _guard: guard,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
 
 pub struct Fixture {
     dir: TempDir,

--- a/rust/crates/ccusage-test-support/src/lib.rs
+++ b/rust/crates/ccusage-test-support/src/lib.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use assert_fs::{
-    fixture::{ChildPath, FileWriteStr, PathChild, PathCreateDir},
     TempDir,
+    fixture::{ChildPath, FileWriteStr, PathChild, PathCreateDir},
 };
 
 pub struct Fixture {
@@ -62,7 +62,7 @@ impl Default for Fixture {
 
 #[macro_export]
 macro_rules! fs_fixture {
-    ({ $($path:literal : $contents:expr),* $(,)? }) => {{
+    ({ $($path:literal : $contents:expr_2021),* $(,)? }) => {{
         let fixture = $crate::Fixture::new();
         $(
             let _ = fixture.write_file($path, $contents);
@@ -90,8 +90,10 @@ mod tests {
         let fixture = fs_fixture!({});
         let _ = fixture.write_file("projects/example/session/chat.jsonl", "{}\n");
 
-        assert!(fixture
-            .path("projects/example/session/chat.jsonl")
-            .is_file());
+        assert!(
+            fixture
+                .path("projects/example/session/chat.jsonl")
+                .is_file()
+        );
     }
 }

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccusage"
 version = "20.0.11"
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 [[bin]]

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -1,15 +1,15 @@
 use std::{collections::BTreeMap, sync::mpsc, thread};
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    CodexGroup, LoadedEntry, ModelBreakdown, PricingMap, Result, SessionAccumulator, UsageSummary,
     adapter::{
         amp, claude, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo, kimi, openclaw,
         opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, SharedArgs, WeekDay},
-    filter_loaded_entries_by_date, json_float, CodexGroup, LoadedEntry, ModelBreakdown, PricingMap,
-    Result, SessionAccumulator, UsageSummary,
+    filter_loaded_entries_by_date, json_float,
 };
 
 use super::{
@@ -559,10 +559,10 @@ fn summary_metadata(agent: &'static str, summary: &UsageSummary) -> Option<Value
         if let Some(last_activity) = summary.last_activity.as_ref() {
             metadata.insert("lastActivity".to_string(), json!(last_activity));
         }
-        if agent == "pi" {
-            if let Some(project_path) = summary.project_path.as_ref() {
-                metadata.insert("projectPath".to_string(), json!(project_path));
-            }
+        if agent == "pi"
+            && let Some(project_path) = summary.project_path.as_ref()
+        {
+            metadata.insert("projectPath".to_string(), json!(project_path));
         }
     }
     if metadata.is_empty() {

--- a/rust/crates/ccusage/src/adapter/all/mod.rs
+++ b/rust/crates/ccusage/src/adapter/all/mod.rs
@@ -2,7 +2,7 @@ mod loader;
 mod report;
 mod types;
 
-use crate::{cli::AgentCommandArgs, print_json_or_jq, wants_json, Result};
+use crate::{Result, cli::AgentCommandArgs, print_json_or_jq, wants_json};
 
 pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     let kind = args.kind;

--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -1,12 +1,12 @@
 use std::{collections::BTreeSet, io::IsTerminal};
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    Align, Color, ModelBreakdown, Result, SimpleTable, UsageSummary,
     cli::{AgentReportKind, SharedArgs, SortOrder},
     color, format_currency, format_models_multiline, format_number, json_float, print_box_title,
-    short_model_name, should_use_compact_layout, Align, Color, ModelBreakdown, Result, SimpleTable,
-    UsageSummary,
+    short_model_name, should_use_compact_layout,
 };
 
 use super::types::AllRow;

--- a/rust/crates/ccusage/src/adapter/all/tests.rs
+++ b/rust/crates/ccusage/src/adapter/all/tests.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
     thread,
     time::{Duration, Instant},
@@ -11,8 +11,8 @@ use serde_json::json;
 
 use super::*;
 use crate::{
-    cli::{AgentReportKind, CodexSpeed},
     Align, CodexGroup, CodexModelUsage, ModelBreakdown, PricingMap,
+    cli::{AgentReportKind, CodexSpeed},
 };
 
 fn test_agent_rows(agent: &'static str) -> AgentRows {

--- a/rust/crates/ccusage/src/adapter/all/types.rs
+++ b/rust/crates/ccusage/src/adapter/all/types.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use serde_json::Value;
 
-use crate::{fast::FxHashMap, ModelBreakdown};
+use crate::{ModelBreakdown, fast::FxHashMap};
 
 #[derive(Debug, Clone)]
 pub(super) struct AllRow {

--- a/rust/crates/ccusage/src/adapter/amp/loader.rs
+++ b/rust/crates/ccusage/src/adapter/amp/loader.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::SharedArgs, collect_files_with_extension, parse_tz, LoadedEntry, PricingMap, Result,
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, collect_files_with_extension, parse_tz,
 };
 
 use super::{parser, paths};

--- a/rust/crates/ccusage/src/adapter/amp/mod.rs
+++ b/rust/crates/ccusage/src/adapter/amp/mod.rs
@@ -4,8 +4,8 @@ mod paths;
 mod report;
 
 use crate::{
-    adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
-    sort_summaries, wants_json, PricingMap, Result,
+    PricingMap, Result, adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date,
+    print_json_or_jq, sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;

--- a/rust/crates/ccusage/src/adapter/amp/parser.rs
+++ b/rust/crates/ccusage/src/adapter/amp/parser.rs
@@ -4,9 +4,9 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
 use crate::{
+    LoadedEntry, PricingMap, Result, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost, cli::CostMode, format_date_tz, json_value_u64,
-    missing_pricing_model_for_usage, non_empty_json_string, LoadedEntry, PricingMap, Result,
-    TokenUsageRaw, UsageEntry, UsageMessage,
+    missing_pricing_model_for_usage, non_empty_json_string,
 };
 
 pub(crate) fn read_thread_file(

--- a/rust/crates/ccusage/src/adapter/amp/report.rs
+++ b/rust/crates/ccusage/src/adapter/amp/report.rs
@@ -1,11 +1,11 @@
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::io::IsTerminal;
 
 use crate::{
-    adapter::opencode, cli::AgentReportKind, cli::SharedArgs, cli::WeekDay, format_currency,
-    format_models_multiline, format_number, json_value_u64, print_box_title,
-    should_use_compact_layout, summarize_by_key, summarize_summaries_by_bucket, totals_json, Align,
-    BucketKind, Color, LoadedEntry, Result, SimpleTable,
+    Align, BucketKind, Color, LoadedEntry, Result, SimpleTable, adapter::opencode,
+    cli::AgentReportKind, cli::SharedArgs, cli::WeekDay, format_currency, format_models_multiline,
+    format_number, json_value_u64, print_box_title, should_use_compact_layout, summarize_by_key,
+    summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/claude/daily.rs
+++ b/rust/crates/ccusage/src/adapter/claude/daily.rs
@@ -11,12 +11,11 @@ use memchr::memmem;
 use serde::Deserialize;
 
 use crate::{
-    calculate_cost_for_usage,
-    cli::{CostMode, SharedArgs},
-    fast::{byte_lines, suffix_string, FxHashMap, SmallIndexVec},
-    format_date_tz, log_level, missing_pricing_model_for_usage, parse_ts_timestamp, parse_tz,
     ModelBreakdown, PricingMap, Result, Speed, TimestampMs, TokenCounts, TokenUsageRaw,
-    UsageSummary,
+    UsageSummary, calculate_cost_for_usage,
+    cli::{CostMode, SharedArgs},
+    fast::{FxHashMap, SmallIndexVec, byte_lines, suffix_string},
+    format_date_tz, log_level, missing_pricing_model_for_usage, parse_ts_timestamp, parse_tz,
 };
 
 use super::{
@@ -60,10 +59,10 @@ pub(super) fn load_daily_summaries_inner(
     let mut deduped = Vec::with_capacity(loaded_files.iter().map(|file| file.entries.len()).sum());
     for loaded_file in loaded_files {
         for entry in loaded_file.entries {
-            if let Some(filter) = project_filter {
-                if entry.project.as_ref() != filter {
-                    continue;
-                }
+            if let Some(filter) = project_filter
+                && entry.project.as_ref() != filter
+            {
+                continue;
             }
             push_deduped_daily_entry(entry, &mut deduped_indexes, &mut deduped);
         }
@@ -513,7 +512,7 @@ impl DailyAccumulator {
 mod tests {
     use std::sync::Arc;
 
-    use super::{push_deduped_daily_entry, DailyLoadedEntry};
+    use super::{DailyLoadedEntry, push_deduped_daily_entry};
     use crate::TokenUsageRaw;
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/claude/mod.rs
+++ b/rust/crates/ccusage/src/adapter/claude/mod.rs
@@ -14,13 +14,13 @@ use memchr::memmem;
 use rustc_hash::FxHasher;
 
 use crate::{
+    LoadedEntry, LoadedFile, PricingMap, Result, Speed, TimestampMs, UsageEntry, UsageSummary,
     calculate_cost,
     cli::{CostMode, SharedArgs},
     debug_log,
-    fast::{byte_lines, suffix_string, FxHashMap, SmallIndexVec},
+    fast::{FxHashMap, SmallIndexVec, byte_lines, suffix_string},
     format_date_tz, log_level, missing_pricing_model_for_usage, parse_ts_timestamp, parse_tz,
-    progress, LoadedEntry, LoadedFile, PricingMap, Result, Speed, TimestampMs, UsageEntry,
-    UsageSummary,
+    progress,
 };
 
 #[cfg(test)]
@@ -107,10 +107,10 @@ fn load_entries_inner(
         Vec::with_capacity(loaded_files.iter().map(|file| file.entries.len()).sum());
     for loaded_file in loaded_files {
         for entry in loaded_file.entries {
-            if let Some(filter) = project_filter {
-                if entry.project.as_ref() != filter {
-                    continue;
-                }
+            if let Some(filter) = project_filter
+                && entry.project.as_ref() != filter
+            {
+                continue;
             }
             push_deduped_entry(entry, &mut deduped_indexes, &mut deduped);
         }

--- a/rust/crates/ccusage/src/adapter/claude/paths.rs
+++ b/rust/crates/ccusage/src/adapter/claude/paths.rs
@@ -6,9 +6,9 @@ use std::{
 #[cfg(test)]
 use memchr::memmem;
 
-use crate::{cli_error, fast::FxHashSet, home, Result};
+use crate::{Result, cli_error, fast::FxHashSet, home};
 #[cfg(test)]
-use crate::{parse_ts_timestamp, TimestampMs};
+use crate::{TimestampMs, parse_ts_timestamp};
 
 pub(crate) fn claude_paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
@@ -53,15 +53,15 @@ fn normalize_claude_config_path(raw: &str) -> PathBuf {
 }
 
 fn expand_home_path(raw: &str) -> PathBuf {
-    if raw == "~" {
-        if let Some(home) = home::home_dir() {
-            return home;
-        }
+    if raw == "~"
+        && let Some(home) = home::home_dir()
+    {
+        return home;
     }
-    if let Some(rest) = raw.strip_prefix("~/") {
-        if let Some(home) = home::home_dir() {
-            return home.join(rest);
-        }
+    if let Some(rest) = raw.strip_prefix("~/")
+        && let Some(home) = home::home_dir()
+    {
+        return home.join(rest);
     }
     PathBuf::from(raw)
 }
@@ -160,10 +160,10 @@ pub(crate) fn extract_session_parts(path: &Path) -> (String, String) {
         .last()
         .and_then(|file_name| file_name.strip_suffix(".jsonl"))
         .filter(|session_id| !session_id.is_empty());
-    if relative.len() == 2 {
-        if let Some(session_id) = file_session_id {
-            return (session_id.to_string(), relative[0].to_string());
-        }
+    if relative.len() == 2
+        && let Some(session_id) = file_session_id
+    {
+        return (session_id.to_string(), relative[0].to_string());
     }
     if relative.len() >= 4 && relative.get(relative.len() - 2) == Some(&"subagents") {
         let session_id = relative[relative.len() - 3].to_string();

--- a/rust/crates/ccusage/src/adapter/codebuff/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff/loader.rs
@@ -80,44 +80,22 @@ use super::report::{report_from_rows, summarize_entries};
 
 #[cfg(test)]
 mod tests {
-    use std::{env, path::Path, sync::Mutex};
-
     use super::super::{parser::parse_usage_object, paths::CODEBUFF_DATA_DIR_ENV};
     use super::*;
     use crate::{
         TokenUsageRaw, UsageEntry, UsageMessage, cli::AgentReportKind, parse_ts_timestamp,
     };
-    use ccusage_test_support::fs_fixture;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvDirGuard {
-        key: &'static str,
-    }
-
-    impl EnvDirGuard {
-        fn set(key: &'static str, dir: &Path) -> Self {
-            unsafe { env::set_var(key, dir) };
-            Self { key }
-        }
-    }
-
-    impl Drop for EnvDirGuard {
-        fn drop(&mut self) {
-            unsafe { env::remove_var(self.key) };
-        }
-    }
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
 
     #[test]
     fn loads_assistant_usage_from_chat_messages() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "projects/project-a/chats/2026-01-02T03-04-05.000Z/chat-messages.json": r#"[
                 {"role":"user","text":"hello"},
                 {"id":"assistant-message","role":"assistant","timestamp":"2026-01-02T03:04:06.000Z","metadata":{"model":"claude-sonnet-4-20250514","usage":{"inputTokens":100,"outputTokens":50,"cacheCreationInputTokens":20,"cacheReadInputTokens":10}},"credits":1.25}
             ]"#,
         });
-        let _cleanup = EnvDirGuard::set(CODEBUFF_DATA_DIR_ENV, fixture.root());
+        let _cleanup = EnvVarGuard::set(CODEBUFF_DATA_DIR_ENV, fixture.root());
 
         let pricing = PricingMap::load_embedded();
         let shared = SharedArgs {
@@ -145,7 +123,6 @@ mod tests {
 
     #[test]
     fn falls_back_to_run_state_provider_usage() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "projects/project-a/chats/2026-01-02T03-04-05.000Z/chat-messages.json": r#"[
                 {"variant":"agent","metadata":{"runState":{"sessionState":{"mainAgentState":{"messageHistory":[
@@ -154,7 +131,7 @@ mod tests {
                 ]}}}}}
             ]"#,
         });
-        let _cleanup = EnvDirGuard::set(CODEBUFF_DATA_DIR_ENV, fixture.root());
+        let _cleanup = EnvVarGuard::set(CODEBUFF_DATA_DIR_ENV, fixture.root());
 
         let pricing = PricingMap::load_embedded();
         let entries = load_entries(&SharedArgs::default(), &pricing).unwrap();

--- a/rust/crates/ccusage/src/adapter/codebuff/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff/loader.rs
@@ -3,12 +3,12 @@ use std::{collections::HashMap, sync::Arc};
 use jiff::tz::TimeZone as JiffTimeZone;
 
 use super::{
-    parser::{calculate_codebuff_cost, load_chat_file, missing_codebuff_pricing, CodebuffEntry},
+    parser::{CodebuffEntry, calculate_codebuff_cost, load_chat_file, missing_codebuff_pricing},
     paths::discover_chat_files,
 };
 use crate::{
-    cli::SharedArgs, format_date_tz, parse_tz, LoadedEntry, PricingMap, Result, UsageEntry,
-    UsageMessage,
+    LoadedEntry, PricingMap, Result, UsageEntry, UsageMessage, cli::SharedArgs, format_date_tz,
+    parse_tz,
 };
 
 pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
@@ -85,7 +85,7 @@ mod tests {
     use super::super::{parser::parse_usage_object, paths::CODEBUFF_DATA_DIR_ENV};
     use super::*;
     use crate::{
-        cli::AgentReportKind, parse_ts_timestamp, TokenUsageRaw, UsageEntry, UsageMessage,
+        TokenUsageRaw, UsageEntry, UsageMessage, cli::AgentReportKind, parse_ts_timestamp,
     };
     use ccusage_test_support::fs_fixture;
 
@@ -97,14 +97,14 @@ mod tests {
 
     impl EnvDirGuard {
         fn set(key: &'static str, dir: &Path) -> Self {
-            env::set_var(key, dir);
+            unsafe { env::set_var(key, dir) };
             Self { key }
         }
     }
 
     impl Drop for EnvDirGuard {
         fn drop(&mut self) {
-            env::remove_var(self.key);
+            unsafe { env::remove_var(self.key) };
         }
     }
 

--- a/rust/crates/ccusage/src/adapter/codebuff/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff/mod.rs
@@ -5,7 +5,7 @@ mod report;
 
 use crate::cli::AgentCommandArgs;
 use crate::{
-    filter_loaded_entries_by_date, print_json_or_jq, sort_summaries, wants_json, PricingMap, Result,
+    PricingMap, Result, filter_loaded_entries_by_date, print_json_or_jq, sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;

--- a/rust/crates/ccusage/src/adapter/codebuff/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff/parser.rs
@@ -3,8 +3,8 @@ use std::{fs, path::Path};
 use serde_json::Value;
 
 use crate::{
-    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_rfc3339_millis,
-    missing_pricing_model_for_candidates, parse_ts_timestamp, PricingMap, Result, TokenUsageRaw,
+    PricingMap, Result, TokenUsageRaw, apply_total_token_fallback, calculate_cost_for_usage,
+    cli::CostMode, format_rfc3339_millis, missing_pricing_model_for_candidates, parse_ts_timestamp,
 };
 
 const DEFAULT_CODEBUFF_MODEL: &str = "codebuff-unknown";

--- a/rust/crates/ccusage/src/adapter/codebuff/paths.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff/paths.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, env, path::PathBuf};
 
-use crate::{collect_files_with_extension, Result};
+use crate::{Result, collect_files_with_extension};
 
 pub(super) const CODEBUFF_DATA_DIR_ENV: &str = "CODEBUFF_DATA_DIR";
 const CHANNELS: &[&str] = &["manicode", "manicode-dev", "manicode-staging"];

--- a/rust/crates/ccusage/src/adapter/codebuff/report.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff/report.rs
@@ -1,9 +1,9 @@
 use serde_json::Value;
 
 use crate::{
+    BucketKind, LoadedEntry, Result, UsageSummary,
     cli::{AgentReportKind, WeekDay},
-    summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind, LoadedEntry, Result,
-    UsageSummary,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -10,10 +10,10 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use rustc_hash::FxHasher;
 
 use crate::{
+    CodexGroup, CodexTokenUsageEvent, Result,
     cli::{AgentReportKind, SharedArgs, WeekDay},
     fast::FxHashSet,
-    format_date_tz, parse_ts_timestamp, parse_tz, wants_json, week_start, CodexGroup,
-    CodexTokenUsageEvent, Result,
+    format_date_tz, parse_ts_timestamp, parse_tz, wants_json, week_start,
 };
 
 use super::{parser, paths};

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -6,15 +6,15 @@ use std::{
 use compact_str::CompactString;
 
 use crate::{
-    chunk_file_indexes_by_size, cli::SharedArgs, fast::FxHashSet, progress, CodexTokenUsageEvent,
-    Result,
+    CodexTokenUsageEvent, Result, chunk_file_indexes_by_size, cli::SharedArgs, fast::FxHashSet,
+    progress,
 };
 
 use super::{
     parser::visit_codex_session_file,
     paths::{
-        codex_usage_sources, collect_codex_usage_files, collect_deduped_codex_usage_files,
-        CodexUsageSource,
+        CodexUsageSource, codex_usage_sources, collect_codex_usage_files,
+        collect_deduped_codex_usage_files,
     },
 };
 
@@ -617,10 +617,12 @@ mod tests {
         // File mtime is "now" at fixture creation, which is on or after every
         // entry currently in the fallback table, so resolution lands on the
         // newest known model. The exact value updates when the table grows.
-        assert!(events.iter().all(|event| event
-            .model
-            .as_deref()
-            .is_some_and(|model| model.starts_with("gpt-5"))));
+        assert!(events.iter().all(|event| {
+            event
+                .model
+                .as_deref()
+                .is_some_and(|model| model.starts_with("gpt-5"))
+        }));
         assert!(events.iter().all(|event| event.is_fallback_model));
     }
 

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -6,7 +6,7 @@ mod report;
 mod speed;
 mod types;
 
-use crate::{cli::AgentCommandArgs, log_level, print_json_or_jq, wants_json, PricingMap, Result};
+use crate::{PricingMap, Result, cli::AgentCommandArgs, log_level, print_json_or_jq, wants_json};
 
 pub(crate) use aggregate::{aggregate_events, filter_events_by_date, load_groups};
 pub(crate) use loader::load_codex_events;
@@ -22,8 +22,8 @@ use report::{print_table_from_groups, report_from_groups};
 
 #[cfg(test)]
 use crate::{
-    cli::{AgentReportKind, CodexSpeed},
     CodexTokenUsageEvent,
+    cli::{AgentReportKind, CodexSpeed},
 };
 
 #[cfg(test)]

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -170,35 +170,34 @@ pub(super) fn visit_codex_session_file(
                 let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(&line) else {
                     continue;
                 };
-                if let Some(ref replay_ts) = replay_second {
-                    if skip_replay
-                        && value.entry_type.as_deref() == Some("event_msg")
-                        && value
+                if let Some(ref replay_ts) = replay_second
+                    && skip_replay
+                    && value.entry_type.as_deref() == Some("event_msg")
+                    && value
+                        .payload
+                        .as_ref()
+                        .is_some_and(|p| p.payload_type.as_deref() == Some("token_count"))
+                {
+                    let Some(ts) = codex_session_timestamp(value.timestamp.as_ref()) else {
+                        continue;
+                    };
+                    let matches_replay = ts
+                        .as_bytes()
+                        .get(0..19)
+                        .is_some_and(|sec| sec.len() == 19 && sec == replay_ts.as_slice());
+                    if matches_replay {
+                        if let Some(total_usage) = value
                             .payload
                             .as_ref()
-                            .is_some_and(|p| p.payload_type.as_deref() == Some("token_count"))
-                    {
-                        let Some(ts) = codex_session_timestamp(value.timestamp.as_ref()) else {
-                            continue;
-                        };
-                        let matches_replay = ts
-                            .as_bytes()
-                            .get(0..19)
-                            .is_some_and(|sec| sec.len() == 19 && sec == replay_ts.as_slice());
-                        if matches_replay {
-                            if let Some(total_usage) = value
-                                .payload
-                                .as_ref()
-                                .and_then(|payload| payload.info.as_ref())
-                                .and_then(|info| info.total_token_usage.as_ref())
-                                .copied()
-                            {
-                                previous_totals.replace(total_usage);
-                            }
-                            continue;
+                            .and_then(|payload| payload.info.as_ref())
+                            .and_then(|info| info.total_token_usage.as_ref())
+                            .copied()
+                        {
+                            previous_totals.replace(total_usage);
                         }
-                        skip_replay = false;
+                        continue;
                     }
+                    skip_replay = false;
                 }
                 visit_codex_session_entry(
                     &session_id,
@@ -991,8 +990,10 @@ mod tests {
         assert_eq!(fallbacks[0].model, "gpt-5.5");
         assert_eq!(fallbacks[6].released_on, "2025-08-07");
         assert_eq!(fallbacks[6].model, "gpt-5");
-        assert!(fallbacks
-            .windows(2)
-            .all(|window| window[0].released_on > window[1].released_on));
+        assert!(
+            fallbacks
+                .windows(2)
+                .all(|window| window[0].released_on > window[1].released_on)
+        );
     }
 }

--- a/rust/crates/ccusage/src/adapter/codex/paths.rs
+++ b/rust/crates/ccusage/src/adapter/codex/paths.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{cli_error, fast::FxHashSet, home, Result};
+use crate::{Result, cli_error, fast::FxHashSet, home};
 
 pub(super) fn codex_usage_sources() -> Result<Vec<CodexUsageSource>> {
     Ok(codex_usage_sources_from_homes(codex_home_paths()?))

--- a/rust/crates/ccusage/src/adapter/codex/report.rs
+++ b/rust/crates/ccusage/src/adapter/codex/report.rs
@@ -1,13 +1,13 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    Align, CodexGroup, CodexModelUsage, Color, PricingMap, Result, SimpleTable,
     cli::{AgentReportKind, CodexSpeed, SharedArgs},
     color, format_currency, format_models_multiline, format_number, json_float,
     missing_pricing_model_for_token_total, print_box_title,
-    print_missing_pricing_warnings_for_models, Align, CodexGroup, CodexModelUsage, Color,
-    PricingMap, Result, SimpleTable,
+    print_missing_pricing_warnings_for_models,
 };
 
 pub(super) fn report_from_groups(

--- a/rust/crates/ccusage/src/adapter/copilot/loader.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/loader.rs
@@ -3,12 +3,12 @@ use std::{path::Path, sync::Arc};
 use jiff::tz::TimeZone as JiffTimeZone;
 
 use super::{
-    parser::{parse_otel_file, CopilotUsageEntry},
+    parser::{CopilotUsageEntry, parse_otel_file},
     paths::paths,
 };
 use crate::{
-    calculate_cost_for_usage, cli::CostMode, format_date_tz, missing_pricing_model_for_usage,
-    parse_tz, LoadedEntry, Result, TokenUsageRaw, UsageEntry, UsageMessage,
+    LoadedEntry, Result, TokenUsageRaw, UsageEntry, UsageMessage, calculate_cost_for_usage,
+    cli::CostMode, format_date_tz, missing_pricing_model_for_usage, parse_tz,
 };
 
 pub(crate) fn load_entries(

--- a/rust/crates/ccusage/src/adapter/copilot/mod.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/mod.rs
@@ -5,8 +5,8 @@ mod report;
 
 use crate::cli::AgentCommandArgs;
 use crate::{
-    filter_loaded_entries_by_date, print_json_or_jq, print_usage_table, sort_summaries, wants_json,
-    PricingMap, Result,
+    PricingMap, Result, filter_loaded_entries_by_date, print_json_or_jq, print_usage_table,
+    sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;

--- a/rust/crates/ccusage/src/adapter/copilot/parser.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/parser.rs
@@ -6,7 +6,7 @@ use std::{
 
 use serde_json::{Map, Value};
 
-use crate::{apply_total_token_fallback, Result, TimestampMs, TokenUsageRaw};
+use crate::{Result, TimestampMs, TokenUsageRaw, apply_total_token_fallback};
 
 #[derive(Debug, Clone)]
 pub(super) struct CopilotUsageEntry {
@@ -103,11 +103,11 @@ fn collect_trace_contexts(records: &[Map<String, Value>]) -> HashMap<String, Tra
         if context.model.is_none() {
             context.model = first_non_empty_attr(attributes, MODEL_ATTRS);
         }
-        if let Some((session_id, priority)) = best_session_attr(attributes) {
-            if priority > context.session_id_priority {
-                context.session_id = Some(session_id);
-                context.session_id_priority = priority;
-            }
+        if let Some((session_id, priority)) = best_session_attr(attributes)
+            && priority > context.session_id_priority
+        {
+            context.session_id = Some(session_id);
+            context.session_id_priority = priority;
         }
     }
     contexts

--- a/rust/crates/ccusage/src/adapter/copilot/paths.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/paths.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, env, path::PathBuf};
 
-use crate::{collect_files_with_extension, Result};
+use crate::{Result, collect_files_with_extension};
 
 pub(crate) const COPILOT_OTEL_FILE_EXPORTER_PATH_ENV: &str = "COPILOT_OTEL_FILE_EXPORTER_PATH";
 

--- a/rust/crates/ccusage/src/adapter/copilot/report.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/report.rs
@@ -1,8 +1,9 @@
 use serde_json::Value;
 
 use crate::{
+    LoadedEntry, Result,
     cli::{AgentReportKind, WeekDay},
-    summarize_by_key, summarize_summaries_by_bucket, LoadedEntry, Result,
+    summarize_by_key, summarize_summaries_by_bucket,
 };
 
 pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/droid/loader.rs
+++ b/rust/crates/ccusage/src/adapter/droid/loader.rs
@@ -3,12 +3,12 @@ use std::{collections::HashSet, sync::Arc};
 use jiff::tz::TimeZone as JiffTimeZone;
 
 use super::{
-    parser::{calculate_droid_cost, load_settings_file, missing_droid_pricing, DroidEntry},
+    parser::{DroidEntry, calculate_droid_cost, load_settings_file, missing_droid_pricing},
     paths::discover_settings_files,
 };
 use crate::{
-    cli::SharedArgs, format_date_tz, parse_tz, LoadedEntry, PricingMap, Result, UsageEntry,
-    UsageMessage,
+    LoadedEntry, PricingMap, Result, UsageEntry, UsageMessage, cli::SharedArgs, format_date_tz,
+    parse_tz,
 };
 
 pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
@@ -93,7 +93,7 @@ mod tests {
     };
     use super::*;
     use crate::{
-        cli::AgentReportKind, parse_ts_timestamp, TokenUsageRaw, UsageEntry, UsageMessage,
+        TokenUsageRaw, UsageEntry, UsageMessage, cli::AgentReportKind, parse_ts_timestamp,
     };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -104,14 +104,14 @@ mod tests {
 
     impl EnvDirGuard {
         fn set(key: &'static str, dir: &Path) -> Self {
-            env::set_var(key, dir);
+            unsafe { env::set_var(key, dir) };
             Self { key }
         }
     }
 
     impl Drop for EnvDirGuard {
         fn drop(&mut self) {
-            env::remove_var(self.key);
+            unsafe { env::remove_var(self.key) };
         }
     }
 

--- a/rust/crates/ccusage/src/adapter/droid/loader.rs
+++ b/rust/crates/ccusage/src/adapter/droid/loader.rs
@@ -82,9 +82,7 @@ use super::report::{report_from_rows, summarize_entries};
 
 #[cfg(test)]
 mod tests {
-    use std::{env, path::Path, sync::Mutex};
-
-    use ccusage_test_support::fs_fixture;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
     use serde_json::json;
 
     use super::super::{
@@ -95,26 +93,6 @@ mod tests {
     use crate::{
         TokenUsageRaw, UsageEntry, UsageMessage, cli::AgentReportKind, parse_ts_timestamp,
     };
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvDirGuard {
-        key: &'static str,
-    }
-
-    impl EnvDirGuard {
-        fn set(key: &'static str, dir: &Path) -> Self {
-            unsafe { env::set_var(key, dir) };
-            Self { key }
-        }
-    }
-
-    impl Drop for EnvDirGuard {
-        fn drop(&mut self) {
-            unsafe { env::remove_var(self.key) };
-        }
-    }
-
     #[test]
     fn normalizes_droid_model_names() {
         assert_eq!(
@@ -144,7 +122,6 @@ mod tests {
 
     #[test]
     fn loads_usage_from_droid_settings_files() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "session-a.settings.json": r#"{
                 "model": "Claude-Sonnet-4-[Anthropic]",
@@ -160,7 +137,7 @@ mod tests {
             }"#,
             "zero.settings.json": r#"{"model":"gpt-5","tokenUsage":{"inputTokens":0}}"#,
         });
-        let _cleanup = EnvDirGuard::set(DROID_SESSIONS_DIR_ENV, fixture.root());
+        let _cleanup = EnvVarGuard::set(DROID_SESSIONS_DIR_ENV, fixture.root());
 
         let pricing = PricingMap::load_embedded();
         let shared = SharedArgs {
@@ -185,7 +162,6 @@ mod tests {
 
     #[test]
     fn falls_back_to_sidecar_jsonl_model() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "session-b.settings.json": r#"{
                 "providerLock": "anthropic",
@@ -194,7 +170,7 @@ mod tests {
             }"#,
             "session-b.jsonl": r#"{"content":"Model: Claude Opus 4.5 Thinking [Anthropic]"}"#,
         });
-        let _cleanup = EnvDirGuard::set(DROID_SESSIONS_DIR_ENV, fixture.root());
+        let _cleanup = EnvVarGuard::set(DROID_SESSIONS_DIR_ENV, fixture.root());
 
         let pricing = PricingMap::load_embedded();
         let entries = load_entries(&SharedArgs::default(), &pricing).unwrap();
@@ -208,7 +184,6 @@ mod tests {
 
     #[test]
     fn keeps_latest_snapshot_for_duplicate_session_ids() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "archive/session-c.settings.json": r#"{
                 "model": "gpt-5",
@@ -223,7 +198,7 @@ mod tests {
                 "tokenUsage": {"inputTokens": 100, "outputTokens": 200}
             }"#,
         });
-        let _cleanup = EnvDirGuard::set(DROID_SESSIONS_DIR_ENV, fixture.root());
+        let _cleanup = EnvVarGuard::set(DROID_SESSIONS_DIR_ENV, fixture.root());
 
         let pricing = PricingMap::load_embedded();
         let entries = load_entries(&SharedArgs::default(), &pricing).unwrap();

--- a/rust/crates/ccusage/src/adapter/droid/mod.rs
+++ b/rust/crates/ccusage/src/adapter/droid/mod.rs
@@ -5,8 +5,8 @@ mod report;
 
 use crate::cli::AgentCommandArgs;
 use crate::{
-    filter_loaded_entries_by_date, print_json_or_jq, print_usage_table, sort_summaries, wants_json,
-    PricingMap, Result,
+    PricingMap, Result, filter_loaded_entries_by_date, print_json_or_jq, print_usage_table,
+    sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;

--- a/rust/crates/ccusage/src/adapter/droid/parser.rs
+++ b/rust/crates/ccusage/src/adapter/droid/parser.rs
@@ -3,9 +3,9 @@ use std::{collections::HashSet, fs, io, path::Path};
 use serde_json::Value;
 
 use crate::{
-    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_rfc3339_millis,
-    json_value_u64, missing_pricing_model_for_candidates, parse_ts_timestamp, PricingMap, Result,
-    TokenUsageRaw,
+    PricingMap, Result, TokenUsageRaw, apply_total_token_fallback, calculate_cost_for_usage,
+    cli::CostMode, format_rfc3339_millis, json_value_u64, missing_pricing_model_for_candidates,
+    parse_ts_timestamp,
 };
 
 #[derive(Clone)]
@@ -124,10 +124,10 @@ fn settings_timestamp(
     settings: &serde_json::Map<String, Value>,
     path: &Path,
 ) -> Option<(crate::TimestampMs, String)> {
-    if let Some(timestamp_text) = string_field(settings, "providerLockTimestamp") {
-        if let Some(timestamp) = parse_ts_timestamp(&timestamp_text) {
-            return Some((timestamp, format_rfc3339_millis(timestamp)));
-        }
+    if let Some(timestamp_text) = string_field(settings, "providerLockTimestamp")
+        && let Some(timestamp) = parse_ts_timestamp(&timestamp_text)
+    {
+        return Some((timestamp, format_rfc3339_millis(timestamp)));
     }
     let modified = fs::metadata(path).ok()?.modified().ok()?;
     let millis = modified

--- a/rust/crates/ccusage/src/adapter/droid/paths.rs
+++ b/rust/crates/ccusage/src/adapter/droid/paths.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, env, path::PathBuf};
 
-use crate::{collect_files_with_extension, Result};
+use crate::{Result, collect_files_with_extension};
 
 pub(super) const DROID_SESSIONS_DIR_ENV: &str = "DROID_SESSIONS_DIR";
 

--- a/rust/crates/ccusage/src/adapter/droid/report.rs
+++ b/rust/crates/ccusage/src/adapter/droid/report.rs
@@ -1,9 +1,9 @@
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    BucketKind, LoadedEntry, Result, UsageSummary,
     cli::{AgentReportKind, WeekDay},
-    summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind, LoadedEntry, Result,
-    UsageSummary,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/gemini/loader.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/loader.rs
@@ -1,4 +1,4 @@
-use crate::{cli::SharedArgs, parse_tz, LoadedEntry, PricingMap, Result};
+use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, parse_tz};
 
 use super::{
     parser::{event_to_loaded, parse_json_file, parse_jsonl_file},

--- a/rust/crates/ccusage/src/adapter/gemini/loader.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/loader.rs
@@ -35,7 +35,6 @@ mod tests {
 
     #[test]
     fn loads_jsonl_token_events_and_separates_cached_input() {
-        let _guard = super::super::GEMINI_DATA_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "project/chats/session-a.jsonl": [
                 r#"{"sessionId":"session-a","projectHash":"project-a","startTime":"2026-05-17T11:07:00.000Z"}"#,

--- a/rust/crates/ccusage/src/adapter/gemini/mod.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/mod.rs
@@ -12,28 +12,15 @@ pub(crate) use loader::load_entries;
 pub(crate) use report::{report_from_rows, summarize_entries};
 
 #[cfg(test)]
-static GEMINI_DATA_DIR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-#[cfg(test)]
 struct GeminiDataDirEnvGuard {
-    previous: Option<std::ffi::OsString>,
+    _guard: ccusage_test_support::EnvVarGuard,
 }
 
 #[cfg(test)]
 impl GeminiDataDirEnvGuard {
     fn set(path: &std::path::Path) -> Self {
-        let previous = std::env::var_os(paths::GEMINI_DATA_DIR_ENV);
-        unsafe { std::env::set_var(paths::GEMINI_DATA_DIR_ENV, path) };
-        Self { previous }
-    }
-}
-
-#[cfg(test)]
-impl Drop for GeminiDataDirEnvGuard {
-    fn drop(&mut self) {
-        match &self.previous {
-            Some(value) => unsafe { std::env::set_var(paths::GEMINI_DATA_DIR_ENV, value) },
-            None => unsafe { std::env::remove_var(paths::GEMINI_DATA_DIR_ENV) },
+        Self {
+            _guard: ccusage_test_support::EnvVarGuard::set(paths::GEMINI_DATA_DIR_ENV, path),
         }
     }
 }

--- a/rust/crates/ccusage/src/adapter/gemini/mod.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/mod.rs
@@ -4,8 +4,8 @@ mod paths;
 mod report;
 
 use crate::{
-    adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
-    print_usage_table, sort_summaries, wants_json, PricingMap, Result,
+    PricingMap, Result, adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date,
+    print_json_or_jq, print_usage_table, sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;
@@ -23,7 +23,7 @@ struct GeminiDataDirEnvGuard {
 impl GeminiDataDirEnvGuard {
     fn set(path: &std::path::Path) -> Self {
         let previous = std::env::var_os(paths::GEMINI_DATA_DIR_ENV);
-        std::env::set_var(paths::GEMINI_DATA_DIR_ENV, path);
+        unsafe { std::env::set_var(paths::GEMINI_DATA_DIR_ENV, path) };
         Self { previous }
     }
 }
@@ -32,8 +32,8 @@ impl GeminiDataDirEnvGuard {
 impl Drop for GeminiDataDirEnvGuard {
     fn drop(&mut self) {
         match &self.previous {
-            Some(value) => std::env::set_var(paths::GEMINI_DATA_DIR_ENV, value),
-            None => std::env::remove_var(paths::GEMINI_DATA_DIR_ENV),
+            Some(value) => unsafe { std::env::set_var(paths::GEMINI_DATA_DIR_ENV, value) },
+            None => unsafe { std::env::remove_var(paths::GEMINI_DATA_DIR_ENV) },
         }
     }
 }

--- a/rust/crates/ccusage/src/adapter/gemini/parser.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/parser.rs
@@ -4,9 +4,9 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{Map, Value};
 
 use crate::{
+    LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    missing_pricing_model_for_candidates, non_empty_json_string, LoadedEntry, PricingMap, Result,
-    TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    missing_pricing_model_for_candidates, non_empty_json_string,
 };
 
 const DEFAULT_MODEL: &str = "unknown";

--- a/rust/crates/ccusage/src/adapter/gemini/paths.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/paths.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, env, path::PathBuf};
 
-use crate::{collect_files_with_extension, Result};
+use crate::{Result, collect_files_with_extension};
 
 pub(super) const GEMINI_DATA_DIR_ENV: &str = "GEMINI_DATA_DIR";
 

--- a/rust/crates/ccusage/src/adapter/gemini/paths.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/paths.rs
@@ -48,7 +48,6 @@ mod tests {
 
     #[test]
     fn discovers_json_and_jsonl_logs() {
-        let _guard = super::super::GEMINI_DATA_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "chats/a.json": "{}",
             "chats/b.jsonl": "{}\n",

--- a/rust/crates/ccusage/src/adapter/gemini/report.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/report.rs
@@ -1,9 +1,10 @@
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    BucketKind, LoadedEntry, Result,
     adapter::opencode,
     cli::{AgentReportKind, WeekDay},
-    summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind, LoadedEntry, Result,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/goose/loader.rs
+++ b/rust/crates/ccusage/src/adapter/goose/loader.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, path::Path};
 
 use jiff::tz::TimeZone as JiffTimeZone;
 
-use crate::{cli::SharedArgs, debug_log, parse_tz, LoadedEntry, PricingMap, Result};
+use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz};
 
 use super::{parser::row_to_entry, paths::goose_db_paths};
 

--- a/rust/crates/ccusage/src/adapter/goose/mod.rs
+++ b/rust/crates/ccusage/src/adapter/goose/mod.rs
@@ -4,8 +4,8 @@ mod paths;
 mod report;
 
 use crate::{
-    cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq, sort_summaries,
-    wants_json, PricingMap, Result,
+    PricingMap, Result, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
+    sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;

--- a/rust/crates/ccusage/src/adapter/goose/parser.rs
+++ b/rust/crates/ccusage/src/adapter/goose/parser.rs
@@ -4,8 +4,8 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
 use crate::{
-    calculate_cost_for_usage, cli::CostMode, format_date_tz, missing_pricing_model_for_candidates,
-    LoadedEntry, PricingMap, TokenUsageRaw, UsageEntry, UsageMessage,
+    LoadedEntry, PricingMap, TokenUsageRaw, UsageEntry, UsageMessage, calculate_cost_for_usage,
+    cli::CostMode, format_date_tz, missing_pricing_model_for_candidates,
 };
 
 pub(super) fn row_to_entry(

--- a/rust/crates/ccusage/src/adapter/goose/paths.rs
+++ b/rust/crates/ccusage/src/adapter/goose/paths.rs
@@ -48,35 +48,17 @@ fn default_goose_db_candidates() -> Result<Vec<PathBuf>> {
 
 #[cfg(test)]
 mod tests {
-    use std::{env, path::Path, sync::Mutex};
+    use std::path::Path;
 
     use super::*;
-    use ccusage_test_support::fs_fixture;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvDirGuard;
-
-    impl EnvDirGuard {
-        fn set(dir: &Path) -> Self {
-            unsafe { env::set_var(GOOSE_PATH_ROOT_ENV, dir) };
-            Self
-        }
-    }
-
-    impl Drop for EnvDirGuard {
-        fn drop(&mut self) {
-            unsafe { env::remove_var(GOOSE_PATH_ROOT_ENV) };
-        }
-    }
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
 
     #[test]
     fn discovers_goose_path_root_database() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "data/sessions/sessions.db": "",
         });
-        let _cleanup = EnvDirGuard::set(fixture.root());
+        let _cleanup = EnvVarGuard::set(GOOSE_PATH_ROOT_ENV, fixture.root());
 
         let paths = goose_db_paths().unwrap();
 

--- a/rust/crates/ccusage/src/adapter/goose/paths.rs
+++ b/rust/crates/ccusage/src/adapter/goose/paths.rs
@@ -11,10 +11,12 @@ pub(super) fn goose_db_paths() -> Result<Vec<PathBuf>> {
         if root.is_empty() {
             default_goose_db_candidates()?
         } else {
-            vec![PathBuf::from(root)
-                .join("data")
-                .join("sessions")
-                .join(GOOSE_DB_FILE_NAME)]
+            vec![
+                PathBuf::from(root)
+                    .join("data")
+                    .join("sessions")
+                    .join(GOOSE_DB_FILE_NAME),
+            ]
         }
     } else {
         default_goose_db_candidates()?
@@ -57,14 +59,14 @@ mod tests {
 
     impl EnvDirGuard {
         fn set(dir: &Path) -> Self {
-            env::set_var(GOOSE_PATH_ROOT_ENV, dir);
+            unsafe { env::set_var(GOOSE_PATH_ROOT_ENV, dir) };
             Self
         }
     }
 
     impl Drop for EnvDirGuard {
         fn drop(&mut self) {
-            env::remove_var(GOOSE_PATH_ROOT_ENV);
+            unsafe { env::remove_var(GOOSE_PATH_ROOT_ENV) };
         }
     }
 

--- a/rust/crates/ccusage/src/adapter/goose/report.rs
+++ b/rust/crates/ccusage/src/adapter/goose/report.rs
@@ -1,9 +1,9 @@
 use serde_json::Value;
 
 use crate::{
+    BucketKind, LoadedEntry, Result, UsageSummary,
     cli::{AgentReportKind, WeekDay},
-    summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind, LoadedEntry, Result,
-    UsageSummary,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/hermes/loader.rs
+++ b/rust/crates/ccusage/src/adapter/hermes/loader.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashSet, path::Path};
 
-use crate::{cli::SharedArgs, LoadedEntry, PricingMap, Result};
+use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs};
 
 use super::{
-    parser::{read_session_row, to_loaded_entry, HermesEntry},
+    parser::{HermesEntry, read_session_row, to_loaded_entry},
     paths::hermes_state_db_paths,
 };
 

--- a/rust/crates/ccusage/src/adapter/hermes/mod.rs
+++ b/rust/crates/ccusage/src/adapter/hermes/mod.rs
@@ -4,8 +4,8 @@ mod paths;
 mod report;
 
 use crate::{
-    cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq, print_usage_table,
-    sort_summaries, wants_json, PricingMap, Result,
+    PricingMap, Result, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
+    print_usage_table, sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;

--- a/rust/crates/ccusage/src/adapter/hermes/parser.rs
+++ b/rust/crates/ccusage/src/adapter/hermes/parser.rs
@@ -3,9 +3,9 @@ use std::{collections::HashSet, sync::Arc};
 use jiff::tz::TimeZone as JiffTimeZone;
 
 use crate::{
+    LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     calculate_cost_for_usage, cli::CostMode, format_date_tz, format_rfc3339_millis,
-    missing_pricing_model_for_candidates, LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw,
-    UsageEntry, UsageMessage,
+    missing_pricing_model_for_candidates,
 };
 
 pub(super) struct HermesEntry {

--- a/rust/crates/ccusage/src/adapter/hermes/report.rs
+++ b/rust/crates/ccusage/src/adapter/hermes/report.rs
@@ -1,9 +1,9 @@
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    BucketKind, LoadedEntry, Result, UsageSummary,
     cli::{AgentReportKind, WeekDay},
-    summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind, LoadedEntry, Result,
-    UsageSummary,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/kilo/loader.rs
+++ b/rust/crates/ccusage/src/adapter/kilo/loader.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, path::Path};
 use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
-use crate::{cli::SharedArgs, debug_log, parse_tz, LoadedEntry, PricingMap, Result};
+use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz};
 
 use super::{
     parser::message_value_to_entry,
@@ -25,10 +25,10 @@ fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<L
             continue;
         };
         for entry in load_entries_from_database(&db_path, tz.as_ref(), shared, pricing) {
-            if let Some(id) = entry.data.message.id.as_deref() {
-                if !seen.insert(id.to_string()) {
-                    continue;
-                }
+            if let Some(id) = entry.data.message.id.as_deref()
+                && !seen.insert(id.to_string())
+            {
+                continue;
             }
             entries.push(entry);
         }
@@ -105,7 +105,7 @@ mod tests {
     use std::{env, path::Path, sync::Mutex};
 
     use super::*;
-    use crate::{cli::CostMode, PricingMap};
+    use crate::{PricingMap, cli::CostMode};
     use ccusage_test_support::fs_fixture;
 
     static KILO_DATA_DIR_LOCK: Mutex<()> = Mutex::new(());
@@ -133,14 +133,14 @@ mod tests {
             "session-a",
             r#"{"id":"msg-1","role":"assistant","providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":100,"output":50,"reasoning":5,"cache":{"read":10,"write":20}},"cost":0.02,"agent":"build"}"#,
         );
-        env::set_var(super::super::paths::KILO_DATA_DIR_ENV, fixture.root());
+        unsafe { env::set_var(super::super::paths::KILO_DATA_DIR_ENV, fixture.root()) };
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),
             ..SharedArgs::default()
         };
         let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
-        env::remove_var(super::super::paths::KILO_DATA_DIR_ENV);
+        unsafe { env::remove_var(super::super::paths::KILO_DATA_DIR_ENV) };
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].date, "2026-01-02");
@@ -170,10 +170,10 @@ mod tests {
             "session-a",
             r#"{"role":"assistant","providerID":"openai","modelID":"gpt-5","tokens":{"input":1,"output":1,"cache":{"read":0,"write":0}}}"#,
         );
-        env::set_var(super::super::paths::KILO_DATA_DIR_ENV, fixture.root());
+        unsafe { env::set_var(super::super::paths::KILO_DATA_DIR_ENV, fixture.root()) };
         let shared = SharedArgs::default();
         let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
-        env::remove_var(super::super::paths::KILO_DATA_DIR_ENV);
+        unsafe { env::remove_var(super::super::paths::KILO_DATA_DIR_ENV) };
 
         assert!(entries.is_empty());
     }
@@ -193,13 +193,15 @@ mod tests {
                 ),
             );
         }
-        env::set_var(
-            super::super::paths::KILO_DATA_DIR_ENV,
-            format!("{},{}", first.root().display(), second.root().display()),
-        );
+        unsafe {
+            env::set_var(
+                super::super::paths::KILO_DATA_DIR_ENV,
+                format!("{},{}", first.root().display(), second.root().display()),
+            )
+        };
         let shared = SharedArgs::default();
         let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
-        env::remove_var(super::super::paths::KILO_DATA_DIR_ENV);
+        unsafe { env::remove_var(super::super::paths::KILO_DATA_DIR_ENV) };
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].data.message.usage.input_tokens, 10);

--- a/rust/crates/ccusage/src/adapter/kilo/loader.rs
+++ b/rust/crates/ccusage/src/adapter/kilo/loader.rs
@@ -102,13 +102,11 @@ fn load_entries_from_database(
 
 #[cfg(test)]
 mod tests {
-    use std::{env, path::Path, sync::Mutex};
+    use std::path::Path;
 
     use super::*;
     use crate::{PricingMap, cli::CostMode};
-    use ccusage_test_support::fs_fixture;
-
-    static KILO_DATA_DIR_LOCK: Mutex<()> = Mutex::new(());
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
 
     fn create_db_message(path: &Path, id: &str, session_id: &str, data: &str) {
         let db = sqlite::open(path).unwrap();
@@ -125,7 +123,6 @@ mod tests {
 
     #[test]
     fn loads_kilo_messages_from_sqlite() {
-        let _guard = KILO_DATA_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({});
         create_db_message(
             &fixture.path(super::super::paths::KILO_DB_FILE_NAME),
@@ -133,14 +130,13 @@ mod tests {
             "session-a",
             r#"{"id":"msg-1","role":"assistant","providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":100,"output":50,"reasoning":5,"cache":{"read":10,"write":20}},"cost":0.02,"agent":"build"}"#,
         );
-        unsafe { env::set_var(super::super::paths::KILO_DATA_DIR_ENV, fixture.root()) };
+        let _cleanup = EnvVarGuard::set(super::super::paths::KILO_DATA_DIR_ENV, fixture.root());
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),
             ..SharedArgs::default()
         };
         let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
-        unsafe { env::remove_var(super::super::paths::KILO_DATA_DIR_ENV) };
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].date, "2026-01-02");
@@ -162,7 +158,6 @@ mod tests {
 
     #[test]
     fn ignores_kilo_messages_without_timestamps() {
-        let _guard = KILO_DATA_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({});
         create_db_message(
             &fixture.path(super::super::paths::KILO_DB_FILE_NAME),
@@ -170,17 +165,15 @@ mod tests {
             "session-a",
             r#"{"role":"assistant","providerID":"openai","modelID":"gpt-5","tokens":{"input":1,"output":1,"cache":{"read":0,"write":0}}}"#,
         );
-        unsafe { env::set_var(super::super::paths::KILO_DATA_DIR_ENV, fixture.root()) };
+        let _cleanup = EnvVarGuard::set(super::super::paths::KILO_DATA_DIR_ENV, fixture.root());
         let shared = SharedArgs::default();
         let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
-        unsafe { env::remove_var(super::super::paths::KILO_DATA_DIR_ENV) };
 
         assert!(entries.is_empty());
     }
 
     #[test]
     fn deduplicates_kilo_messages_across_data_dirs() {
-        let _guard = KILO_DATA_DIR_LOCK.lock().unwrap();
         let first = fs_fixture!({});
         let second = fs_fixture!({});
         for (fixture, input) in [(&first, 10), (&second, 20)] {
@@ -193,15 +186,12 @@ mod tests {
                 ),
             );
         }
-        unsafe {
-            env::set_var(
-                super::super::paths::KILO_DATA_DIR_ENV,
-                format!("{},{}", first.root().display(), second.root().display()),
-            )
-        };
+        let _cleanup = EnvVarGuard::set(
+            super::super::paths::KILO_DATA_DIR_ENV,
+            format!("{},{}", first.root().display(), second.root().display()),
+        );
         let shared = SharedArgs::default();
         let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
-        unsafe { env::remove_var(super::super::paths::KILO_DATA_DIR_ENV) };
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].data.message.usage.input_tokens, 10);

--- a/rust/crates/ccusage/src/adapter/kilo/mod.rs
+++ b/rust/crates/ccusage/src/adapter/kilo/mod.rs
@@ -4,8 +4,8 @@ mod paths;
 mod report;
 
 use crate::{
-    adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
-    print_usage_table, sort_summaries, wants_json, PricingMap, Result,
+    PricingMap, Result, adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date,
+    print_json_or_jq, print_usage_table, sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;

--- a/rust/crates/ccusage/src/adapter/kilo/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kilo/parser.rs
@@ -4,9 +4,9 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
 use crate::{
+    LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_candidates, non_empty_json_string, LoadedEntry,
-    PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    json_value_u64, missing_pricing_model_for_candidates, non_empty_json_string,
 };
 
 pub(super) fn message_value_to_entry(

--- a/rust/crates/ccusage/src/adapter/kilo/report.rs
+++ b/rust/crates/ccusage/src/adapter/kilo/report.rs
@@ -1,9 +1,10 @@
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    BucketKind, LoadedEntry, Result,
     adapter::opencode,
     cli::{AgentReportKind, WeekDay},
-    summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind, LoadedEntry, Result,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/kimi/loader.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/loader.rs
@@ -36,30 +36,12 @@ fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<L
 
 #[cfg(test)]
 mod tests {
-    use std::{env, path::Path};
-
     use super::super::paths::KIMI_DATA_DIR_ENV;
     use super::*;
-    use ccusage_test_support::fs_fixture;
-
-    struct EnvDirGuard;
-
-    impl EnvDirGuard {
-        fn set(dir: &Path) -> Self {
-            unsafe { env::set_var(KIMI_DATA_DIR_ENV, dir) };
-            Self
-        }
-    }
-
-    impl Drop for EnvDirGuard {
-        fn drop(&mut self) {
-            unsafe { env::remove_var(KIMI_DATA_DIR_ENV) };
-        }
-    }
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
 
     #[test]
     fn loads_status_update_token_usage_from_wire_files() {
-        let _guard = super::super::KIMI_DATA_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "config.json": r#"{"model":"kimi-k2"}"#,
             "sessions/group/session-a/wire.jsonl": [
@@ -69,7 +51,7 @@ mod tests {
             ]
             .join("\n"),
         });
-        let _cleanup = EnvDirGuard::set(fixture.root());
+        let _cleanup = EnvVarGuard::set(KIMI_DATA_DIR_ENV, fixture.root());
         let shared = SharedArgs {
             timezone: Some("UTC".to_string()),
             ..SharedArgs::default()
@@ -91,7 +73,6 @@ mod tests {
 
     #[test]
     fn skips_malformed_and_zero_token_wire_lines() {
-        let _guard = super::super::KIMI_DATA_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "sessions/group/session-a/wire.jsonl": [
                 "not json",
@@ -99,7 +80,7 @@ mod tests {
             ]
             .join("\n"),
         });
-        let _cleanup = EnvDirGuard::set(fixture.root());
+        let _cleanup = EnvVarGuard::set(KIMI_DATA_DIR_ENV, fixture.root());
         let entries = load_entries(&SharedArgs::default(), &PricingMap::load_embedded()).unwrap();
 
         assert!(entries.is_empty());

--- a/rust/crates/ccusage/src/adapter/kimi/loader.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/loader.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::{cli::SharedArgs, parse_tz, LoadedEntry, PricingMap, Result};
+use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, parse_tz};
 
 use super::{
     parser::{kimi_entry_key, kimi_entry_to_loaded, read_wire_file},
@@ -46,14 +46,14 @@ mod tests {
 
     impl EnvDirGuard {
         fn set(dir: &Path) -> Self {
-            env::set_var(KIMI_DATA_DIR_ENV, dir);
+            unsafe { env::set_var(KIMI_DATA_DIR_ENV, dir) };
             Self
         }
     }
 
     impl Drop for EnvDirGuard {
         fn drop(&mut self) {
-            env::remove_var(KIMI_DATA_DIR_ENV);
+            unsafe { env::remove_var(KIMI_DATA_DIR_ENV) };
         }
     }
 

--- a/rust/crates/ccusage/src/adapter/kimi/mod.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/mod.rs
@@ -11,9 +11,6 @@ use crate::{
 pub(crate) use loader::load_entries;
 pub(crate) use report::{report_from_rows, summarize_entries};
 
-#[cfg(test)]
-static KIMI_DATA_DIR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     let shared = args.shared;
     let pricing = PricingMap::load_with_overrides(

--- a/rust/crates/ccusage/src/adapter/kimi/mod.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/mod.rs
@@ -4,8 +4,8 @@ mod paths;
 mod report;
 
 use crate::{
-    adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
-    print_usage_table, sort_summaries, wants_json, PricingMap, Result,
+    PricingMap, Result, adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date,
+    print_json_or_jq, print_usage_table, sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;

--- a/rust/crates/ccusage/src/adapter/kimi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/parser.rs
@@ -8,9 +8,9 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
 use crate::{
+    LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_candidates, non_empty_json_string, LoadedEntry,
-    PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    json_value_u64, missing_pricing_model_for_candidates, non_empty_json_string,
 };
 
 const DEFAULT_MODEL: &str = "kimi-for-coding";

--- a/rust/crates/ccusage/src/adapter/kimi/paths.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/paths.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
-use crate::{collect_files_with_extension, Result};
+use crate::{Result, collect_files_with_extension};
 
 pub(super) const KIMI_DATA_DIR_ENV: &str = "KIMI_DATA_DIR";
 pub(super) const KIMI_SESSIONS_DIR_NAME: &str = "sessions";
@@ -82,9 +82,9 @@ mod tests {
             "sessions/group/session/other.jsonl": "{}\n",
             "sessions/nested/path/session/wire.jsonl": "{}\n",
         });
-        env::set_var(KIMI_DATA_DIR_ENV, fixture.root());
+        unsafe { env::set_var(KIMI_DATA_DIR_ENV, fixture.root()) };
         let files = discover_wire_files().unwrap();
-        env::remove_var(KIMI_DATA_DIR_ENV);
+        unsafe { env::remove_var(KIMI_DATA_DIR_ENV) };
 
         assert_eq!(
             files,

--- a/rust/crates/ccusage/src/adapter/kimi/paths.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/paths.rs
@@ -69,22 +69,18 @@ fn is_kimi_wire_file(sessions_path: &Path, file_path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::env;
-
     use super::*;
-    use ccusage_test_support::fs_fixture;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
 
     #[test]
     fn discovers_wire_jsonl_files_under_sessions_group_session() {
-        let _guard = super::super::KIMI_DATA_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "sessions/group/session/wire.jsonl": "{}\n",
             "sessions/group/session/other.jsonl": "{}\n",
             "sessions/nested/path/session/wire.jsonl": "{}\n",
         });
-        unsafe { env::set_var(KIMI_DATA_DIR_ENV, fixture.root()) };
+        let _cleanup = EnvVarGuard::set(KIMI_DATA_DIR_ENV, fixture.root());
         let files = discover_wire_files().unwrap();
-        unsafe { env::remove_var(KIMI_DATA_DIR_ENV) };
 
         assert_eq!(
             files,

--- a/rust/crates/ccusage/src/adapter/kimi/report.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/report.rs
@@ -1,9 +1,10 @@
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    BucketKind, LoadedEntry, Result,
     adapter::opencode,
     cli::{AgentReportKind, WeekDay},
-    summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind, LoadedEntry, Result,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/openclaw/loader.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/loader.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::{cli::SharedArgs, parse_tz, LoadedEntry, PricingMap, Result};
+use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, parse_tz};
 
 use super::{
     parser::{entry_id, parse_session_file},

--- a/rust/crates/ccusage/src/adapter/openclaw/mod.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/mod.rs
@@ -4,8 +4,8 @@ mod paths;
 mod report;
 
 use crate::{
-    cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq, print_usage_table,
-    sort_summaries, wants_json, Result,
+    Result, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
+    print_usage_table, sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;

--- a/rust/crates/ccusage/src/adapter/openclaw/parser.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/parser.rs
@@ -9,9 +9,9 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{Map, Value};
 
 use crate::{
+    LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_usage, non_empty_json_string, LoadedEntry,
-    PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    json_value_u64, missing_pricing_model_for_usage, non_empty_json_string,
 };
 
 #[derive(Debug, Clone)]

--- a/rust/crates/ccusage/src/adapter/openclaw/paths.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/paths.rs
@@ -12,10 +12,10 @@ pub(super) fn paths(custom_path: Option<&str>) -> Vec<PathBuf> {
     if let Some(custom_path) = custom_path.filter(|path| !path.trim().is_empty()) {
         return existing_path_list(custom_path);
     }
-    if let Ok(env_paths) = env::var(OPENCLAW_DIR_ENV) {
-        if !env_paths.trim().is_empty() {
-            return existing_path_list(&env_paths);
-        }
+    if let Ok(env_paths) = env::var(OPENCLAW_DIR_ENV)
+        && !env_paths.trim().is_empty()
+    {
+        return existing_path_list(&env_paths);
     }
     let Some(home) = crate::home::home_dir() else {
         return Vec::new();

--- a/rust/crates/ccusage/src/adapter/openclaw/report.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/report.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    BucketKind, LoadedEntry, Result, SessionAccumulator,
     cli::{AgentReportKind, WeekDay},
-    summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind, LoadedEntry, Result,
-    SessionAccumulator,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/opencode/loader.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/loader.rs
@@ -9,8 +9,9 @@ use serde_json::Value;
 
 use super::{parser::message_value_to_entry, paths::paths};
 use crate::{
+    LoadedEntry, PricingMap, Result,
     cli::{CostMode, SharedArgs},
-    collect_files_with_extension, debug_log, parse_tz, LoadedEntry, PricingMap, Result,
+    collect_files_with_extension, debug_log, parse_tz,
 };
 
 pub(crate) fn load_entries(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
@@ -26,10 +27,10 @@ fn load_entries_inner(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
     let mut seen = HashSet::new();
     for path in paths()? {
         for entry in load_entries_from_directory(&path, shared)? {
-            if let Some(id) = entry_id(&entry) {
-                if !seen.insert(id.to_string()) {
-                    continue;
-                }
+            if let Some(id) = entry_id(&entry)
+                && !seen.insert(id.to_string())
+            {
+                continue;
             }
             entries.push(entry);
         }
@@ -58,10 +59,10 @@ pub(crate) fn load_entries_from_directory(
         for entry in
             load_entries_from_database(&db_path, tz.as_ref(), shared.mode, pricing.as_ref(), shared)
         {
-            if let Some(id) = entry_id(&entry) {
-                if !seen.insert(id.to_string()) {
-                    continue;
-                }
+            if let Some(id) = entry_id(&entry)
+                && !seen.insert(id.to_string())
+            {
+                continue;
             }
             entries.push(entry);
         }
@@ -72,10 +73,10 @@ pub(crate) fn load_entries_from_directory(
     collect_files_with_extension(&messages_dir, "json", &mut files);
     for file in files {
         if let Some(entry) = read_message_file(&file, tz.as_ref(), shared.mode, pricing.as_ref())? {
-            if let Some(id) = entry_id(&entry) {
-                if !seen.insert(id.to_string()) {
-                    continue;
-                }
+            if let Some(id) = entry_id(&entry)
+                && !seen.insert(id.to_string())
+            {
+                continue;
             }
             entries.push(entry);
         }

--- a/rust/crates/ccusage/src/adapter/opencode/mod.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/mod.rs
@@ -8,8 +8,8 @@ pub(crate) use report::{
 };
 
 use crate::{
-    cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq, print_usage_table,
-    sort_summaries, wants_json, Result,
+    Result, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
+    print_usage_table, sort_summaries, wants_json,
 };
 
 pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {

--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -4,9 +4,9 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
 use crate::{
-    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_candidates, non_empty_json_string, LoadedEntry,
-    PricingMap, TokenUsageRaw, UsageEntry, UsageMessage,
+    LoadedEntry, PricingMap, TokenUsageRaw, UsageEntry, UsageMessage, apply_total_token_fallback,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz, json_value_u64,
+    missing_pricing_model_for_candidates, non_empty_json_string,
 };
 
 pub(crate) fn message_value_to_entry(
@@ -162,21 +162,21 @@ fn resolve_open_code_model_name(model: &str) -> String {
 fn normalize_open_code_model_name(model: &str) -> String {
     for family in ["claude-haiku-", "claude-opus-", "claude-sonnet-"] {
         if let Some(rest) = model.strip_prefix(family) {
-            if let Some((major, minor_and_suffix)) = rest.split_once('.') {
-                if major.chars().all(|ch| ch.is_ascii_digit())
-                    && minor_and_suffix
-                        .chars()
-                        .next()
-                        .is_some_and(|ch| ch.is_ascii_digit())
-                {
-                    return format!("{family}{major}-{minor_and_suffix}");
-                }
+            if let Some((major, minor_and_suffix)) = rest.split_once('.')
+                && major.chars().all(|ch| ch.is_ascii_digit())
+                && minor_and_suffix
+                    .chars()
+                    .next()
+                    .is_some_and(|ch| ch.is_ascii_digit())
+            {
+                return format!("{family}{major}-{minor_and_suffix}");
             }
             let mut chars = rest.chars();
-            if let (Some(major), Some(minor)) = (chars.next(), chars.next()) {
-                if major.is_ascii_digit() && minor.is_ascii_digit() {
-                    return format!("{family}{major}-{minor}{}", chars.collect::<String>());
-                }
+            if let (Some(major), Some(minor)) = (chars.next(), chars.next())
+                && major.is_ascii_digit()
+                && minor.is_ascii_digit()
+            {
+                return format!("{family}{major}-{minor}{}", chars.collect::<String>());
             }
         }
     }
@@ -188,7 +188,7 @@ mod tests {
     use serde_json::json;
 
     use super::{message_value_to_entry, open_code_model_candidates};
-    use crate::{cli::CostMode, LoadedEntry, PricingMap};
+    use crate::{LoadedEntry, PricingMap, cli::CostMode};
 
     fn entry_snapshot(entry: &LoadedEntry) -> serde_json::Value {
         json!({

--- a/rust/crates/ccusage/src/adapter/opencode/report.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/report.rs
@@ -1,9 +1,9 @@
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    BucketKind, LoadedEntry, Result, SessionAccumulator,
     cli::{AgentReportKind, SortOrder, WeekDay},
-    sort_summaries, summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind,
-    LoadedEntry, Result, SessionAccumulator,
+    sort_summaries, summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_json(
@@ -48,27 +48,25 @@ pub(crate) fn agent_summary_json(
     if let (Some(obj), Some(message_count)) = (value.as_object_mut(), row.message_count) {
         obj.insert("messageCount".to_string(), json!(message_count));
     }
-    if include_session_metadata {
-        if let Some(obj) = value.as_object_mut() {
-            obj.insert(
-                "lastActivity".to_string(),
-                row.last_activity
-                    .as_ref()
-                    .map_or(Value::Null, |value| json!(value)),
-            );
-            obj.insert(
-                "firstActivity".to_string(),
-                row.first_activity
-                    .as_ref()
-                    .map_or(Value::Null, |value| json!(value)),
-            );
-            obj.insert(
-                "projectPath".to_string(),
-                row.project_path
-                    .as_ref()
-                    .map_or(Value::Null, |value| json!(value)),
-            );
-        }
+    if include_session_metadata && let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "lastActivity".to_string(),
+            row.last_activity
+                .as_ref()
+                .map_or(Value::Null, |value| json!(value)),
+        );
+        obj.insert(
+            "firstActivity".to_string(),
+            row.first_activity
+                .as_ref()
+                .map_or(Value::Null, |value| json!(value)),
+        );
+        obj.insert(
+            "projectPath".to_string(),
+            row.project_path
+                .as_ref()
+                .map_or(Value::Null, |value| json!(value)),
+        );
     }
     value
 }
@@ -170,8 +168,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        cli::AgentReportKind, format_rfc3339_millis, LoadedEntry, ModelBreakdown, TimestampMs,
-        TokenUsageRaw, UsageEntry, UsageMessage, UsageSummary,
+        LoadedEntry, ModelBreakdown, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+        UsageSummary, cli::AgentReportKind, format_rfc3339_millis,
     };
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/pi/loader.rs
+++ b/rust/crates/ccusage/src/adapter/pi/loader.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::{
-    cli::SharedArgs, collect_files_with_extension, parse_tz, LoadedEntry, PricingMap, Result,
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, collect_files_with_extension, parse_tz,
 };
 
 use super::{parser, paths};

--- a/rust/crates/ccusage/src/adapter/pi/mod.rs
+++ b/rust/crates/ccusage/src/adapter/pi/mod.rs
@@ -4,8 +4,8 @@ mod paths;
 mod report;
 
 use crate::{
-    cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq, print_usage_table,
-    sort_summaries, wants_json, Result,
+    Result, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
+    print_usage_table, sort_summaries, wants_json,
 };
 
 pub(crate) use loader::load_entries;

--- a/rust/crates/ccusage/src/adapter/pi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/pi/parser.rs
@@ -4,9 +4,9 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::Value;
 
 use crate::{
+    LoadedEntry, PricingMap, Result, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_usage, non_empty_json_string, LoadedEntry,
-    PricingMap, Result, TokenUsageRaw, UsageEntry, UsageMessage,
+    json_value_u64, missing_pricing_model_for_usage, non_empty_json_string,
 };
 
 pub(crate) fn read_session_file(

--- a/rust/crates/ccusage/src/adapter/pi/paths.rs
+++ b/rust/crates/ccusage/src/adapter/pi/paths.rs
@@ -8,10 +8,10 @@ pub(super) fn paths(custom_path: Option<&str>) -> Result<Vec<PathBuf>> {
     if let Some(custom_path) = custom_path.filter(|path| !path.trim().is_empty()) {
         return Ok(existing_path_list(custom_path));
     }
-    if let Ok(env_paths) = env::var(PI_AGENT_DIR_ENV) {
-        if !env_paths.trim().is_empty() {
-            return Ok(existing_path_list(&env_paths));
-        }
+    if let Ok(env_paths) = env::var(PI_AGENT_DIR_ENV)
+        && !env_paths.trim().is_empty()
+    {
+        return Ok(existing_path_list(&env_paths));
     }
 
     let home =

--- a/rust/crates/ccusage/src/adapter/pi/report.rs
+++ b/rust/crates/ccusage/src/adapter/pi/report.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
-    cli::AgentReportKind, cli::WeekDay, summarize_by_key, summarize_summaries_by_bucket,
-    totals_json, BucketKind, LoadedEntry, Result, SessionAccumulator,
+    BucketKind, LoadedEntry, Result, SessionAccumulator, cli::AgentReportKind, cli::WeekDay,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/adapter/qwen/loader.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/loader.rs
@@ -1,4 +1,4 @@
-use crate::{cli::SharedArgs, LoadedEntry, Result};
+use crate::{LoadedEntry, Result, cli::SharedArgs};
 
 use super::parser;
 

--- a/rust/crates/ccusage/src/adapter/qwen/mod.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/mod.rs
@@ -66,38 +66,12 @@ pub(crate) fn has_data() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::{env, ffi::OsString, path::Path, sync::Mutex};
-
-    use ccusage_test_support::fs_fixture;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
     use serde_json::json;
 
     use super::*;
     use crate::UsageSummary;
     use crate::cli::{CostMode, SharedArgs};
-
-    static QWEN_DATA_DIR_LOCK: Mutex<()> = Mutex::new(());
-
-    struct QwenDataDirGuard {
-        previous: Option<OsString>,
-    }
-
-    impl QwenDataDirGuard {
-        fn set(path: &Path) -> Self {
-            let previous = env::var_os("QWEN_DATA_DIR");
-            unsafe { env::set_var("QWEN_DATA_DIR", path) };
-            Self { previous }
-        }
-    }
-
-    impl Drop for QwenDataDirGuard {
-        fn drop(&mut self) {
-            if let Some(previous) = self.previous.take() {
-                unsafe { env::set_var("QWEN_DATA_DIR", previous) };
-            } else {
-                unsafe { env::remove_var("QWEN_DATA_DIR") };
-            }
-        }
-    }
 
     #[test]
     fn loads_qwen_jsonl_usage_entries() {
@@ -114,8 +88,7 @@ mod tests {
             timezone: Some("UTC".to_string()),
             ..SharedArgs::default()
         };
-        let _lock = QWEN_DATA_DIR_LOCK.lock().unwrap();
-        let _guard = QwenDataDirGuard::set(fixture.root());
+        let _guard = EnvVarGuard::set("QWEN_DATA_DIR", fixture.root());
         let entries = load_entries(&shared).unwrap();
 
         assert_eq!(entries.len(), 1);
@@ -140,8 +113,7 @@ mod tests {
             timezone: Some("UTC".to_string()),
             ..SharedArgs::default()
         };
-        let _lock = QWEN_DATA_DIR_LOCK.lock().unwrap();
-        let _guard = QwenDataDirGuard::set(fixture.root());
+        let _guard = EnvVarGuard::set("QWEN_DATA_DIR", fixture.root());
         let entries = load_entries(&shared).unwrap();
         let rows = summarize_entries(&entries, AgentReportKind::Daily).unwrap();
         let report = report_from_rows(&rows, AgentReportKind::Daily);

--- a/rust/crates/ccusage/src/adapter/qwen/mod.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/mod.rs
@@ -4,9 +4,9 @@ mod paths;
 mod report;
 
 use crate::{
+    Result,
     cli::{AgentCommandArgs, AgentReportKind, SharedArgs},
     filter_loaded_entries_by_date, print_json_or_jq, print_usage_table, sort_summaries, wants_json,
-    Result,
 };
 
 pub(crate) use loader::load_entries;
@@ -72,8 +72,8 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::cli::{CostMode, SharedArgs};
     use crate::UsageSummary;
+    use crate::cli::{CostMode, SharedArgs};
 
     static QWEN_DATA_DIR_LOCK: Mutex<()> = Mutex::new(());
 
@@ -84,7 +84,7 @@ mod tests {
     impl QwenDataDirGuard {
         fn set(path: &Path) -> Self {
             let previous = env::var_os("QWEN_DATA_DIR");
-            env::set_var("QWEN_DATA_DIR", path);
+            unsafe { env::set_var("QWEN_DATA_DIR", path) };
             Self { previous }
         }
     }
@@ -92,9 +92,9 @@ mod tests {
     impl Drop for QwenDataDirGuard {
         fn drop(&mut self) {
             if let Some(previous) = self.previous.take() {
-                env::set_var("QWEN_DATA_DIR", previous);
+                unsafe { env::set_var("QWEN_DATA_DIR", previous) };
             } else {
-                env::remove_var("QWEN_DATA_DIR");
+                unsafe { env::remove_var("QWEN_DATA_DIR") };
             }
         }
     }

--- a/rust/crates/ccusage/src/adapter/qwen/parser.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/parser.rs
@@ -12,11 +12,11 @@ use serde_json::Value;
 
 use super::paths;
 use crate::{
+    LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
     format_date_tz, format_rfc3339_millis, json_value_u64, missing_pricing_model_for_candidates,
-    non_empty_json_string, parse_ts_timestamp, parse_tz, LoadedEntry, PricingMap, Result,
-    TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    non_empty_json_string, parse_ts_timestamp, parse_tz,
 };
 
 const DEFAULT_QWEN_MODEL: &str = "unknown";

--- a/rust/crates/ccusage/src/adapter/qwen/paths.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/paths.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
-use crate::{collect_files_with_extension, Result};
+use crate::{Result, collect_files_with_extension};
 
 const QWEN_DATA_DIR_ENV: &str = "QWEN_DATA_DIR";
 
@@ -62,12 +62,16 @@ fn is_chat_file(projects: &Path, file: &Path) -> bool {
 pub(super) fn project_from_file(file: &Path) -> Option<String> {
     let parts = file.components().collect::<Vec<_>>();
     for window in parts.windows(4).rev() {
-        if let [Component::Normal(projects), Component::Normal(project), Component::Normal(chats), Component::Normal(_)] =
-            window
+        if let [
+            Component::Normal(projects),
+            Component::Normal(project),
+            Component::Normal(chats),
+            Component::Normal(_),
+        ] = window
+            && projects.to_str() == Some("projects")
+            && chats.to_str() == Some("chats")
         {
-            if projects.to_str() == Some("projects") && chats.to_str() == Some("chats") {
-                return Some(project.to_string_lossy().into_owned());
-            }
+            return Some(project.to_string_lossy().into_owned());
         }
     }
     None

--- a/rust/crates/ccusage/src/adapter/qwen/report.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/report.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    BucketKind, LoadedEntry, Result, SessionAccumulator,
     cli::{AgentReportKind, WeekDay},
-    summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind, LoadedEntry, Result,
-    SessionAccumulator,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
 };
 
 pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {

--- a/rust/crates/ccusage/src/blocks.rs
+++ b/rust/crates/ccusage/src/blocks.rs
@@ -1,17 +1,17 @@
 use std::io::IsTerminal;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
-    am_pm,
+    Align, BLOCKS_COMPACT_WIDTH_THRESHOLD, BLOCKS_WARNING_THRESHOLD, BurnRate, Color, LoadedEntry,
+    MILLIS_PER_HOUR, MILLIS_PER_MINUTE, Projection, Result, SessionBlock, SimpleTable, TimestampMs,
+    TokenCounts, am_pm,
     cli::{SharedArgs, SortOrder},
     color,
     fast::FxHashSet,
     format_currency, format_date, format_models_multiline, format_number, format_rfc3339_millis,
     format_utc_second, hour_12, json_float, local_parts, print_box_title,
-    should_use_compact_layout, terminal_width, utc_now, Align, BurnRate, Color, LoadedEntry,
-    Projection, Result, SessionBlock, SimpleTable, TimestampMs, TokenCounts,
-    BLOCKS_COMPACT_WIDTH_THRESHOLD, BLOCKS_WARNING_THRESHOLD, MILLIS_PER_HOUR, MILLIS_PER_MINUTE,
+    should_use_compact_layout, terminal_width, utc_now,
 };
 
 pub(crate) fn identify_session_blocks(
@@ -58,10 +58,10 @@ pub(crate) fn identify_session_blocks(
         current_entries.push(entry);
     }
 
-    if let Some(start) = current_start {
-        if !current_entries.is_empty() {
-            blocks.push(create_block(start, current_entries, now, session_duration));
-        }
+    if let Some(start) = current_start
+        && !current_entries.is_empty()
+    {
+        blocks.push(create_block(start, current_entries, now, session_duration));
     }
     blocks
 }
@@ -87,10 +87,10 @@ fn create_block(
     for entry in &entries {
         token_counts.add_usage(entry.data.message.usage);
         cost += entry.cost;
-        if let Some(model) = &entry.model {
-            if seen_models.insert(model.clone()) {
-                models.push(model.clone());
-            }
+        if let Some(model) = &entry.model
+            && seen_models.insert(model.clone())
+        {
+            models.push(model.clone());
         }
         usage_limit_reset_time = usage_limit_reset_time.or(entry.usage_limit_reset_time);
     }
@@ -227,7 +227,9 @@ fn format_block_time(block: &SessionBlock, compact: bool) -> String {
         let remaining_hours = remaining / 60;
         let remaining_minutes = remaining.rem_euclid(60);
         return if compact {
-            format!("{start}\n({elapsed_hours}h{elapsed_minutes}m/{remaining_hours}h{remaining_minutes}m)")
+            format!(
+                "{start}\n({elapsed_hours}h{elapsed_minutes}m/{remaining_hours}h{remaining_minutes}m)"
+            )
         } else {
             format!(
                 "{start} ({elapsed_hours}h {elapsed_minutes}m elapsed, {remaining_hours}h {remaining_minutes}m remaining)"

--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -2,7 +2,7 @@ use std::{env, ffi::OsString, process};
 
 pub(crate) use ccusage_cli::*;
 
-use crate::{config::ConfigContext, DEFAULT_SESSION_DURATION_HOURS};
+use crate::{DEFAULT_SESSION_DURATION_HOURS, config::ConfigContext};
 
 pub(crate) fn parse() -> Cli {
     let args = env::args_os().collect::<Vec<_>>();

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -11,7 +11,9 @@ use serde_json::json;
 
 use crate::pricing::PricingMap;
 use crate::{
-    block_json, calculate_burn_rate,
+    BucketKind, Color, Context, DEFAULT_RECENT_DAYS, DEFAULT_SESSION_DURATION_HOURS,
+    MILLIS_PER_DAY, MILLIS_PER_MINUTE, Result, SessionAccumulator, TimestampMs, block_json,
+    calculate_burn_rate,
     cli::{
         BlocksArgs, CostSource, DailyArgs, SessionArgs, SharedArgs, SortOrder, StatuslineArgs,
         VisualBurnRate, WeekDay, WeeklyArgs,
@@ -23,8 +25,7 @@ use crate::{
     load_daily_summaries, load_entries, print_active_block_detail, print_blocks_table,
     print_json_or_jq, print_usage_table, session_summary_json, sort_blocks, sort_summaries,
     summarize_by_key, summarize_summaries_by_bucket, summary_json, total_usage_tokens, totals_json,
-    utc_now, wants_json, BucketKind, Color, Context, Result, SessionAccumulator, TimestampMs,
-    DEFAULT_RECENT_DAYS, DEFAULT_SESSION_DURATION_HOURS, MILLIS_PER_DAY, MILLIS_PER_MINUTE,
+    utc_now, wants_json,
 };
 
 pub(crate) fn run_daily(args: DailyArgs) -> Result<()> {
@@ -344,13 +345,12 @@ pub(crate) fn run_statusline(args: StatuslineArgs) -> Result<()> {
         None
     };
 
-    if let Some(cache) = initial_cache.as_ref() {
-        if let Some(output) =
+    if let Some(cache) = initial_cache.as_ref()
+        && let Some(output) =
             cached_statusline_output(cache, current_mtime, now_millis(), args.refresh_interval)
-        {
-            println!("{output}");
-            return Ok(());
-        }
+    {
+        println!("{output}");
+        return Ok(());
     }
 
     if cache_enabled {
@@ -912,9 +912,11 @@ mod tests {
         assert_eq!(today_shared.since.as_deref(), Some("20260522"));
         assert_eq!(today_shared.until.as_deref(), Some("20260522"));
         assert_eq!(today_shared.timezone.as_deref(), Some("Asia/Tokyo"));
-        assert!(today_shared
-            .pricing_overrides
-            .contains_key("statusline-model"));
+        assert!(
+            today_shared
+                .pricing_overrides
+                .contains_key("statusline-model")
+        );
     }
 
     #[test]

--- a/rust/crates/ccusage/src/config.rs
+++ b/rust/crates/ccusage/src/config.rs
@@ -8,9 +8,8 @@ use serde_json::{Map, Value};
 
 use crate::{
     cli::{
-        normalize_date_bound, BlocksArgs, CodexSpeed, CostMode, CostSource, DailyArgs,
-        PricingOverride, SharedArgs, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay,
-        WeeklyArgs,
+        BlocksArgs, CodexSpeed, CostMode, CostSource, DailyArgs, PricingOverride, SharedArgs,
+        SortOrder, StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs, normalize_date_bound,
     },
     config_schema::{
         BlocksSpecificOptions, CodexOptions, ConfigCodexSpeed, ConfigCostMode, ConfigCostSource,
@@ -180,11 +179,11 @@ fn command_tokens(args: &[String]) -> Vec<String> {
     let mut index = 0;
     while index < args.len() {
         let arg = &args[index];
-        if let Some((flag, _)) = arg.split_once('=') {
-            if flag.starts_with('-') {
-                index += 1;
-                continue;
-            }
+        if let Some((flag, _)) = arg.split_once('=')
+            && flag.starts_with('-')
+        {
+            index += 1;
+            continue;
         }
         if arg.starts_with('-') {
             index += if option_takes_value(arg) { 2 } else { 1 };
@@ -366,15 +365,15 @@ pub(crate) fn apply_config_to_agent_args(
         if let Some(speed) = codex_options.speed {
             *codex_speed = speed.into();
         }
-        if let Some(pi_path) = pi_path.as_deref_mut() {
-            if let Some(path) = PiOptions::from_map(options).pi_path {
-                *pi_path = Some(path);
-            }
+        if let Some(pi_path) = pi_path.as_deref_mut()
+            && let Some(path) = PiOptions::from_map(options).pi_path
+        {
+            *pi_path = Some(path);
         }
-        if let Some(open_claw_path) = open_claw_path.as_deref_mut() {
-            if let Some(path) = OpenClawOptions::from_map(options).open_claw_path {
-                *open_claw_path = Some(path);
-            }
+        if let Some(open_claw_path) = open_claw_path.as_deref_mut()
+            && let Some(path) = OpenClawOptions::from_map(options).open_claw_path
+        {
+            *open_claw_path = Some(path);
         }
     }
 }
@@ -606,15 +605,15 @@ impl From<ConfigCostSource> for CostSource {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::*;
     use crate::{
+        DEFAULT_SESSION_DURATION_HOURS,
         cli::{
             BlocksArgs, CodexSpeed, CostMode, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay,
             WeeklyArgs,
         },
-        DEFAULT_SESSION_DURATION_HOURS,
     };
 
     #[test]

--- a/rust/crates/ccusage/src/config_schema.rs
+++ b/rust/crates/ccusage/src/config_schema.rs
@@ -2,11 +2,11 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use serde_json::{json, Map, Value};
+use serde::de::DeserializeOwned;
+use serde_json::{Map, Value, json};
 
-use schemars::{r#gen::SchemaSettings, JsonSchema};
+use schemars::{JsonSchema, r#gen::SchemaSettings};
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -970,10 +970,10 @@ fn wrap_root_schema(schema: &mut Value) {
 mod tests {
     use std::collections::BTreeSet;
 
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
-    use super::generate_config_schema_json;
     use super::StatuslineSpecificOptions;
+    use super::generate_config_schema_json;
 
     #[test]
     fn schema_option_sets_expose_expected_keys() {

--- a/rust/crates/ccusage/src/cost.rs
+++ b/rust/crates/ccusage/src/cost.rs
@@ -136,10 +136,10 @@ pub(crate) fn tiered_cost(tokens: u64, base: f64, above: Option<f64>) -> f64 {
     if tokens == 0 {
         return 0.0;
     }
-    if let Some(above) = above {
-        if tokens > THRESHOLD {
-            return (THRESHOLD as f64 * base) + ((tokens - THRESHOLD) as f64 * above);
-        }
+    if let Some(above) = above
+        && tokens > THRESHOLD
+    {
+        return (THRESHOLD as f64 * base) + ((tokens - THRESHOLD) as f64 * above);
     }
     tokens as f64 * base
 }

--- a/rust/crates/ccusage/src/date_utils.rs
+++ b/rust/crates/ccusage/src/date_utils.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use jiff::{tz::TimeZone as JiffTimeZone, Timestamp as JiffTimestamp};
+use jiff::{Timestamp as JiffTimestamp, tz::TimeZone as JiffTimeZone};
 
 pub(crate) const MILLIS_PER_SECOND: i64 = 1_000;
 pub(crate) const MILLIS_PER_MINUTE: i64 = 60 * MILLIS_PER_SECOND;
@@ -299,17 +299,9 @@ pub(crate) fn local_parts(timestamp: TimestampMs) -> UtcParts {
 
 pub(crate) fn hour_12(hour: u32) -> u32 {
     let hour = hour % 12;
-    if hour == 0 {
-        12
-    } else {
-        hour
-    }
+    if hour == 0 { 12 } else { hour }
 }
 
 pub(crate) fn am_pm(hour: u32) -> &'static str {
-    if hour < 12 {
-        "AM"
-    } else {
-        "PM"
-    }
+    if hour < 12 { "AM" } else { "PM" }
 }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -159,13 +159,9 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashMap,
-        env, fs,
-        sync::{Arc, Mutex},
-    };
+    use std::{collections::HashMap, fs, sync::Arc};
 
-    use ccusage_test_support::fs_fixture;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
     use serde_json::json;
 
     use super::*;
@@ -173,8 +169,6 @@ mod tests {
         cli::{CostMode, SharedArgs, SortOrder, WeekDay},
         cost::tiered_cost,
     };
-
-    static CLAUDE_CONFIG_DIR_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn formats_numbers_with_commas() {
@@ -301,7 +295,6 @@ mod tests {
 
     #[test]
     fn keeps_most_complete_duplicate_usage_entry() {
-        let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "projects/project1/session1/chat.jsonl": [
                 r#"{"timestamp":"2025-01-10T10:00:00.000Z","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_456","costUSD":0.001}"#,
@@ -310,18 +303,12 @@ mod tests {
             .join("\n"),
         });
 
-        let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.root()) };
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
         let shared = SharedArgs {
             mode: CostMode::Display,
             ..SharedArgs::default()
         };
         let entries = load_entries(&shared, None).unwrap();
-        if let Some(previous) = previous {
-            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
-        } else {
-            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
-        }
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].data.message.usage.input_tokens, 100);
@@ -331,7 +318,6 @@ mod tests {
 
     #[test]
     fn dedupes_usage_entries_by_message_id_without_request_id() {
-        let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "projects/project1/session1/chat.jsonl": [
                 r#"{"timestamp":"2025-01-10T10:00:00.000Z","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"costUSD":0.001}"#,
@@ -340,18 +326,12 @@ mod tests {
             .join("\n"),
         });
 
-        let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.root()) };
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
         let shared = SharedArgs {
             mode: CostMode::Display,
             ..SharedArgs::default()
         };
         let entries = load_entries(&shared, None).unwrap();
-        if let Some(previous) = previous {
-            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
-        } else {
-            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
-        }
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].data.message.usage.output_tokens, 250);
@@ -360,23 +340,16 @@ mod tests {
 
     #[test]
     fn accepts_projects_directory_in_claude_config_dir() {
-        let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "projects/project1/session1/chat.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"costUSD":0.001}"#,
         });
 
-        let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.path("projects")) };
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.path("projects"));
         let shared = SharedArgs {
             mode: CostMode::Display,
             ..SharedArgs::default()
         };
         let entries = load_entries(&shared, None).unwrap();
-        if let Some(previous) = previous {
-            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
-        } else {
-            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
-        }
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].project.as_ref(), "project1");
@@ -384,7 +357,6 @@ mod tests {
 
     #[test]
     fn loads_daily_summaries_like_loaded_entry_aggregation() {
-        let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "projects/project-a/session-a/chat.jsonl": [
                 r#"{"timestamp":"2025-01-10T09:59:00.000Z","version":"not-semver","message":{"id":"bad","model":"claude-opus-4-6","usage":{"input_tokens":999,"output_tokens":999,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},"requestId":"bad","costUSD":9}"#,
@@ -396,8 +368,7 @@ mod tests {
             "projects/project-b/session-b/chat.jsonl": r#"{"timestamp":"2025-01-10T12:00:00.000Z","version":"1.2.3","sessionId":"session-b","message":{"id":"msg_b","model":"claude-sonnet-4-20250514","usage":{"input_tokens":20,"output_tokens":30,"cache_creation_input_tokens":4,"cache_read_input_tokens":2}},"requestId":"req_b","costUSD":0.04}"#,
         });
 
-        let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.root()) };
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),
@@ -406,11 +377,6 @@ mod tests {
         let entries = load_entries(&shared, None).unwrap();
         let daily = load_daily_summaries(&shared, None, false).unwrap();
         let grouped_daily = load_daily_summaries(&shared, None, true).unwrap();
-        if let Some(previous) = previous {
-            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
-        } else {
-            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
-        }
 
         let expected_daily = summarize_by_key(
             &entries,
@@ -446,7 +412,6 @@ mod tests {
 
     #[test]
     fn keeps_nested_agent_progress_in_daily_model_order() {
-        let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "projects/project-a/session-a.jsonl": [
                 r#"{"timestamp":"2026-03-10T06:00:00.000Z","version":"1.2.3","sessionId":"session-a","message":{"id":"msg_fast","model":"claude-opus-4-6","role":"assistant","usage":{"input_tokens":10,"output_tokens":1,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"speed":"fast"}},"requestId":"req_fast","costUSD":0.03}"#,
@@ -457,19 +422,13 @@ mod tests {
             "projects/project-a/session-a/subagents/agent-a.jsonl": r#"{"timestamp":"2026-03-10T06:00:01.000Z","version":"1.2.3","sessionId":"session-a","message":{"id":"msg_haiku","model":"claude-haiku-4-5-20251001","role":"assistant","usage":{"input_tokens":20,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},"requestId":"req_haiku","costUSD":0.06}"#,
         });
 
-        let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.root()) };
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),
             ..SharedArgs::default()
         };
         let daily = load_daily_summaries(&shared, None, false).unwrap();
-        if let Some(previous) = previous {
-            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
-        } else {
-            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
-        }
 
         assert_eq!(daily.len(), 1);
         assert_eq!(
@@ -485,14 +444,12 @@ mod tests {
 
     #[test]
     fn uses_direct_subagent_cost_for_duplicate_daily_agent_progress() {
-        let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
             "projects/project-a/session-a.jsonl": r#"{"sessionId":"session-a","version":"1.2.3","type":"progress","data":{"message":{"type":"assistant","timestamp":"2026-03-10T06:00:01.000Z","message":{"model":"claude-haiku-4-5-20251001","id":"msg_haiku","type":"message","role":"assistant","content":[],"usage":{"input_tokens":20,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},"requestId":"req_haiku","uuid":"nested"}},"timestamp":"2026-03-10T06:00:01.001Z"}"#,
             "projects/project-a/session-a/subagents/agent-a.jsonl": r#"{"timestamp":"2026-03-10T06:00:01.000Z","version":"1.2.3","sessionId":"session-a","message":{"id":"msg_haiku","model":"claude-haiku-4-5-20251001","role":"assistant","usage":{"input_tokens":20,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},"requestId":"req_haiku","costUSD":0.06}"#,
         });
 
-        let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.root()) };
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),
@@ -500,11 +457,6 @@ mod tests {
         };
         let entries = load_entries(&shared, None).unwrap();
         let daily = load_daily_summaries(&shared, None, false).unwrap();
-        if let Some(previous) = previous {
-            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
-        } else {
-            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
-        }
 
         let expected_daily = summarize_by_key(
             &entries,

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -41,16 +41,16 @@ pub(crate) use output::{
 };
 pub(crate) use project_names::{format_project_name, parse_project_aliases, short_model_name};
 pub(crate) use summary::{
-    filter_and_sort_summaries, sort_summaries, summarize_by_key, summarize_summaries_by_bucket,
-    week_start, BucketKind, SessionAccumulator,
+    BucketKind, SessionAccumulator, filter_and_sort_summaries, sort_summaries, summarize_by_key,
+    summarize_summaries_by_bucket, week_start,
 };
 pub(crate) use types::*;
 pub(crate) use utils::{
     apply_total_token_fallback, json_value_u64, non_empty_json_string, total_usage_tokens,
 };
 
-use ccusage_terminal::{terminal_width, TerminalStyle};
 pub(crate) use ccusage_terminal::{Align, Color, SimpleTable};
+use ccusage_terminal::{TerminalStyle, terminal_width};
 use cli::{AgentCommandArgs, AgentReportKind, Command};
 use pricing::PricingMap;
 
@@ -293,10 +293,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(format_rfc3339_millis(timestamp), "2026-05-11T12:34:56.789Z");
-        assert!(adapter::claude::timestamp_from_line(
-            r#"{"timestamp": "2026-05-11T12:34:56.789Z"}"#
-        )
-        .is_none());
+        assert!(
+            adapter::claude::timestamp_from_line(r#"{"timestamp": "2026-05-11T12:34:56.789Z"}"#)
+                .is_none()
+        );
     }
 
     #[test]
@@ -311,16 +311,16 @@ mod tests {
         });
 
         let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        env::set_var("CLAUDE_CONFIG_DIR", fixture.root());
+        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.root()) };
         let shared = SharedArgs {
             mode: CostMode::Display,
             ..SharedArgs::default()
         };
         let entries = load_entries(&shared, None).unwrap();
         if let Some(previous) = previous {
-            env::set_var("CLAUDE_CONFIG_DIR", previous);
+            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
         } else {
-            env::remove_var("CLAUDE_CONFIG_DIR");
+            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
         }
 
         assert_eq!(entries.len(), 1);
@@ -341,16 +341,16 @@ mod tests {
         });
 
         let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        env::set_var("CLAUDE_CONFIG_DIR", fixture.root());
+        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.root()) };
         let shared = SharedArgs {
             mode: CostMode::Display,
             ..SharedArgs::default()
         };
         let entries = load_entries(&shared, None).unwrap();
         if let Some(previous) = previous {
-            env::set_var("CLAUDE_CONFIG_DIR", previous);
+            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
         } else {
-            env::remove_var("CLAUDE_CONFIG_DIR");
+            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
         }
 
         assert_eq!(entries.len(), 1);
@@ -366,16 +366,16 @@ mod tests {
         });
 
         let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        env::set_var("CLAUDE_CONFIG_DIR", fixture.path("projects"));
+        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.path("projects")) };
         let shared = SharedArgs {
             mode: CostMode::Display,
             ..SharedArgs::default()
         };
         let entries = load_entries(&shared, None).unwrap();
         if let Some(previous) = previous {
-            env::set_var("CLAUDE_CONFIG_DIR", previous);
+            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
         } else {
-            env::remove_var("CLAUDE_CONFIG_DIR");
+            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
         }
 
         assert_eq!(entries.len(), 1);
@@ -397,7 +397,7 @@ mod tests {
         });
 
         let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        env::set_var("CLAUDE_CONFIG_DIR", fixture.root());
+        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.root()) };
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),
@@ -407,9 +407,9 @@ mod tests {
         let daily = load_daily_summaries(&shared, None, false).unwrap();
         let grouped_daily = load_daily_summaries(&shared, None, true).unwrap();
         if let Some(previous) = previous {
-            env::set_var("CLAUDE_CONFIG_DIR", previous);
+            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
         } else {
-            env::remove_var("CLAUDE_CONFIG_DIR");
+            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
         }
 
         let expected_daily = summarize_by_key(
@@ -458,7 +458,7 @@ mod tests {
         });
 
         let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        env::set_var("CLAUDE_CONFIG_DIR", fixture.root());
+        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.root()) };
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),
@@ -466,9 +466,9 @@ mod tests {
         };
         let daily = load_daily_summaries(&shared, None, false).unwrap();
         if let Some(previous) = previous {
-            env::set_var("CLAUDE_CONFIG_DIR", previous);
+            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
         } else {
-            env::remove_var("CLAUDE_CONFIG_DIR");
+            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
         }
 
         assert_eq!(daily.len(), 1);
@@ -492,7 +492,7 @@ mod tests {
         });
 
         let previous = env::var("CLAUDE_CONFIG_DIR").ok();
-        env::set_var("CLAUDE_CONFIG_DIR", fixture.root());
+        unsafe { env::set_var("CLAUDE_CONFIG_DIR", fixture.root()) };
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),
@@ -501,9 +501,9 @@ mod tests {
         let entries = load_entries(&shared, None).unwrap();
         let daily = load_daily_summaries(&shared, None, false).unwrap();
         if let Some(previous) = previous {
-            env::set_var("CLAUDE_CONFIG_DIR", previous);
+            unsafe { env::set_var("CLAUDE_CONFIG_DIR", previous) };
         } else {
-            env::remove_var("CLAUDE_CONFIG_DIR");
+            unsafe { env::remove_var("CLAUDE_CONFIG_DIR") };
         }
 
         let expected_daily = summarize_by_key(
@@ -953,10 +953,12 @@ mod tests {
             "2025-01-10T10:00:00.000Z"
         );
         assert!(adapter::claude::usage_limit_reset_time_from_line(line, Some(false)).is_none());
-        assert!(adapter::claude::usage_limit_reset_time_from_line(
-            r#"{"message":{"content":[{"text":"Claude AI usage limit reached|0"}]}}"#,
-            Some(true)
-        )
-        .is_none());
+        assert!(
+            adapter::claude::usage_limit_reset_time_from_line(
+                r#"{"message":{"content":[{"text":"Claude AI usage limit reached|0"}]}}"#,
+                Some(true)
+            )
+            .is_none()
+        );
     }
 }

--- a/rust/crates/ccusage/src/output.rs
+++ b/rust/crates/ccusage/src/output.rs
@@ -3,12 +3,12 @@ use std::{
     io::{self, BufWriter, IsTerminal, Write},
 };
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
+    Align, Color, Result, SimpleTable, USAGE_COMPACT_WIDTH_THRESHOLD, UsageSummary,
     cli::SharedArgs, cli_error, color, format_project_name, parse_project_aliases, print_box_title,
-    short_model_name, terminal_width, Align, Color, Result, SimpleTable, UsageSummary,
-    USAGE_COMPACT_WIDTH_THRESHOLD,
+    short_model_name, terminal_width,
 };
 
 pub(crate) fn wants_json(shared: &SharedArgs) -> bool {
@@ -212,20 +212,19 @@ pub(crate) fn print_usage_table(
     let aliases = parse_project_aliases(project_aliases);
     let mut current_project: Option<&str> = None;
     for row in rows {
-        if group_projects {
-            if let Some(project) = row.project.as_deref() {
-                if current_project != Some(project) {
-                    if current_project.is_some() {
-                        table.separator();
-                    }
-                    table.push(project_header_row(
-                        table.column_count(),
-                        &format_project_name(project, &aliases),
-                        shared,
-                    ));
-                    current_project = Some(project);
-                }
+        if group_projects
+            && let Some(project) = row.project.as_deref()
+            && current_project != Some(project)
+        {
+            if current_project.is_some() {
+                table.separator();
             }
+            table.push(project_header_row(
+                table.column_count(),
+                &format_project_name(project, &aliases),
+                shared,
+            ));
+            current_project = Some(project);
         }
         let label = row
             .date

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1001,23 +1001,22 @@ fn parse_litellm_pricing(value: Value) -> Option<LiteLlmPricing> {
     if value
         .as_object()
         .is_some_and(|entry| entry.contains_key("i") && entry.contains_key("o"))
+        && let Ok(compact) = serde_json::from_value::<CompactLiteLlmPricing>(value.clone())
     {
-        if let Ok(compact) = serde_json::from_value::<CompactLiteLlmPricing>(value.clone()) {
-            return Some(LiteLlmPricing {
-                input_cost_per_token: Some(compact.i),
-                output_cost_per_token: Some(compact.o),
-                cache_creation_input_token_cost: compact.cc,
-                cache_read_input_token_cost: compact.cr,
-                input_cost_per_token_above_200k_tokens: compact.ia,
-                output_cost_per_token_above_200k_tokens: compact.oa,
-                cache_creation_input_token_cost_above_200k_tokens: compact.cca,
-                cache_read_input_token_cost_above_200k_tokens: compact.cra,
-                max_input_tokens: compact.ctx,
-                provider_specific_entry: compact
-                    .fast
-                    .map(|fast| ProviderSpecificEntry { fast: Some(fast) }),
-            });
-        }
+        return Some(LiteLlmPricing {
+            input_cost_per_token: Some(compact.i),
+            output_cost_per_token: Some(compact.o),
+            cache_creation_input_token_cost: compact.cc,
+            cache_read_input_token_cost: compact.cr,
+            input_cost_per_token_above_200k_tokens: compact.ia,
+            output_cost_per_token_above_200k_tokens: compact.oa,
+            cache_creation_input_token_cost_above_200k_tokens: compact.cca,
+            cache_read_input_token_cost_above_200k_tokens: compact.cra,
+            max_input_tokens: compact.ctx,
+            provider_specific_entry: compact
+                .fast
+                .map(|fast| ProviderSpecificEntry { fast: Some(fast) }),
+        });
     }
     let pricing = serde_json::from_value::<LiteLlmPricing>(value).ok()?;
     pricing
@@ -1232,8 +1231,8 @@ fn fetch_json_url(url: &str) -> std::io::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        embedded_models_dev_pricing, Pricing, PricingMap, BUILD_TIME_MODELS_DEV_JSON,
-        BUILD_TIME_PRICING_JSON,
+        BUILD_TIME_MODELS_DEV_JSON, BUILD_TIME_PRICING_JSON, Pricing, PricingMap,
+        embedded_models_dev_pricing,
     };
     use ccusage_test_support::fs_fixture;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1458,12 +1457,14 @@ mod tests {
     fn keeps_models_dev_fallback_disabled_for_embedded_and_offline_pricing() {
         use ccusage_cli::PricingOverride;
         assert!(!PricingMap::load_embedded().models_dev_fallback_enabled());
-        assert!(!PricingMap::load_with_overrides(
-            true,
-            false,
-            std::iter::empty::<(&String, &PricingOverride)>(),
-        )
-        .models_dev_fallback_enabled());
+        assert!(
+            !PricingMap::load_with_overrides(
+                true,
+                false,
+                std::iter::empty::<(&String, &PricingOverride)>(),
+            )
+            .models_dev_fallback_enabled()
+        );
     }
 
     #[test]
@@ -1699,9 +1700,10 @@ mod tests {
     #[test]
     fn embedded_models_dev_snapshot_is_parseable() {
         let mut map = PricingMap::default();
-        assert!(map
-            .load_models_dev_json_missing(BUILD_TIME_MODELS_DEV_JSON)
-            .is_some());
+        assert!(
+            map.load_models_dev_json_missing(BUILD_TIME_MODELS_DEV_JSON)
+                .is_some()
+        );
     }
 
     #[test]
@@ -2268,7 +2270,7 @@ mod tests {
             let entry = pricing.find("claude-model").unwrap();
             assert_eq!(entry.input, 2e-6);
             assert_eq!(entry.output, 15e-6); // unchanged
-                                             // cache_create: 3.75e-6 * (2/3) = 2.5e-6
+            // cache_create: 3.75e-6 * (2/3) = 2.5e-6
             assert!((entry.cache_create - 2.5e-6).abs() < 1e-15);
             // cache_read: 3e-7 * (2/3) = 2e-7
             assert!((entry.cache_read - 2e-7).abs() < 1e-15);
@@ -2337,7 +2339,7 @@ mod tests {
             let entry = pricing.find("model").unwrap();
             assert_eq!(entry.input, 2e-6);
             assert_eq!(entry.cache_read, 5e-7); // explicit value, not 2e-7
-                                                // cache_create still scaled since not explicitly provided
+            // cache_create still scaled since not explicitly provided
             assert!((entry.cache_create - 2.5e-6).abs() < 1e-15);
         }
     }

--- a/rust/crates/ccusage/src/progress.rs
+++ b/rust/crates/ccusage/src/progress.rs
@@ -156,24 +156,26 @@ impl UsageLoadProgress {
         let running = Arc::new((Mutex::new(true), Condvar::new()));
         let worker = {
             let running = Arc::clone(&running);
-            Some(thread::spawn(move || loop {
-                if let Ok(mut state) = state.lock() {
-                    if state.has_content() {
+            Some(thread::spawn(move || {
+                loop {
+                    if let Ok(mut state) = state.lock()
+                        && state.has_content()
+                    {
                         state.render();
                     }
-                }
-                let (lock, cvar) = &*running;
-                let Ok(guard) = lock.lock() else {
-                    break;
-                };
-                if !*guard {
-                    break;
-                }
-                let Ok((guard, _)) = cvar.wait_timeout(guard, SPINNER_INTERVAL) else {
-                    break;
-                };
-                if !*guard {
-                    break;
+                    let (lock, cvar) = &*running;
+                    let Ok(guard) = lock.lock() else {
+                        break;
+                    };
+                    if !*guard {
+                        break;
+                    }
+                    let Ok((guard, _)) = cvar.wait_timeout(guard, SPINNER_INTERVAL) else {
+                        break;
+                    };
+                    if !*guard {
+                        break;
+                    }
                 }
             }))
         };
@@ -220,15 +222,15 @@ impl UsageLoadProgress {
         if let Some(worker) = self.worker.take() {
             let _ = worker.join();
         }
-        if let Some(controller) = self.controller.as_ref() {
-            if let Ok(mut state) = controller.state.lock() {
-                if state.rendered {
-                    let _ = write!(io::stderr(), "\r\x1b[K\x1b[?25h");
-                    let _ = io::stderr().flush();
-                }
-                state.status = None;
-                state.states.clear();
+        if let Some(controller) = self.controller.as_ref()
+            && let Ok(mut state) = controller.state.lock()
+        {
+            if state.rendered {
+                let _ = write!(io::stderr(), "\r\x1b[K\x1b[?25h");
+                let _ = io::stderr().flush();
             }
+            state.status = None;
+            state.states.clear();
         }
         ACTIVE_PROGRESS.with(|active| {
             *active.borrow_mut() = None;

--- a/rust/crates/ccusage/src/summary.rs
+++ b/rust/crates/ccusage/src/summary.rs
@@ -4,11 +4,11 @@ use std::{
 };
 
 use crate::{
+    LoadedEntry, ModelBreakdown, Result, TimestampMs, TokenCounts, UsageSummary,
     cli::{SharedArgs, SortOrder, WeekDay},
     cli_error,
     fast::{FxHashMap, FxHashSet},
-    format_naive_date, format_rfc3339_millis, parse_iso_date, LoadedEntry, ModelBreakdown, Result,
-    TimestampMs, TokenCounts, UsageSummary,
+    format_naive_date, format_rfc3339_millis, parse_iso_date,
 };
 
 pub(crate) fn summarize_by_key<F, M>(
@@ -314,8 +314,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        cli::{normalize_date_bound, SharedArgs, SortOrder},
-        format_rfc3339_millis, ModelBreakdown, TokenUsageRaw, UsageEntry, UsageMessage,
+        ModelBreakdown, TokenUsageRaw, UsageEntry, UsageMessage,
+        cli::{SharedArgs, SortOrder, normalize_date_bound},
+        format_rfc3339_millis,
     };
 
     #[test]


### PR DESCRIPTION
## Summary
- migrate all Rust crates from edition 2021 to edition 2024
- align treefmt rustfmt configuration with edition 2024
- apply cargo fix, clippy --fix, and rustfmt output for edition-compatible code

## Notes
- This is intentionally separate from the Rust 1.96 toolchain bump in #1307.
- Most source churn is mechanical rustfmt import ordering and Clippy let-chain simplification after switching the edition.
- Rust 2024 makes std::env::set_var/remove_var unsafe, so test-only environment guards now wrap those calls in unsafe blocks.

## Validation
- cargo fix --manifest-path rust/Cargo.toml --workspace --edition
- cargo test --manifest-path rust/Cargo.toml --workspace
- just fmt
- cargo clippy --fix --allow-dirty --manifest-path rust/Cargo.toml --release --workspace --all-targets -- -D warnings
- nix flake check --print-build-logs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate all Rust crates to edition 2024 and align formatting. No functional changes; adopts 2024 syntax/safety rules and centralizes test env-var handling.

- **Refactors**
  - Set `edition = "2024"` in all crates and updated `treefmt` `rustfmt` edition to 2024.
  - Applied `cargo fix`, `clippy --fix`, and `rustfmt` for 2024 patterns (let-chains, import ordering).
  - Centralized unsafe env-var access in tests with a shared `EnvVarGuard` (process-wide mutex + RAII), replacing ad-hoc locks and direct mutations.

<sup>Written for commit 00f4790e24a09089c44e49f8721bee6da83c3a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust edition to 2024 across the project.
  * Internal refactors for consistency: simplified conditionals, reordered imports, and cleaned up assertion formatting.
* **Tests**
  * Test helpers and environment guards standardized; tests reformatted without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->