### PR TITLE
refactor(adapter): unify JSONL parsing with typed structs and a shared helper

### DIFF
--- a/rust/crates/ccusage/src/adapter/amp/parser.rs
+++ b/rust/crates/ccusage/src/adapter/amp/parser.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, fs, path::Path, sync::Arc};
 
 use jiff::tz::TimeZone as JiffTimeZone;
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
@@ -9,29 +10,83 @@ use crate::{
     missing_pricing_model_for_usage, non_empty_json_string,
 };
 
+/// A single Amp thread file: one JSON object holding the thread id, the chat
+/// messages, and an optional usage ledger.
+///
+/// Polymorphic and leniency-sensitive leaves (token blocks, ids, credits) stay
+/// as raw [`Value`]s so navigation matches the historical `Value::get` parsing
+/// exactly instead of failing the whole file on an unexpected field type.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AmpThread {
+    #[serde(default, deserialize_with = "super::super::jsonl::non_empty_string")]
+    id: Option<String>,
+    #[serde(default)]
+    messages: Vec<AmpMessage>,
+    #[serde(default)]
+    usage_ledger: Option<AmpUsageLedger>,
+}
+
+/// Wrapper around the ledger's `events` array.
+#[derive(Debug, Default, Deserialize)]
+struct AmpUsageLedger {
+    #[serde(default)]
+    events: Vec<AmpLedgerEvent>,
+}
+
+/// A single ledger event carrying token counts and pricing metadata.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AmpLedgerEvent {
+    #[serde(default)]
+    id: Option<Value>,
+    #[serde(default, deserialize_with = "super::super::jsonl::non_empty_string")]
+    timestamp: Option<String>,
+    #[serde(default, deserialize_with = "super::super::jsonl::non_empty_string")]
+    model: Option<String>,
+    #[serde(default)]
+    tokens: Option<Value>,
+    #[serde(default)]
+    to_message_id: Option<Value>,
+    #[serde(default)]
+    credits: Option<Value>,
+}
+
+/// A single chat message in the thread.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AmpMessage {
+    #[serde(default)]
+    role: Option<Value>,
+    #[serde(default)]
+    usage: Option<Value>,
+    #[serde(default)]
+    timestamp: Option<Value>,
+    #[serde(default)]
+    model: Option<Value>,
+    #[serde(default)]
+    message_id: Option<Value>,
+}
+
 pub(crate) fn read_thread_file(
     path: &Path,
     tz: Option<&JiffTimeZone>,
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Result<Vec<LoadedEntry>> {
-    let content = fs::read_to_string(path)?;
-    let Ok(value) = serde_json::from_str::<Value>(&content) else {
+    let content = fs::read(path)?;
+    let Ok(thread) = serde_json::from_slice::<AmpThread>(&content) else {
         return Ok(Vec::new());
     };
-    let Some(thread_id) = non_empty_json_string(value.get("id")) else {
+    let Some(thread_id) = thread.id else {
         return Ok(Vec::new());
     };
-    let messages = value.get("messages");
+    let messages = &thread.messages;
 
-    if let Some(events) = value
-        .get("usageLedger")
-        .and_then(|ledger| ledger.get("events"))
-        .and_then(Value::as_array)
-    {
+    if let Some(ledger) = thread.usage_ledger.as_ref() {
         let cache_tokens = cache_tokens_by_message_id(messages);
         return Ok(parse_ledger_events(
-            events,
+            &ledger.events,
             &cache_tokens,
             &thread_id,
             tz,
@@ -44,7 +99,7 @@ pub(crate) fn read_thread_file(
 }
 
 fn parse_ledger_events(
-    events: &[Value],
+    events: &[AmpLedgerEvent],
     cache_tokens: &HashMap<i64, (u64, u64)>,
     thread_id: &str,
     tz: Option<&JiffTimeZone>,
@@ -53,20 +108,21 @@ fn parse_ledger_events(
 ) -> Vec<LoadedEntry> {
     let mut entries = Vec::new();
     for event in events {
-        let Some(timestamp_text) = non_empty_json_string(event.get("timestamp")) else {
+        let Some(timestamp_text) = event.timestamp.clone() else {
             continue;
         };
         let Some(timestamp) = crate::parse_ts_timestamp(&timestamp_text) else {
             continue;
         };
-        let Some(model) = non_empty_json_string(event.get("model")) else {
+        let Some(model) = event.model.clone() else {
             continue;
         };
-        let Some(tokens) = event.get("tokens") else {
+        let Some(tokens) = event.tokens.as_ref() else {
             continue;
         };
         let cache = event
-            .get("toMessageId")
+            .to_message_id
+            .as_ref()
             .and_then(Value::as_i64)
             .and_then(|id| cache_tokens.get(&id).copied())
             .unwrap_or_default();
@@ -95,7 +151,7 @@ fn parse_ledger_events(
             message: UsageMessage {
                 usage,
                 model: Some(model.clone()),
-                id: non_empty_json_string(event.get("id")),
+                id: non_empty_json_string(event.id.as_ref()),
             },
             cost_usd: None,
             request_id: None,
@@ -133,7 +189,7 @@ fn parse_ledger_events(
             project_path: Arc::from("Amp"),
             cost,
             extra_total_tokens,
-            credits: json_value_f64(event.get("credits")),
+            credits: json_value_f64(event.credits.as_ref()),
             message_count: None,
             model: Some(model),
             usage_limit_reset_time: None,
@@ -145,25 +201,22 @@ fn parse_ledger_events(
 }
 
 fn parse_message_usage(
-    messages: Option<&Value>,
+    messages: &[AmpMessage],
     thread_id: &str,
     tz: Option<&JiffTimeZone>,
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Vec<LoadedEntry> {
     let mut entries = Vec::new();
-    let Some(messages) = messages.and_then(Value::as_array) else {
-        return entries;
-    };
     for message in messages {
-        if message.get("role").and_then(Value::as_str) != Some("assistant") {
+        if message.role.as_ref().and_then(Value::as_str) != Some("assistant") {
             continue;
         }
-        let Some(usage) = message.get("usage") else {
+        let Some(usage) = message.usage.as_ref() else {
             continue;
         };
         let Some(timestamp_text) = non_empty_json_string(usage.get("timestamp"))
-            .or_else(|| non_empty_json_string(message.get("timestamp")))
+            .or_else(|| non_empty_json_string(message.timestamp.as_ref()))
         else {
             continue;
         };
@@ -171,7 +224,7 @@ fn parse_message_usage(
             continue;
         };
         let Some(model) = non_empty_json_string(usage.get("model"))
-            .or_else(|| non_empty_json_string(message.get("model")))
+            .or_else(|| non_empty_json_string(message.model.as_ref()))
         else {
             continue;
         };
@@ -194,7 +247,7 @@ fn parse_message_usage(
         {
             continue;
         }
-        let message_id = message.get("messageId").and_then(|id| {
+        let message_id = message.message_id.as_ref().and_then(|id| {
             id.as_i64()
                 .map(|v| v.to_string())
                 .or_else(|| id.as_str().map(str::to_string))
@@ -255,19 +308,16 @@ fn parse_message_usage(
     entries
 }
 
-fn cache_tokens_by_message_id(messages: Option<&Value>) -> HashMap<i64, (u64, u64)> {
+fn cache_tokens_by_message_id(messages: &[AmpMessage]) -> HashMap<i64, (u64, u64)> {
     let mut cache_tokens = HashMap::new();
-    let Some(messages) = messages.and_then(Value::as_array) else {
-        return cache_tokens;
-    };
     for message in messages {
-        if message.get("role").and_then(Value::as_str) != Some("assistant") {
+        if message.role.as_ref().and_then(Value::as_str) != Some("assistant") {
             continue;
         }
-        let Some(message_id) = message.get("messageId").and_then(Value::as_i64) else {
+        let Some(message_id) = message.message_id.as_ref().and_then(Value::as_i64) else {
             continue;
         };
-        let usage = message.get("usage");
+        let usage = message.usage.as_ref();
         cache_tokens.insert(
             message_id,
             (

--- a/rust/crates/ccusage/src/adapter/amp/parser.rs
+++ b/rust/crates/ccusage/src/adapter/amp/parser.rs
@@ -21,17 +21,17 @@ use crate::{
 struct AmpThread {
     #[serde(default, deserialize_with = "super::super::jsonl::non_empty_string")]
     id: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "super::super::jsonl::lenient_vec")]
     messages: Vec<AmpMessage>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "super::super::jsonl::lenient_object")]
     usage_ledger: Option<AmpUsageLedger>,
 }
 
 /// Wrapper around the ledger's `events` array.
 #[derive(Debug, Default, Deserialize)]
 struct AmpUsageLedger {
-    #[serde(default)]
-    events: Vec<AmpLedgerEvent>,
+    #[serde(default, deserialize_with = "super::super::jsonl::lenient_array")]
+    events: Option<Vec<AmpLedgerEvent>>,
 }
 
 /// A single ledger event carrying token counts and pricing metadata.
@@ -83,10 +83,12 @@ pub(crate) fn read_thread_file(
     };
     let messages = &thread.messages;
 
-    if let Some(ledger) = thread.usage_ledger.as_ref() {
+    if let Some(ledger) = thread.usage_ledger.as_ref()
+        && let Some(events) = ledger.events.as_ref()
+    {
         let cache_tokens = cache_tokens_by_message_id(messages);
         return Ok(parse_ledger_events(
-            &ledger.events,
+            events,
             &cache_tokens,
             &thread_id,
             tz,
@@ -474,5 +476,61 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].data.message.usage.output_tokens, 345);
         assert_eq!(entries[0].extra_total_tokens, 0);
+    }
+
+    #[test]
+    fn empty_usage_ledger_falls_back_to_message_usage() {
+        // A `usageLedger` object without a usable `events` array must not win
+        // precedence over `messages`; the thread should still report message
+        // usage instead of returning nothing.
+        let fixture = fs_fixture!({
+            "thread.json": r#"{
+                "id":"T-thread-a",
+                "usageLedger":{},
+                "messages":[
+                    {"role":"assistant","usage":{
+                        "model":"claude-haiku-4-5-20251001",
+                        "inputTokens":10,
+                        "outputTokens":178,
+                        "timestamp":"2026-01-19T11:42:10.652Z"
+                    }}
+                ]
+            }"#,
+        });
+        let file = fixture.path("thread.json");
+
+        let entries = read_thread_file(&file, None, CostMode::Auto, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.input_tokens, 10);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 178);
+    }
+
+    #[test]
+    fn malformed_message_element_does_not_drop_the_thread() {
+        // A non-object entry in `messages` (and a non-object `usageLedger`) must
+        // be skipped gracefully rather than failing the whole thread.
+        let fixture = fs_fixture!({
+            "thread.json": r#"{
+                "id":"T-thread-a",
+                "usageLedger":"not-an-object",
+                "messages":[
+                    "garbage",
+                    {"role":"assistant","usage":{
+                        "model":"claude-haiku-4-5-20251001",
+                        "inputTokens":10,
+                        "outputTokens":178,
+                        "timestamp":"2026-01-19T11:42:10.652Z"
+                    }}
+                ]
+            }"#,
+        });
+        let file = fixture.path("thread.json");
+
+        let entries = read_thread_file(&file, None, CostMode::Auto, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.input_tokens, 10);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 178);
     }
 }

--- a/rust/crates/ccusage/src/adapter/claude/mod.rs
+++ b/rust/crates/ccusage/src/adapter/claude/mod.rs
@@ -486,7 +486,8 @@ fn is_unsupported_nullable_field(field: &[u8]) -> bool {
     // hash computation a `phf::Set` lookup would incur on every call.
     matches!(
         field,
-        b"id" | b"cwd"
+        b"id"
+            | b"cwd"
             | b"model"
             | b"speed"
             | b"costUSD"

--- a/rust/crates/ccusage/src/adapter/codebuff/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff/parser.rs
@@ -38,11 +38,8 @@ struct CodebuffContext {
 }
 
 pub(super) fn load_chat_file(path: &Path) -> Result<Vec<CodebuffEntry>> {
-    let content = fs::read_to_string(path)?;
-    let Ok(messages) = serde_json::from_str::<Value>(&content) else {
-        return Ok(Vec::new());
-    };
-    let Some(messages) = messages.as_array() else {
+    let content = fs::read(path)?;
+    let Ok(messages) = serde_json::from_slice::<Vec<Value>>(&content) else {
         return Ok(Vec::new());
     };
     let context = derive_context(path);

--- a/rust/crates/ccusage/src/adapter/copilot/parser.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/parser.rs
@@ -4,9 +4,54 @@ use std::{
     path::Path,
 };
 
+use serde::Deserialize;
 use serde_json::{Map, Value};
 
+use super::super::jsonl;
 use crate::{Result, TimestampMs, TokenUsageRaw, apply_total_token_fallback};
+
+/// Cheap substring prefilter: every usable Copilot OTel record carries the
+/// `attributes` object, so lines without it are skipped before JSON parsing.
+const COPILOT_ATTRIBUTES_MARKER: &[u8] = b"\"attributes\"";
+
+/// A single parsed Copilot OpenTelemetry record. Only the fields ccusage
+/// consumes are declared; serde skips everything else. The `attributes` block
+/// is kept as a dynamic map because Copilot addresses it by arbitrary dotted
+/// keys (for example `gen_ai.usage.input_tokens`), and the timestamp-bearing
+/// fields stay as raw values because they appear as both numeric scalars and
+/// `[seconds, nanos]` arrays depending on the exporter.
+#[derive(Debug, Deserialize)]
+struct CopilotRecord {
+    #[serde(rename = "type")]
+    record_type: Option<Value>,
+    name: Option<Value>,
+    #[serde(rename = "spanId")]
+    span_id: Option<Value>,
+    #[serde(rename = "traceId")]
+    trace_id: Option<Value>,
+    #[serde(rename = "spanContext")]
+    span_context: Option<Value>,
+    #[serde(rename = "startTime")]
+    start_time: Option<Value>,
+    #[serde(rename = "endTime")]
+    end_time: Option<Value>,
+    duration: Option<Value>,
+    kind: Option<Value>,
+    #[serde(rename = "hrTime")]
+    hr_time: Option<Value>,
+    #[serde(rename = "_hrTime")]
+    underscore_hr_time: Option<Value>,
+    time: Option<Value>,
+    timestamp: Option<Value>,
+    #[serde(rename = "observedTimestamp")]
+    observed_timestamp: Option<Value>,
+    #[serde(rename = "timeUnixNano")]
+    time_unix_nano: Option<Value>,
+    body: Option<Value>,
+    #[serde(rename = "_body")]
+    underscore_body: Option<Value>,
+    attributes: Option<Map<String, Value>>,
+}
 
 #[derive(Debug, Clone)]
 pub(super) struct CopilotUsageEntry {
@@ -53,12 +98,8 @@ struct CopilotUsageCandidate {
 }
 
 pub(super) fn parse_otel_file(path: &Path) -> Result<Vec<CopilotUsageEntry>> {
-    let content = fs::read_to_string(path)?;
-    let records = content
-        .lines()
-        .filter(|line| line.contains("\"attributes\""))
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .filter_map(|value| value.as_object().cloned())
+    let content = fs::read(path)?;
+    let records = jsonl::records::<CopilotRecord>(&content, Some(COPILOT_ATTRIBUTES_MARKER))
         .collect::<Vec<_>>();
     let trace_contexts = collect_trace_contexts(&records);
     let fallback_timestamp = file_modified_timestamp(path);
@@ -88,13 +129,13 @@ pub(super) fn parse_otel_file(path: &Path) -> Result<Vec<CopilotUsageEntry>> {
         .collect())
 }
 
-fn collect_trace_contexts(records: &[Map<String, Value>]) -> HashMap<String, TraceContext> {
+fn collect_trace_contexts(records: &[CopilotRecord]) -> HashMap<String, TraceContext> {
     let mut contexts = HashMap::new();
     for record in records {
         let Some(trace_id) = trace_id_from_record(record) else {
             continue;
         };
-        let Some(attributes) = record.get("attributes").and_then(Value::as_object) else {
+        let Some(attributes) = record.attributes.as_ref() else {
             continue;
         };
         let context = contexts
@@ -114,12 +155,12 @@ fn collect_trace_contexts(records: &[Map<String, Value>]) -> HashMap<String, Tra
 }
 
 fn to_candidate(
-    record: &Map<String, Value>,
+    record: &CopilotRecord,
     index: usize,
     fallback_timestamp: TimestampMs,
     trace_contexts: &HashMap<String, TraceContext>,
 ) -> Option<CopilotUsageCandidate> {
-    let attributes = record.get("attributes")?.as_object()?;
+    let attributes = record.attributes.as_ref()?;
     let source = if is_chat_span_record(record, attributes) {
         CopilotUsageSource::ChatSpan
     } else if is_inference_log_record(record, attributes) {
@@ -299,43 +340,40 @@ const SESSION_ATTRS: &[(&str, u8)] = &[
     ("gen_ai.response.id", 1),
 ];
 
-fn is_span_record(record: &Map<String, Value>) -> bool {
-    if let Some(record_type) = record.get("type").and_then(Value::as_str) {
+fn is_span_record(record: &CopilotRecord) -> bool {
+    if let Some(record_type) = record.record_type.as_ref().and_then(Value::as_str) {
         return record_type == "span";
     }
-    string_value(record.get("name")).is_some()
-        && (string_value(record.get("spanId")).is_some()
-            || string_value(record.get("traceId")).is_some()
-            || record.get("startTime").is_some()
-            || record.get("endTime").is_some()
-            || record.get("duration").is_some()
-            || record.get("kind").is_some())
+    string_value(record.name.as_ref()).is_some()
+        && (string_value(record.span_id.as_ref()).is_some()
+            || string_value(record.trace_id.as_ref()).is_some()
+            || record.start_time.is_some()
+            || record.end_time.is_some()
+            || record.duration.is_some()
+            || record.kind.is_some())
 }
 
-fn is_chat_span_record(record: &Map<String, Value>, attributes: &Map<String, Value>) -> bool {
+fn is_chat_span_record(record: &CopilotRecord, attributes: &Map<String, Value>) -> bool {
     is_span_record(record)
         && (attr_string(attributes, "gen_ai.operation.name").as_deref() == Some("chat")
-            || string_value(record.get("name")).is_some_and(|name| name.starts_with("chat ")))
+            || string_value(record.name.as_ref()).is_some_and(|name| name.starts_with("chat ")))
 }
 
-fn is_agent_summary_span_record(
-    record: &Map<String, Value>,
-    attributes: &Map<String, Value>,
-) -> bool {
+fn is_agent_summary_span_record(record: &CopilotRecord, attributes: &Map<String, Value>) -> bool {
     is_span_record(record)
         && (attr_string(attributes, "gen_ai.operation.name").as_deref() == Some("invoke_agent")
-            || string_value(record.get("name"))
+            || string_value(record.name.as_ref())
                 .is_some_and(|name| name.starts_with("invoke_agent ")))
 }
 
-fn is_inference_log_record(record: &Map<String, Value>, attributes: &Map<String, Value>) -> bool {
+fn is_inference_log_record(record: &CopilotRecord, attributes: &Map<String, Value>) -> bool {
     !is_span_record(record)
         && (attr_string(attributes, "event.name").as_deref()
             == Some("gen_ai.client.inference.operation.details")
             || record_body(record).is_some_and(|body| body.starts_with("GenAI inference:")))
 }
 
-fn is_agent_turn_log_record(record: &Map<String, Value>, attributes: &Map<String, Value>) -> bool {
+fn is_agent_turn_log_record(record: &CopilotRecord, attributes: &Map<String, Value>) -> bool {
     !is_span_record(record)
         && (attr_string(attributes, "event.name").as_deref() == Some("copilot_chat.agent.turn")
             || record_body(record).is_some_and(|body| body.starts_with("copilot_chat.agent.turn")))
@@ -343,7 +381,7 @@ fn is_agent_turn_log_record(record: &Map<String, Value>, attributes: &Map<String
 
 fn dedup_key_for_record(
     source: CopilotUsageSource,
-    record: &Map<String, Value>,
+    record: &CopilotRecord,
     attributes: &Map<String, Value>,
     trace_id: &Option<String>,
     session_id: &str,
@@ -376,28 +414,27 @@ fn dedup_key_for_record(
     }
 }
 
-fn trace_id_from_record(record: &Map<String, Value>) -> Option<String> {
-    string_value(record.get("traceId"))
+fn trace_id_from_record(record: &CopilotRecord) -> Option<String> {
+    string_value(record.trace_id.as_ref())
         .map(str::to_string)
-        .or_else(|| nested_string(record, "spanContext", "traceId"))
+        .or_else(|| nested_string(record.span_context.as_ref(), "traceId"))
 }
 
-fn span_id_from_record(record: &Map<String, Value>) -> Option<String> {
-    string_value(record.get("spanId"))
+fn span_id_from_record(record: &CopilotRecord) -> Option<String> {
+    string_value(record.span_id.as_ref())
         .map(str::to_string)
-        .or_else(|| nested_string(record, "spanContext", "spanId"))
+        .or_else(|| nested_string(record.span_context.as_ref(), "spanId"))
 }
 
-fn nested_string(record: &Map<String, Value>, object: &str, key: &str) -> Option<String> {
-    record
-        .get(object)
+fn nested_string(object: Option<&Value>, key: &str) -> Option<String> {
+    object
         .and_then(Value::as_object)
         .and_then(|object| string_value(object.get(key)))
         .map(str::to_string)
 }
 
-fn record_body(record: &Map<String, Value>) -> Option<&str> {
-    string_value(record.get("body")).or_else(|| string_value(record.get("_body")))
+fn record_body(record: &CopilotRecord) -> Option<&str> {
+    string_value(record.body.as_ref()).or_else(|| string_value(record.underscore_body.as_ref()))
 }
 
 fn string_value(value: Option<&Value>) -> Option<&str> {
@@ -443,15 +480,15 @@ fn best_session_attr(attributes: &Map<String, Value>) -> Option<(String, u8)> {
         .max_by_key(|(_, priority)| *priority)
 }
 
-fn timestamp_from_record(record: &Map<String, Value>) -> Option<TimestampMs> {
-    timestamp_from_parts(record.get("endTime"))
-        .or_else(|| timestamp_from_parts(record.get("startTime")))
-        .or_else(|| timestamp_from_parts(record.get("hrTime")))
-        .or_else(|| timestamp_from_parts(record.get("_hrTime")))
-        .or_else(|| timestamp_from_parts(record.get("time")))
-        .or_else(|| timestamp_from_scalar(record.get("timestamp")))
-        .or_else(|| timestamp_from_scalar(record.get("observedTimestamp")))
-        .or_else(|| timestamp_from_unix_nanos(record.get("timeUnixNano")))
+fn timestamp_from_record(record: &CopilotRecord) -> Option<TimestampMs> {
+    timestamp_from_parts(record.end_time.as_ref())
+        .or_else(|| timestamp_from_parts(record.start_time.as_ref()))
+        .or_else(|| timestamp_from_parts(record.hr_time.as_ref()))
+        .or_else(|| timestamp_from_parts(record.underscore_hr_time.as_ref()))
+        .or_else(|| timestamp_from_parts(record.time.as_ref()))
+        .or_else(|| timestamp_from_scalar(record.timestamp.as_ref()))
+        .or_else(|| timestamp_from_scalar(record.observed_timestamp.as_ref()))
+        .or_else(|| timestamp_from_unix_nanos(record.time_unix_nano.as_ref()))
 }
 
 fn timestamp_from_parts(value: Option<&Value>) -> Option<TimestampMs> {

--- a/rust/crates/ccusage/src/adapter/copilot/parser.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/parser.rs
@@ -8,11 +8,7 @@ use serde::Deserialize;
 use serde_json::{Map, Value};
 
 use super::super::jsonl;
-use crate::{Result, TimestampMs, TokenUsageRaw, apply_total_token_fallback};
-
-/// Cheap substring prefilter: every usable Copilot OTel record carries the
-/// `attributes` object, so lines without it are skipped before JSON parsing.
-const COPILOT_ATTRIBUTES_MARKER: &[u8] = b"\"attributes\"";
+use crate::{Result, TimestampMs, TokenUsageRaw, apply_total_token_fallback, fast::LinePrefilter};
 
 /// A single parsed Copilot OpenTelemetry record. Only the fields ccusage
 /// consumes are declared; serde skips everything else. The `attributes` block
@@ -99,8 +95,10 @@ struct CopilotUsageCandidate {
 
 pub(super) fn parse_otel_file(path: &Path) -> Result<Vec<CopilotUsageEntry>> {
     let content = fs::read(path)?;
-    let records = jsonl::records::<CopilotRecord>(&content, Some(COPILOT_ATTRIBUTES_MARKER))
-        .collect::<Vec<_>>();
+    // Every usable Copilot OTel record carries the `attributes` object, so
+    // lines without it are skipped before JSON parsing.
+    let prefilter = LinePrefilter::all(&[br#""attributes""#]);
+    let records = jsonl::records::<CopilotRecord>(&content, Some(&prefilter)).collect::<Vec<_>>();
     let trace_contexts = collect_trace_contexts(&records);
     let fallback_timestamp = file_modified_timestamp(path);
     let candidates = records

--- a/rust/crates/ccusage/src/adapter/gemini/parser.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/parser.rs
@@ -24,7 +24,7 @@ const PROVIDER_PREFIXES: [&str; 4] = ["google", "gemini", "vertex_ai", "openrout
 /// integer-only [`jsonl::lenient_u64`] helper.
 #[derive(Debug, Default, Deserialize)]
 struct GeminiRecord {
-    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    #[serde(default, deserialize_with = "lenient_str")]
     r#type: Option<String>,
     #[serde(default, deserialize_with = "jsonl::non_empty_string")]
     #[serde(rename = "sessionId")]
@@ -54,9 +54,11 @@ struct GeminiRecord {
 /// Deserialize a JSON value into an optional, untrimmed [`String`] with the same
 /// rules as [`serde_json::Value::as_str`]: JSON strings are returned verbatim,
 /// while numbers, nulls, and other types become `None` instead of failing the
-/// line. Used for timestamp fields that are fed directly to
+/// line. Used for fields that the original code navigated with raw
+/// `Value::as_str`: the `type` discriminator (compared exactly against
+/// `"gemini"`, so it must not be trimmed) and the timestamp fields fed to
 /// [`crate::parse_ts_timestamp`], whose strict length checks must see the raw,
-/// untrimmed text exactly as the original `Value::as_str` navigation did.
+/// untrimmed text.
 fn lenient_str<'de, D>(deserializer: D) -> std::result::Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -567,5 +569,26 @@ mod tests {
 
         assert_eq!(event.output_tokens, 654);
         assert_eq!(event.reasoning_tokens, 0);
+    }
+
+    #[test]
+    fn type_discriminator_is_untrimmed_and_tolerates_non_strings() {
+        // Exact match still works.
+        let exact = serde_json::from_str::<GeminiRecord>(r#"{"type":"gemini"}"#).unwrap();
+        assert_eq!(exact.r#type.as_deref(), Some("gemini"));
+
+        // Surrounding whitespace must NOT be trimmed, so a padded value does not
+        // spuriously match the "gemini" discriminator. This mirrors the original
+        // raw `Value::as_str` comparison rather than the trimming
+        // `non_empty_string` helper.
+        let padded = serde_json::from_str::<GeminiRecord>(r#"{"type":" gemini "}"#).unwrap();
+        assert_eq!(padded.r#type.as_deref(), Some(" gemini "));
+        assert_ne!(padded.r#type.as_deref(), Some("gemini"));
+
+        // A non-string type becomes None without failing the line, so the record
+        // still falls through to stats parsing.
+        let numeric = serde_json::from_str::<GeminiRecord>(r#"{"type":5,"stats":{}}"#).unwrap();
+        assert_eq!(numeric.r#type, None);
+        assert!(numeric.stats.is_some());
     }
 }

--- a/rust/crates/ccusage/src/adapter/gemini/parser.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/parser.rs
@@ -1,8 +1,10 @@
 use std::{collections::HashMap, fs, path::Path, sync::Arc};
 
 use jiff::tz::TimeZone as JiffTimeZone;
+use serde::Deserialize;
 use serde_json::{Map, Value};
 
+use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
@@ -11,6 +13,78 @@ use crate::{
 
 const DEFAULT_MODEL: &str = "unknown";
 const PROVIDER_PREFIXES: [&str; 4] = ["google", "gemini", "vertex_ai", "openrouter/google"];
+
+/// A Gemini log record envelope, used both for whole-file JSON documents and for
+/// individual JSONL lines. Only the fields ccusage consumes are declared; serde
+/// skips everything else.
+///
+/// Token counts are intentionally kept as raw [`Value`] trees (`tokens`,
+/// `stats`, `result`) because [`parse_tokens`] accepts many key aliases and
+/// truncates floating-point token counts, semantics that differ from the shared
+/// integer-only [`jsonl::lenient_u64`] helper.
+#[derive(Debug, Default, Deserialize)]
+struct GeminiRecord {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    r#type: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    #[serde(rename = "sessionId")]
+    session_id_camel: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    session_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    id: Option<String>,
+    #[serde(default, deserialize_with = "lenient_str")]
+    timestamp: Option<String>,
+    #[serde(default, deserialize_with = "lenient_str")]
+    created_at: Option<String>,
+    #[serde(default, deserialize_with = "lenient_str")]
+    #[serde(rename = "startTime")]
+    start_time: Option<String>,
+    #[serde(default, deserialize_with = "lenient_str")]
+    #[serde(rename = "lastUpdated")]
+    last_updated: Option<String>,
+    messages: Option<Value>,
+    tokens: Option<Value>,
+    stats: Option<Value>,
+    result: Option<Value>,
+}
+
+/// Deserialize a JSON value into an optional, untrimmed [`String`] with the same
+/// rules as [`serde_json::Value::as_str`]: JSON strings are returned verbatim,
+/// while numbers, nulls, and other types become `None` instead of failing the
+/// line. Used for timestamp fields that are fed directly to
+/// [`crate::parse_ts_timestamp`], whose strict length checks must see the raw,
+/// untrimmed text exactly as the original `Value::as_str` navigation did.
+fn lenient_str<'de, D>(deserializer: D) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    Ok(value
+        .as_ref()
+        .and_then(Value::as_str)
+        .map(ToString::to_string))
+}
+
+impl GeminiRecord {
+    /// Resolve the session id, preferring `sessionId` then `session_id`,
+    /// matching the original `string_at(record, "sessionId").or_else(...)`.
+    fn session_id(&self) -> Option<String> {
+        self.session_id_camel
+            .clone()
+            .or_else(|| self.session_id.clone())
+    }
+
+    /// Resolve the `stats` value, preferring the top-level `stats` then the
+    /// nested `result.stats`, matching the original lookup order.
+    fn stats(&self) -> Option<&Value> {
+        self.stats
+            .as_ref()
+            .or_else(|| self.result.as_ref().and_then(|result| result.get("stats")))
+    }
+}
 
 #[derive(Debug, Clone, Copy, Default)]
 struct GeminiTokens {
@@ -39,24 +113,27 @@ pub(super) struct GeminiUsageEvent {
 pub(super) fn parse_json_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
     let fallback_timestamp = file_modified_timestamp(path);
     let content = fs::read_to_string(path)?;
-    let Ok(value) = serde_json::from_str::<Value>(&content) else {
+    let Ok(record) = serde_json::from_str::<GeminiRecord>(&content) else {
         return Ok(Vec::new());
     };
-    let Some(record) = value.as_object() else {
-        return Ok(Vec::new());
-    };
-    let session_id = string_at(record, "sessionId")
-        .or_else(|| string_at(record, "session_id"))
-        .unwrap_or_else(|| {
-            path.file_stem()
-                .and_then(|stem| stem.to_str())
-                .unwrap_or("unknown")
-                .to_string()
-        });
-    let session_timestamp = timestamp_at(record, "startTime")
-        .or_else(|| timestamp_at(record, "lastUpdated"))
+    let session_id = record.session_id().unwrap_or_else(|| {
+        path.file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("unknown")
+            .to_string()
+    });
+    let session_timestamp = record
+        .start_time
+        .as_deref()
+        .and_then(crate::parse_ts_timestamp)
+        .or_else(|| {
+            record
+                .last_updated
+                .as_deref()
+                .and_then(crate::parse_ts_timestamp)
+        })
         .unwrap_or(fallback_timestamp);
-    if let Some(messages) = record.get("messages").and_then(Value::as_array) {
+    if let Some(messages) = record.messages.as_ref().and_then(Value::as_array) {
         return Ok(messages
             .iter()
             .filter_map(Value::as_object)
@@ -64,21 +141,22 @@ pub(super) fn parse_json_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
             .filter_map(|message| parse_direct_event(message, None, &session_id, session_timestamp))
             .collect());
     }
-    if record.get("type").and_then(Value::as_str) == Some("gemini") {
+    if record.r#type.as_deref() == Some("gemini") {
         return Ok(
-            parse_direct_event(record, None, &session_id, fallback_timestamp)
+            parse_direct_event_record(&record, None, &session_id, fallback_timestamp)
                 .into_iter()
                 .collect(),
         );
     }
-    let stats = record
-        .get("stats")
-        .or_else(|| record.get("result").and_then(|result| result.get("stats")));
     Ok(parse_stats_events(
-        stats,
-        string_at(record, "model").as_deref(),
+        record.stats(),
+        record.model.as_deref(),
         &session_id,
-        timestamp_at(record, "timestamp").unwrap_or(fallback_timestamp),
+        record
+            .timestamp
+            .as_deref()
+            .and_then(crate::parse_ts_timestamp)
+            .unwrap_or(fallback_timestamp),
     ))
 }
 
@@ -92,32 +170,24 @@ pub(super) fn parse_jsonl_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
     let mut current_model = None::<String>;
     let mut events = Vec::new();
     let mut direct_event_indexes = HashMap::<String, usize>::new();
-    let content = fs::read_to_string(path)?;
-    for line in content.lines() {
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
-            continue;
-        };
-        let Some(record) = value.as_object() else {
-            continue;
-        };
-        if let Some(value) =
-            string_at(record, "sessionId").or_else(|| string_at(record, "session_id"))
-        {
+    let content = fs::read(path)?;
+    for record in jsonl::records::<GeminiRecord>(&content, None) {
+        if let Some(value) = record.session_id() {
             session_id = value;
         }
-        if let Some(model) = string_at(record, "model") {
+        if let Some(model) = record.model.clone() {
             current_model = Some(model);
         }
-        if record.get("type").and_then(Value::as_str) == Some("gemini") {
-            let Some(event) = parse_direct_event(
-                record,
+        if record.r#type.as_deref() == Some("gemini") {
+            let Some(event) = parse_direct_event_record(
+                &record,
                 current_model.as_deref(),
                 &session_id,
                 fallback_timestamp,
             ) else {
                 continue;
             };
-            if let Some(id) = string_at(record, "id") {
+            if let Some(id) = record.id.clone() {
                 if let Some(index) = direct_event_indexes.get(&id).copied() {
                     events[index] = event;
                 } else {
@@ -129,15 +199,17 @@ pub(super) fn parse_jsonl_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
             }
             continue;
         }
-        let stats = record
-            .get("stats")
-            .or_else(|| record.get("result").and_then(|result| result.get("stats")));
+        let stats = record.stats();
         if stats.is_some() {
             events.extend(parse_stats_events(
                 stats,
                 current_model.as_deref(),
                 &session_id,
-                timestamp_at(record, "timestamp").unwrap_or(fallback_timestamp),
+                record
+                    .timestamp
+                    .as_deref()
+                    .and_then(crate::parse_ts_timestamp)
+                    .unwrap_or(fallback_timestamp),
             ));
         }
     }
@@ -160,6 +232,37 @@ fn parse_direct_event(
         tokens,
         normalize_session_input,
         string_at(record, "id"),
+    )
+}
+
+/// Build a direct Gemini usage event from a typed [`GeminiRecord`].
+///
+/// Mirrors [`parse_direct_event`] for the top-level-record code paths where the
+/// envelope is already deserialized into a struct.
+fn parse_direct_event_record(
+    record: &GeminiRecord,
+    model_hint: Option<&str>,
+    session_id: &str,
+    fallback_timestamp: TimestampMs,
+) -> Option<GeminiUsageEvent> {
+    let tokens = parse_tokens(record.tokens.as_ref())?;
+    build_event(
+        record.model.as_deref().or(model_hint),
+        session_id,
+        record
+            .timestamp
+            .as_deref()
+            .and_then(crate::parse_ts_timestamp)
+            .or_else(|| {
+                record
+                    .created_at
+                    .as_deref()
+                    .and_then(crate::parse_ts_timestamp)
+            })
+            .unwrap_or(fallback_timestamp),
+        tokens,
+        normalize_session_input,
+        record.id.clone(),
     )
 }
 

--- a/rust/crates/ccusage/src/adapter/goose/parser.rs
+++ b/rust/crates/ccusage/src/adapter/goose/parser.rs
@@ -1,12 +1,21 @@
 use std::sync::Arc;
 
 use jiff::tz::TimeZone as JiffTimeZone;
-use serde_json::Value;
+use serde::Deserialize;
 
+use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, TokenUsageRaw, UsageEntry, UsageMessage, calculate_cost_for_usage,
     cli::CostMode, format_date_tz, missing_pricing_model_for_candidates,
 };
+
+/// Goose stores the per-session model selection as a JSON blob in the
+/// `model_config_json` column. Only the human-readable model name is consumed.
+#[derive(Debug, Deserialize)]
+struct GooseModelConfig {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model_name: Option<String>,
+}
 
 pub(super) fn row_to_entry(
     statement: &sqlite::Statement<'_>,
@@ -97,9 +106,8 @@ fn read_timestamp_value(statement: &sqlite::Statement<'_>, index: usize) -> Opti
 }
 
 fn parse_goose_model_config(value: &str) -> Option<String> {
-    let value = serde_json::from_str::<Value>(value).ok()?;
-    let model = value.get("model_name")?.as_str()?.trim();
-    (!model.is_empty()).then(|| model.to_string())
+    let config = serde_json::from_str::<GooseModelConfig>(value).ok()?;
+    config.model_name
 }
 
 fn parse_goose_timestamp(value: &str) -> Option<crate::TimestampMs> {

--- a/rust/crates/ccusage/src/adapter/jsonl.rs
+++ b/rust/crates/ccusage/src/adapter/jsonl.rs
@@ -1,0 +1,247 @@
+//! Shared JSONL parsing helpers for agent adapters.
+//!
+//! Adapters historically parsed each log line into a dynamic
+//! [`serde_json::Value`] and then hand-navigated it with `Value::get`. This
+//! module centralizes the faster gold-standard approach used by the Claude
+//! loader so every adapter shares the same optimizations:
+//!
+//! 1. Read the whole file once and split it into byte slices with
+//!    [`byte_lines`](crate::fast::byte_lines), avoiding a `String` allocation
+//!    per line.
+//! 2. Skip lines that cannot possibly match using a precompiled `memmem`
+//!    substring prefilter, before any JSON parsing happens.
+//! 3. Deserialize the surviving lines directly into a typed struct with
+//!    `serde_json::from_slice`, so unused fields are skipped instead of being
+//!    materialized into an intermediate `Value` tree.
+
+use memchr::memmem;
+use serde::{Deserialize, Deserializer, de::DeserializeOwned};
+
+use crate::fast::byte_lines;
+
+/// Iterate over deserialized JSONL records contained in `content`.
+///
+/// When `marker` is provided, lines that do not contain that byte substring are
+/// skipped before any JSON parsing, mirroring the per-line `memmem` prefilter
+/// used by the Claude loader. Pick a marker that appears in every line the
+/// adapter would accept (for example the required `"usage"` key) so the
+/// prefilter never drops a usable record. Pass `None` to parse every line.
+///
+/// Lines that fail to deserialize into `T` are silently skipped, matching the
+/// historical `serde_json::from_str::<Value>(line).ok()` behavior.
+///
+/// # Examples
+///
+/// ```ignore
+/// #[derive(serde::Deserialize)]
+/// struct Record {
+///     model: Option<String>,
+/// }
+///
+/// let content = b"{\"model\":\"qwen3-coder\"}\n{}\n";
+/// let models: Vec<_> = jsonl::records::<Record>(content, Some(b"model"))
+///     .filter_map(|record| record.model)
+///     .collect();
+/// assert_eq!(models, ["qwen3-coder"]);
+/// ```
+pub(crate) fn records<'data, T>(
+    content: &'data [u8],
+    marker: Option<&[u8]>,
+) -> impl Iterator<Item = T> + 'data
+where
+    T: DeserializeOwned + 'data,
+{
+    // Build the finder once and move it into the closure so the needle is
+    // compiled a single time and reused for every line in the file.
+    let finder = marker.map(|needle| memmem::Finder::new(needle).into_owned());
+    byte_lines(content).filter_map(move |line| {
+        if let Some(finder) = &finder
+            && finder.find(line).is_none()
+        {
+            return None;
+        }
+        serde_json::from_slice::<T>(line).ok()
+    })
+}
+
+/// Deserialize a JSON value into `u64` with the same lenient rules as
+/// [`serde_json::Value::as_u64`].
+///
+/// Non-negative integers that fit in `u64` are returned as-is; floats, strings,
+/// nulls, negative numbers, and missing values all become `0`. This reproduces
+/// the historical `json_value_u64(value.get(...))` behavior so typed structs
+/// match the previous dynamic-`Value` parsing instead of failing the whole line
+/// when a token count is encoded unexpectedly.
+///
+/// Use with `#[serde(default, deserialize_with = "jsonl::lenient_u64")]` so a
+/// missing field also defaults to `0`.
+pub(crate) fn lenient_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value
+        .as_ref()
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_default())
+}
+
+/// Deserialize a JSON value into `Option<i64>` with the same lenient rules as
+/// [`serde_json::Value::as_i64`].
+///
+/// Any integer that fits in `i64` is returned; floats, strings, nulls, and
+/// missing values become `None`. This reproduces the historical
+/// `Value::as_i64` navigation so an unexpectedly typed field does not fail the
+/// whole record.
+///
+/// Use with `#[serde(default, deserialize_with = "jsonl::lenient_i64")]`.
+pub(crate) fn lenient_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.as_ref().and_then(serde_json::Value::as_i64))
+}
+
+/// Deserialize a JSON value into `Option<f64>` with the same lenient rules as
+/// [`serde_json::Value::as_f64`].
+///
+/// Any JSON number yields a value; strings, nulls, and missing values become
+/// `None`. This reproduces the historical `Value::as_f64` navigation so an
+/// unexpectedly typed number (for example a cost field) does not fail the whole
+/// record.
+///
+/// Use with `#[serde(default, deserialize_with = "jsonl::lenient_f64")]`.
+pub(crate) fn lenient_f64<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.as_ref().and_then(serde_json::Value::as_f64))
+}
+
+/// Deserialize a JSON value into a trimmed, non-empty [`String`].
+///
+/// Mirrors [`crate::non_empty_json_string`]: non-string values and
+/// empty-after-trim strings become `None`, and surviving strings are trimmed.
+/// This keeps typed structs lenient about unexpected field types instead of
+/// erroring on the whole line.
+///
+/// Use with `#[serde(default, deserialize_with = "jsonl::non_empty_string")]`.
+pub(crate) fn non_empty_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(crate::non_empty_json_string(value.as_ref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::{lenient_f64, lenient_i64, lenient_u64, non_empty_string, records};
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct Record {
+        #[serde(default, deserialize_with = "non_empty_string")]
+        model: Option<String>,
+        #[serde(default, deserialize_with = "lenient_u64")]
+        tokens: u64,
+    }
+
+    #[test]
+    fn records_skips_lines_without_marker() {
+        let content =
+            b"{\"model\":\"a\",\"tokens\":1}\n{\"other\":true}\n{\"model\":\"b\",\"tokens\":2}\n";
+        let parsed = records::<Record>(content, Some(b"model")).collect::<Vec<_>>();
+
+        assert_eq!(
+            parsed,
+            [
+                Record {
+                    model: Some("a".to_string()),
+                    tokens: 1,
+                },
+                Record {
+                    model: Some("b".to_string()),
+                    tokens: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn records_skips_unparsable_lines() {
+        let content = b"{\"tokens\":1}\nnot json\n{\"tokens\":2}\n";
+        let parsed = records::<Record>(content, None).collect::<Vec<_>>();
+
+        assert_eq!(
+            parsed
+                .iter()
+                .map(|record| record.tokens)
+                .collect::<Vec<_>>(),
+            [1, 2]
+        );
+    }
+
+    #[test]
+    fn lenient_u64_matches_value_as_u64() {
+        let coerce = |raw: &str| {
+            serde_json::from_str::<Record>(&format!("{{\"tokens\":{raw}}}"))
+                .unwrap()
+                .tokens
+        };
+
+        assert_eq!(coerce("42"), 42);
+        assert_eq!(coerce("12.5"), 0);
+        assert_eq!(coerce("-1"), 0);
+        assert_eq!(coerce("\"7\""), 0);
+        assert_eq!(coerce("null"), 0);
+    }
+
+    #[test]
+    fn lenient_i64_and_f64_match_value_accessors() {
+        #[derive(Deserialize)]
+        struct Numbers {
+            #[serde(default, deserialize_with = "lenient_i64")]
+            created: Option<i64>,
+            #[serde(default, deserialize_with = "lenient_f64")]
+            cost: Option<f64>,
+        }
+
+        let parse = |raw: &str| serde_json::from_str::<Numbers>(raw).unwrap();
+
+        let both = parse("{\"created\":-5,\"cost\":1.5}");
+        assert_eq!(both.created, Some(-5));
+        assert_eq!(both.cost, Some(1.5));
+
+        // i64 rejects floats; f64 accepts any number.
+        let mixed = parse("{\"created\":1.5,\"cost\":7}");
+        assert_eq!(mixed.created, None);
+        assert_eq!(mixed.cost, Some(7.0));
+
+        // Strings, nulls, and missing values all become None.
+        let strings = parse("{\"created\":\"3\",\"cost\":\"x\"}");
+        assert_eq!(strings.created, None);
+        assert_eq!(strings.cost, None);
+
+        let missing = parse("{}");
+        assert_eq!(missing.created, None);
+        assert_eq!(missing.cost, None);
+    }
+
+    #[test]
+    fn non_empty_string_trims_and_drops_empty() {
+        let parse = |raw: &str| {
+            serde_json::from_str::<Record>(&format!("{{\"model\":{raw}}}"))
+                .unwrap()
+                .model
+        };
+
+        assert_eq!(parse("\"  qwen  \""), Some("qwen".to_string()));
+        assert_eq!(parse("\"   \""), None);
+        assert_eq!(parse("123"), None);
+        assert_eq!(parse("null"), None);
+    }
+}

--- a/rust/crates/ccusage/src/adapter/jsonl.rs
+++ b/rust/crates/ccusage/src/adapter/jsonl.rs
@@ -117,6 +117,29 @@ where
     Ok(value.as_ref().and_then(serde_json::Value::as_f64))
 }
 
+/// Deserialize a nested JSON object into `Option<T>` leniently.
+///
+/// JSON objects are deserialized into `T`; any non-object value (number,
+/// string, array, bool), nulls, and missing values become `None`. An object
+/// that fails to deserialize into `T` also yields `None` rather than failing
+/// the whole record. This reproduces the historical
+/// `Value::get(...).map_or(.., ..)` navigation, where a malformed nested object
+/// was simply treated as absent instead of discarding an otherwise usable
+/// record.
+///
+/// Use with `#[serde(default, deserialize_with = "jsonl::lenient_object")]`.
+pub(crate) fn lenient_object<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializeOwned,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(match value {
+        Some(value @ serde_json::Value::Object(_)) => serde_json::from_value(value).ok(),
+        _ => None,
+    })
+}
+
 /// Deserialize a JSON value into a trimmed, non-empty [`String`].
 ///
 /// Mirrors [`crate::non_empty_json_string`]: non-string values and
@@ -137,7 +160,7 @@ where
 mod tests {
     use serde::Deserialize;
 
-    use super::{lenient_f64, lenient_i64, lenient_u64, non_empty_string, records};
+    use super::{lenient_f64, lenient_i64, lenient_object, lenient_u64, non_empty_string, records};
     use crate::fast::LinePrefilter;
 
     #[derive(Debug, PartialEq, Deserialize)]
@@ -228,6 +251,53 @@ mod tests {
         let missing = parse("{}");
         assert_eq!(missing.created, None);
         assert_eq!(missing.cost, None);
+    }
+
+    #[test]
+    fn lenient_object_keeps_record_when_nested_field_is_not_an_object() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Nested {
+            #[serde(default, deserialize_with = "lenient_u64")]
+            read: u64,
+        }
+
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Outer {
+            #[serde(default, deserialize_with = "lenient_object")]
+            cache: Option<Nested>,
+            #[serde(default, deserialize_with = "lenient_u64")]
+            input: u64,
+        }
+
+        let parse = |raw: &str| serde_json::from_str::<Outer>(raw).unwrap();
+
+        // A real object deserializes as expected.
+        assert_eq!(
+            parse("{\"cache\":{\"read\":5},\"input\":7}"),
+            Outer {
+                cache: Some(Nested { read: 5 }),
+                input: 7,
+            }
+        );
+
+        // Non-object cache payloads become None instead of failing the record,
+        // preserving the sibling `input` value.
+        for raw in [
+            "{\"cache\":5,\"input\":7}",
+            "{\"cache\":\"oops\",\"input\":7}",
+            "{\"cache\":[1,2],\"input\":7}",
+            "{\"cache\":null,\"input\":7}",
+            "{\"input\":7}",
+        ] {
+            assert_eq!(
+                parse(raw),
+                Outer {
+                    cache: None,
+                    input: 7,
+                },
+                "raw: {raw}"
+            );
+        }
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/jsonl.rs
+++ b/rust/crates/ccusage/src/adapter/jsonl.rs
@@ -14,17 +14,16 @@
 //!    `serde_json::from_slice`, so unused fields are skipped instead of being
 //!    materialized into an intermediate `Value` tree.
 
-use memchr::memmem;
 use serde::{Deserialize, Deserializer, de::DeserializeOwned};
 
-use crate::fast::byte_lines;
+use crate::fast::{LinePrefilter, byte_lines};
 
 /// Iterate over deserialized JSONL records contained in `content`.
 ///
-/// When `marker` is provided, lines that do not contain that byte substring are
-/// skipped before any JSON parsing, mirroring the per-line `memmem` prefilter
-/// used by the Claude loader. Pick a marker that appears in every line the
-/// adapter would accept (for example the required `"usage"` key) so the
+/// When `prefilter` is provided, lines that it rejects are skipped before any
+/// JSON parsing, mirroring the per-line `memmem` prefilter used by the Claude
+/// loader. Build the [`LinePrefilter`] from markers that appear in every line
+/// the adapter would accept (for example the required `"usage"` key) so the
 /// prefilter never drops a usable record. Pass `None` to parse every line.
 ///
 /// Lines that fail to deserialize into `T` are silently skipped, matching the
@@ -39,24 +38,22 @@ use crate::fast::byte_lines;
 /// }
 ///
 /// let content = b"{\"model\":\"qwen3-coder\"}\n{}\n";
-/// let models: Vec<_> = jsonl::records::<Record>(content, Some(b"model"))
+/// let prefilter = LinePrefilter::all(&[b"model"]);
+/// let models: Vec<_> = jsonl::records::<Record>(content, Some(&prefilter))
 ///     .filter_map(|record| record.model)
 ///     .collect();
 /// assert_eq!(models, ["qwen3-coder"]);
 /// ```
 pub(crate) fn records<'data, T>(
     content: &'data [u8],
-    marker: Option<&[u8]>,
+    prefilter: Option<&'data LinePrefilter>,
 ) -> impl Iterator<Item = T> + 'data
 where
     T: DeserializeOwned + 'data,
 {
-    // Build the finder once and move it into the closure so the needle is
-    // compiled a single time and reused for every line in the file.
-    let finder = marker.map(|needle| memmem::Finder::new(needle).into_owned());
     byte_lines(content).filter_map(move |line| {
-        if let Some(finder) = &finder
-            && finder.find(line).is_none()
+        if let Some(prefilter) = prefilter
+            && !prefilter.matches(line)
         {
             return None;
         }
@@ -141,6 +138,7 @@ mod tests {
     use serde::Deserialize;
 
     use super::{lenient_f64, lenient_i64, lenient_u64, non_empty_string, records};
+    use crate::fast::LinePrefilter;
 
     #[derive(Debug, PartialEq, Deserialize)]
     struct Record {
@@ -154,7 +152,8 @@ mod tests {
     fn records_skips_lines_without_marker() {
         let content =
             b"{\"model\":\"a\",\"tokens\":1}\n{\"other\":true}\n{\"model\":\"b\",\"tokens\":2}\n";
-        let parsed = records::<Record>(content, Some(b"model")).collect::<Vec<_>>();
+        let prefilter = LinePrefilter::all(&[b"model"]);
+        let parsed = records::<Record>(content, Some(&prefilter)).collect::<Vec<_>>();
 
         assert_eq!(
             parsed,

--- a/rust/crates/ccusage/src/adapter/jsonl.rs
+++ b/rust/crates/ccusage/src/adapter/jsonl.rs
@@ -140,6 +140,51 @@ where
     })
 }
 
+/// Deserialize a JSON array into `Option<Vec<T>>` leniently, skipping elements
+/// that fail to deserialize into `T`.
+///
+/// A JSON array yields `Some(vec)` containing only the elements that
+/// successfully deserialize (malformed entries are dropped, not fatal); any
+/// non-array value, null, and missing values become `None`. This reproduces the
+/// historical `Value::as_array` navigation, where a non-array field was treated
+/// as absent and individual bad elements were skipped instead of discarding the
+/// whole record. The `Some`/`None` distinction lets callers tell an array that
+/// was present (even if empty) apart from a missing or non-array field.
+///
+/// Use with `#[serde(default, deserialize_with = "jsonl::lenient_array")]`.
+pub(crate) fn lenient_array<'de, D, T>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializeOwned,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(match value {
+        Some(serde_json::Value::Array(items)) => Some(
+            items
+                .into_iter()
+                .filter_map(|item| serde_json::from_value(item).ok())
+                .collect(),
+        ),
+        _ => None,
+    })
+}
+
+/// Deserialize a JSON array into `Vec<T>` leniently, skipping elements that fail
+/// to deserialize into `T`.
+///
+/// Like [`lenient_array`] but collapses the missing/non-array case to an empty
+/// `Vec` for callers that do not need to distinguish a present-but-empty array
+/// from an absent field.
+///
+/// Use with `#[serde(default, deserialize_with = "jsonl::lenient_vec")]`.
+pub(crate) fn lenient_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializeOwned,
+{
+    Ok(lenient_array(deserializer)?.unwrap_or_default())
+}
+
 /// Deserialize a JSON value into a trimmed, non-empty [`String`].
 ///
 /// Mirrors [`crate::non_empty_json_string`]: non-string values and
@@ -160,7 +205,10 @@ where
 mod tests {
     use serde::Deserialize;
 
-    use super::{lenient_f64, lenient_i64, lenient_object, lenient_u64, non_empty_string, records};
+    use super::{
+        lenient_array, lenient_f64, lenient_i64, lenient_object, lenient_u64, lenient_vec,
+        non_empty_string, records,
+    };
     use crate::fast::LinePrefilter;
 
     #[derive(Debug, PartialEq, Deserialize)]
@@ -297,6 +345,52 @@ mod tests {
                 },
                 "raw: {raw}"
             );
+        }
+    }
+
+    #[test]
+    fn lenient_array_and_vec_skip_bad_elements_and_tolerate_non_arrays() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Item {
+            #[serde(default, deserialize_with = "lenient_u64")]
+            value: u64,
+        }
+
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Outer {
+            #[serde(default, deserialize_with = "lenient_array")]
+            optional: Option<Vec<Item>>,
+            #[serde(default, deserialize_with = "lenient_vec")]
+            required: Vec<Item>,
+        }
+
+        let parse = |raw: &str| serde_json::from_str::<Outer>(raw).unwrap();
+
+        // Non-object array elements are skipped instead of failing the record.
+        let mixed =
+            parse(r#"{"optional":[{"value":1},"oops",{"value":2}],"required":[3,{"value":4}]}"#);
+        assert_eq!(
+            mixed.optional,
+            Some(vec![Item { value: 1 }, Item { value: 2 }])
+        );
+        assert_eq!(mixed.required, vec![Item { value: 4 }]);
+
+        // A present-but-empty array stays distinguishable from a missing field
+        // for `lenient_array`, while `lenient_vec` collapses both to an empty
+        // vec.
+        let empty = parse(r#"{"optional":[],"required":[]}"#);
+        assert_eq!(empty.optional, Some(vec![]));
+        assert_eq!(empty.required, vec![]);
+
+        // Non-array and missing values become None / empty without erroring.
+        for raw in [
+            r#"{"optional":5,"required":"nope"}"#,
+            r#"{"optional":null,"required":null}"#,
+            r#"{}"#,
+        ] {
+            let parsed = parse(raw);
+            assert_eq!(parsed.optional, None, "raw: {raw}");
+            assert_eq!(parsed.required, Vec::<Item>::new(), "raw: {raw}");
         }
     }
 

--- a/rust/crates/ccusage/src/adapter/kilo/loader.rs
+++ b/rust/crates/ccusage/src/adapter/kilo/loader.rs
@@ -1,12 +1,11 @@
 use std::{collections::HashSet, path::Path};
 
 use jiff::tz::TimeZone as JiffTimeZone;
-use serde_json::Value;
 
 use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz};
 
 use super::{
-    parser::message_value_to_entry,
+    parser::{KiloMessage, message_value_to_entry},
     paths::{db_path, paths},
 };
 
@@ -72,7 +71,7 @@ fn load_entries_from_database(
                 let Ok(data) = statement.read::<String, _>(2) else {
                     continue;
                 };
-                let Ok(value) = serde_json::from_str::<Value>(&data) else {
+                let Ok(value) = serde_json::from_str::<KiloMessage>(&data) else {
                     continue;
                 };
                 if let Some(entry) = message_value_to_entry(

--- a/rust/crates/ccusage/src/adapter/kilo/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kilo/parser.rs
@@ -1,16 +1,75 @@
 use std::{path::Path, sync::Arc};
 
 use jiff::tz::TimeZone as JiffTimeZone;
-use serde_json::Value;
+use serde::Deserialize;
 
+use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_candidates, non_empty_json_string,
+    missing_pricing_model_for_candidates,
 };
 
+/// A single parsed Kilo message row payload. Only the fields ccusage consumes
+/// are declared; serde skips everything else.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct KiloMessage {
+    #[serde(default)]
+    role: Option<String>,
+    tokens: Option<KiloTokens>,
+    #[serde(
+        rename = "modelID",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    model_id: Option<String>,
+    time: Option<KiloTime>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    session_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::lenient_f64")]
+    cost: Option<f64>,
+    #[serde(
+        rename = "providerID",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    provider_id: Option<String>,
+}
+
+/// Token usage block carried by Kilo assistant messages.
+#[derive(Debug, Default, Deserialize)]
+struct KiloTokens {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output: u64,
+    cache: Option<KiloCache>,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    reasoning: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    total: u64,
+}
+
+/// Cache read/write counts nested under Kilo token usage.
+#[derive(Debug, Default, Deserialize)]
+struct KiloCache {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    read: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    write: u64,
+}
+
+/// Creation timestamp block carried by Kilo messages.
+#[derive(Debug, Default, Deserialize)]
+struct KiloTime {
+    #[serde(default, deserialize_with = "jsonl::lenient_i64")]
+    created: Option<i64>,
+}
+
 pub(super) fn message_value_to_entry(
-    value: &Value,
+    value: &KiloMessage,
     row_id: &str,
     row_session_id: &str,
     db_path: &Path,
@@ -18,24 +77,21 @@ pub(super) fn message_value_to_entry(
     mode: CostMode,
     pricing: &PricingMap,
 ) -> Option<LoadedEntry> {
-    if value.get("role").and_then(Value::as_str) != Some("assistant") {
+    if value.role.as_deref() != Some("assistant") {
         return None;
     }
-    let tokens = value.get("tokens")?;
+    let tokens = value.tokens.as_ref()?;
+    let cache = tokens.cache.as_ref();
     let usage = TokenUsageRaw {
-        input_tokens: json_value_u64(tokens.get("input")),
-        output_tokens: json_value_u64(tokens.get("output")),
-        cache_creation_input_tokens: tokens
-            .get("cache")
-            .map_or(0, |cache| json_value_u64(cache.get("write"))),
-        cache_read_input_tokens: tokens
-            .get("cache")
-            .map_or(0, |cache| json_value_u64(cache.get("read"))),
+        input_tokens: tokens.input,
+        output_tokens: tokens.output,
+        cache_creation_input_tokens: cache.map_or(0, |cache| cache.write),
+        cache_read_input_tokens: cache.map_or(0, |cache| cache.read),
         speed: None,
         cache_creation: None,
     };
-    let reasoning_tokens = json_value_u64(tokens.get("reasoning"));
-    let total_tokens = json_value_u64(tokens.get("total"));
+    let reasoning_tokens = tokens.reasoning;
+    let total_tokens = tokens.total;
     let (usage, extra_total_tokens) =
         apply_total_token_fallback(usage, reasoning_tokens, total_tokens);
     if usage.input_tokens == 0
@@ -46,18 +102,22 @@ pub(super) fn message_value_to_entry(
     {
         return None;
     }
-    let model = non_empty_json_string(value.get("modelID"))?;
+    let model = value.model_id.clone()?;
     let timestamp = value
-        .get("time")
-        .and_then(|time| time.get("created"))
-        .and_then(Value::as_i64)
+        .time
+        .as_ref()
+        .and_then(|time| time.created)
         .and_then(normalize_timestamp)?;
     let timestamp_text = crate::format_rfc3339_millis(timestamp);
-    let session_id = non_empty_json_string(value.get("session_id"))
+    let session_id = value
+        .session_id
+        .clone()
         .unwrap_or_else(|| row_session_id.to_string());
-    let message_id = non_empty_json_string(value.get("id"))
+    let message_id = value
+        .id
+        .clone()
         .unwrap_or_else(|| format!("{}:{row_id}", db_path.display()));
-    let cost_usd = value.get("cost").and_then(Value::as_f64);
+    let cost_usd = value.cost;
     let data = UsageEntry {
         session_id: Some(session_id.clone()),
         timestamp: timestamp_text,
@@ -72,7 +132,7 @@ pub(super) fn message_value_to_entry(
         is_api_error_message: None,
         is_sidechain: None,
     };
-    let provider = non_empty_json_string(value.get("providerID"));
+    let provider = value.provider_id.clone();
     let cost_data = UsageEntry {
         message: UsageMessage {
             usage: TokenUsageRaw {
@@ -201,14 +261,15 @@ mod tests {
 
     #[test]
     fn falls_back_to_total_tokens_when_kilo_parts_are_missing() {
-        let value = serde_json::json!({
+        let value = serde_json::from_value::<KiloMessage>(serde_json::json!({
             "id": "msg-1",
             "role": "assistant",
             "providerID": "openai",
             "modelID": "gpt-5",
             "time": { "created": 1767312000000_i64 },
             "tokens": { "total": 234 }
-        });
+        }))
+        .unwrap();
         let entry = message_value_to_entry(
             &value,
             "row-1",

--- a/rust/crates/ccusage/src/adapter/kilo/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kilo/parser.rs
@@ -16,6 +16,7 @@ use crate::{
 pub(super) struct KiloMessage {
     #[serde(default)]
     role: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
     tokens: Option<KiloTokens>,
     #[serde(
         rename = "modelID",
@@ -23,6 +24,7 @@ pub(super) struct KiloMessage {
         deserialize_with = "jsonl::non_empty_string"
     )]
     model_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
     time: Option<KiloTime>,
     #[serde(default, deserialize_with = "jsonl::non_empty_string")]
     session_id: Option<String>,
@@ -45,6 +47,7 @@ struct KiloTokens {
     input: u64,
     #[serde(default, deserialize_with = "jsonl::lenient_u64")]
     output: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
     cache: Option<KiloCache>,
     #[serde(default, deserialize_with = "jsonl::lenient_u64")]
     reasoning: u64,
@@ -258,6 +261,34 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+
+    #[test]
+    fn keeps_kilo_record_when_cache_field_is_not_an_object() {
+        let value = serde_json::from_value::<KiloMessage>(serde_json::json!({
+            "id": "msg-1",
+            "role": "assistant",
+            "providerID": "openai",
+            "modelID": "gpt-5",
+            "time": { "created": 1767312000000_i64 },
+            "tokens": { "input": 100, "output": 10, "cache": 0 }
+        }))
+        .unwrap();
+        let entry = message_value_to_entry(
+            &value,
+            "row-1",
+            "session-a",
+            Path::new("/tmp/kilo.db"),
+            None,
+            CostMode::Auto,
+            &PricingMap::load_embedded(),
+        )
+        .unwrap();
+
+        assert_eq!(entry.data.message.usage.input_tokens, 100);
+        assert_eq!(entry.data.message.usage.output_tokens, 10);
+        assert_eq!(entry.data.message.usage.cache_creation_input_tokens, 0);
+        assert_eq!(entry.data.message.usage.cache_read_input_tokens, 0);
+    }
 
     #[test]
     fn falls_back_to_total_tokens_when_kilo_parts_are_missing() {

--- a/rust/crates/ccusage/src/adapter/kimi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/parser.rs
@@ -10,18 +10,13 @@ use serde::Deserialize;
 use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
-    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    missing_pricing_model_for_candidates,
+    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, fast::LinePrefilter,
+    format_date_tz, missing_pricing_model_for_candidates,
 };
 
 const DEFAULT_MODEL: &str = "kimi-for-coding";
 const DEFAULT_PROVIDER: &str = "moonshot";
 const KIMI_FOR_CODING_K2_6_CUTOFF_MS: i64 = 1_776_698_890_072;
-
-/// Cheap substring prefilter: every usable Kimi wire line carries a token usage
-/// payload under the `token_usage` key, so lines without it are skipped before
-/// JSON parsing.
-const KIMI_TOKEN_USAGE_MARKER: &[u8] = b"\"token_usage\"";
 
 /// Kimi `config.json` document, used to read the configured display model.
 #[derive(Debug, Deserialize)]
@@ -90,11 +85,12 @@ pub(super) fn read_wire_file(path: &Path) -> Result<Vec<KimiUsageEntry>> {
     let model = read_model_from_config(path);
     let fallback_timestamp = file_modified_timestamp(path);
     let content = fs::read(path)?;
-    Ok(
-        jsonl::records::<KimiWireLine>(&content, Some(KIMI_TOKEN_USAGE_MARKER))
-            .filter_map(|line| wire_line_to_entry(&line, path, &model, fallback_timestamp))
-            .collect::<Vec<_>>(),
-    )
+    // Usable Kimi wire lines are `StatusUpdate` records carrying a
+    // `token_usage` payload, so require both substrings before JSON parsing.
+    let prefilter = LinePrefilter::all(&[br#""StatusUpdate""#, br#""token_usage""#]);
+    Ok(jsonl::records::<KimiWireLine>(&content, Some(&prefilter))
+        .filter_map(|line| wire_line_to_entry(&line, path, &model, fallback_timestamp))
+        .collect::<Vec<_>>())
 }
 
 fn read_model_from_config(file_path: &Path) -> String {

--- a/rust/crates/ccusage/src/adapter/kimi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/parser.rs
@@ -5,17 +5,72 @@ use std::{
 };
 
 use jiff::tz::TimeZone as JiffTimeZone;
-use serde_json::Value;
+use serde::Deserialize;
 
+use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_candidates, non_empty_json_string,
+    missing_pricing_model_for_candidates,
 };
 
 const DEFAULT_MODEL: &str = "kimi-for-coding";
 const DEFAULT_PROVIDER: &str = "moonshot";
 const KIMI_FOR_CODING_K2_6_CUTOFF_MS: i64 = 1_776_698_890_072;
+
+/// Cheap substring prefilter: every usable Kimi wire line carries a token usage
+/// payload under the `token_usage` key, so lines without it are skipped before
+/// JSON parsing.
+const KIMI_TOKEN_USAGE_MARKER: &[u8] = b"\"token_usage\"";
+
+/// Kimi `config.json` document, used to read the configured display model.
+#[derive(Debug, Deserialize)]
+struct KimiConfig {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model: Option<String>,
+}
+
+/// A single Kimi wire JSONL line. Only the fields ccusage consumes are declared;
+/// serde skips everything else.
+#[derive(Debug, Deserialize)]
+struct KimiWireLine {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    r#type: Option<String>,
+    message: Option<KimiWireMessage>,
+    #[serde(default, deserialize_with = "jsonl::lenient_f64")]
+    timestamp: Option<f64>,
+}
+
+/// The `message` block carried by a Kimi wire line.
+#[derive(Debug, Deserialize)]
+struct KimiWireMessage {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    r#type: Option<String>,
+    payload: Option<KimiWirePayload>,
+}
+
+/// The `message.payload` block carrying token usage and the message id.
+#[derive(Debug, Deserialize)]
+struct KimiWirePayload {
+    token_usage: Option<KimiTokenUsage>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    message_id: Option<String>,
+}
+
+/// Token counts reported under `message.payload.token_usage`.
+#[derive(Debug, Default, Deserialize)]
+struct KimiTokenUsage {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input_other: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input_cache_creation: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input_cache_read: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    total: u64,
+}
 
 #[derive(Debug, Clone)]
 pub(super) struct KimiUsageEntry {
@@ -34,13 +89,12 @@ pub(super) struct KimiUsageEntry {
 pub(super) fn read_wire_file(path: &Path) -> Result<Vec<KimiUsageEntry>> {
     let model = read_model_from_config(path);
     let fallback_timestamp = file_modified_timestamp(path);
-    let content = fs::read_to_string(path)?;
-    Ok(content
-        .lines()
-        .filter(|line| line.contains("\"StatusUpdate\"") && line.contains("\"token_usage\""))
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .filter_map(|value| wire_line_to_entry(&value, path, &model, fallback_timestamp))
-        .collect::<Vec<_>>())
+    let content = fs::read(path)?;
+    Ok(
+        jsonl::records::<KimiWireLine>(&content, Some(KIMI_TOKEN_USAGE_MARKER))
+            .filter_map(|line| wire_line_to_entry(&line, path, &model, fallback_timestamp))
+            .collect::<Vec<_>>(),
+    )
 }
 
 fn read_model_from_config(file_path: &Path) -> String {
@@ -50,10 +104,10 @@ fn read_model_from_config(file_path: &Path) -> String {
     let Ok(content) = fs::read_to_string(root.join("config.json")) else {
         return DEFAULT_MODEL.to_string();
     };
-    let Ok(value) = serde_json::from_str::<Value>(&content) else {
+    let Ok(config) = serde_json::from_str::<KimiConfig>(&content) else {
         return DEFAULT_MODEL.to_string();
     };
-    non_empty_json_string(value.get("model")).unwrap_or_else(|| DEFAULT_MODEL.to_string())
+    config.model.unwrap_or_else(|| DEFAULT_MODEL.to_string())
 }
 
 fn kimi_root_from_wire_path(file_path: &Path) -> Option<PathBuf> {
@@ -76,25 +130,25 @@ fn file_modified_timestamp(path: &Path) -> TimestampMs {
 }
 
 fn wire_line_to_entry(
-    value: &Value,
+    line: &KimiWireLine,
     file_path: &Path,
     model: &str,
     fallback_timestamp: TimestampMs,
 ) -> Option<KimiUsageEntry> {
-    if value.get("type").and_then(Value::as_str) == Some("metadata") {
+    if line.r#type.as_deref() == Some("metadata") {
         return None;
     }
-    let message = value.get("message")?;
-    if message.get("type").and_then(Value::as_str) != Some("StatusUpdate") {
+    let message = line.message.as_ref()?;
+    if message.r#type.as_deref() != Some("StatusUpdate") {
         return None;
     }
-    let payload = message.get("payload")?;
-    let token_usage = payload.get("token_usage")?;
-    let input_tokens = json_value_u64(token_usage.get("input_other"));
-    let output_tokens = json_value_u64(token_usage.get("output"));
-    let cache_creation_tokens = json_value_u64(token_usage.get("input_cache_creation"));
-    let cache_read_tokens = json_value_u64(token_usage.get("input_cache_read"));
-    let total_tokens = json_value_u64(token_usage.get("total"));
+    let payload = message.payload.as_ref()?;
+    let token_usage = payload.token_usage.as_ref()?;
+    let input_tokens = token_usage.input_other;
+    let output_tokens = token_usage.output;
+    let cache_creation_tokens = token_usage.input_cache_creation;
+    let cache_read_tokens = token_usage.input_cache_read;
+    let total_tokens = token_usage.total;
     let usage = TokenUsageRaw {
         input_tokens,
         output_tokens,
@@ -107,9 +161,8 @@ fn wire_line_to_entry(
     if crate::total_usage_tokens(usage) + extra_total_tokens == 0 {
         return None;
     }
-    let timestamp = value
-        .get("timestamp")
-        .and_then(Value::as_f64)
+    let timestamp = line
+        .timestamp
         .and_then(timestamp_from_seconds)
         .unwrap_or(fallback_timestamp);
     Some(KimiUsageEntry {
@@ -117,7 +170,7 @@ fn wire_line_to_entry(
         timestamp_text: crate::format_rfc3339_millis(timestamp),
         session_id: extract_session_id(file_path),
         model: model.to_string(),
-        message_id: non_empty_json_string(payload.get("message_id")),
+        message_id: payload.message_id.clone(),
         input_tokens: usage.input_tokens,
         output_tokens: usage.output_tokens,
         cache_creation_tokens: usage.cache_creation_input_tokens,
@@ -285,7 +338,7 @@ mod tests {
             "sessions/group/session-a/wire.jsonl": "",
         });
         let file = fixture.path("sessions/group/session-a/wire.jsonl");
-        let value = serde_json::json!({
+        let line = serde_json::from_value::<KimiWireLine>(serde_json::json!({
             "timestamp": 1770983427.123,
             "message": {
                 "type": "StatusUpdate",
@@ -295,9 +348,10 @@ mod tests {
                     }
                 }
             }
-        });
+        }))
+        .unwrap();
 
-        let entry = wire_line_to_entry(&value, &file, "kimi-k2", TimestampMs::UNIX_EPOCH).unwrap();
+        let entry = wire_line_to_entry(&line, &file, "kimi-k2", TimestampMs::UNIX_EPOCH).unwrap();
 
         assert_eq!(entry.output_tokens, 432);
         assert_eq!(entry.extra_total_tokens, 0);

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod droid;
 pub(crate) mod gemini;
 pub(crate) mod goose;
 pub(crate) mod hermes;
+pub(crate) mod jsonl;
 pub(crate) mod kilo;
 pub(crate) mod kimi;
 pub(crate) mod openclaw;

--- a/rust/crates/ccusage/src/adapter/openclaw/parser.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/parser.rs
@@ -33,6 +33,11 @@ struct OpenClawLine {
     model: Option<String>,
     #[serde(default, deserialize_with = "jsonl::non_empty_string")]
     provider: Option<String>,
+    // A non-object `message` previously navigated to no usage without dropping
+    // the line, so deserialize it leniently. Otherwise a malformed `message` on
+    // a model-tracking line would fail the whole record and lose the
+    // model/provider state update for subsequent usage entries.
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
     message: Option<OpenClawMessage>,
     timestamp: Option<Value>,
 }
@@ -381,7 +386,32 @@ pub(super) fn entry_id(entry: &LoadedEntry) -> String {
 
 #[cfg(test)]
 mod tests {
+    use ccusage_test_support::fs_fixture;
+
     use super::*;
+
+    #[test]
+    fn malformed_message_does_not_drop_model_tracking_line() {
+        // A `model_change` line whose `message` field is a non-object must still
+        // deserialize and update the tracked model/provider, instead of being
+        // dropped by `records().ok()` and losing state for later usage entries.
+        let fixture = fs_fixture!({
+            "session.jsonl": concat!(
+                r#"{"type":"model_change","modelId":"gpt-5.2","provider":"openai","message":"not-an-object"}"#,
+                "\n",
+                r#"{"type":"message","message":{"role":"assistant","usage":{"input":10,"output":20}}}"#,
+                "\n",
+            ),
+        });
+        let file = fixture.path("session.jsonl");
+
+        let entries = parse_session_file(&file, None, CostMode::Auto, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].model.as_deref(), Some("[openclaw] gpt-5.2"));
+        assert_eq!(entries[0].data.version.as_deref(), Some("openai"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 10);
+    }
 
     #[test]
     fn falls_back_to_total_tokens_when_openclaw_parts_are_missing() {

--- a/rust/crates/ccusage/src/adapter/openclaw/parser.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/parser.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
-    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    missing_pricing_model_for_usage,
+    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, fast::LinePrefilter,
+    format_date_tz, missing_pricing_model_for_usage,
 };
 
 /// A single parsed OpenClaw session line. Only the fields ccusage consumes are
@@ -164,10 +164,15 @@ pub(super) fn parse_session_file(
     let session_id = extract_session_id(path);
     let fallback_timestamp = file_modified_timestamp(path);
     let content = fs::read(path)?;
+    // OpenClaw lines that matter are either model-tracking records
+    // (`model_change`/`model-snapshot`) or assistant records carrying `usage`,
+    // so admit lines containing any of those substrings before JSON parsing.
+    let prefilter =
+        LinePrefilter::any(&[br#""model_change""#, br#""model-snapshot""#, br#""usage""#]);
     let mut current_model = None::<String>;
     let mut current_provider = None::<String>;
     let mut entries = Vec::new();
-    for record in jsonl::records::<OpenClawLine>(&content, None) {
+    for record in jsonl::records::<OpenClawLine>(&content, Some(&prefilter)) {
         if is_model_change(&record) {
             let (source_model_id, source_model, source_provider) = match record.data.as_ref() {
                 Some(source) => (

--- a/rust/crates/ccusage/src/adapter/openclaw/parser.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/parser.rs
@@ -1,18 +1,144 @@
-use std::{
-    fs,
-    io::{BufRead, BufReader},
-    path::Path,
-    sync::Arc,
-};
+use std::{fs, path::Path, sync::Arc};
 
 use jiff::tz::TimeZone as JiffTimeZone;
-use serde_json::{Map, Value};
+use serde::Deserialize;
+use serde_json::Value;
 
+use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_usage, non_empty_json_string,
+    missing_pricing_model_for_usage,
 };
+
+/// A single parsed OpenClaw session line. Only the fields ccusage consumes are
+/// declared; serde skips everything else. Both `model_change`/`model-snapshot`
+/// records and assistant `message` records share this struct so the stateful
+/// model/provider tracking can read either shape in order.
+#[derive(Debug, Default, Deserialize)]
+struct OpenClawLine {
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(rename = "customType", default)]
+    custom_type: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_model_source")]
+    data: Option<OpenClawModelSource>,
+    #[serde(
+        rename = "modelId",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    model_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    provider: Option<String>,
+    message: Option<OpenClawMessage>,
+    timestamp: Option<Value>,
+}
+
+/// Deserialize the `data` block of a model-change record, mirroring the
+/// historical `Value::as_object` navigation: only JSON objects yield a source,
+/// while any other shape (or a missing key) becomes `None` instead of failing
+/// the whole line.
+fn deserialize_model_source<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<OpenClawModelSource>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|value| {
+        value
+            .is_object()
+            .then(|| serde_json::from_value(value).ok())
+            .flatten()
+    }))
+}
+
+/// Model/provider fields carried either at the root of a `model_change` record
+/// or nested under its `data` key.
+#[derive(Debug, Default, Deserialize)]
+struct OpenClawModelSource {
+    #[serde(
+        rename = "modelId",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    model_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    provider: Option<String>,
+}
+
+/// Assistant message payload carrying token usage and per-message metadata.
+#[derive(Debug, Default, Deserialize)]
+struct OpenClawMessage {
+    #[serde(default)]
+    role: Option<String>,
+    usage: Option<OpenClawUsage>,
+    timestamp: Option<Value>,
+    #[serde(
+        rename = "modelId",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    model_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    provider: Option<String>,
+}
+
+/// Token usage block carried by OpenClaw assistant messages.
+#[derive(Debug, Default, Deserialize)]
+struct OpenClawUsage {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output: u64,
+    #[serde(rename = "cacheRead", default, deserialize_with = "jsonl::lenient_u64")]
+    cache_read: u64,
+    #[serde(
+        rename = "cacheWrite",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    cache_write: u64,
+    #[serde(
+        rename = "totalTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    total_tokens: u64,
+    #[serde(default, deserialize_with = "deserialize_cost")]
+    cost: Option<OpenClawCost>,
+}
+
+/// Deserialize the `cost` block, mirroring the historical
+/// `usage.get("cost").and_then(|cost| cost.get("total"))` navigation: only JSON
+/// objects yield a cost, while any other shape (or a missing key) becomes `None`
+/// instead of failing the whole line.
+fn deserialize_cost<'de, D>(deserializer: D) -> std::result::Result<Option<OpenClawCost>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|value| {
+        value
+            .is_object()
+            .then(|| serde_json::from_value(value).ok())
+            .flatten()
+    }))
+}
+
+/// Precomputed cost block carried alongside OpenClaw usage.
+#[derive(Debug, Default, Deserialize)]
+struct OpenClawCost {
+    #[serde(default, deserialize_with = "jsonl::lenient_f64")]
+    total: Option<f64>,
+}
 
 #[derive(Debug, Clone)]
 struct OpenClawEntry {
@@ -37,42 +163,34 @@ pub(super) fn parse_session_file(
 ) -> Result<Vec<LoadedEntry>> {
     let session_id = extract_session_id(path);
     let fallback_timestamp = file_modified_timestamp(path);
-    let input = fs::File::open(path)?;
-    let reader = BufReader::new(input);
+    let content = fs::read(path)?;
     let mut current_model = None::<String>;
     let mut current_provider = None::<String>;
     let mut entries = Vec::new();
-    for line in reader.lines() {
-        let line = line?;
-        if !line.contains("\"model_change\"")
-            && !line.contains("\"model-snapshot\"")
-            && !line.contains("\"usage\"")
-        {
-            continue;
-        }
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
-            continue;
-        };
-        let Some(record) = value.as_object() else {
-            continue;
-        };
-        if is_model_change(record) {
-            let source = record
-                .get("data")
-                .and_then(Value::as_object)
-                .unwrap_or(record);
-            if let Some(model) = non_empty_json_string(source.get("modelId"))
-                .or_else(|| non_empty_json_string(source.get("model")))
-            {
+    for record in jsonl::records::<OpenClawLine>(&content, None) {
+        if is_model_change(&record) {
+            let (source_model_id, source_model, source_provider) = match record.data.as_ref() {
+                Some(source) => (
+                    source.model_id.clone(),
+                    source.model.clone(),
+                    source.provider.clone(),
+                ),
+                None => (
+                    record.model_id.clone(),
+                    record.model.clone(),
+                    record.provider.clone(),
+                ),
+            };
+            if let Some(model) = source_model_id.or(source_model) {
                 current_model = Some(model);
             }
-            if let Some(provider) = non_empty_json_string(source.get("provider")) {
+            if let Some(provider) = source_provider {
                 current_provider = Some(provider);
             }
             continue;
         }
         if let Some(entry) = parse_message_entry(
-            record,
+            &record,
             &session_id,
             current_model.as_deref(),
             current_provider.as_deref(),
@@ -84,34 +202,34 @@ pub(super) fn parse_session_file(
     Ok(entries)
 }
 
-fn is_model_change(record: &Map<String, Value>) -> bool {
-    if record.get("type").and_then(Value::as_str) == Some("model_change") {
+fn is_model_change(record: &OpenClawLine) -> bool {
+    if record.r#type.as_deref() == Some("model_change") {
         return true;
     }
-    record.get("type").and_then(Value::as_str) == Some("custom")
-        && record.get("customType").and_then(Value::as_str) == Some("model-snapshot")
+    record.r#type.as_deref() == Some("custom")
+        && record.custom_type.as_deref() == Some("model-snapshot")
 }
 
 fn parse_message_entry(
-    record: &Map<String, Value>,
+    record: &OpenClawLine,
     session_id: &str,
     current_model: Option<&str>,
     current_provider: Option<&str>,
     fallback_timestamp: TimestampMs,
 ) -> Option<OpenClawEntry> {
-    if record.get("type").and_then(Value::as_str) != Some("message") {
+    if record.r#type.as_deref() != Some("message") {
         return None;
     }
-    let message = record.get("message")?.as_object()?;
-    if message.get("role").and_then(Value::as_str) != Some("assistant") {
+    let message = record.message.as_ref()?;
+    if message.role.as_deref() != Some("assistant") {
         return None;
     }
-    let usage = message.get("usage")?.as_object()?;
-    let input_tokens = json_value_u64(usage.get("input"));
-    let output_tokens = json_value_u64(usage.get("output"));
-    let cache_read_tokens = json_value_u64(usage.get("cacheRead"));
-    let cache_creation_tokens = json_value_u64(usage.get("cacheWrite"));
-    let total_tokens = json_value_u64(usage.get("totalTokens"));
+    let usage = message.usage.as_ref()?;
+    let input_tokens = usage.input;
+    let output_tokens = usage.output;
+    let cache_read_tokens = usage.cache_read;
+    let cache_creation_tokens = usage.cache_write;
+    let total_tokens = usage.total_tokens;
     let raw_usage = TokenUsageRaw {
         input_tokens,
         output_tokens,
@@ -125,14 +243,17 @@ fn parse_message_entry(
         return None;
     }
     let total_tokens = total_tokens.max(crate::total_usage_tokens(raw_usage) + extra_total_tokens);
-    let timestamp =
-        timestamp_from_value(message.get("timestamp").or_else(|| record.get("timestamp")))
-            .unwrap_or(fallback_timestamp);
-    let model = non_empty_json_string(message.get("modelId"))
-        .or_else(|| non_empty_json_string(message.get("model")))
+    let timestamp = timestamp_from_value(message.timestamp.as_ref().or(record.timestamp.as_ref()))
+        .unwrap_or(fallback_timestamp);
+    let model = message
+        .model_id
+        .clone()
+        .or_else(|| message.model.clone())
         .or_else(|| current_model.map(str::to_string))
         .unwrap_or_else(|| "unknown".to_string());
-    let provider = non_empty_json_string(message.get("provider"))
+    let provider = message
+        .provider
+        .clone()
         .or_else(|| current_provider.map(str::to_string));
     Some(OpenClawEntry {
         timestamp,
@@ -145,10 +266,7 @@ fn parse_message_entry(
         cache_creation_tokens: raw_usage.cache_creation_input_tokens,
         cache_read_tokens: raw_usage.cache_read_input_tokens,
         total_tokens,
-        cost: usage
-            .get("cost")
-            .and_then(|cost| cost.get("total"))
-            .and_then(Value::as_f64),
+        cost: usage.cost.as_ref().and_then(|cost| cost.total),
     })
 }
 
@@ -262,7 +380,7 @@ mod tests {
 
     #[test]
     fn falls_back_to_total_tokens_when_openclaw_parts_are_missing() {
-        let record = serde_json::json!({
+        let record = serde_json::from_value::<OpenClawLine>(serde_json::json!({
             "type": "message",
             "message": {
                 "role": "assistant",
@@ -271,15 +389,10 @@ mod tests {
                     "totalTokens": 222
                 }
             }
-        });
-        let entry = parse_message_entry(
-            record.as_object().unwrap(),
-            "session-a",
-            None,
-            None,
-            TimestampMs::UNIX_EPOCH,
-        )
+        }))
         .unwrap();
+        let entry =
+            parse_message_entry(&record, "session-a", None, None, TimestampMs::UNIX_EPOCH).unwrap();
 
         assert_eq!(entry.output_tokens, 222);
         assert_eq!(entry.total_tokens, 222);

--- a/rust/crates/ccusage/src/adapter/opencode/loader.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/loader.rs
@@ -5,9 +5,11 @@ use std::{
 };
 
 use jiff::tz::TimeZone as JiffTimeZone;
-use serde_json::Value;
 
-use super::{parser::message_value_to_entry, paths::paths};
+use super::{
+    parser::{OpenCodeMessage, message_value_to_entry},
+    paths::paths,
+};
 use crate::{
     LoadedEntry, PricingMap, Result,
     cli::{CostMode, SharedArgs},
@@ -150,7 +152,7 @@ fn load_entries_from_database(
                 let Ok(data) = statement.read::<String, _>(2) else {
                     continue;
                 };
-                let Ok(value) = serde_json::from_str::<Value>(&data) else {
+                let Ok(value) = serde_json::from_str::<OpenCodeMessage>(&data) else {
                     continue;
                 };
                 if let Some(entry) =
@@ -178,8 +180,8 @@ fn read_message_file(
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Result<Option<LoadedEntry>> {
-    let content = fs::read_to_string(path)?;
-    let Ok(value) = serde_json::from_str::<Value>(&content) else {
+    let content = fs::read(path)?;
+    let Ok(value) = serde_json::from_slice::<OpenCodeMessage>(&content) else {
         return Ok(None);
     };
     Ok(message_value_to_entry(

--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -13,6 +13,7 @@ use crate::{
 /// declared; serde skips everything else.
 #[derive(Debug, Default, Deserialize)]
 pub(crate) struct OpenCodeMessage {
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
     tokens: Option<OpenCodeTokens>,
     #[serde(
         rename = "modelID",
@@ -26,6 +27,7 @@ pub(crate) struct OpenCodeMessage {
         deserialize_with = "jsonl::non_empty_string"
     )]
     provider_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
     time: Option<OpenCodeTime>,
     #[serde(default, deserialize_with = "jsonl::non_empty_string")]
     id: Option<String>,
@@ -46,6 +48,7 @@ struct OpenCodeTokens {
     input: u64,
     #[serde(default, deserialize_with = "jsonl::lenient_u64")]
     output: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
     cache: Option<OpenCodeCache>,
     #[serde(default, deserialize_with = "jsonl::lenient_u64")]
     total: u64,
@@ -337,6 +340,37 @@ mod tests {
         )
         .unwrap();
 
+        assert_eq!(entry.cost, 0.02);
+    }
+
+    #[test]
+    fn keeps_opencode_record_when_cache_field_is_not_an_object() {
+        let entry = message_value_to_entry(
+            &message(json!({
+                "id": "message-a",
+                "sessionID": "session-a",
+                "providerID": "openai",
+                "modelID": "gpt-test",
+                "time": { "created": 0 },
+                "tokens": {
+                    "input": 100,
+                    "output": 10,
+                    "cache": 0
+                },
+                "cost": 0.02
+            })),
+            None,
+            None,
+            None,
+            CostMode::Auto,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(entry.data.message.usage.input_tokens, 100);
+        assert_eq!(entry.data.message.usage.output_tokens, 10);
+        assert_eq!(entry.data.message.usage.cache_creation_input_tokens, 0);
+        assert_eq!(entry.data.message.usage.cache_read_input_tokens, 0);
         assert_eq!(entry.cost, 0.02);
     }
 

--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -1,36 +1,91 @@
 use std::sync::Arc;
 
 use jiff::tz::TimeZone as JiffTimeZone;
-use serde_json::Value;
+use serde::Deserialize;
 
+use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, TokenUsageRaw, UsageEntry, UsageMessage, apply_total_token_fallback,
-    calculate_cost_for_usage, cli::CostMode, format_date_tz, json_value_u64,
-    missing_pricing_model_for_candidates, non_empty_json_string,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz, missing_pricing_model_for_candidates,
 };
 
+/// A single parsed OpenCode message. Only the fields ccusage consumes are
+/// declared; serde skips everything else.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct OpenCodeMessage {
+    tokens: Option<OpenCodeTokens>,
+    #[serde(
+        rename = "modelID",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    model_id: Option<String>,
+    #[serde(
+        rename = "providerID",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    provider_id: Option<String>,
+    time: Option<OpenCodeTime>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    id: Option<String>,
+    #[serde(
+        rename = "sessionID",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    session_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::lenient_f64")]
+    cost: Option<f64>,
+}
+
+/// Token usage block carried by OpenCode messages.
+#[derive(Debug, Default, Deserialize)]
+struct OpenCodeTokens {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output: u64,
+    cache: Option<OpenCodeCache>,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    total: u64,
+}
+
+/// Cache read/write counts nested under OpenCode token usage.
+#[derive(Debug, Default, Deserialize)]
+struct OpenCodeCache {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    read: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    write: u64,
+}
+
+/// Creation timestamp block carried by OpenCode messages.
+#[derive(Debug, Default, Deserialize)]
+struct OpenCodeTime {
+    #[serde(default, deserialize_with = "jsonl::lenient_i64")]
+    created: Option<i64>,
+}
+
 pub(crate) fn message_value_to_entry(
-    value: &Value,
+    value: &OpenCodeMessage,
     id: Option<String>,
     session_id: Option<String>,
     tz: Option<&JiffTimeZone>,
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Option<LoadedEntry> {
-    let tokens = value.get("tokens")?;
+    let tokens = value.tokens.as_ref()?;
+    let cache = tokens.cache.as_ref();
     let usage = TokenUsageRaw {
-        input_tokens: json_value_u64(tokens.get("input")),
-        output_tokens: json_value_u64(tokens.get("output")),
-        cache_creation_input_tokens: tokens
-            .get("cache")
-            .map_or(0, |cache| json_value_u64(cache.get("write"))),
-        cache_read_input_tokens: tokens
-            .get("cache")
-            .map_or(0, |cache| json_value_u64(cache.get("read"))),
+        input_tokens: tokens.input,
+        output_tokens: tokens.output,
+        cache_creation_input_tokens: cache.map_or(0, |cache| cache.write),
+        cache_read_input_tokens: cache.map_or(0, |cache| cache.read),
         speed: None,
         cache_creation: None,
     };
-    let total_tokens = json_value_u64(tokens.get("total"));
+    let total_tokens = tokens.total;
     let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, total_tokens);
     if usage.input_tokens == 0
         && usage.output_tokens == 0
@@ -40,17 +95,17 @@ pub(crate) fn message_value_to_entry(
     {
         return None;
     }
-    let model = non_empty_json_string(value.get("modelID"))?;
-    let provider = non_empty_json_string(value.get("providerID"))?;
+    let model = value.model_id.clone()?;
+    let provider = value.provider_id.clone()?;
     let millis = value
-        .get("time")
-        .and_then(|time| time.get("created"))
-        .and_then(Value::as_i64)
+        .time
+        .as_ref()
+        .and_then(|time| time.created)
         .unwrap_or(0);
     let timestamp = crate::TimestampMs::from_millis(millis);
     let timestamp_text = crate::format_rfc3339_millis(timestamp);
-    let message_id = id.or_else(|| non_empty_json_string(value.get("id")));
-    let session_id = session_id.or_else(|| non_empty_json_string(value.get("sessionID")));
+    let message_id = id.or_else(|| value.id.clone());
+    let session_id = session_id.or_else(|| value.session_id.clone());
     let data = UsageEntry {
         session_id: session_id.clone(),
         timestamp: timestamp_text,
@@ -60,7 +115,7 @@ pub(crate) fn message_value_to_entry(
             model: Some(model.clone()),
             id: message_id,
         },
-        cost_usd: value.get("cost").and_then(Value::as_f64),
+        cost_usd: value.cost,
         request_id: None,
         is_api_error_message: None,
         is_sidechain: None,
@@ -187,8 +242,12 @@ fn normalize_open_code_model_name(model: &str) -> String {
 mod tests {
     use serde_json::json;
 
-    use super::{message_value_to_entry, open_code_model_candidates};
+    use super::{OpenCodeMessage, message_value_to_entry, open_code_model_candidates};
     use crate::{LoadedEntry, PricingMap, cli::CostMode};
+
+    fn message(value: serde_json::Value) -> OpenCodeMessage {
+        serde_json::from_value(value).unwrap()
+    }
 
     fn entry_snapshot(entry: &LoadedEntry) -> serde_json::Value {
         json!({
@@ -232,7 +291,7 @@ mod tests {
             }"#,
         );
         let entry = message_value_to_entry(
-            &json!({
+            &message(json!({
                 "id": "message-a",
                 "sessionID": "session-a",
                 "providerID": "openai",
@@ -244,7 +303,7 @@ mod tests {
                     "cache": { "read": 50 }
                 },
                 "cost": 0
-            }),
+            })),
             None,
             None,
             None,
@@ -259,7 +318,7 @@ mod tests {
     #[test]
     fn keeps_positive_opencode_cost() {
         let entry = message_value_to_entry(
-            &json!({
+            &message(json!({
                 "id": "message-a",
                 "sessionID": "session-a",
                 "providerID": "openai",
@@ -269,7 +328,7 @@ mod tests {
                     "input": 100
                 },
                 "cost": 0.02
-            }),
+            })),
             None,
             None,
             None,
@@ -284,7 +343,7 @@ mod tests {
     #[test]
     fn falls_back_to_total_tokens_when_opencode_token_parts_are_missing() {
         let entry = message_value_to_entry(
-            &json!({
+            &message(json!({
                 "id": "message-a",
                 "sessionID": "session-a",
                 "providerID": "openai",
@@ -293,7 +352,7 @@ mod tests {
                 "tokens": {
                     "total": 123
                 }
-            }),
+            })),
             None,
             None,
             None,
@@ -323,7 +382,7 @@ mod tests {
     fn calculates_cost_for_k2p6_when_opencode_stores_zero_cost() {
         let pricing = PricingMap::load_embedded();
         let entry = message_value_to_entry(
-            &json!({
+            &message(json!({
                 "id": "message-a",
                 "sessionID": "session-a",
                 "providerID": "kimi-for-coding",
@@ -335,7 +394,7 @@ mod tests {
                     "cache": { "read": 50 }
                 },
                 "cost": 0
-            }),
+            })),
             None,
             None,
             None,
@@ -360,7 +419,7 @@ mod tests {
             }"#,
         );
         let calculated = message_value_to_entry(
-            &json!({
+            &message(json!({
                 "id": "message-a",
                 "sessionID": "session-a",
                 "providerID": "github-copilot",
@@ -373,7 +432,7 @@ mod tests {
                     "total": 185
                 },
                 "cost": 0
-            }),
+            })),
             None,
             None,
             None,
@@ -382,14 +441,14 @@ mod tests {
         )
         .unwrap();
         let display_cost = message_value_to_entry(
-            &json!({
+            &message(json!({
                 "id": "message-b",
                 "providerID": "openai",
                 "modelID": "gpt-test",
                 "time": { "created": 0 },
                 "tokens": { "total": 123 },
                 "cost": 0.02
-            }),
+            })),
             None,
             Some("explicit-session".to_string()),
             None,

--- a/rust/crates/ccusage/src/adapter/pi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/pi/parser.rs
@@ -52,6 +52,9 @@ struct PiUsage {
         deserialize_with = "jsonl::lenient_u64"
     )]
     total_tokens: u64,
+    // A non-object `cost` previously left display cost absent without dropping
+    // the record, so deserialize it leniently instead of failing the line.
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
     cost: Option<PiCost>,
 }
 

--- a/rust/crates/ccusage/src/adapter/pi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/pi/parser.rs
@@ -274,4 +274,20 @@ mod tests {
         // In Auto mode with a display cost present, no missing pricing warning
         assert_eq!(entries[0].missing_pricing_model, None);
     }
+
+    #[test]
+    fn keeps_record_when_cost_is_not_an_object() {
+        // A non-object `cost` must not fail the whole line; the usage tokens
+        // should still be counted with display cost treated as missing.
+        let fixture = fs_fixture!({
+            "sessions/project-a/agent_session-a.jsonl": r#"{"type":"message","timestamp":"2026-01-02T00:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":100,"output":200,"cost":0}}}"#,
+        });
+        let file = fixture.path("sessions/project-a/agent_session-a.jsonl");
+
+        let entries = read_session_file(&file, None, CostMode::Display, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.input_tokens, 100);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 200);
+    }
 }

--- a/rust/crates/ccusage/src/adapter/pi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/pi/parser.rs
@@ -6,16 +6,9 @@ use serde::Deserialize;
 use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, Result, TokenUsageRaw, UsageEntry, UsageMessage,
-    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    missing_pricing_model_for_usage,
+    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, fast::LinePrefilter,
+    format_date_tz, missing_pricing_model_for_usage,
 };
-
-/// Cheap substring prefilter: every usable pi line carries token counts under
-/// the `usage` key, so lines without it are skipped before JSON parsing. The
-/// companion `"message"` requirement is enforced downstream by
-/// [`is_pi_message_usage`], which only accepts records whose message object
-/// carries a usage block.
-const PI_USAGE_MARKER: &[u8] = b"\"usage\"";
 
 /// A single parsed pi session record. Only the fields ccusage consumes are
 /// declared; serde skips everything else.
@@ -78,9 +71,12 @@ pub(crate) fn read_session_file(
     let content = fs::read(path)?;
     let project = extract_project(path);
     let session_id = extract_session_id(path);
+    // Usable pi lines carry token counts under a `usage` key nested in a
+    // `message` object, so require both substrings before JSON parsing.
+    let prefilter = LinePrefilter::all(&[br#""usage""#, br#""message""#]);
     let mut entries = Vec::new();
 
-    for record in jsonl::records::<PiLine>(&content, Some(PI_USAGE_MARKER)) {
+    for record in jsonl::records::<PiLine>(&content, Some(&prefilter)) {
         if !is_pi_message_usage(&record) {
             continue;
         }

--- a/rust/crates/ccusage/src/adapter/pi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/pi/parser.rs
@@ -1,13 +1,73 @@
 use std::{fs, path::Path, sync::Arc};
 
 use jiff::tz::TimeZone as JiffTimeZone;
-use serde_json::Value;
+use serde::Deserialize;
 
+use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, Result, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
-    json_value_u64, missing_pricing_model_for_usage, non_empty_json_string,
+    missing_pricing_model_for_usage,
 };
+
+/// Cheap substring prefilter: every usable pi line carries token counts under
+/// the `usage` key, so lines without it are skipped before JSON parsing. The
+/// companion `"message"` requirement is enforced downstream by
+/// [`is_pi_message_usage`], which only accepts records whose message object
+/// carries a usage block.
+const PI_USAGE_MARKER: &[u8] = b"\"usage\"";
+
+/// A single parsed pi session record. Only the fields ccusage consumes are
+/// declared; serde skips everything else.
+#[derive(Debug, Deserialize)]
+struct PiLine {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    r#type: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    timestamp: Option<String>,
+    message: Option<PiMessage>,
+}
+
+/// The pi `message` block carried by assistant records.
+#[derive(Debug, Deserialize)]
+struct PiMessage {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    role: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model: Option<String>,
+    usage: Option<PiUsage>,
+}
+
+/// Token counts and optional display cost carried by a pi assistant message.
+#[derive(Debug, Default, Deserialize)]
+struct PiUsage {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output: u64,
+    #[serde(rename = "cacheRead", default, deserialize_with = "jsonl::lenient_u64")]
+    cache_read: u64,
+    #[serde(
+        rename = "cacheWrite",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    cache_write: u64,
+    #[serde(
+        rename = "totalTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    total_tokens: u64,
+    cost: Option<PiCost>,
+}
+
+/// Optional display cost block carried by a pi assistant message.
+#[derive(Debug, Default, Deserialize)]
+struct PiCost {
+    #[serde(default, deserialize_with = "jsonl::lenient_f64")]
+    total: Option<f64>,
+}
 
 pub(crate) fn read_session_file(
     path: &Path,
@@ -15,38 +75,32 @@ pub(crate) fn read_session_file(
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Result<Vec<LoadedEntry>> {
-    let content = fs::read_to_string(path)?;
+    let content = fs::read(path)?;
     let project = extract_project(path);
     let session_id = extract_session_id(path);
     let mut entries = Vec::new();
 
-    for line in content.lines() {
-        if !line.contains("\"usage\"") || !line.contains("\"message\"") {
+    for record in jsonl::records::<PiLine>(&content, Some(PI_USAGE_MARKER)) {
+        if !is_pi_message_usage(&record) {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
-            continue;
-        };
-        if !is_pi_message_usage(&value) {
-            continue;
-        }
-        let Some(timestamp_text) = non_empty_json_string(value.get("timestamp")) else {
+        let Some(timestamp_text) = record.timestamp.clone() else {
             continue;
         };
         let Some(timestamp) = crate::parse_ts_timestamp(&timestamp_text) else {
             continue;
         };
-        let Some(message) = value.get("message") else {
+        let Some(message) = record.message.as_ref() else {
             continue;
         };
-        let Some(usage_value) = message.get("usage") else {
+        let Some(usage_value) = message.usage.as_ref() else {
             continue;
         };
-        let input = json_value_u64(usage_value.get("input"));
-        let output = json_value_u64(usage_value.get("output"));
-        let cache_read = json_value_u64(usage_value.get("cacheRead"));
-        let cache_create = json_value_u64(usage_value.get("cacheWrite"));
-        let total = json_value_u64(usage_value.get("totalTokens"));
+        let input = usage_value.input;
+        let output = usage_value.output;
+        let cache_read = usage_value.cache_read;
+        let cache_create = usage_value.cache_write;
+        let total = usage_value.total_tokens;
         let usage = TokenUsageRaw {
             input_tokens: input,
             output_tokens: output,
@@ -59,12 +113,8 @@ pub(crate) fn read_session_file(
         if crate::total_usage_tokens(usage) + extra_total_tokens == 0 {
             continue;
         }
-        let model =
-            non_empty_json_string(message.get("model")).map(|model| format!("[pi] {model}"));
-        let display_cost = usage_value
-            .get("cost")
-            .and_then(|cost| cost.get("total"))
-            .and_then(Value::as_f64);
+        let model = message.model.clone().map(|model| format!("[pi] {model}"));
+        let display_cost = usage_value.cost.as_ref().and_then(|cost| cost.total);
         let cost = calculate_cost_for_usage(model.as_deref(), usage, display_cost, mode, pricing);
         let missing_pricing_model =
             missing_pricing_model_for_usage(model.as_deref(), usage, display_cost, mode, pricing);
@@ -101,16 +151,18 @@ pub(crate) fn read_session_file(
     Ok(entries)
 }
 
-fn is_pi_message_usage(value: &Value) -> bool {
-    let message_type = value.get("type").and_then(Value::as_str);
-    if message_type.is_some_and(|message_type| message_type != "message") {
+fn is_pi_message_usage(record: &PiLine) -> bool {
+    if record
+        .r#type
+        .as_deref()
+        .is_some_and(|message_type| message_type != "message")
+    {
         return false;
     }
-    let Some(message) = value.get("message") else {
+    let Some(message) = record.message.as_ref() else {
         return false;
     };
-    message.get("role").and_then(Value::as_str) == Some("assistant")
-        && message.get("usage").is_some()
+    message.role.as_deref() == Some("assistant") && message.usage.is_some()
 }
 
 fn extract_session_id(path: &Path) -> String {

--- a/rust/crates/ccusage/src/adapter/qwen/parser.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/parser.rs
@@ -14,15 +14,12 @@ use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
+    fast::LinePrefilter,
     format_date_tz, format_rfc3339_millis, missing_pricing_model_for_candidates,
     parse_ts_timestamp, parse_tz,
 };
 
 const DEFAULT_QWEN_MODEL: &str = "unknown";
-
-/// Cheap substring prefilter: every usable Qwen line carries token counts under
-/// the `usageMetadata` key, so lines without it are skipped before JSON parsing.
-const QWEN_USAGE_MARKER: &[u8] = b"usageMetadata";
 
 /// A single parsed Qwen chat record. Only the fields ccusage consumes are
 /// declared; serde skips everything else.
@@ -89,8 +86,11 @@ fn read_chat_file(
 ) -> Result<Vec<LoadedEntry>> {
     let fallback = file_timestamp(file, shared);
     let content = fs::read(file)?;
+    // Every usable Qwen line carries token counts under the `usageMetadata`
+    // key, so lines without it are skipped before JSON parsing.
+    let prefilter = LinePrefilter::all(&[br#""usageMetadata""#]);
     let mut entries = Vec::new();
-    for record in jsonl::records::<QwenLine>(&content, Some(QWEN_USAGE_MARKER)) {
+    for record in jsonl::records::<QwenLine>(&content, Some(&prefilter)) {
         if let Some(entry) = parse_line(file, fallback, &record, tz, mode, pricing) {
             entries.push(entry);
         }

--- a/rust/crates/ccusage/src/adapter/qwen/parser.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/parser.rs
@@ -1,25 +1,60 @@
 use std::{
     collections::HashSet,
-    fs::{self, File},
-    io::{BufRead, BufReader},
+    fs,
     path::Path,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use jiff::tz::TimeZone as JiffTimeZone;
-use serde_json::Value;
+use serde::Deserialize;
 
-use super::paths;
+use super::{super::jsonl, paths};
 use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
-    format_date_tz, format_rfc3339_millis, json_value_u64, missing_pricing_model_for_candidates,
-    non_empty_json_string, parse_ts_timestamp, parse_tz,
+    format_date_tz, format_rfc3339_millis, missing_pricing_model_for_candidates,
+    parse_ts_timestamp, parse_tz,
 };
 
 const DEFAULT_QWEN_MODEL: &str = "unknown";
+
+/// Cheap substring prefilter: every usable Qwen line carries token counts under
+/// the `usageMetadata` key, so lines without it are skipped before JSON parsing.
+const QWEN_USAGE_MARKER: &[u8] = b"usageMetadata";
+
+/// A single parsed Qwen chat record. Only the fields ccusage consumes are
+/// declared; serde skips everything else.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QwenLine {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    r#type: Option<String>,
+    usage_metadata: Option<QwenUsageMetadata>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    timestamp: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    session_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model: Option<String>,
+}
+
+/// Gemini-style usage metadata block carried by Qwen assistant records.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QwenUsageMetadata {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    prompt_token_count: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    candidates_token_count: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    thoughts_token_count: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    cached_content_token_count: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    total_token_count: u64,
+}
 
 pub(super) fn load_entries(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
     let pricing = if shared.mode == CostMode::Display {
@@ -53,17 +88,10 @@ fn read_chat_file(
     shared: &SharedArgs,
 ) -> Result<Vec<LoadedEntry>> {
     let fallback = file_timestamp(file, shared);
-    let input = File::open(file)?;
-    let reader = BufReader::new(input);
+    let content = fs::read(file)?;
     let mut entries = Vec::new();
-    for line in reader.lines() {
-        let Ok(line) = line else {
-            continue;
-        };
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
-            continue;
-        };
-        if let Some(entry) = parse_line(file, fallback, &value, tz, mode, pricing) {
+    for record in jsonl::records::<QwenLine>(&content, Some(QWEN_USAGE_MARKER)) {
+        if let Some(entry) = parse_line(file, fallback, &record, tz, mode, pricing) {
             entries.push(entry);
         }
     }
@@ -73,21 +101,20 @@ fn read_chat_file(
 fn parse_line(
     file: &Path,
     fallback: TimestampMs,
-    value: &Value,
+    record: &QwenLine,
     tz: Option<&JiffTimeZone>,
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Option<LoadedEntry> {
-    let record = value.as_object()?;
-    if record.get("type").and_then(Value::as_str) != Some("assistant") {
+    if record.r#type.as_deref() != Some("assistant") {
         return None;
     }
-    let usage = record.get("usageMetadata")?;
-    let input_tokens = json_value_u64(usage.get("promptTokenCount"));
-    let output_tokens = json_value_u64(usage.get("candidatesTokenCount"));
-    let reasoning_tokens = json_value_u64(usage.get("thoughtsTokenCount"));
-    let cache_read_tokens = json_value_u64(usage.get("cachedContentTokenCount"));
-    let total_tokens = json_value_u64(usage.get("totalTokenCount"));
+    let usage = record.usage_metadata.as_ref()?;
+    let input_tokens = usage.prompt_token_count;
+    let output_tokens = usage.candidates_token_count;
+    let reasoning_tokens = usage.thoughts_token_count;
+    let cache_read_tokens = usage.cached_content_token_count;
+    let total_tokens = usage.total_token_count;
     let display_usage = TokenUsageRaw {
         input_tokens,
         output_tokens,
@@ -106,19 +133,23 @@ fn parse_line(
         return None;
     }
 
-    let timestamp_text = non_empty_json_string(record.get("timestamp"))
+    let timestamp_text = record
+        .timestamp
+        .clone()
         .and_then(|value| parse_ts_timestamp(&value).map(|_| value))
         .unwrap_or_else(|| format_rfc3339_millis(fallback));
     let timestamp = parse_ts_timestamp(&timestamp_text).unwrap_or(fallback);
     let project = paths::project_from_file(file).unwrap_or_else(|| "unknown".to_string());
-    let session_id = non_empty_json_string(record.get("sessionId")).unwrap_or_else(|| {
+    let session_id = record.session_id.clone().unwrap_or_else(|| {
         let stem = file
             .file_stem()
             .and_then(|stem| stem.to_str())
             .unwrap_or("unknown");
         format!("{project}-{stem}")
     });
-    let model = non_empty_json_string(record.get("model"))
+    let model = record
+        .model
+        .clone()
         .unwrap_or_else(|| DEFAULT_QWEN_MODEL.to_string());
     let billable_usage = TokenUsageRaw {
         output_tokens: display_usage
@@ -285,18 +316,20 @@ mod tests {
 
     #[test]
     fn falls_back_to_total_token_count_when_qwen_parts_are_missing() {
+        let record = serde_json::from_value::<QwenLine>(serde_json::json!({
+            "type": "assistant",
+            "timestamp": "2026-01-02T00:00:00.000Z",
+            "sessionId": "session-a",
+            "model": "qwen3-coder",
+            "usageMetadata": {
+                "totalTokenCount": 321
+            }
+        }))
+        .unwrap();
         let entry = parse_line(
             Path::new("/tmp/project/chat.jsonl"),
             TimestampMs::UNIX_EPOCH,
-            &serde_json::json!({
-                "type": "assistant",
-                "timestamp": "2026-01-02T00:00:00.000Z",
-                "sessionId": "session-a",
-                "model": "qwen3-coder",
-                "usageMetadata": {
-                    "totalTokenCount": 321
-                }
-            }),
+            &record,
             None,
             CostMode::Auto,
             None,

--- a/rust/crates/ccusage/src/fast.rs
+++ b/rust/crates/ccusage/src/fast.rs
@@ -1,9 +1,74 @@
-use memchr::memchr;
+use memchr::{memchr, memmem::Finder};
 use smallvec::SmallVec;
 
 pub(crate) type FxHashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 pub(crate) type FxHashSet<T> = rustc_hash::FxHashSet<T>;
 pub(crate) type SmallIndexVec = SmallVec<[usize; 1]>;
+
+/// Whether a [`LinePrefilter`] requires every marker or just one of them.
+#[derive(Clone, Copy)]
+enum PrefilterMode {
+    /// The line must contain every configured marker.
+    All,
+    /// The line must contain at least one configured marker.
+    Any,
+}
+
+/// Reusable byte-substring prefilter for newline-delimited JSON logs.
+///
+/// JSONL adapters skip lines that cannot contain a usage record before paying
+/// for a full `serde_json` parse. Building the [`Finder`] needles once and
+/// reusing them across every line keeps that skip check on the SIMD-accelerated
+/// `memmem` path instead of allocating a fresh searcher per `str::contains`
+/// call.
+pub(crate) struct LinePrefilter {
+    finders: SmallVec<[Finder<'static>; 4]>,
+    mode: PrefilterMode,
+}
+
+impl LinePrefilter {
+    /// Build a prefilter that only admits lines containing *all* `markers`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let prefilter = LinePrefilter::all(&[b"\"usage\"", b"\"message\""]);
+    /// assert!(prefilter.matches(br#"{"message":{"usage":{}}}"#));
+    /// assert!(!prefilter.matches(br#"{"message":{}}"#));
+    /// ```
+    pub(crate) fn all(markers: &[&[u8]]) -> Self {
+        Self::new(markers, PrefilterMode::All)
+    }
+
+    /// Build a prefilter that admits lines containing *any* of `markers`.
+    pub(crate) fn any(markers: &[&[u8]]) -> Self {
+        Self::new(markers, PrefilterMode::Any)
+    }
+
+    fn new(markers: &[&[u8]], mode: PrefilterMode) -> Self {
+        // `Finder::new` borrows the needle, so take an owned copy to outlive the
+        // caller's marker slice and allow the prefilter to be stored freely.
+        let finders = markers
+            .iter()
+            .map(|marker| Finder::new(marker).into_owned())
+            .collect();
+        Self { finders, mode }
+    }
+
+    /// Return `true` when `line` passes the filter and is worth parsing.
+    pub(crate) fn matches(&self, line: &[u8]) -> bool {
+        match self.mode {
+            PrefilterMode::All => self
+                .finders
+                .iter()
+                .all(|finder| finder.find(line).is_some()),
+            PrefilterMode::Any => self
+                .finders
+                .iter()
+                .any(|finder| finder.find(line).is_some()),
+        }
+    }
+}
 
 pub(crate) struct ByteLines<'a> {
     bytes: &'a [u8],
@@ -47,7 +112,25 @@ pub(crate) fn suffix_string(value: &str, suffix: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{byte_lines, suffix_string};
+    use super::{LinePrefilter, byte_lines, suffix_string};
+
+    #[test]
+    fn line_prefilter_all_requires_every_marker() {
+        let prefilter = LinePrefilter::all(&[b"\"usage\"", b"\"message\""]);
+
+        assert!(prefilter.matches(br#"{"message":{"usage":{"input":1}}}"#));
+        assert!(!prefilter.matches(br#"{"message":{"role":"user"}}"#));
+        assert!(!prefilter.matches(br#"{"usage":{"input":1}}"#));
+    }
+
+    #[test]
+    fn line_prefilter_any_requires_one_marker() {
+        let prefilter = LinePrefilter::any(&[b"\"model_change\"", b"\"usage\""]);
+
+        assert!(prefilter.matches(br#"{"type":"model_change"}"#));
+        assert!(prefilter.matches(br#"{"message":{"usage":{}}}"#));
+        assert!(!prefilter.matches(br#"{"type":"message"}"#));
+    }
 
     #[test]
     fn byte_lines_returns_newline_delimited_slices() {


### PR DESCRIPTION
## Summary

Unifies how the agent adapters parse their log files and brings every adapter onto the same optimized fast path. Previously the optimization level was inconsistent: the Claude loader read whole files as bytes, prefiltered lines with `memmem`, and deserialized into typed structs, while most other adapters parsed every line into a dynamic `serde_json::Value` and hand-navigated it with `Value::get` (and several allocated a `String` per line via `BufReader::lines()`).

**Supersedes #1326** — folds that PR's `LinePrefilter` (multi-marker AND/OR prefilter) into this broader typed-parsing refactor.

## What changed

- **New `adapter/jsonl.rs`**:
  - `records::<T>(content, prefilter)` — iterate byte-lines (no per-line `String` allocation), skip lines rejected by a reusable `LinePrefilter` before any JSON parsing, then `from_slice` survivors into a typed struct (unused fields skipped, no intermediate `Value` tree).
  - `lenient_u64` / `lenient_i64` / `lenient_f64` / `non_empty_string` — `deserialize_with` helpers that exactly reproduce `Value::as_u64` / `as_i64` / `as_f64` / `non_empty_json_string` leniency, so typed structs tolerate unexpectedly encoded fields instead of failing the whole line.
- **New `fast::LinePrefilter`** (from #1326): builds the `memmem` needles once and supports "contains all markers" / "contains any marker" modes. Restores precise prefilters: pi (`usage` + `message`), kimi (`StatusUpdate` + `token_usage`), openclaw (any of `model_change` / `model-snapshot` / `usage`, previously unfiltered), qwen, copilot.
- **Converted adapters** to typed `#[derive(Deserialize)]` structs + the shared helpers: amp, codebuff, copilot, gemini, goose, kilo, kimi, openclaw, opencode, pi, qwen. (Claude and Codex already used typed parsing.)
- A few polymorphic / multi-alias leaves are intentionally kept as `Value` where typing them would change numeric coercion or drop records (documented inline).

## Why

- Consistent performance across all agents (byte-line reads, precise prefilter, no full `Value` tree per line).
- One shared, well-tested implementation of the parse loop, the prefilter, and the lenient field accessors instead of per-adapter copies.

## Behavior parity

Output is preserved exactly:

- Lenient `deserialize_with` helpers match the old `Value` accessor semantics.
- Prefilter markers never drop an accepted line.
- Parse / non-object handling keeps the same skip-vs-error outcomes. Droid is intentionally left on its existing path (no JSONL hot path; typing it would add edge divergences with no benefit).

Verified `--json` output for `daily`/`monthly`/`weekly`/`session` is **byte-for-byte identical** to both the previous `main` build and `ccusage@latest`, for every agent with local logs (claude, codex, amp, copilot, gemini, opencode, pi). Adapters without local logs (codebuff, droid, goose, kilo, kimi, openclaw, qwen, hermes) are covered by the existing fixture-backed tests.

Note: adapters now read files as bytes (`fs::read`) rather than `fs::read_to_string`; a file with invalid UTF-8 is now skipped gracefully per-line instead of failing the whole command — a minor, intentional robustness improvement consistent with the Claude loader.

## Testing

- `cargo test -p ccusage` — 276 passed
- `cargo clippy -p ccusage` — clean
- `cargo fmt --check` — clean
- Manual output parity diff vs `main` and `ccusage@latest` (see above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added newline-log prefiltering to skip irrelevant records before full parsing, improving import speed.

* **Refactor**
  * Improved robustness of usage-log import across multiple adapters by moving to typed, lenient JSON/JSONL parsing with shared ingestion helpers.
  * Updated file ingestion to read raw data and decode directly for more consistent handling of missing/optional fields.

* **Bug Fixes / Tests**
  * Strengthened parsing to ignore malformed or unexpected elements (including empty/malformed ledgers, non-object entries, and invalid cost shapes) without failing the whole import.
  * Added unit test coverage for these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->