### PR TITLE
fix(pricing): avoid slow fallback for display model aliases

### DIFF
--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -361,13 +361,19 @@ impl PricingMap {
     }
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
-        let model = crate::model_aliases::resolve_model_name(model);
-        self.find_entry_or_alias(model.as_ref())
+        let alias = crate::model_aliases::resolve_model_name(model);
+        let fallback_model = alias.as_ref();
+        self.find_entry_or_alias(model)
+            .or_else(|| {
+                (fallback_model != model)
+                    .then(|| self.find_entry_or_alias(fallback_model))
+                    .flatten()
+            })
             .or_else(|| {
                 self.enable_models_dev_fallback
                     .then(|| {
                         models_dev_pricing()
-                            .and_then(|pricing| pricing.find_entry_or_alias(model.as_ref()))
+                            .and_then(|pricing| pricing.find_entry_or_alias(fallback_model))
                     })
                     .flatten()
             })
@@ -376,7 +382,7 @@ impl PricingMap {
             // fuzzy alias matching. It works offline, unlike the network source.
             .or_else(|| {
                 self.enable_embedded_models_dev_fallback
-                    .then(|| embedded_models_dev_pricing().find_entry_or_alias(model.as_ref()))
+                    .then(|| embedded_models_dev_pricing().find_entry_or_alias(fallback_model))
                     .flatten()
             })
     }
@@ -402,13 +408,19 @@ impl PricingMap {
     }
 
     pub(crate) fn context_limit(&self, model: &str) -> Option<u64> {
-        let model = crate::model_aliases::resolve_model_name(model);
-        self.context_limit_entry_or_alias(model.as_ref())
+        let alias = crate::model_aliases::resolve_model_name(model);
+        let fallback_model = alias.as_ref();
+        self.context_limit_entry_or_alias(model)
+            .or_else(|| {
+                (fallback_model != model)
+                    .then(|| self.context_limit_entry_or_alias(fallback_model))
+                    .flatten()
+            })
             .or_else(|| {
                 self.enable_models_dev_fallback
                     .then(|| {
                         models_dev_pricing().and_then(|pricing| {
-                            pricing.context_limit_entry_or_alias(model.as_ref())
+                            pricing.context_limit_entry_or_alias(fallback_model)
                         })
                     })
                     .flatten()
@@ -416,7 +428,7 @@ impl PricingMap {
             .or_else(|| {
                 self.enable_embedded_models_dev_fallback
                     .then(|| {
-                        embedded_models_dev_pricing().context_limit_entry_or_alias(model.as_ref())
+                        embedded_models_dev_pricing().context_limit_entry_or_alias(fallback_model)
                     })
                     .flatten()
             })
@@ -1804,6 +1816,22 @@ mod tests {
             pricing.find("gpt-5.5").unwrap().input
         );
         assert_eq!(pricing.context_limit("private-gpt-55"), Some(1_050_000));
+    }
+
+    #[test]
+    fn pricing_lookup_prefers_known_original_model_before_alias() {
+        let _aliases =
+            crate::model_aliases::set_model_aliases_for_tests([("claude-opus-4-8", "mythos-5")]);
+        let pricing = PricingMap::load_embedded();
+
+        let original = pricing.find_entry("claude-opus-4-8").unwrap();
+        let resolved = pricing.find("claude-opus-4-8").unwrap();
+
+        assert_eq!(resolved.input, original.input);
+        assert_eq!(
+            pricing.context_limit("claude-opus-4-8"),
+            pricing.context_limit_entry("claude-opus-4-8")
+        );
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -362,18 +362,18 @@ impl PricingMap {
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
         let alias = crate::model_aliases::resolve_model_name(model);
-        let fallback_model = alias.as_ref();
+        let resolved_alias = alias.as_ref();
         self.find_entry_or_alias(model)
             .or_else(|| {
-                (fallback_model != model)
-                    .then(|| self.find_entry_or_alias(fallback_model))
+                (resolved_alias != model)
+                    .then(|| self.find_entry_or_alias(resolved_alias))
                     .flatten()
             })
             .or_else(|| {
                 self.enable_models_dev_fallback
                     .then(|| {
                         models_dev_pricing()
-                            .and_then(|pricing| pricing.find_entry_or_alias(fallback_model))
+                            .and_then(|pricing| pricing.find_entry_or_alias(resolved_alias))
                     })
                     .flatten()
             })
@@ -382,7 +382,7 @@ impl PricingMap {
             // fuzzy alias matching. It works offline, unlike the network source.
             .or_else(|| {
                 self.enable_embedded_models_dev_fallback
-                    .then(|| embedded_models_dev_pricing().find_entry_or_alias(fallback_model))
+                    .then(|| embedded_models_dev_pricing().find_entry_or_alias(resolved_alias))
                     .flatten()
             })
     }
@@ -409,18 +409,18 @@ impl PricingMap {
 
     pub(crate) fn context_limit(&self, model: &str) -> Option<u64> {
         let alias = crate::model_aliases::resolve_model_name(model);
-        let fallback_model = alias.as_ref();
+        let resolved_alias = alias.as_ref();
         self.context_limit_entry_or_alias(model)
             .or_else(|| {
-                (fallback_model != model)
-                    .then(|| self.context_limit_entry_or_alias(fallback_model))
+                (resolved_alias != model)
+                    .then(|| self.context_limit_entry_or_alias(resolved_alias))
                     .flatten()
             })
             .or_else(|| {
                 self.enable_models_dev_fallback
                     .then(|| {
                         models_dev_pricing().and_then(|pricing| {
-                            pricing.context_limit_entry_or_alias(fallback_model)
+                            pricing.context_limit_entry_or_alias(resolved_alias)
                         })
                     })
                     .flatten()
@@ -428,7 +428,7 @@ impl PricingMap {
             .or_else(|| {
                 self.enable_embedded_models_dev_fallback
                     .then(|| {
-                        embedded_models_dev_pricing().context_limit_entry_or_alias(fallback_model)
+                        embedded_models_dev_pricing().context_limit_entry_or_alias(resolved_alias)
                     })
                     .flatten()
             })


### PR DESCRIPTION
Fixes model alias pricing lookup so display-oriented aliases do not force slow online pricing fallback when the original model is already known.

Previously, CCUSAGE_MODEL_ALIASES replaced the model before pricing/context lookup, so aliases such as claude-opus-4-8=mythos-5 tried to price mythos-5 and could block on models.dev. The lookup now prefers the original model first, then falls back to the alias target for private raw slugs that need canonical pricing.

Testing:
- cargo fmt --manifest-path rust/Cargo.toml --all --check
- cargo test --manifest-path rust/Cargo.toml -p ccusage pricing_lookup
- cargo test --manifest-path rust/Cargo.toml -p ccusage model_aliases
- pre-push hook: clippy, treefmt, gitleaks, cargo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer the original model over its display alias when resolving pricing and context limits to avoid unnecessary online fallback and speed up lookups. Preserves canonical pricing for private raw slugs while preventing blocking calls for display-only aliases.

- **Bug Fixes**
  - Changed lookup order: original model → alias target → models.dev → embedded pricing.
  - Added regression test to ensure a known model like `claude-opus-4-8` resolves locally even if aliased to `mythos-5`.

- **Refactors**
  - Renamed internal fallback variable to `resolved_alias` for clearer intent.

<sup>Written for commit ee69618be62e65397ea9e5d237f5b3d6cf7c614c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing lookup precedence for models with alternative names so the original model identifier is prioritized before any alias mapping, yielding more accurate pricing and context limit results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->