### PR TITLE
refactor(claude): drop phf for byte-slice match in null-field check

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -116,7 +116,6 @@ dependencies = [
  "memchr",
  "mimalloc",
  "minreq",
- "phf",
  "rustc-hash",
  "schemars",
  "serde",
@@ -488,49 +487,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_macros",
- "phf_shared",
- "serde",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,12 +755,6 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "smallvec"

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -23,7 +23,6 @@ jiff = { version = "0.2.24", default-features = false, features = [
 ] }
 memchr = "2"
 compact_str = "0.9"
-phf = { version = "0.13", features = ["macros"] }
 rustc-hash = "2"
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/rust/crates/ccusage/src/adapter/claude/mod.rs
+++ b/rust/crates/ccusage/src/adapter/claude/mod.rs
@@ -480,21 +480,23 @@ pub(super) fn has_unsupported_null_field(line: &[u8]) -> bool {
 }
 
 fn is_unsupported_nullable_field(field: &[u8]) -> bool {
-    static FIELDS: phf::Set<&'static str> = phf::phf_set! {
-        "id",
-        "cwd",
-        "model",
-        "speed",
-        "costUSD",
-        "version",
-        "sessionId",
-        "requestId",
-        "isApiErrorMessage",
-        "cache_read_input_tokens",
-        "cache_creation_input_tokens",
-    };
-
-    std::str::from_utf8(field).is_ok_and(|field| FIELDS.contains(field))
+    // Match the raw field bytes directly against the known set of fields that
+    // are not allowed to be `null`. Comparing byte slices lets rustc dispatch on
+    // length before comparing bytes, which avoids both UTF-8 validation and the
+    // hash computation a `phf::Set` lookup would incur on every call.
+    matches!(
+        field,
+        b"id" | b"cwd"
+            | b"model"
+            | b"speed"
+            | b"costUSD"
+            | b"version"
+            | b"sessionId"
+            | b"requestId"
+            | b"isApiErrorMessage"
+            | b"cache_read_input_tokens"
+            | b"cache_creation_input_tokens"
+    )
 }
 
 pub(super) fn is_semver_prefix(value: &str) -> bool {


### PR DESCRIPTION
## Summary

Replace the `phf::Set` lookup in `is_unsupported_nullable_field` (Claude adapter null-field filter) with a `matches!` over byte-string literals. Matching the raw `&[u8]` lets rustc dispatch on length before comparing bytes, and removes both the UTF-8 validation (`from_utf8`) and the per-call hash computation the perfect-hash set incurred.

Inspired by the Bun lexer optimization, where a length-grouped byte-comparison switch beats a perfect hash function whose input hashing shows up in parser/lexer profiles:

https://github.com/oven-sh/bun/commit/bf79fe702c95f3424bd5a065ba956bc2fec8521f

`phf` was the **only** consumer of that dependency, so this also drops `phf`, `phf_macros`, `phf_generator`, `phf_shared`, and `siphasher` from the build graph.

## Measured impact (real local logs, `--until 20260614`)

| Metric | Result |
| --- | --- |
| Runtime | `hyperfine daily --offline --json` head vs main = **1.03x ± 0.19** — within the noise floor, no measurable end-to-end speedup |
| Binary size | **Unchanged** (byte-identical release binary, 2,747,200 bytes) |
| Clean-build time | **~1.5s less** (phf subtree no longer compiles); incremental builds unaffected |
| Output parity | **Byte-identical** to `ccusage@latest` across `daily`, `monthly`, `weekly`, `session`, `blocks` for every agent with logs (claude, codex, opencode, amp, pi, copilot, gemini) |
| Tests | Claude adapter suite passes |
| CodeRabbit (local) | No findings |

### Why no runtime gain here

Unlike Bun's lexer, where keyword matching runs **per identifier token**, `is_unsupported_nullable_field` is only called when a line contains a `:null` substring, and per-line cost is dominated by `serde_json` deserialization. So the technique applies cleanly but the hot-path conditions that make it a win in Bun do not hold here.

## Final judgment

This is **not a performance PR** — runtime and binary size are unchanged. The tangible wins are a dropped dependency, removed UTF-8 validation, marginally faster clean builds (~1.5s), and simpler/more idiomatic code, with output verified identical to `ccusage@latest`. Treat as an optional cleanup; merge if the dependency reduction is considered worthwhile, otherwise it is fine to close.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Claude adapter null-field check with a byte-slice match to remove `phf` and avoid UTF-8 validation and hashing. Behavior is identical; clean builds are ~1.5s faster, runtime and binary size unchanged.

- **Refactors**
  - Use `matches!` on `&[u8]` in `is_unsupported_nullable_field`.
  - Skip `from_utf8` and per-call hashing.

- **Dependencies**
  - Remove `phf`, `phf_macros`, `phf_generator`, `phf_shared`, and `siphasher`.

<sup>Written for commit b7ffa410a3313a691ceb5670aa3b6f9fa1b21c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

