### PR TITLE
build(ccusage): use nix for unix native fallback

### DIFF
--- a/apps/ccusage/scripts/ensure-native-binary.nu
+++ b/apps/ccusage/scripts/ensure-native-binary.nu
@@ -14,7 +14,6 @@ def main [] {
     } else {
         $native_package_root | path join bin $binary_name
     }
-    let cargo_binary = ($repo_root | path join rust target release $binary_name)
     let version = (expected_version $repo_root)
     if ((native_package_includes_binary $native_package_root $binary_name) and (has_expected_version $native_binary $version)) {
         if not (is_portable_binary $target_platform $native_binary) {
@@ -24,10 +23,19 @@ def main [] {
         }
         exit 0
     }
-    ^cargo build --manifest-path ($repo_root | path join rust Cargo.toml) --release --bin ccusage
-    if not (has_expected_version $cargo_binary $version) {
+    let built_binary = if ($target_platform == 'linux') or ($target_platform == 'darwin') {
+        build_nix_binary $repo_root $target_platform $target_arch $binary_name
+    } else {
+        build_cargo_binary $repo_root $binary_name
+    }
+    if not (has_expected_version $built_binary $version) {
         error make {
-            msg: $"($cargo_binary) did not report version ($version) after cargo build"
+            msg: $"($built_binary) did not report version ($version) after native build"
+        }
+    }
+    if not (is_portable_binary $target_platform $built_binary) {
+        error make {
+            msg: $"($built_binary) depends on dynamic libraries that do not exist on end-user machines; rebuild it \(Linux packages must be static, macOS packages may only link system dylibs)"
         }
     }
 }
@@ -56,6 +64,50 @@ def matching_native_package_root [repo_root: path, target_platform: string, targ
     $candidates | get --optional 0
 }
 def list_contains [value, needle: string] { (($value | describe) =~ '^list') and ($value | any {|item| $item == $needle }) }
+def nix_build_attr [target_platform: string, target_arch: string] {
+    if $target_platform == 'linux' {
+        'ccusage-static'
+    } else if $target_platform == 'darwin' and $target_arch == 'x64' {
+        'ccusage-darwin-x64'
+    } else if $target_platform == 'darwin' and $target_arch == 'arm64' {
+        'ccusage'
+    } else {
+        null
+    }
+}
+def build_nix_binary [
+    repo_root: path
+    target_platform: string
+    target_arch: string
+    binary_name: string
+] {
+    let attr = (nix_build_attr $target_platform $target_arch)
+    if $attr == null {
+        error make {
+            msg: $"No Nix package is configured for ($target_platform)-($target_arch)"
+        }
+    }
+    let flake_ref = $"($repo_root)#($attr)"
+    let result = (run-external nix build $flake_ref '--no-link' '--print-out-paths' '--print-build-logs' | complete)
+    if $result.exit_code != 0 {
+        error make {
+            msg: $"nix build ($flake_ref) failed\n($result.stderr)"
+        }
+    }
+    let out_path = (
+        $result.stdout | lines | where {|line| $line | is-not-empty } | last
+    )
+    if $out_path == null {
+        error make {
+            msg: $"nix build ($flake_ref) did not print an output path"
+        }
+    }
+    $out_path | path join bin $binary_name
+}
+def build_cargo_binary [repo_root: path, binary_name: string] {
+    ^cargo build --manifest-path ($repo_root | path join rust Cargo.toml) --release --bin ccusage
+    $repo_root | path join rust target release $binary_name
+}
 def expected_version [repo_root: path] {
     let package_json = (open ($repo_root | path join apps ccusage package.json))
     if (($package_json.version? | describe) != 'string') {

--- a/apps/ccusage/scripts/ensure-native-binary.nu
+++ b/apps/ccusage/scripts/ensure-native-binary.nu
@@ -34,6 +34,14 @@ def main [] {
             msg: $"($built_binary) depends on dynamic libraries that do not exist on end-user machines; rebuild it \(Linux packages must be static, macOS packages may only link system dylibs)"
         }
     }
+    if $native_package_root == null {
+        error make {
+            msg: $"No native package directory matches ($target_platform)-($target_arch)"
+        }
+    }
+    mkdir ($native_package_root | path join bin)
+    cp -f $built_binary $native_binary
+    chmod 755 $native_binary
 }
 def node_platform [] { match $nu.os-info.name {
     'macos' => 'darwin'

--- a/apps/ccusage/scripts/ensure-native-binary.nu
+++ b/apps/ccusage/scripts/ensure-native-binary.nu
@@ -23,11 +23,7 @@ def main [] {
         }
         exit 0
     }
-    let built_binary = if ($target_platform == 'linux') or ($target_platform == 'darwin') {
-        build_nix_binary $repo_root $target_platform $target_arch $binary_name
-    } else {
-        build_cargo_binary $repo_root $binary_name
-    }
+    let built_binary = (build_nix_binary $repo_root $target_platform $target_arch $binary_name)
     if not (has_expected_version $built_binary $version) {
         error make {
             msg: $"($built_binary) did not report version ($version) after native build"
@@ -102,10 +98,6 @@ def build_nix_binary [
     }
     let out_path = ($out_lines | last)
     $out_path | path join bin $binary_name
-}
-def build_cargo_binary [repo_root: path, executable_name: string] {
-    ^cargo build --manifest-path ($repo_root | path join rust Cargo.toml) --release --bin ccusage
-    $repo_root | path join rust target release $executable_name
 }
 def expected_version [repo_root: path] {
     let package_json = (open ($repo_root | path join apps ccusage package.json))

--- a/apps/ccusage/scripts/ensure-native-binary.nu
+++ b/apps/ccusage/scripts/ensure-native-binary.nu
@@ -103,9 +103,9 @@ def build_nix_binary [
     let out_path = ($out_lines | last)
     $out_path | path join bin $binary_name
 }
-def build_cargo_binary [repo_root: path, binary_name: string] {
+def build_cargo_binary [repo_root: path, executable_name: string] {
     ^cargo build --manifest-path ($repo_root | path join rust Cargo.toml) --release --bin ccusage
-    $repo_root | path join rust target release $binary_name
+    $repo_root | path join rust target release $executable_name
 }
 def expected_version [repo_root: path] {
     let package_json = (open ($repo_root | path join apps ccusage package.json))

--- a/apps/ccusage/scripts/ensure-native-binary.nu
+++ b/apps/ccusage/scripts/ensure-native-binary.nu
@@ -88,20 +88,19 @@ def build_nix_binary [
         }
     }
     let flake_ref = $"($repo_root)#($attr)"
-    let result = (run-external nix build $flake_ref '--no-link' '--print-out-paths' '--print-build-logs' | complete)
+    let result = (^nix build $flake_ref '--no-link' '--print-out-paths' '--print-build-logs' | complete)
     if $result.exit_code != 0 {
         error make {
             msg: $"nix build ($flake_ref) failed\n($result.stderr)"
         }
     }
-    let out_path = (
-        $result.stdout | lines | where {|line| $line | is-not-empty } | last
-    )
-    if $out_path == null {
+    let out_lines = ($result.stdout | lines | where {|line| $line | is-not-empty })
+    if ($out_lines | is-empty) {
         error make {
             msg: $"nix build ($flake_ref) did not print an output path"
         }
     }
+    let out_path = ($out_lines | last)
     $out_path | path join bin $binary_name
 }
 def build_cargo_binary [repo_root: path, binary_name: string] {

--- a/apps/ccusage/scripts/ensure-native-binary.test.nu
+++ b/apps/ccusage/scripts/ensure-native-binary.test.nu
@@ -1,0 +1,7 @@
+use std/assert
+source ensure-native-binary.nu
+assert equal (nix_build_attr linux x64) ccusage-static
+assert equal (nix_build_attr linux arm64) ccusage-static
+assert equal (nix_build_attr darwin x64) ccusage-darwin-x64
+assert equal (nix_build_attr darwin arm64) ccusage
+assert equal (nix_build_attr win32 x64) null

--- a/justfile
+++ b/justfile
@@ -26,13 +26,17 @@ build: ccusage::build docs::build
 typecheck:
     oxlint .
 
-# Run the full test suite (Rust workspace + Node test) in parallel
+# Run the full test suite (Rust workspace + Node and script tests) in parallel
 [parallel]
-test: rust::test test-node
+test: rust::test test-node test-nu-scripts
 
 # Run Node's built-in test runner for TypeScript package and tooling tests
 test-node:
     TZ=UTC node --test apps/ccusage/src/cli.test.ts nix/models-dev-compact.test.ts
+
+# Run focused tests for Nushell package scripts
+test-nu-scripts:
+    cd apps/ccusage/scripts && nu ensure-native-binary.test.nu
 
 # Generate a large benchmark fixture for PR performance comparisons
 generate-large-fixture output_dir codex_output_dir size_mib="1024":

--- a/nix/static-package.nix
+++ b/nix/static-package.nix
@@ -8,8 +8,8 @@
 #   * `ccusage-static` (this file) cross-compiles to musl and links fully
 #     statically, producing the portable binary that `release.yaml` ships to
 #     npm. The release matrix runs `nix build .#ccusage-static` for Linux;
-#     macOS arm64 uses the native Nix build, while macOS x64 and Windows fall
-#     back to `cargo build` because Nix cannot target those runners.
+#     macOS arm64 uses the native Nix build, macOS x64 uses
+#     `.#ccusage-darwin-x64`, and Windows falls back to `cargo build`.
 #
 # So Linux release artifacts must come from `.#ccusage-static`, never the
 # default `.#ccusage`, which would embed unusable `/nix/store` paths.


### PR DESCRIPTION
Switches the ccusage native-binary fallback to Nix-backed package builds.

Linux now builds the static flake package, macOS x64 uses the dedicated Darwin x64 package, and macOS arm64 uses the native ccusage package. Unsupported platforms fail when no Nix package mapping exists; Windows native packages are built by the dedicated CI action instead of this prepack script.

Testing:
- direnv exec . just fmt
- direnv exec . just test-nu-scripts
- direnv exec . fish -c "cd apps/ccusage && scripts/ensure-native-binary.nu"
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved native binary build workflow by preferring Nix-built binaries on supported Linux/macOS, reusing existing matching outputs when available, and performing stricter version and portability validation.
  * Added clearer failures when expected native build outputs can’t be located or produced.
* **Tests**
  * Added Nushell coverage across multiple OS/architecture combinations, including a case where no output is expected.
  * Updated the main test workflow to include these Nushell checks alongside existing suites.
* **Documentation**
  * Refined notes describing macOS/Windows build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->