### PR TITLE
feat(model): support internal model aliases

### DIFF
--- a/rust/crates/ccusage/src/adapter/claude/daily.rs
+++ b/rust/crates/ccusage/src/adapter/claude/daily.rs
@@ -458,6 +458,7 @@ impl DailyAccumulator {
         self.counts.add_usage(entry.usage);
         self.cost += entry.cost;
         if let Some(model) = &entry.model {
+            let model = crate::model_aliases::resolve_model_name(model).into_owned();
             let index = if let Some(index) = self.breakdown_indexes.get(model.as_str()) {
                 *index
             } else {

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -297,7 +297,8 @@ fn add_deduped_event_to_groups(
         AgentReportKind::Session => event.session_id.clone(),
     };
     let group = groups.entry(period).or_default();
-    accumulate_codex_event_into_group(group, event, model);
+    let model = crate::model_aliases::resolve_model_name(model);
+    accumulate_codex_event_into_group(group, event, model.as_ref());
     Ok(())
 }
 
@@ -432,7 +433,8 @@ pub(crate) fn aggregate_events(
             AgentReportKind::Session => event.session_id.clone(),
         };
         let group = groups.entry(period).or_insert_with(CodexGroup::default);
-        accumulate_codex_event_into_group(group, event, model);
+        let model = crate::model_aliases::resolve_model_name(model);
+        accumulate_codex_event_into_group(group, event, model.as_ref());
     }
     Ok(groups)
 }

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -235,12 +235,13 @@ fn add_event_to_groups(
     let Some(model) = event.model.as_deref().filter(|model| !model.is_empty()) else {
         return Ok(());
     };
+    let model = crate::model_aliases::resolve_model_name(model);
     let timestamp = parse_ts_timestamp(&event.timestamp)
         .ok_or_else(|| crate::cli_error(format!("Invalid Codex timestamp: {}", event.timestamp)))?;
-    if !insert_event_key(event, timestamp, model, kind, seen) {
+    if !insert_event_key(event, timestamp, model.as_ref(), kind, seen) {
         return Ok(());
     }
-    add_deduped_event_to_groups(event, model, timestamp, kind, timezone, shared, groups)
+    add_deduped_event_to_groups(event, model.as_ref(), timestamp, kind, timezone, shared, groups)
 }
 
 fn add_event_to_groups_local(
@@ -253,17 +254,18 @@ fn add_event_to_groups_local(
     let Some(model) = event.model.as_deref().filter(|model| !model.is_empty()) else {
         return Ok(());
     };
+    let model = crate::model_aliases::resolve_model_name(model);
     let timestamp = parse_ts_timestamp(&event.timestamp)
         .ok_or_else(|| crate::cli_error(format!("Invalid Codex timestamp: {}", event.timestamp)))?;
     if !aggregation
         .seen
-        .insert(codex_event_key(event, timestamp, model, kind))
+        .insert(codex_event_key(event, timestamp, model.as_ref(), kind))
     {
         return Ok(());
     }
     add_deduped_event_to_groups(
         event,
-        model,
+        model.as_ref(),
         timestamp,
         kind,
         timezone,
@@ -297,8 +299,7 @@ fn add_deduped_event_to_groups(
         AgentReportKind::Session => event.session_id.clone(),
     };
     let group = groups.entry(period).or_default();
-    let model = crate::model_aliases::resolve_model_name(model);
-    accumulate_codex_event_into_group(group, event, model.as_ref());
+    accumulate_codex_event_into_group(group, event, model);
     Ok(())
 }
 

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -241,7 +241,15 @@ fn add_event_to_groups(
     if !insert_event_key(event, timestamp, model.as_ref(), kind, seen) {
         return Ok(());
     }
-    add_deduped_event_to_groups(event, model.as_ref(), timestamp, kind, timezone, shared, groups)
+    add_deduped_event_to_groups(
+        event,
+        model.as_ref(),
+        timestamp,
+        kind,
+        timezone,
+        shared,
+        groups,
+    )
 }
 
 fn add_event_to_groups_local(

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -479,7 +479,9 @@ mod tests {
     use ccusage_test_support::fs_fixture;
     use serde_json::json;
 
-    use crate::adapter::codex::paths::CodexUsageSource;
+    use crate::{
+        adapter::codex::paths::CodexUsageSource, model_aliases::set_model_aliases_for_tests,
+    };
 
     #[test]
     fn dedupes_copied_token_usage_across_session_files() {
@@ -526,6 +528,70 @@ mod tests {
             assert_eq!(group.output_tokens, 200);
             assert_eq!(group.reasoning_output_tokens, 20);
             assert_eq!(group.total_tokens, 1_200);
+        }
+    }
+
+    #[test]
+    fn dedupes_copied_token_usage_after_model_alias_resolution() {
+        let _aliases = set_model_aliases_for_tests([("private-alpha", "gpt-5.2")]);
+        let private_usage_line = json!({
+            "timestamp": "2026-05-29T08:01:00.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "model": "private-alpha",
+                    "last_token_usage": {
+                        "input_tokens": 1_000,
+                        "cached_input_tokens": 100,
+                        "output_tokens": 200,
+                        "reasoning_output_tokens": 20,
+                        "total_tokens": 1_200,
+                    },
+                },
+            },
+        })
+        .to_string();
+        let canonical_usage_line = json!({
+            "timestamp": "2026-05-29T08:01:00.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "model": "gpt-5.2",
+                    "last_token_usage": {
+                        "input_tokens": 1_000,
+                        "cached_input_tokens": 100,
+                        "output_tokens": 200,
+                        "reasoning_output_tokens": 20,
+                        "total_tokens": 1_200,
+                    },
+                },
+            },
+        })
+        .to_string();
+        let fixture = fs_fixture!({
+            "sessions/root.jsonl": &private_usage_line,
+            "sessions/goal.jsonl": &canonical_usage_line,
+        });
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                single_thread,
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            };
+
+            let groups = load_groups_from_directory(
+                &fixture.path("sessions"),
+                &shared,
+                AgentReportKind::Daily,
+            )
+            .unwrap();
+
+            let group = groups.get("2026-05-29").unwrap();
+            assert_eq!(group.input_tokens, 1_000);
+            assert_eq!(group.models.len(), 1);
+            assert_eq!(group.models["gpt-5.2"].input_tokens, 1_000);
         }
     }
 

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -158,6 +158,54 @@ mod tests {
     }
 
     #[test]
+    fn reports_codex_model_aliases_without_raw_model_names() {
+        let _aliases = crate::model_aliases::set_model_aliases_for_tests([
+            ("private-codex-alpha", "gpt-5.5"),
+            ("private-codex-beta", "gpt-5.5"),
+        ]);
+        let pricing = PricingMap::default();
+        let report = report_json(
+            &[
+                CodexTokenUsageEvent {
+                    session_id: "session-1".to_string(),
+                    timestamp: "2026-01-02T00:00:00.000Z".to_string(),
+                    model: Some("private-codex-alpha".to_string()),
+                    input_tokens: 100,
+                    cached_input_tokens: 10,
+                    output_tokens: 5,
+                    reasoning_output_tokens: 0,
+                    total_tokens: 105,
+                    is_fallback_model: false,
+                },
+                CodexTokenUsageEvent {
+                    session_id: "session-1".to_string(),
+                    timestamp: "2026-01-02T00:00:01.000Z".to_string(),
+                    model: Some("private-codex-beta".to_string()),
+                    input_tokens: 50,
+                    cached_input_tokens: 5,
+                    output_tokens: 3,
+                    reasoning_output_tokens: 0,
+                    total_tokens: 53,
+                    is_fallback_model: false,
+                },
+            ],
+            AgentReportKind::Daily,
+            Some("UTC"),
+            &pricing,
+            CodexSpeed::Standard,
+        )
+        .unwrap();
+
+        let models = report["daily"][0]["models"].as_object().unwrap();
+        assert!(models.contains_key("gpt-5.5"));
+        assert!(!models.contains_key("private-codex-alpha"));
+        assert!(!models.contains_key("private-codex-beta"));
+        assert_eq!(models["gpt-5.5"]["inputTokens"], 135);
+        assert_eq!(models["gpt-5.5"]["cacheReadTokens"], 15);
+        assert_eq!(models["gpt-5.5"]["outputTokens"], 8);
+    }
+
+    #[test]
     fn charges_cached_input_at_input_rate_when_codex_pricing_omits_cache_read_rate() {
         let mut pricing = PricingMap::default();
         pricing.load_json(

--- a/rust/crates/ccusage/src/blocks.rs
+++ b/rust/crates/ccusage/src/blocks.rs
@@ -87,10 +87,11 @@ fn create_block(
     for entry in &entries {
         token_counts.add_usage(entry.data.message.usage);
         cost += entry.cost;
-        if let Some(model) = &entry.model
-            && seen_models.insert(model.clone())
-        {
-            models.push(model.clone());
+        if let Some(model) = &entry.model {
+            let model = crate::model_aliases::resolve_model_name(model).into_owned();
+            if seen_models.insert(model.clone()) {
+                models.push(model);
+            }
         }
         usage_limit_reset_time = usage_limit_reset_time.or(entry.usage_limit_reset_time);
     }

--- a/rust/crates/ccusage/src/cost.rs
+++ b/rust/crates/ccusage/src/cost.rs
@@ -59,7 +59,10 @@ pub(crate) fn missing_pricing_model_for_token_total(
     }
     let model = model?;
     let pricing = pricing?;
-    pricing.find(model).is_none().then(|| model.to_string())
+    pricing
+        .find(model)
+        .is_none()
+        .then(|| crate::model_aliases::resolve_model_name(model).into_owned())
 }
 
 pub(crate) fn missing_pricing_model_for_candidates(
@@ -75,7 +78,7 @@ pub(crate) fn missing_pricing_model_for_candidates(
     candidates
         .into_iter()
         .all(|candidate| pricing.find(&candidate).is_none())
-        .then(|| model.to_string())
+        .then(|| crate::model_aliases::resolve_model_name(model).into_owned())
 }
 
 fn calculate_cost_from_tokens(

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -11,6 +11,7 @@ mod date_utils;
 mod fast;
 mod home;
 mod logger;
+mod model_aliases;
 mod output;
 mod pricing;
 mod progress;

--- a/rust/crates/ccusage/src/model_aliases.rs
+++ b/rust/crates/ccusage/src/model_aliases.rs
@@ -17,10 +17,10 @@ pub(crate) fn resolve_model_name(model: &str) -> Cow<'_, str> {
     if let Some(alias) = aliases.get(model).filter(|alias| !alias.is_empty()) {
         return Cow::Owned(alias.clone());
     }
-    if let Some(base_model) = model.strip_suffix("-fast") {
-        if let Some(alias) = aliases.get(base_model).filter(|alias| !alias.is_empty()) {
-            return Cow::Owned(format!("{alias}-fast"));
-        }
+    if let Some(base_model) = model.strip_suffix("-fast")
+        && let Some(alias) = aliases.get(base_model).filter(|alias| !alias.is_empty())
+    {
+        return Cow::Owned(format!("{alias}-fast"));
     }
     Cow::Borrowed(model)
 }

--- a/rust/crates/ccusage/src/model_aliases.rs
+++ b/rust/crates/ccusage/src/model_aliases.rs
@@ -38,8 +38,10 @@ fn load_model_aliases_from_env() -> BTreeMap<String, String> {
 
 fn parse_model_aliases(raw: &str) -> BTreeMap<String, String> {
     let trimmed = raw.trim();
-    if trimmed.starts_with('{') {
-        return serde_json::from_str::<BTreeMap<String, String>>(trimmed).unwrap_or_default();
+    if trimmed.starts_with('{')
+        && let Ok(parsed) = serde_json::from_str::<BTreeMap<String, String>>(trimmed)
+    {
+        return parsed;
     }
 
     trimmed
@@ -114,6 +116,16 @@ mod tests {
 
         assert_eq!(
             aliases.get("private-alpha").map(String::as_str),
+            Some("gpt-5.5")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_delimited_parsing_when_json_is_malformed() {
+        let aliases = parse_model_aliases(r#"{private-alpha=gpt-5.5"#);
+
+        assert_eq!(
+            aliases.get("{private-alpha").map(String::as_str),
             Some("gpt-5.5")
         );
     }

--- a/rust/crates/ccusage/src/model_aliases.rs
+++ b/rust/crates/ccusage/src/model_aliases.rs
@@ -1,0 +1,129 @@
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    env,
+    sync::{OnceLock, RwLock},
+};
+
+const MODEL_ALIASES_ENV: &str = "CCUSAGE_MODEL_ALIASES";
+
+static MODEL_ALIASES: OnceLock<RwLock<BTreeMap<String, String>>> = OnceLock::new();
+#[cfg(test)]
+static TEST_MODEL_ALIASES_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+pub(crate) fn resolve_model_name(model: &str) -> Cow<'_, str> {
+    let aliases = model_aliases();
+    let aliases = aliases.read().unwrap_or_else(|error| error.into_inner());
+    if let Some(alias) = aliases.get(model).filter(|alias| !alias.is_empty()) {
+        return Cow::Owned(alias.clone());
+    }
+    if let Some(base_model) = model.strip_suffix("-fast") {
+        if let Some(alias) = aliases.get(base_model).filter(|alias| !alias.is_empty()) {
+            return Cow::Owned(format!("{alias}-fast"));
+        }
+    }
+    Cow::Borrowed(model)
+}
+
+fn model_aliases() -> &'static RwLock<BTreeMap<String, String>> {
+    MODEL_ALIASES.get_or_init(|| RwLock::new(load_model_aliases_from_env()))
+}
+
+fn load_model_aliases_from_env() -> BTreeMap<String, String> {
+    env::var(MODEL_ALIASES_ENV)
+        .ok()
+        .map(|raw| parse_model_aliases(&raw))
+        .unwrap_or_default()
+}
+
+fn parse_model_aliases(raw: &str) -> BTreeMap<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.starts_with('{') {
+        return serde_json::from_str::<BTreeMap<String, String>>(trimmed).unwrap_or_default();
+    }
+
+    trimmed
+        .split([',', ';', '\n'])
+        .filter_map(|pair| {
+            let (from, to) = pair.split_once('=')?;
+            let from = from.trim();
+            let to = to.trim();
+            (!from.is_empty() && !to.is_empty()).then(|| (from.to_string(), to.to_string()))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+pub(crate) fn set_model_aliases_for_tests<const N: usize>(
+    aliases: [(&'static str, &'static str); N],
+) -> ModelAliasesGuard {
+    let guard = TEST_MODEL_ALIASES_LOCK
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let lock = model_aliases();
+    let mut current = lock.write().unwrap_or_else(|error| error.into_inner());
+    let previous = std::mem::replace(
+        &mut *current,
+        aliases
+            .into_iter()
+            .map(|(from, to)| (from.to_string(), to.to_string()))
+            .collect(),
+    );
+    ModelAliasesGuard {
+        previous,
+        _guard: guard,
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct ModelAliasesGuard {
+    previous: BTreeMap<String, String>,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl Drop for ModelAliasesGuard {
+    fn drop(&mut self) {
+        let lock = model_aliases();
+        let mut current = lock.write().unwrap_or_else(|error| error.into_inner());
+        *current = std::mem::take(&mut self.previous);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_model_aliases, resolve_model_name, set_model_aliases_for_tests};
+
+    #[test]
+    fn parses_delimited_model_aliases() {
+        let aliases = parse_model_aliases(" private-alpha = gpt-5.5, other-alpha=claude-sonnet-4 ");
+
+        assert_eq!(
+            aliases.get("private-alpha").map(String::as_str),
+            Some("gpt-5.5")
+        );
+        assert_eq!(
+            aliases.get("other-alpha").map(String::as_str),
+            Some("claude-sonnet-4")
+        );
+    }
+
+    #[test]
+    fn parses_json_model_aliases() {
+        let aliases = parse_model_aliases(r#"{"private-alpha":"gpt-5.5"}"#);
+
+        assert_eq!(
+            aliases.get("private-alpha").map(String::as_str),
+            Some("gpt-5.5")
+        );
+    }
+
+    #[test]
+    fn resolves_configured_model_alias() {
+        let _aliases = set_model_aliases_for_tests([("private-alpha", "gpt-5.5")]);
+
+        assert_eq!(resolve_model_name("private-alpha"), "gpt-5.5");
+        assert_eq!(resolve_model_name("private-alpha-fast"), "gpt-5.5-fast");
+        assert_eq!(resolve_model_name("gpt-5"), "gpt-5");
+    }
+}

--- a/rust/crates/ccusage/src/model_aliases.rs
+++ b/rust/crates/ccusage/src/model_aliases.rs
@@ -44,9 +44,12 @@ fn parse_model_aliases(raw: &str) -> BTreeMap<String, String> {
         return parsed;
     }
 
-    trimmed
-        .trim_start_matches('{')
-        .trim_end_matches('}')
+    let stripped = trimmed
+        .strip_prefix('{')
+        .and_then(|inner| inner.strip_suffix('}'))
+        .unwrap_or(trimmed);
+
+    stripped
         .split([',', ';', '\n'])
         .filter_map(|pair| {
             let (from, to) = pair.split_once('=')?;

--- a/rust/crates/ccusage/src/model_aliases.rs
+++ b/rust/crates/ccusage/src/model_aliases.rs
@@ -11,6 +11,7 @@ static MODEL_ALIASES: OnceLock<RwLock<BTreeMap<String, String>>> = OnceLock::new
 #[cfg(test)]
 static TEST_MODEL_ALIASES_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Resolves a model name through `CCUSAGE_MODEL_ALIASES`, including `-fast` variants.
 pub(crate) fn resolve_model_name(model: &str) -> Cow<'_, str> {
     let aliases = model_aliases();
     let aliases = aliases.read().unwrap_or_else(|error| error.into_inner());
@@ -127,11 +128,16 @@ mod tests {
 
     #[test]
     fn falls_back_to_delimited_parsing_when_json_is_malformed() {
-        let aliases = parse_model_aliases(r#"{private-alpha=gpt-5.5}"#);
+        let aliases =
+            parse_model_aliases(r#"{private-alpha=gpt-5.5, other-alpha=claude-sonnet-4}"#);
 
         assert_eq!(
             aliases.get("private-alpha").map(String::as_str),
             Some("gpt-5.5")
+        );
+        assert_eq!(
+            aliases.get("other-alpha").map(String::as_str),
+            Some("claude-sonnet-4")
         );
     }
 

--- a/rust/crates/ccusage/src/model_aliases.rs
+++ b/rust/crates/ccusage/src/model_aliases.rs
@@ -45,6 +45,8 @@ fn parse_model_aliases(raw: &str) -> BTreeMap<String, String> {
     }
 
     trimmed
+        .trim_start_matches('{')
+        .trim_end_matches('}')
         .split([',', ';', '\n'])
         .filter_map(|pair| {
             let (from, to) = pair.split_once('=')?;
@@ -122,10 +124,10 @@ mod tests {
 
     #[test]
     fn falls_back_to_delimited_parsing_when_json_is_malformed() {
-        let aliases = parse_model_aliases(r#"{private-alpha=gpt-5.5"#);
+        let aliases = parse_model_aliases(r#"{private-alpha=gpt-5.5}"#);
 
         assert_eq!(
-            aliases.get("{private-alpha").map(String::as_str),
+            aliases.get("private-alpha").map(String::as_str),
             Some("gpt-5.5")
         );
     }

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -361,11 +361,13 @@ impl PricingMap {
     }
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
-        self.find_entry_or_alias(model)
+        let model = crate::model_aliases::resolve_model_name(model);
+        self.find_entry_or_alias(model.as_ref())
             .or_else(|| {
                 self.enable_models_dev_fallback
                     .then(|| {
-                        models_dev_pricing().and_then(|pricing| pricing.find_entry_or_alias(model))
+                        models_dev_pricing()
+                            .and_then(|pricing| pricing.find_entry_or_alias(model.as_ref()))
                     })
                     .flatten()
             })
@@ -374,7 +376,7 @@ impl PricingMap {
             // fuzzy alias matching. It works offline, unlike the network source.
             .or_else(|| {
                 self.enable_embedded_models_dev_fallback
-                    .then(|| embedded_models_dev_pricing().find_entry_or_alias(model))
+                    .then(|| embedded_models_dev_pricing().find_entry_or_alias(model.as_ref()))
                     .flatten()
             })
     }
@@ -400,18 +402,22 @@ impl PricingMap {
     }
 
     pub(crate) fn context_limit(&self, model: &str) -> Option<u64> {
-        self.context_limit_entry_or_alias(model)
+        let model = crate::model_aliases::resolve_model_name(model);
+        self.context_limit_entry_or_alias(model.as_ref())
             .or_else(|| {
                 self.enable_models_dev_fallback
                     .then(|| {
-                        models_dev_pricing()
-                            .and_then(|pricing| pricing.context_limit_entry_or_alias(model))
+                        models_dev_pricing().and_then(|pricing| {
+                            pricing.context_limit_entry_or_alias(model.as_ref())
+                        })
                     })
                     .flatten()
             })
             .or_else(|| {
                 self.enable_embedded_models_dev_fallback
-                    .then(|| embedded_models_dev_pricing().context_limit_entry_or_alias(model))
+                    .then(|| {
+                        embedded_models_dev_pricing().context_limit_entry_or_alias(model.as_ref())
+                    })
                     .flatten()
             })
     }
@@ -1785,6 +1791,19 @@ mod tests {
         assert!(gpt_55.cache_read_explicit);
         assert_eq!(gpt_55.fast_multiplier, 2.5);
         assert_eq!(pricing.context_limit("gpt-5.5"), Some(1_050_000));
+    }
+
+    #[test]
+    fn pricing_lookup_resolves_model_aliases() {
+        let _aliases =
+            crate::model_aliases::set_model_aliases_for_tests([("private-gpt-55", "gpt-5.5")]);
+        let pricing = PricingMap::load_embedded();
+
+        assert_eq!(
+            pricing.find("private-gpt-55").unwrap().input,
+            pricing.find("gpt-5.5").unwrap().input
+        );
+        assert_eq!(pricing.context_limit("private-gpt-55"), Some(1_050_000));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/summary.rs
+++ b/rust/crates/ccusage/src/summary.rs
@@ -60,6 +60,7 @@ impl UsageAccumulator {
             *self.message_count.get_or_insert(0) += message_count;
         }
         if let Some(model) = &entry.model {
+            let model = crate::model_aliases::resolve_model_name(model).into_owned();
             let index = if let Some(index) = self.breakdown_indexes.get(model.as_str()) {
                 *index
             } else {
@@ -583,6 +584,58 @@ mod tests {
 
         assert_eq!(row.model_breakdowns[0].model_name, "claude-opus-4-9");
         assert!(row.model_breakdowns[0].missing_pricing);
+    }
+
+    #[test]
+    fn applies_model_aliases_to_model_breakdowns() {
+        let _aliases = crate::model_aliases::set_model_aliases_for_tests([
+            ("private-alpha", "gpt-5.5"),
+            ("another-private-alpha", "gpt-5.5"),
+        ]);
+        let mut accumulator = SessionAccumulator::default();
+        accumulator.add_entry(&loaded_entry(LoadedEntryFixture {
+            date: "2026-01-02",
+            timestamp: 1_767_316_800_000,
+            session_id: "session-a",
+            project_path: "/workspace/project",
+            model: Some("private-alpha"),
+            input_tokens: 20,
+            output_tokens: 5,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            extra_total_tokens: 0,
+            cost: 0.02,
+            credits: None,
+            message_count: Some(1),
+            version: Some("1.0.0"),
+            missing_pricing_model: None,
+        }));
+        accumulator.add_entry(&loaded_entry(LoadedEntryFixture {
+            date: "2026-01-02",
+            timestamp: 1_767_316_801_000,
+            session_id: "session-a",
+            project_path: "/workspace/project",
+            model: Some("another-private-alpha"),
+            input_tokens: 30,
+            output_tokens: 7,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            extra_total_tokens: 0,
+            cost: 0.03,
+            credits: None,
+            message_count: Some(1),
+            version: Some("1.0.0"),
+            missing_pricing_model: None,
+        }));
+
+        let row = accumulator.into_summary().unwrap();
+
+        assert_eq!(row.models_used, vec!["gpt-5.5"]);
+        assert_eq!(row.model_breakdowns.len(), 1);
+        assert_eq!(row.model_breakdowns[0].model_name, "gpt-5.5");
+        assert_eq!(row.model_breakdowns[0].input_tokens, 50);
+        assert_eq!(row.model_breakdowns[0].output_tokens, 12);
+        assert_eq!(row.model_breakdowns[0].cost, 0.05);
     }
 
     struct LoadedEntryFixture {

--- a/rust/crates/ccusage/src/summary.rs
+++ b/rust/crates/ccusage/src/summary.rs
@@ -60,15 +60,16 @@ impl UsageAccumulator {
             *self.message_count.get_or_insert(0) += message_count;
         }
         if let Some(model) = &entry.model {
-            let model = crate::model_aliases::resolve_model_name(model).into_owned();
-            let index = if let Some(index) = self.breakdown_indexes.get(model.as_str()) {
+            let model = crate::model_aliases::resolve_model_name(model);
+            let index = if let Some(index) = self.breakdown_indexes.get(model.as_ref()) {
                 *index
             } else {
                 let index = self.breakdowns.len();
-                self.breakdown_indexes.insert(model.clone(), index);
-                self.models.push(model.clone());
+                let owned = model.into_owned();
+                self.breakdown_indexes.insert(owned.clone(), index);
+                self.models.push(owned.clone());
                 self.breakdowns.push(ModelBreakdown {
-                    model_name: model.clone(),
+                    model_name: owned,
                     ..ModelBreakdown::default()
                 });
                 index


### PR DESCRIPTION
Adds an internal runtime model alias resolver so local runs can map raw model slugs to canonical model names without exposing a public CLI flag or config schema option.

The alias is applied to pricing/context lookup and report aggregation paths, including Codex grouped model keys, Claude daily aggregation, shared summaries, and blocks output.

Testing:
- nix develop --command just fmt
- nix develop --command cargo test --manifest-path rust/Cargo.toml -p ccusage
- nix develop --command just test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime model alias resolver so local runs can map provider slugs to canonical model names via `CCUSAGE_MODEL_ALIASES` (supports `a=b,c=d` or JSON; honors `-fast`).
Aliases apply to pricing/context-limit lookup and all report paths (summaries, blocks, Claude daily, Codex groups), resolve before Codex dedupe keys to prevent double-counting, show canonical names in missing-pricing and model lists, and on malformed JSON fall back to delimited parsing while stripping a single outer brace pair; summary aggregation avoids extra allocations when a model already exists.

<sup>Written for commit 71846074e1d4629b65b76a24c828f41907ff80d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable model aliasing via an environment variable to map model names to canonical names.

* **Bug Fixes**
  * Normalized model names across pricing lookups, aggregation, daily summaries, and cost reporting so usage and cost totals consistently group under canonical names.

* **Tests**
  * Added unit tests validating alias parsing and that reporting/aggregation use canonical model names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->