### PR TITLE
perf(adapter): unify JSONL prefilter and byte_lines across agents

### DIFF
--- a/rust/crates/ccusage/src/adapter/copilot/parser.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/parser.rs
@@ -6,7 +6,10 @@ use std::{
 
 use serde_json::{Map, Value};
 
-use crate::{Result, TimestampMs, TokenUsageRaw, apply_total_token_fallback};
+use crate::{
+    Result, TimestampMs, TokenUsageRaw, apply_total_token_fallback,
+    fast::{LinePrefilter, byte_lines},
+};
 
 #[derive(Debug, Clone)]
 pub(super) struct CopilotUsageEntry {
@@ -53,11 +56,11 @@ struct CopilotUsageCandidate {
 }
 
 pub(super) fn parse_otel_file(path: &Path) -> Result<Vec<CopilotUsageEntry>> {
-    let content = fs::read_to_string(path)?;
-    let records = content
-        .lines()
-        .filter(|line| line.contains("\"attributes\""))
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+    let content = fs::read(path)?;
+    let prefilter = LinePrefilter::all(&[br#""attributes""#]);
+    let records = byte_lines(&content)
+        .filter(|line| prefilter.matches(line))
+        .filter_map(|line| serde_json::from_slice::<Value>(line).ok())
         .filter_map(|value| value.as_object().cloned())
         .collect::<Vec<_>>();
     let trace_contexts = collect_trace_contexts(&records);

--- a/rust/crates/ccusage/src/adapter/copilot/parser.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/parser.rs
@@ -8,7 +8,7 @@ use serde_json::{Map, Value};
 
 use crate::{
     Result, TimestampMs, TokenUsageRaw, apply_total_token_fallback,
-    fast::{LinePrefilter, byte_lines},
+    fast::{LinePrefilter, prefiltered_json_values},
 };
 
 #[derive(Debug, Clone)]
@@ -58,9 +58,7 @@ struct CopilotUsageCandidate {
 pub(super) fn parse_otel_file(path: &Path) -> Result<Vec<CopilotUsageEntry>> {
     let content = fs::read(path)?;
     let prefilter = LinePrefilter::all(&[br#""attributes""#]);
-    let records = byte_lines(&content)
-        .filter(|line| prefilter.matches(line))
-        .filter_map(|line| serde_json::from_slice::<Value>(line).ok())
+    let records = prefiltered_json_values(&content, &prefilter)
         .filter_map(|value| value.as_object().cloned())
         .collect::<Vec<_>>();
     let trace_contexts = collect_trace_contexts(&records);

--- a/rust/crates/ccusage/src/adapter/kimi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/parser.rs
@@ -9,8 +9,10 @@ use serde_json::Value;
 
 use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
-    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_candidates, non_empty_json_string,
+    apply_total_token_fallback, calculate_cost_for_usage,
+    cli::CostMode,
+    fast::{LinePrefilter, byte_lines},
+    format_date_tz, json_value_u64, missing_pricing_model_for_candidates, non_empty_json_string,
 };
 
 const DEFAULT_MODEL: &str = "kimi-for-coding";
@@ -34,11 +36,11 @@ pub(super) struct KimiUsageEntry {
 pub(super) fn read_wire_file(path: &Path) -> Result<Vec<KimiUsageEntry>> {
     let model = read_model_from_config(path);
     let fallback_timestamp = file_modified_timestamp(path);
-    let content = fs::read_to_string(path)?;
-    Ok(content
-        .lines()
-        .filter(|line| line.contains("\"StatusUpdate\"") && line.contains("\"token_usage\""))
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+    let content = fs::read(path)?;
+    let prefilter = LinePrefilter::all(&[br#""StatusUpdate""#, br#""token_usage""#]);
+    Ok(byte_lines(&content)
+        .filter(|line| prefilter.matches(line))
+        .filter_map(|line| serde_json::from_slice::<Value>(line).ok())
         .filter_map(|value| wire_line_to_entry(&value, path, &model, fallback_timestamp))
         .collect::<Vec<_>>())
 }

--- a/rust/crates/ccusage/src/adapter/kimi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/parser.rs
@@ -11,7 +11,7 @@ use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage,
     cli::CostMode,
-    fast::{LinePrefilter, byte_lines},
+    fast::{LinePrefilter, prefiltered_json_values},
     format_date_tz, json_value_u64, missing_pricing_model_for_candidates, non_empty_json_string,
 };
 
@@ -38,9 +38,7 @@ pub(super) fn read_wire_file(path: &Path) -> Result<Vec<KimiUsageEntry>> {
     let fallback_timestamp = file_modified_timestamp(path);
     let content = fs::read(path)?;
     let prefilter = LinePrefilter::all(&[br#""StatusUpdate""#, br#""token_usage""#]);
-    Ok(byte_lines(&content)
-        .filter(|line| prefilter.matches(line))
-        .filter_map(|line| serde_json::from_slice::<Value>(line).ok())
+    Ok(prefiltered_json_values(&content, &prefilter)
         .filter_map(|value| wire_line_to_entry(&value, path, &model, fallback_timestamp))
         .collect::<Vec<_>>())
 }

--- a/rust/crates/ccusage/src/adapter/openclaw/parser.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/parser.rs
@@ -1,17 +1,14 @@
-use std::{
-    fs,
-    io::{BufRead, BufReader},
-    path::Path,
-    sync::Arc,
-};
+use std::{fs, path::Path, sync::Arc};
 
 use jiff::tz::TimeZone as JiffTimeZone;
 use serde_json::{Map, Value};
 
 use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
-    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_usage, non_empty_json_string,
+    apply_total_token_fallback, calculate_cost_for_usage,
+    cli::CostMode,
+    fast::{LinePrefilter, byte_lines},
+    format_date_tz, json_value_u64, missing_pricing_model_for_usage, non_empty_json_string,
 };
 
 #[derive(Debug, Clone)]
@@ -37,20 +34,17 @@ pub(super) fn parse_session_file(
 ) -> Result<Vec<LoadedEntry>> {
     let session_id = extract_session_id(path);
     let fallback_timestamp = file_modified_timestamp(path);
-    let input = fs::File::open(path)?;
-    let reader = BufReader::new(input);
+    let content = fs::read(path)?;
     let mut current_model = None::<String>;
     let mut current_provider = None::<String>;
     let mut entries = Vec::new();
-    for line in reader.lines() {
-        let line = line?;
-        if !line.contains("\"model_change\"")
-            && !line.contains("\"model-snapshot\"")
-            && !line.contains("\"usage\"")
-        {
+    let prefilter =
+        LinePrefilter::any(&[br#""model_change""#, br#""model-snapshot""#, br#""usage""#]);
+    for line in byte_lines(&content) {
+        if !prefilter.matches(line) {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+        let Ok(value) = serde_json::from_slice::<Value>(line) else {
             continue;
         };
         let Some(record) = value.as_object() else {

--- a/rust/crates/ccusage/src/adapter/openclaw/parser.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/parser.rs
@@ -7,7 +7,7 @@ use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage,
     cli::CostMode,
-    fast::{LinePrefilter, byte_lines},
+    fast::{LinePrefilter, prefiltered_json_values},
     format_date_tz, json_value_u64, missing_pricing_model_for_usage, non_empty_json_string,
 };
 
@@ -40,13 +40,7 @@ pub(super) fn parse_session_file(
     let mut entries = Vec::new();
     let prefilter =
         LinePrefilter::any(&[br#""model_change""#, br#""model-snapshot""#, br#""usage""#]);
-    for line in byte_lines(&content) {
-        if !prefilter.matches(line) {
-            continue;
-        }
-        let Ok(value) = serde_json::from_slice::<Value>(line) else {
-            continue;
-        };
+    for value in prefiltered_json_values(&content, &prefilter) {
         let Some(record) = value.as_object() else {
             continue;
         };

--- a/rust/crates/ccusage/src/adapter/pi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/pi/parser.rs
@@ -5,8 +5,10 @@ use serde_json::Value;
 
 use crate::{
     LoadedEntry, PricingMap, Result, TokenUsageRaw, UsageEntry, UsageMessage,
-    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_usage, non_empty_json_string,
+    apply_total_token_fallback, calculate_cost_for_usage,
+    cli::CostMode,
+    fast::{LinePrefilter, byte_lines},
+    format_date_tz, json_value_u64, missing_pricing_model_for_usage, non_empty_json_string,
 };
 
 pub(crate) fn read_session_file(
@@ -15,16 +17,17 @@ pub(crate) fn read_session_file(
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Result<Vec<LoadedEntry>> {
-    let content = fs::read_to_string(path)?;
+    let content = fs::read(path)?;
     let project = extract_project(path);
     let session_id = extract_session_id(path);
     let mut entries = Vec::new();
 
-    for line in content.lines() {
-        if !line.contains("\"usage\"") || !line.contains("\"message\"") {
+    let prefilter = LinePrefilter::all(&[br#""usage""#, br#""message""#]);
+    for line in byte_lines(&content) {
+        if !prefilter.matches(line) {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
+        let Ok(value) = serde_json::from_slice::<Value>(line) else {
             continue;
         };
         if !is_pi_message_usage(&value) {

--- a/rust/crates/ccusage/src/adapter/pi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/pi/parser.rs
@@ -7,7 +7,7 @@ use crate::{
     LoadedEntry, PricingMap, Result, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage,
     cli::CostMode,
-    fast::{LinePrefilter, byte_lines},
+    fast::{LinePrefilter, prefiltered_json_values},
     format_date_tz, json_value_u64, missing_pricing_model_for_usage, non_empty_json_string,
 };
 
@@ -23,13 +23,7 @@ pub(crate) fn read_session_file(
     let mut entries = Vec::new();
 
     let prefilter = LinePrefilter::all(&[br#""usage""#, br#""message""#]);
-    for line in byte_lines(&content) {
-        if !prefilter.matches(line) {
-            continue;
-        }
-        let Ok(value) = serde_json::from_slice::<Value>(line) else {
-            continue;
-        };
+    for value in prefiltered_json_values(&content, &prefilter) {
         if !is_pi_message_usage(&value) {
             continue;
         }

--- a/rust/crates/ccusage/src/adapter/qwen/parser.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/parser.rs
@@ -14,7 +14,7 @@ use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
-    fast::{LinePrefilter, byte_lines},
+    fast::{LinePrefilter, prefiltered_json_values},
     format_date_tz, format_rfc3339_millis, json_value_u64, missing_pricing_model_for_candidates,
     non_empty_json_string, parse_ts_timestamp, parse_tz,
 };
@@ -56,13 +56,7 @@ fn read_chat_file(
     let content = fs::read(file)?;
     let mut entries = Vec::new();
     let prefilter = LinePrefilter::all(&[br#""usageMetadata""#]);
-    for line in byte_lines(&content) {
-        if !prefilter.matches(line) {
-            continue;
-        }
-        let Ok(value) = serde_json::from_slice::<Value>(line) else {
-            continue;
-        };
+    for value in prefiltered_json_values(&content, &prefilter) {
         if let Some(entry) = parse_line(file, fallback, &value, tz, mode, pricing) {
             entries.push(entry);
         }

--- a/rust/crates/ccusage/src/adapter/qwen/parser.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/parser.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashSet,
-    fs::{self, File},
-    io::{BufRead, BufReader},
+    fs,
     path::Path,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
@@ -15,6 +14,7 @@ use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
+    fast::{LinePrefilter, byte_lines},
     format_date_tz, format_rfc3339_millis, json_value_u64, missing_pricing_model_for_candidates,
     non_empty_json_string, parse_ts_timestamp, parse_tz,
 };
@@ -53,14 +53,14 @@ fn read_chat_file(
     shared: &SharedArgs,
 ) -> Result<Vec<LoadedEntry>> {
     let fallback = file_timestamp(file, shared);
-    let input = File::open(file)?;
-    let reader = BufReader::new(input);
+    let content = fs::read(file)?;
     let mut entries = Vec::new();
-    for line in reader.lines() {
-        let Ok(line) = line else {
+    let prefilter = LinePrefilter::all(&[br#""usageMetadata""#]);
+    for line in byte_lines(&content) {
+        if !prefilter.matches(line) {
             continue;
-        };
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+        }
+        let Ok(value) = serde_json::from_slice::<Value>(line) else {
             continue;
         };
         if let Some(entry) = parse_line(file, fallback, &value, tz, mode, pricing) {

--- a/rust/crates/ccusage/src/fast.rs
+++ b/rust/crates/ccusage/src/fast.rs
@@ -1,4 +1,5 @@
 use memchr::{memchr, memmem::Finder};
+use serde_json::Value;
 use smallvec::SmallVec;
 
 pub(crate) type FxHashMap<K, V> = rustc_hash::FxHashMap<K, V>;
@@ -103,6 +104,33 @@ pub(crate) fn byte_lines(bytes: &[u8]) -> ByteLines<'_> {
     ByteLines::new(bytes)
 }
 
+/// Parse newline-delimited JSON, yielding each owned [`Value`] whose source
+/// line passes `prefilter`.
+///
+/// This is the shared fast-path used by the line-delimited agent adapters: it
+/// iterates the raw bytes with [`byte_lines`], skips lines rejected by the
+/// reusable [`LinePrefilter`] before paying for a parse, and silently drops
+/// lines that fail to deserialize (matching the per-adapter `let Ok(..) else`
+/// behavior). Callers keep ownership of `content` and the `prefilter`.
+///
+/// # Example
+///
+/// ```ignore
+/// let content = std::fs::read(path)?;
+/// let prefilter = LinePrefilter::all(&[b"\"usage\""]);
+/// for value in prefiltered_json_values(&content, &prefilter) {
+///     // adapter-specific handling of `value`
+/// }
+/// ```
+pub(crate) fn prefiltered_json_values<'a>(
+    content: &'a [u8],
+    prefilter: &'a LinePrefilter,
+) -> impl Iterator<Item = Value> + 'a {
+    byte_lines(content)
+        .filter(move |line| prefilter.matches(line))
+        .filter_map(|line| serde_json::from_slice::<Value>(line).ok())
+}
+
 pub(crate) fn suffix_string(value: &str, suffix: &str) -> String {
     let mut output = String::with_capacity(value.len() + suffix.len());
     output.push_str(value);
@@ -112,7 +140,28 @@ pub(crate) fn suffix_string(value: &str, suffix: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{LinePrefilter, byte_lines, suffix_string};
+    use super::{LinePrefilter, byte_lines, prefiltered_json_values, suffix_string};
+
+    #[test]
+    fn prefiltered_json_values_skips_filtered_and_malformed_lines() {
+        let content = concat!(
+            r#"{"usage":{"input":1}}"#,
+            "\n",
+            r#"{"role":"user"}"#,
+            "\n",
+            r#"not json but has "usage""#,
+            "\n",
+            r#"{"usage":{"input":2}}"#,
+        )
+        .as_bytes();
+        let prefilter = LinePrefilter::all(&[b"\"usage\""]);
+
+        let inputs = prefiltered_json_values(content, &prefilter)
+            .filter_map(|value| value.get("usage")?.get("input")?.as_u64())
+            .collect::<Vec<_>>();
+
+        assert_eq!(inputs, [1, 2]);
+    }
 
     #[test]
     fn line_prefilter_all_requires_every_marker() {

--- a/rust/crates/ccusage/src/fast.rs
+++ b/rust/crates/ccusage/src/fast.rs
@@ -1,9 +1,74 @@
-use memchr::memchr;
+use memchr::{memchr, memmem::Finder};
 use smallvec::SmallVec;
 
 pub(crate) type FxHashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 pub(crate) type FxHashSet<T> = rustc_hash::FxHashSet<T>;
 pub(crate) type SmallIndexVec = SmallVec<[usize; 1]>;
+
+/// Whether a [`LinePrefilter`] requires every marker or just one of them.
+#[derive(Clone, Copy)]
+enum PrefilterMode {
+    /// The line must contain every configured marker.
+    All,
+    /// The line must contain at least one configured marker.
+    Any,
+}
+
+/// Reusable byte-substring prefilter for newline-delimited JSON logs.
+///
+/// JSONL adapters skip lines that cannot contain a usage record before paying
+/// for a full `serde_json` parse. Building the [`Finder`] needles once and
+/// reusing them across every line keeps that skip check on the SIMD-accelerated
+/// `memmem` path instead of allocating a fresh searcher per `str::contains`
+/// call.
+pub(crate) struct LinePrefilter {
+    finders: SmallVec<[Finder<'static>; 4]>,
+    mode: PrefilterMode,
+}
+
+impl LinePrefilter {
+    /// Build a prefilter that only admits lines containing *all* `markers`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let prefilter = LinePrefilter::all(&[b"\"usage\"", b"\"message\""]);
+    /// assert!(prefilter.matches(br#"{"message":{"usage":{}}}"#));
+    /// assert!(!prefilter.matches(br#"{"message":{}}"#));
+    /// ```
+    pub(crate) fn all(markers: &[&[u8]]) -> Self {
+        Self::new(markers, PrefilterMode::All)
+    }
+
+    /// Build a prefilter that admits lines containing *any* of `markers`.
+    pub(crate) fn any(markers: &[&[u8]]) -> Self {
+        Self::new(markers, PrefilterMode::Any)
+    }
+
+    fn new(markers: &[&[u8]], mode: PrefilterMode) -> Self {
+        // `Finder::new` borrows the needle, so take an owned copy to outlive the
+        // caller's marker slice and allow the prefilter to be stored freely.
+        let finders = markers
+            .iter()
+            .map(|marker| Finder::new(marker).into_owned())
+            .collect();
+        Self { finders, mode }
+    }
+
+    /// Return `true` when `line` passes the filter and is worth parsing.
+    pub(crate) fn matches(&self, line: &[u8]) -> bool {
+        match self.mode {
+            PrefilterMode::All => self
+                .finders
+                .iter()
+                .all(|finder| finder.find(line).is_some()),
+            PrefilterMode::Any => self
+                .finders
+                .iter()
+                .any(|finder| finder.find(line).is_some()),
+        }
+    }
+}
 
 pub(crate) struct ByteLines<'a> {
     bytes: &'a [u8],
@@ -47,7 +112,25 @@ pub(crate) fn suffix_string(value: &str, suffix: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{byte_lines, suffix_string};
+    use super::{LinePrefilter, byte_lines, suffix_string};
+
+    #[test]
+    fn line_prefilter_all_requires_every_marker() {
+        let prefilter = LinePrefilter::all(&[b"\"usage\"", b"\"message\""]);
+
+        assert!(prefilter.matches(br#"{"message":{"usage":{"input":1}}}"#));
+        assert!(!prefilter.matches(br#"{"message":{"role":"user"}}"#));
+        assert!(!prefilter.matches(br#"{"usage":{"input":1}}"#));
+    }
+
+    #[test]
+    fn line_prefilter_any_requires_one_marker() {
+        let prefilter = LinePrefilter::any(&[b"\"model_change\"", b"\"usage\""]);
+
+        assert!(prefilter.matches(br#"{"type":"model_change"}"#));
+        assert!(prefilter.matches(br#"{"message":{"usage":{}}}"#));
+        assert!(!prefilter.matches(br#"{"type":"message"}"#));
+    }
 
     #[test]
     fn byte_lines_returns_newline_delimited_slices() {


### PR DESCRIPTION
## Summary

Unifies the JSONL parsing fast-path across agent adapters. The `claude` and `codex` adapters already read file bytes, iterate newline-delimited slices via `byte_lines`, and use a reusable `memmem` substring prefilter to skip non-usage lines before running `serde_json`. This PR brings the remaining line-delimited adapters — **pi, kimi, qwen, openclaw, copilot** — onto the same path.

A new shared `LinePrefilter` helper in `fast.rs` builds the `memmem::Finder` needles once (owned, reused across every line) instead of allocating a fresh searcher on each `str::contains` call. It supports both "contains all markers" and "contains any marker" modes to match the existing per-adapter filter semantics.

## What changed

| Adapter | Before | After |
| --- | --- | --- |
| pi | `read_to_string().lines()` + `str::contains` | `fs::read` + `byte_lines` + `LinePrefilter::all` |
| kimi | `read_to_string().lines()` + `str::contains` | `fs::read` + `byte_lines` + `LinePrefilter::all` |
| qwen | `BufReader::lines()`, **no prefilter** | `fs::read` + `byte_lines` + `LinePrefilter::all([usageMetadata])` |
| openclaw | `BufReader::lines()` + `str::contains` | `fs::read` + `byte_lines` + `LinePrefilter::any` |
| copilot | `read_to_string().lines()` + `str::contains` | `fs::read` + `byte_lines` + `LinePrefilter::all` |

Parsing logic is otherwise unchanged (still `serde_json::Value`-based).

## Behavioral notes

- pi, kimi, openclaw, copilot keep their **exact** existing marker substrings; only the scanning mechanism changes.
- qwen previously parsed every line; it now skips lines lacking `"usageMetadata"`, which is a required field for any emitted entry (`record.get("usageMetadata")?`), so the result set is unchanged — it just gains a prefilter it didn't have.
- Reading bytes instead of a UTF-8 string makes a single invalid line fail to parse and be skipped rather than aborting the whole file — matching the existing claude/codex behavior.

## Scope notes

- **codex** is left as-is: it already uses `memmem` and streams with `BufReader::read_until`; converting it to whole-file `byte_lines` could regress very large session logs.
- **gemini**'s JSONL path carries cross-line state (session/model set by marker-less lines), so a token-based prefilter would break attribution — excluded.
- **amp, codebuff, droid, goose, hermes, kilo, opencode** read single JSON documents or SQLite, not JSONL — out of scope.
- Migrating these adapters from `serde_json::Value` to fully typed structs is a larger, higher-risk follow-up and is intentionally **not** included here.

## Validation

- `cargo test -p ccusage`: 271 passed (incl. new `LinePrefilter` tests and all adapter loader-level tests).
- `cargo clippy --all-targets`: clean.
- `treefmt` / `just fmt`: clean.
- **JSON parity vs `ccusage@latest` (v20.0.13)**: ran `<agent> daily --json --offline --until 20260614` for every agent with local logs and confirmed **byte-identical** output:
  - migrated adapters with data: `pi` (4 rows), `copilot` (1 row) ✅
  - shared `fast.rs` hot path: `claude` (155 rows), `codex` (110 rows) ✅
  - also identical: `gemini`, `opencode`, `amp`
  - `kimi` / `qwen` / `openclaw` had no local logs (skipped).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the JSONL fast path across agents with `byte_lines`, a reusable `LinePrefilter`, and a shared `prefiltered_json_values` helper to skip non-usage lines before `serde_json`. Migrates `pi`, `kimi`, `qwen`, `openclaw`, and `copilot` to the same path as `claude`/`codex`, improving scan speed and resilience to invalid lines with no output changes.

- **Refactors**
  - Added `LinePrefilter` and `prefiltered_json_values` in `fast.rs` (all/any markers) built on `memchr::memmem::Finder`.
  - Switched the listed adapters to `fs::read` + `prefiltered_json_values` with the same marker substrings as before.
  - `qwen`: now prefilters on `"usageMetadata"`; emitted results stay the same.
  - Parsing bytes now skips bad lines instead of aborting the file; `codex` and `gemini` paths remain unchanged.

<sup>Written for commit 519a249b988f7b1fa5e3e309bb71f3147c9a8607. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved usage-log ingestion speed across multiple providers by switching to byte-oriented JSONL prefiltering, reducing unnecessary parsing work and improving throughput on large files.
  * Updated several provider parsers (including Copilot, Kimi, OpenClaw, Pi, and Qwen) to use the same more efficient filtering approach.
* **Tests**
  * Expanded coverage for the new log prefiltering behavior to ensure filtered and malformed records are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->