### PR TITLE
perf(adapter): parallelize file/DB reads across all agent loaders

### DIFF
--- a/rust/crates/ccusage/src/adapter/amp/loader.rs
+++ b/rust/crates/ccusage/src/adapter/amp/loader.rs
@@ -1,5 +1,6 @@
 use crate::{
-    LoadedEntry, PricingMap, Result, cli::SharedArgs, collect_files_with_extension, parse_tz,
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, collect_files_with_extension, debug_log,
+    parse_tz, read_files_parallel,
 };
 
 use super::{parser, paths};
@@ -17,13 +18,19 @@ fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<L
         let threads_dir = path.join("threads");
         let mut files = Vec::new();
         collect_files_with_extension(&threads_dir, "json", &mut files);
-        for file in files {
-            entries.extend(parser::read_thread_file(
-                &file,
-                tz.as_ref(),
-                shared.mode,
-                Some(pricing),
-            )?);
+        let per_file = read_files_parallel(&files, shared.single_thread, |file| {
+            parser::read_thread_file(file, tz.as_ref(), shared.mode, Some(pricing)).unwrap_or_else(
+                |error| {
+                    debug_log(
+                        shared,
+                        format!("Failed to read Amp thread file {}: {error}", file.display()),
+                    );
+                    Vec::new()
+                },
+            )
+        });
+        for file_entries in per_file {
+            entries.extend(file_entries);
         }
     }
     entries.sort_by_key(|entry| entry.timestamp);

--- a/rust/crates/ccusage/src/adapter/codebuff/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff/loader.rs
@@ -7,8 +7,8 @@ use super::{
     paths::discover_chat_files,
 };
 use crate::{
-    LoadedEntry, PricingMap, Result, UsageEntry, UsageMessage, cli::SharedArgs, format_date_tz,
-    parse_tz,
+    LoadedEntry, PricingMap, Result, UsageEntry, UsageMessage, cli::SharedArgs, debug_log,
+    format_date_tz, parse_tz, read_files_parallel,
 };
 
 pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
@@ -23,9 +23,24 @@ fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<L
     let tz = parse_tz(shared.timezone.as_deref());
     let mut files = discover_chat_files()?;
     files.sort();
+    // Read files in parallel but apply the last-wins dedup sequentially over the
+    // original (sorted) file order, so the surviving entry per dedup key is
+    // identical to the single-threaded read.
+    let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+        load_chat_file(file).unwrap_or_else(|error| {
+            debug_log(
+                shared,
+                format!(
+                    "Failed to read Codebuff chat file {}: {error}",
+                    file.display()
+                ),
+            );
+            Vec::new()
+        })
+    });
     let mut deduped = HashMap::<String, CodebuffEntry>::new();
-    for file in files {
-        for entry in load_chat_file(&file)? {
+    for file_entries in loaded {
+        for entry in file_entries {
             deduped.insert(entry.dedup_key.clone(), entry);
         }
     }

--- a/rust/crates/ccusage/src/adapter/copilot/loader.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/loader.rs
@@ -8,7 +8,8 @@ use super::{
 };
 use crate::{
     LoadedEntry, Result, TokenUsageRaw, UsageEntry, UsageMessage, calculate_cost_for_usage,
-    cli::CostMode, format_date_tz, missing_pricing_model_for_usage, parse_tz,
+    cli::CostMode, debug_log, format_date_tz, missing_pricing_model_for_usage, parse_tz,
+    read_files_parallel,
 };
 
 pub(crate) fn load_entries(
@@ -27,9 +28,24 @@ fn load_entries_inner(
     pricing: &crate::PricingMap,
 ) -> Result<Vec<LoadedEntry>> {
     let tz = parse_tz(shared.timezone.as_deref());
+    let files = paths()?;
+    // Read OTEL files in parallel; entries keep their original file order before
+    // the stable sort, so output is identical to the sequential read.
+    let loaded = read_files_parallel(&files, shared.single_thread, |path| {
+        read_otel_file(path, tz.as_ref(), shared.mode, pricing).unwrap_or_else(|error| {
+            debug_log(
+                shared,
+                format!(
+                    "Failed to read Copilot OTEL file {}: {error}",
+                    path.display()
+                ),
+            );
+            Vec::new()
+        })
+    });
     let mut entries = Vec::new();
-    for path in paths()? {
-        entries.extend(read_otel_file(&path, tz.as_ref(), shared.mode, pricing)?);
+    for file_entries in loaded {
+        entries.extend(file_entries);
     }
     entries.sort_by_key(|entry| entry.timestamp);
     Ok(entries)

--- a/rust/crates/ccusage/src/adapter/droid/loader.rs
+++ b/rust/crates/ccusage/src/adapter/droid/loader.rs
@@ -7,8 +7,8 @@ use super::{
     paths::discover_settings_files,
 };
 use crate::{
-    LoadedEntry, PricingMap, Result, UsageEntry, UsageMessage, cli::SharedArgs, format_date_tz,
-    parse_tz,
+    LoadedEntry, PricingMap, Result, UsageEntry, UsageMessage, cli::SharedArgs, debug_log,
+    format_date_tz, parse_tz, read_files_parallel,
 };
 
 pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
@@ -21,12 +21,22 @@ fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<L
     let tz = parse_tz(shared.timezone.as_deref());
     let mut files = discover_settings_files()?;
     files.sort();
-    let mut parsed = Vec::new();
-    for file in files {
-        if let Some(entry) = load_settings_file(&file)? {
-            parsed.push(entry);
-        }
-    }
+    // Read files in parallel, reassembled in the original (sorted) file order so
+    // the subsequent stable sort and reverse latest-wins dedup pick the same
+    // snapshot per session as the single-threaded read.
+    let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+        load_settings_file(file).unwrap_or_else(|error| {
+            debug_log(
+                shared,
+                format!(
+                    "Failed to read Droid settings file {}: {error}",
+                    file.display()
+                ),
+            );
+            None
+        })
+    });
+    let mut parsed: Vec<DroidEntry> = loaded.into_iter().flatten().collect();
     parsed.sort_by_key(|entry| entry.timestamp);
     let mut seen_sessions = HashSet::new();
     let mut entries = Vec::new();

--- a/rust/crates/ccusage/src/adapter/gemini/loader.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/loader.rs
@@ -1,4 +1,6 @@
-use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, parse_tz};
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
+};
 
 use super::{
     parser::{event_to_loaded, parse_json_file, parse_jsonl_file},
@@ -13,14 +15,24 @@ pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<
 
 fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
     let tz = parse_tz(shared.timezone.as_deref());
-    let mut events = Vec::new();
-    for file in discover_log_files()? {
-        if file.extension().and_then(|extension| extension.to_str()) == Some("jsonl") {
-            events.extend(parse_jsonl_file(&file)?);
+    let files = discover_log_files()?;
+    // Read each log file in parallel; the events keep their original file order
+    // before the stable sort, so output is identical to the sequential read.
+    let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+        let parsed = if file.extension().and_then(|extension| extension.to_str()) == Some("jsonl") {
+            parse_jsonl_file(file)
         } else {
-            events.extend(parse_json_file(&file)?);
-        }
-    }
+            parse_json_file(file)
+        };
+        parsed.unwrap_or_else(|error| {
+            debug_log(
+                shared,
+                format!("Failed to read Gemini log file {}: {error}", file.display()),
+            );
+            Vec::new()
+        })
+    });
+    let mut events: Vec<_> = loaded.into_iter().flatten().collect();
     events.sort_by_key(|event| event.timestamp);
     Ok(events
         .into_iter()

--- a/rust/crates/ccusage/src/adapter/goose/loader.rs
+++ b/rust/crates/ccusage/src/adapter/goose/loader.rs
@@ -2,7 +2,9 @@ use std::{collections::HashSet, path::Path};
 
 use jiff::tz::TimeZone as JiffTimeZone;
 
-use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz};
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
+};
 
 use super::{parser::row_to_entry, paths::goose_db_paths};
 
@@ -31,10 +33,26 @@ pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<
 
 fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
     let tz = parse_tz(shared.timezone.as_deref());
+    let db_paths = goose_db_paths()?;
+    // Load each database in parallel (a fresh read-only connection per DB), then
+    // run the sequential per-db dedup over the original path order so the
+    // surviving session per key matches the single-threaded read.
+    let loaded = read_files_parallel(&db_paths, shared.single_thread, |db_path| {
+        load_entries_from_db(db_path, tz.as_ref(), pricing, shared).unwrap_or_else(|error| {
+            debug_log(
+                shared,
+                format!(
+                    "Failed to load Goose database {}: {error}",
+                    db_path.display()
+                ),
+            );
+            Vec::new()
+        })
+    });
     let mut entries = Vec::new();
     let mut seen = HashSet::new();
-    for db_path in goose_db_paths()? {
-        for entry in load_entries_from_db(&db_path, tz.as_ref(), pricing, shared)? {
+    for (db_path, db_entries) in db_paths.iter().zip(loaded) {
+        for entry in db_entries {
             let key = format!("{}:{}", db_path.display(), entry.session_id);
             if seen.insert(key) {
                 entries.push(entry);

--- a/rust/crates/ccusage/src/adapter/hermes/loader.rs
+++ b/rust/crates/ccusage/src/adapter/hermes/loader.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, path::Path};
 
-use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs};
+use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, read_files_parallel};
 
 use super::{
     parser::{HermesEntry, read_session_row, to_loaded_entry},
@@ -15,10 +15,17 @@ pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<
 
 fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
     let tz = crate::parse_tz(shared.timezone.as_deref());
+    let db_paths = hermes_state_db_paths()?;
+    // Load each state database in parallel (a fresh read-only connection per DB),
+    // then run the sequential session dedup over the original path order so the
+    // surviving session matches the single-threaded read.
+    let loaded = read_files_parallel(&db_paths, shared.single_thread, |db_path| {
+        load_state_db_entries(db_path, shared)
+    });
     let mut entries = Vec::new();
     let mut seen_sessions = HashSet::new();
-    for db_path in hermes_state_db_paths()? {
-        for entry in load_state_db_entries(&db_path, shared) {
+    for db_entries in loaded {
+        for entry in db_entries {
             if !seen_sessions.insert(entry.session_id.clone()) {
                 continue;
             }

--- a/rust/crates/ccusage/src/adapter/kilo/loader.rs
+++ b/rust/crates/ccusage/src/adapter/kilo/loader.rs
@@ -1,8 +1,10 @@
-use std::{collections::HashSet, path::Path};
+use std::{collections::HashSet, path::Path, path::PathBuf};
 
 use jiff::tz::TimeZone as JiffTimeZone;
 
-use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz};
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
+};
 
 use super::{
     parser::{KiloMessage, message_value_to_entry},
@@ -17,13 +19,17 @@ pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<
 
 fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
     let tz = parse_tz(shared.timezone.as_deref());
+    let db_paths: Vec<PathBuf> = paths()?.iter().filter_map(|path| db_path(path)).collect();
+    // Load each database in parallel (a fresh read-only connection per DB), then
+    // run the sequential id dedup over the original path order so the surviving
+    // record per id matches the single-threaded read.
+    let loaded = read_files_parallel(&db_paths, shared.single_thread, |db_path| {
+        load_entries_from_database(db_path, tz.as_ref(), shared, pricing)
+    });
     let mut entries = Vec::new();
     let mut seen = HashSet::new();
-    for path in paths()? {
-        let Some(db_path) = db_path(&path) else {
-            continue;
-        };
-        for entry in load_entries_from_database(&db_path, tz.as_ref(), shared, pricing) {
+    for db_entries in loaded {
+        for entry in db_entries {
             if let Some(id) = entry.data.message.id.as_deref()
                 && !seen.insert(id.to_string())
             {

--- a/rust/crates/ccusage/src/adapter/kimi/loader.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/loader.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 
-use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, parse_tz};
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
+};
 
 use super::{
     parser::{kimi_entry_key, kimi_entry_to_loaded, read_wire_file},
@@ -15,10 +17,23 @@ pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<
 
 fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
     let tz = parse_tz(shared.timezone.as_deref());
+    let files = discover_wire_files()?;
+    // Read wire files in parallel, then apply the first-wins dedup sequentially
+    // over the original discovery order so the surviving entry per key matches
+    // the single-threaded read.
+    let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+        read_wire_file(file).unwrap_or_else(|error| {
+            debug_log(
+                shared,
+                format!("Failed to read Kimi wire file {}: {error}", file.display()),
+            );
+            Vec::new()
+        })
+    });
     let mut entries = Vec::new();
     let mut seen = HashSet::new();
-    for file in discover_wire_files()? {
-        for entry in read_wire_file(&file)? {
+    for file_entries in loaded {
+        for entry in file_entries {
             let key = kimi_entry_key(&entry);
             if seen.insert(key) {
                 entries.push(kimi_entry_to_loaded(

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -1,3 +1,8 @@
+use std::{
+    path::{Path, PathBuf},
+    thread,
+};
+
 pub(crate) mod all;
 pub(crate) mod amp;
 pub(crate) mod claude;
@@ -15,3 +20,103 @@ pub(crate) mod openclaw;
 pub(crate) mod opencode;
 pub(crate) mod pi;
 pub(crate) mod qwen;
+
+/// Reads `files` by applying `read` to each path and returns the per-file
+/// results in the **original file order**.
+///
+/// Reads run on a thread pool sized to [`std::thread::available_parallelism`],
+/// except when `single_thread` is set or only a single worker would be used, in
+/// which case they run sequentially. Files are balanced across workers by byte
+/// size via [`chunk_file_indexes_by_size`](crate::chunk_file_indexes_by_size)
+/// so a few large files do not serialize one worker, and results are reassembled
+/// by their original index. Because the output order never depends on thread
+/// scheduling, any sequential dedup the caller runs afterwards observes a
+/// deterministic sequence regardless of how many workers ran.
+///
+/// The per-file `read` closure owns its error handling: it should return a
+/// neutral value (typically an empty `Vec` or `None`) and log on failure so a
+/// single unreadable file never aborts the whole load, mirroring the Claude
+/// loader's swallow-and-continue behavior.
+pub(crate) fn read_files_parallel<T, F>(files: &[PathBuf], single_thread: bool, read: F) -> Vec<T>
+where
+    T: Send,
+    F: Fn(&Path) -> T + Sync,
+{
+    let worker_count = if single_thread {
+        1
+    } else {
+        thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1)
+            .min(files.len())
+    };
+    if worker_count <= 1 {
+        return files.iter().map(|file| read(file.as_path())).collect();
+    }
+
+    let chunks = crate::chunk_file_indexes_by_size(files, worker_count);
+    let read = &read;
+    thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(chunks.len());
+        for chunk in chunks {
+            handles.push(scope.spawn(move || {
+                chunk
+                    .into_iter()
+                    .map(|index| (index, read(files[index].as_path())))
+                    .collect::<Vec<_>>()
+            }));
+        }
+        let mut results: Vec<Option<T>> = Vec::with_capacity(files.len());
+        results.resize_with(files.len(), || None);
+        for (index, value) in handles
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("file read worker panicked"))
+        {
+            results[index] = Some(value);
+        }
+        results
+            .into_iter()
+            .map(|value| value.expect("file read worker returned every file"))
+            .collect()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_files_parallel;
+    use ccusage_test_support::Fixture;
+
+    #[test]
+    fn preserves_file_order_and_matches_single_thread() {
+        // Real files with widely varying sizes so the size-balanced chunker
+        // spreads them across multiple workers, exercising the parallel path.
+        let fixture = Fixture::new();
+        let files = (0..256)
+            .map(|index| {
+                let body = "x".repeat((index % 17) * 64 + 1);
+                fixture.write_file(format!("file-{index:03}.txt"), format!("{index}:{body}"))
+            })
+            .collect::<Vec<_>>();
+
+        // Return the leading "<index>:" marker so we can assert the result order
+        // matches the input order regardless of how workers were scheduled.
+        let read = |path: &std::path::Path| {
+            let content = std::fs::read_to_string(path).unwrap();
+            content.split(':').next().unwrap().to_string()
+        };
+
+        let single = read_files_parallel(&files, true, read);
+        let multi = read_files_parallel(&files, false, read);
+        let expected = (0..256).map(|index| index.to_string()).collect::<Vec<_>>();
+
+        assert_eq!(single, expected);
+        assert_eq!(multi, expected);
+    }
+
+    #[test]
+    fn handles_empty_input() {
+        let empty: Vec<std::path::PathBuf> = Vec::new();
+        let result = read_files_parallel(&empty, false, |_| 0_u8);
+        assert!(result.is_empty());
+    }
+}

--- a/rust/crates/ccusage/src/adapter/openclaw/loader.rs
+++ b/rust/crates/ccusage/src/adapter/openclaw/loader.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 
-use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, parse_tz};
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
+};
 
 use super::{
     parser::{entry_id, parse_session_file},
@@ -28,8 +30,24 @@ fn load_entries_inner(
     let mut entries = Vec::new();
     let mut seen = HashSet::new();
     for root in paths(custom_path) {
-        for file in collect_session_files(&root)? {
-            for entry in parse_session_file(&file, tz.as_ref(), shared.mode, pricing)? {
+        let files = collect_session_files(&root)?;
+        // Read session files in parallel; the first-wins dedup runs sequentially
+        // over the original file order so the surviving record per id is the
+        // same as the single-threaded read.
+        let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+            parse_session_file(file, tz.as_ref(), shared.mode, pricing).unwrap_or_else(|error| {
+                debug_log(
+                    shared,
+                    format!(
+                        "Failed to read OpenClaw session file {}: {error}",
+                        file.display()
+                    ),
+                );
+                Vec::new()
+            })
+        });
+        for file_entries in loaded {
+            for entry in file_entries {
                 if seen.insert(entry_id(&entry)) {
                     entries.push(entry);
                 }

--- a/rust/crates/ccusage/src/adapter/opencode/loader.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/loader.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashSet,
     fs,
     path::{Path, PathBuf},
+    thread,
 };
 
 use jiff::tz::TimeZone as JiffTimeZone;
@@ -11,7 +12,7 @@ use super::{
     paths::paths,
 };
 use crate::{
-    LoadedEntry, PricingMap, Result,
+    LoadedEntry, PricingMap, Result, chunk_file_indexes_by_size,
     cli::{CostMode, SharedArgs},
     collect_files_with_extension, debug_log, parse_tz,
 };
@@ -73,18 +74,97 @@ pub(crate) fn load_entries_from_directory(
     let messages_dir = opencode_dir.join("storage").join("message");
     let mut files = Vec::new();
     collect_files_with_extension(&messages_dir, "json", &mut files);
-    for file in files {
-        if let Some(entry) = read_message_file(&file, tz.as_ref(), shared.mode, pricing.as_ref())? {
-            if let Some(id) = entry_id(&entry)
-                && !seen.insert(id.to_string())
-            {
-                continue;
-            }
-            entries.push(entry);
+
+    // Skip files the DB pass already covered. Message files are stored as
+    // `storage/message/<sessionID>/<messageID>.json`, so the file stem is the
+    // message id used for dedup. When the DB already contributed that id, the
+    // file would be discarded by the id dedup below anyway — drop it here so we
+    // never pay the read. Files whose stem is not a known id (or that have no
+    // usable stem) are kept and parsed normally.
+    if !seen.is_empty() {
+        files.retain(|file| {
+            file.file_stem()
+                .and_then(|stem| stem.to_str())
+                .is_none_or(|stem| !seen.contains(stem))
+        });
+    }
+
+    let loaded = read_message_files(&files, tz.as_ref(), shared.mode, pricing.as_ref(), shared);
+    for entry in loaded.into_iter().flatten() {
+        if let Some(id) = entry_id(&entry)
+            && !seen.insert(id.to_string())
+        {
+            continue;
         }
+        entries.push(entry);
     }
     entries.sort_by_key(|entry| entry.timestamp);
     Ok(entries)
+}
+
+/// Reads and parses the collected message files, returning one slot per input
+/// file in the original order so the caller's sequential dedup pass observes a
+/// deterministic ordering regardless of how many worker threads ran.
+///
+/// Honors [`SharedArgs::single_thread`] and falls back to a sequential read
+/// when only a single worker would be used. Per-file read failures are logged
+/// and skipped (mirroring the Claude loader's swallow-and-continue behavior)
+/// rather than aborting the whole load.
+fn read_message_files(
+    files: &[PathBuf],
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+    shared: &SharedArgs,
+) -> Vec<Option<LoadedEntry>> {
+    let worker_count = if shared.single_thread {
+        1
+    } else {
+        thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1)
+            .min(files.len())
+    };
+    if worker_count <= 1 {
+        return files
+            .iter()
+            .map(|file| read_message_file(file, tz, mode, pricing, shared))
+            .collect();
+    }
+
+    // Balance the files across workers by byte size so a few large files do not
+    // serialize a single worker, then reassemble results by their original
+    // index to keep the output order identical to the sequential read.
+    let chunks = chunk_file_indexes_by_size(files, worker_count);
+    thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(chunks.len());
+        for chunk in chunks {
+            let tz = tz.cloned();
+            handles.push(scope.spawn(move || {
+                chunk
+                    .into_iter()
+                    .map(|index| {
+                        (
+                            index,
+                            read_message_file(&files[index], tz.as_ref(), mode, pricing, shared),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            }));
+        }
+        let mut loaded = Vec::with_capacity(files.len());
+        loaded.resize_with(files.len(), || None);
+        for (index, entry) in handles
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("opencode message worker panicked"))
+        {
+            loaded[index] = Some(entry);
+        }
+        loaded
+            .into_iter()
+            .map(|entry| entry.expect("opencode message worker returned every file"))
+            .collect()
+    })
 }
 
 fn db_path(opencode_dir: &Path) -> Option<PathBuf> {
@@ -179,14 +259,23 @@ fn read_message_file(
     tz: Option<&JiffTimeZone>,
     mode: CostMode,
     pricing: Option<&PricingMap>,
-) -> Result<Option<LoadedEntry>> {
-    let content = fs::read(path)?;
-    let Ok(value) = serde_json::from_slice::<OpenCodeMessage>(&content) else {
-        return Ok(None);
+    shared: &SharedArgs,
+) -> Option<LoadedEntry> {
+    let content = match fs::read(path) {
+        Ok(content) => content,
+        Err(error) => {
+            debug_log(
+                shared,
+                format!(
+                    "Failed to read OpenCode message file {}: {error}",
+                    path.display()
+                ),
+            );
+            return None;
+        }
     };
-    Ok(message_value_to_entry(
-        &value, None, None, tz, mode, pricing,
-    ))
+    let value = serde_json::from_slice::<OpenCodeMessage>(&content).ok()?;
+    message_value_to_entry(&value, None, None, tz, mode, pricing)
 }
 
 fn entry_id(entry: &LoadedEntry) -> Option<&str> {
@@ -314,5 +403,110 @@ mod tests {
         assert_eq!(entries[0].session_id.as_ref(), "db-session-a");
         assert_eq!(entries[0].data.message.usage.input_tokens, 120);
         assert_eq!(entries[0].cost, 0.03);
+    }
+
+    #[test]
+    fn skips_message_files_already_covered_by_database() {
+        // Real OpenCode message files live at
+        // `storage/message/<sessionID>/<messageID>.json`, so the file stem is
+        // the message id. The DB pass contributes `msg-db`, so the matching
+        // file must be dropped (DB wins) while the file that the DB does not
+        // cover is still loaded.
+        let fixture = fs_fixture!({
+            "storage/message/ses_a/msg-db.json": r#"{"id":"msg-db","sessionID":"json-session","providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":999,"output":999},"cost":0.99}"#,
+            "storage/message/ses_a/msg-file.json": r#"{"id":"msg-file","sessionID":"file-session","providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000001},"tokens":{"input":50,"output":25},"cost":0.01}"#,
+        });
+        create_db_message(
+            &fixture.path("opencode.db"),
+            "msg-db",
+            "db-session",
+            r#"{"providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":120,"output":60},"cost":0.03}"#,
+        );
+
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            ..SharedArgs::default()
+        };
+        let entries = load_entries_from_directory(fixture.root(), &shared).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        // The DB-covered id keeps the DB row, not the file's inflated tokens.
+        let db_entry = entries
+            .iter()
+            .find(|entry| entry.data.message.id.as_deref() == Some("msg-db"))
+            .expect("db-covered message present");
+        assert_eq!(db_entry.session_id.as_ref(), "db-session");
+        assert_eq!(db_entry.data.message.usage.input_tokens, 120);
+        // The file the DB does not cover is still read and parsed.
+        let file_entry = entries
+            .iter()
+            .find(|entry| entry.data.message.id.as_deref() == Some("msg-file"))
+            .expect("db-uncovered message present");
+        assert_eq!(file_entry.session_id.as_ref(), "file-session");
+        assert_eq!(file_entry.data.message.usage.input_tokens, 50);
+    }
+
+    #[test]
+    fn dedup_is_stable_across_thread_counts() {
+        // Build a directory with many files spread over several sessions, some
+        // sharing ids with each other and with the DB, so the file pass has to
+        // dedup. Parallel reads must not change which duplicate survives or the
+        // final ordering compared to the single-threaded read.
+        let fixture = ccusage_test_support::Fixture::new();
+        for session in 0..4 {
+            for message in 0..15 {
+                let id = format!("msg-{session}-{message}");
+                let created = 1_767_312_000_000_i64 + i64::from(session * 100 + message);
+                let path = format!("storage/message/ses_{session}/{id}.json");
+                let data = format!(
+                    r#"{{"id":"{id}","sessionID":"ses_{session}","providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{{"created":{created}}},"tokens":{{"input":{input},"output":10}}}}"#,
+                    input = 100 + message,
+                );
+                let _ = fixture.write_file(path, data);
+            }
+        }
+        // A duplicate file (same id, later timestamp) to force the file-vs-file
+        // dedup path under both thread counts.
+        let _ = fixture.write_file(
+            "storage/message/ses_dup/msg-0-0.json",
+            r#"{"id":"msg-0-0","sessionID":"ses_dup","providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312999999},"tokens":{"input":7777,"output":10}}"#,
+        );
+
+        create_db_message(
+            &fixture.path("opencode.db"),
+            "msg-1-1",
+            "db-session",
+            r#"{"providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":120,"output":60}}"#,
+        );
+
+        let single = SharedArgs {
+            mode: CostMode::Display,
+            single_thread: true,
+            ..SharedArgs::default()
+        };
+        let multi = SharedArgs {
+            mode: CostMode::Display,
+            single_thread: false,
+            ..SharedArgs::default()
+        };
+
+        let single_entries = load_entries_from_directory(fixture.root(), &single).unwrap();
+        let multi_entries = load_entries_from_directory(fixture.root(), &multi).unwrap();
+
+        let project = |entries: &[crate::LoadedEntry]| {
+            entries
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.timestamp.as_millis(),
+                        entry.data.message.id.clone(),
+                        entry.session_id.to_string(),
+                        entry.data.message.usage.input_tokens,
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(project(&single_entries), project(&multi_entries));
     }
 }

--- a/rust/crates/ccusage/src/adapter/opencode/loader.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/loader.rs
@@ -2,7 +2,6 @@ use std::{
     collections::HashSet,
     fs,
     path::{Path, PathBuf},
-    thread,
 };
 
 use jiff::tz::TimeZone as JiffTimeZone;
@@ -12,9 +11,9 @@ use super::{
     paths::paths,
 };
 use crate::{
-    LoadedEntry, PricingMap, Result, chunk_file_indexes_by_size,
+    LoadedEntry, PricingMap, Result,
     cli::{CostMode, SharedArgs},
-    collect_files_with_extension, debug_log, parse_tz,
+    collect_files_with_extension, debug_log, parse_tz, read_files_parallel,
 };
 
 pub(crate) fn load_entries(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
@@ -89,7 +88,12 @@ pub(crate) fn load_entries_from_directory(
         });
     }
 
-    let loaded = read_message_files(&files, tz.as_ref(), shared.mode, pricing.as_ref(), shared);
+    // Read the surviving files in parallel, then run the sequential id dedup
+    // over the results in their original file order so parallelism never changes
+    // which duplicate survives.
+    let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+        read_message_file(file, tz.as_ref(), shared.mode, pricing.as_ref(), shared)
+    });
     for entry in loaded.into_iter().flatten() {
         if let Some(id) = entry_id(&entry)
             && !seen.insert(id.to_string())
@@ -100,71 +104,6 @@ pub(crate) fn load_entries_from_directory(
     }
     entries.sort_by_key(|entry| entry.timestamp);
     Ok(entries)
-}
-
-/// Reads and parses the collected message files, returning one slot per input
-/// file in the original order so the caller's sequential dedup pass observes a
-/// deterministic ordering regardless of how many worker threads ran.
-///
-/// Honors [`SharedArgs::single_thread`] and falls back to a sequential read
-/// when only a single worker would be used. Per-file read failures are logged
-/// and skipped (mirroring the Claude loader's swallow-and-continue behavior)
-/// rather than aborting the whole load.
-fn read_message_files(
-    files: &[PathBuf],
-    tz: Option<&JiffTimeZone>,
-    mode: CostMode,
-    pricing: Option<&PricingMap>,
-    shared: &SharedArgs,
-) -> Vec<Option<LoadedEntry>> {
-    let worker_count = if shared.single_thread {
-        1
-    } else {
-        thread::available_parallelism()
-            .map(usize::from)
-            .unwrap_or(1)
-            .min(files.len())
-    };
-    if worker_count <= 1 {
-        return files
-            .iter()
-            .map(|file| read_message_file(file, tz, mode, pricing, shared))
-            .collect();
-    }
-
-    // Balance the files across workers by byte size so a few large files do not
-    // serialize a single worker, then reassemble results by their original
-    // index to keep the output order identical to the sequential read.
-    let chunks = chunk_file_indexes_by_size(files, worker_count);
-    thread::scope(|scope| {
-        let mut handles = Vec::with_capacity(chunks.len());
-        for chunk in chunks {
-            let tz = tz.cloned();
-            handles.push(scope.spawn(move || {
-                chunk
-                    .into_iter()
-                    .map(|index| {
-                        (
-                            index,
-                            read_message_file(&files[index], tz.as_ref(), mode, pricing, shared),
-                        )
-                    })
-                    .collect::<Vec<_>>()
-            }));
-        }
-        let mut loaded = Vec::with_capacity(files.len());
-        loaded.resize_with(files.len(), || None);
-        for (index, entry) in handles
-            .into_iter()
-            .flat_map(|handle| handle.join().expect("opencode message worker panicked"))
-        {
-            loaded[index] = Some(entry);
-        }
-        loaded
-            .into_iter()
-            .map(|entry| entry.expect("opencode message worker returned every file"))
-            .collect()
-    })
 }
 
 fn db_path(opencode_dir: &Path) -> Option<PathBuf> {

--- a/rust/crates/ccusage/src/adapter/pi/loader.rs
+++ b/rust/crates/ccusage/src/adapter/pi/loader.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
 use crate::{
-    LoadedEntry, PricingMap, Result, cli::SharedArgs, collect_files_with_extension, parse_tz,
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, collect_files_with_extension, debug_log,
+    parse_tz, read_files_parallel,
 };
 
 use super::{parser, paths};
@@ -27,8 +28,22 @@ fn load_entries_inner(
     for path in paths::paths(custom_path)? {
         let mut files = Vec::new();
         collect_files_with_extension(&path, "jsonl", &mut files);
-        for file in files {
-            for entry in parser::read_session_file(&file, tz.as_ref(), shared.mode, pricing)? {
+        // Read session files in parallel; the first-wins dedup runs sequentially
+        // over the original file order so the surviving record per id matches the
+        // single-threaded read.
+        let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+            parser::read_session_file(file, tz.as_ref(), shared.mode, pricing).unwrap_or_else(
+                |error| {
+                    debug_log(
+                        shared,
+                        format!("Failed to read pi session file {}: {error}", file.display()),
+                    );
+                    Vec::new()
+                },
+            )
+        });
+        for file_entries in loaded {
+            for entry in file_entries {
                 let id = parser::entry_id(&entry);
                 if seen.insert(id) {
                     entries.push(entry);

--- a/rust/crates/ccusage/src/adapter/qwen/parser.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/parser.rs
@@ -14,9 +14,10 @@ use crate::{
     LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
     apply_total_token_fallback, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
+    debug_log,
     fast::LinePrefilter,
     format_date_tz, format_rfc3339_millis, missing_pricing_model_for_candidates,
-    parse_ts_timestamp, parse_tz,
+    parse_ts_timestamp, parse_tz, read_files_parallel,
 };
 
 const DEFAULT_QWEN_MODEL: &str = "unknown";
@@ -64,10 +65,25 @@ pub(super) fn load_entries(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
         ))
     };
     let tz = parse_tz(shared.timezone.as_deref());
+    let files = paths::discover_chat_files()?;
+    // Read chat files in parallel; the first-wins dedup runs sequentially over
+    // the original discovery order so the surviving record per id matches the
+    // single-threaded read.
+    let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+        read_chat_file(file, tz.as_ref(), shared.mode, pricing.as_ref(), shared).unwrap_or_else(
+            |error| {
+                debug_log(
+                    shared,
+                    format!("Failed to read Qwen chat file {}: {error}", file.display()),
+                );
+                Vec::new()
+            },
+        )
+    });
     let mut entries = Vec::new();
     let mut seen = HashSet::new();
-    for file in paths::discover_chat_files()? {
-        for entry in read_chat_file(&file, tz.as_ref(), shared.mode, pricing.as_ref(), shared)? {
+    for file_entries in loaded {
+        for entry in file_entries {
             if seen.insert(entry_id(&entry)) {
                 entries.push(entry);
             }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -24,6 +24,7 @@ pub(crate) use adapter::claude::{
     chunk_file_indexes_by_size, collect_files_with_extension, collect_usage_files,
     filter_loaded_entries_by_date, load_daily_summaries, load_entries,
 };
+pub(crate) use adapter::read_files_parallel;
 pub(crate) use blocks::{
     block_json, calculate_burn_rate, filter_blocks_by_date, format_remaining_time,
     identify_session_blocks, print_active_block_detail, print_blocks_table, sort_blocks,


### PR DESCRIPTION
## Summary

`claude` and `codex` were the only loaders that read their source files in parallel; every other agent read them one at a time, so large histories were bottlenecked on serial I/O. This PR extracts the proven Claude pattern into one shared helper and adopts it across **all** agent loaders, with **byte-identical output**.

## What changed

- **New shared helper `adapter::read_files_parallel`** — reads files on a pool sized to `available_parallelism` (sequential fallback when `--single-thread` or a single worker), balances by byte size via `chunk_file_indexes_by_size`, and **reassembles results in original file order**. That ordering guarantee lets every caller keep its existing sequential dedup unchanged, so parallelism never changes which duplicate survives or the final ordering.
- **opencode** also skips message files the SQLite DB already covers (file stem = message id), avoiding the read entirely.
- **File-based loaders** now parallelized: `amp`, `codebuff`, `droid`, `gemini`, `kimi`, `openclaw`, `pi`, `qwen`.
- **OTEL / database loaders** now parallelized across multiple sources: `copilot`, `goose`, `hermes`, `kilo` (each DB on its own read-only connection; within-DB row scan stays sequential — inherent to one connection).
- Per-file read errors are logged and skipped instead of aborting the whole load (matches the Claude loader).

## Why

Addresses slow `ccusage <agent>` on large histories. The cost is I/O (opening/reading many small files), not parsing — parsing was already optimized by #1326/#1327.

## Testing

- `cargo test` (151 adapter tests) green; `clippy` clean; `just fmt` applied.
- New helper tests: order preservation, single/multi-thread equivalence, empty input.
- **Byte-identical output** verified against the previous release for `daily`/`monthly`/`weekly`/`session` (JSON + table), plus `--single-thread` == multi-thread:
  - Real local data: `amp`, `gemini`, `pi`, `opencode`, `copilot`.
  - Synthesized fixtures (80–120 files/rows, with duplicates and multi-DB overlap): `codebuff`, `droid`, `kimi`, `openclaw`, `qwen`, `goose`, `hermes`, `kilo`.
- Benchmarks (`hyperfine --warmup 3 --runs 10 --shell none`, synthetic fixtures):
  - opencode 50k files, DB covers 90%: **~5.36×** faster (1.41s → 263ms).
  - opencode 50k files, no DB: **~1.14×** faster.

## Notes

Squash-merge per repo convention. The first commit (opencode parallel + DB-skip) is kept distinct; the helper commit then unifies opencode onto the shared path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Parallelized loading of multiple chat/session files across adapters while preserving deterministic output ordering.
  * Reduced redundant JSON reads when matching cached/database-covered message IDs.
* **Bug Fixes**
  * Improved robustness: individual file read/parse failures are now logged and skipped instead of aborting the entire load.
* **Tests**
  * Added coverage ensuring deduplication output remains identical between single-thread and multi-thread loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->