### PR TITLE
ci: parallelize test steps and fold check into test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,17 +36,21 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-nix-cache
-      # `nix flake check` only needs the checkout and Nix, so kick it off in the
-      # background right away. It then overlaps the JS toolchain install and the
-      # test runs below instead of occupying a separate runner with its own
-      # checkout and Nix cache restore.
+      # `nix flake check` and the Rust test build (`nix build .#ccusage-tests`)
+      # only need the checkout and Nix — neither touches the JS toolchain — so
+      # start both as background steps right away. They run concurrently while
+      # the JS-only setup (toolchain install + pnpm install) happens below, and
+      # the Node tests join them afterwards via `wait-all`.
+      # https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
       - name: Run nix flake check
         background: true
         run: nix flake check --print-build-logs
-      # Node tests need the JS toolchain; the Rust tests run via `nix build`. Install
-      # just pnpm/node/just instead of realizing the full dev shell, which drags
-      # in every linter, formatter, and the pre-commit hook closure and dominated
-      # this job's wall time.
+      - name: Run Rust tests
+        background: true
+        run: nix build .#ccusage-tests --print-build-logs
+      # Node tests need the JS toolchain. Install just pnpm/node/just instead of
+      # realizing the full dev shell, which drags in every linter, formatter, and
+      # the pre-commit hook closure and dominated this job's wall time.
       - name: Install JS tooling
         run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#just
       - run: pnpm install --frozen-lockfile
@@ -54,18 +58,9 @@ jobs:
         run: |
           mkdir -p "$HOME/.claude/projects"
           mkdir -p "$HOME/.config/claude/projects"
-      # The Node tests (`just test-node`, mostly single-threaded) and the Rust
-      # test build (`nix build`, CPU-heavy) are independent and have different
-      # resource profiles, so run them as concurrent background steps and join
-      # with `wait-all`. This overlaps them instead of paying their wall time
-      # back-to-back on the same runner.
-      # https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
       - name: Run Node tests
         background: true
         run: just test-node
-      - name: Run Rust tests
-        background: true
-        run: nix build .#ccusage-tests --print-build-logs
       - wait-all:
 
   build-native-packages:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,10 +57,19 @@ jobs:
         run: |
           mkdir -p "$HOME/.claude/projects"
           mkdir -p "$HOME/.config/claude/projects"
+      # The Node tests (`just test-node`, mostly single-threaded) and the Rust
+      # test build (`nix build`, CPU-heavy) are independent and have different
+      # resource profiles, so run them as concurrent background steps and join
+      # with `wait-all`. This overlaps them instead of paying their wall time
+      # back-to-back on the same runner.
+      # https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
       - name: Run Node tests
+        background: true
         run: just test-node
       - name: Run Rust tests
+        background: true
         run: nix build .#ccusage-tests --print-build-logs
+      - wait-all:
 
   build-native-packages:
     needs: changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,16 +21,6 @@ jobs:
       - id: detect
         uses: ./.github/actions/detect-code-changes
 
-  check:
-    needs: changes
-    if: needs.changes.outputs.code-changed == 'true'
-    runs-on: blacksmith-32vcpu-ubuntu-2404
-
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: ./.github/actions/setup-nix-cache
-      - run: nix flake check --print-build-logs
-
   test:
     needs: changes
     if: needs.changes.outputs.code-changed == 'true'
@@ -46,6 +36,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-nix-cache
+      # `nix flake check` only needs the checkout and Nix, so kick it off in the
+      # background right away. It then overlaps the JS toolchain install and the
+      # test runs below instead of occupying a separate runner with its own
+      # checkout and Nix cache restore.
+      - name: Run nix flake check
+        background: true
+        run: nix flake check --print-build-logs
       # Node tests need the JS toolchain; the Rust tests run via `nix build`. Install
       # just pnpm/node/just instead of realizing the full dev shell, which drags
       # in every linter, formatter, and the pre-commit hook closure and dominated
@@ -416,7 +413,6 @@ jobs:
   action-timeline:
     needs:
       - changes
-      - check
       - test
       - build-native-packages
       - npm-publish-dry-run-and-upload-pkg-pr-now

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,6 @@ jobs:
       - name: Run Node tests
         background: true
         run: just test-node
-      # actionlint:ignore:syntax-check - wait-all is a new parallel-step join key (2026-06-25), not a run/uses step
       - wait-all:
 
   build-native-packages:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,8 @@ jobs:
       - name: Run Node tests
         background: true
         run: just test-node
-      - wait-all: # actionlint:ignore:syntax-check
+      # actionlint:ignore:syntax-check - wait-all is a new parallel-step join key (2026-06-25), not a run/uses step
+      - wait-all:
 
   build-native-packages:
     needs: changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Run Node tests
         background: true
         run: just test-node
-      - wait-all:
+      - wait-all: # actionlint:ignore:syntax-check
 
   build-native-packages:
     needs: changes

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -101,13 +101,14 @@ in
               # GitHub Actions on 2026-06-25 that actionlint does not yet recognize.
               # actionlint:ignore inline comments cannot suppress syntax-check errors
               # (only expression-evaluation and job-dependency errors support that),
-              # so a global -ignore pattern is the only available mechanism.
-              # The risk is bounded: any step genuinely missing run:/uses: would
-              # fail immediately at GitHub Actions runtime.
+              # so a -ignore pattern is the only available mechanism.
+              # The wait-all ignore is scoped to ci.yaml (via the file path prefix in
+              # the regex) so missing run:/uses: errors in other workflow files are
+              # still caught.
               "-ignore"
               ''unexpected key "background" for step''
               "-ignore"
-              "step must run script with .run. section or run action with .uses. section"
+              ''ci\.yaml.*step must run script with .run. section or run action with .uses. section''
             ];
             includes = [
               ".github/workflows/*.yaml"

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -98,7 +98,7 @@ in
               "-ignore"
               "shellcheck reported issue in this script: SC2016:info:"
               # `background:` and `wait-all:` are new parallel-step keys
-              # (GitHub Actions 2026-06-25) that actionlint does not yet recognise.
+              # (GitHub Actions 2026-06-25) that actionlint does not yet recognize.
               "-ignore"
               ''unexpected key "background" for step''
               "-ignore"

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -97,12 +97,17 @@ in
               ''unknown permission scope "code-quality"''
               "-ignore"
               "shellcheck reported issue in this script: SC2016:info:"
-              # `background:` is a new parallel-step key (GitHub Actions 2026-06-25)
-              # that actionlint does not yet recognize.
-              # `wait-all:` is suppressed with an inline actionlint:ignore comment
-              # in the workflow file itself, keeping the global ignore narrow.
+              # `background:` and `wait-all:` are new parallel-step keys added in
+              # GitHub Actions on 2026-06-25 that actionlint does not yet recognize.
+              # actionlint:ignore inline comments cannot suppress syntax-check errors
+              # (only expression-evaluation and job-dependency errors support that),
+              # so a global -ignore pattern is the only available mechanism.
+              # The risk is bounded: any step genuinely missing run:/uses: would
+              # fail immediately at GitHub Actions runtime.
               "-ignore"
               ''unexpected key "background" for step''
+              "-ignore"
+              "step must run script with .run. section or run action with .uses. section"
             ];
             includes = [
               ".github/workflows/*.yaml"

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -108,7 +108,7 @@ in
               "-ignore"
               ''unexpected key "background" for step''
               "-ignore"
-              ''ci\.yaml.*step must run script with .run. section or run action with .uses. section''
+              "ci.yaml.*step must run script with .run. section or run action with .uses. section"
             ];
             includes = [
               ".github/workflows/*.yaml"

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -101,14 +101,15 @@ in
               # GitHub Actions on 2026-06-25 that actionlint does not yet recognize.
               # actionlint:ignore inline comments cannot suppress syntax-check errors
               # (only expression-evaluation and job-dependency errors support that),
-              # so a -ignore pattern is the only available mechanism.
-              # The wait-all ignore is scoped to ci.yaml (via the file path prefix in
-              # the regex) so missing run:/uses: errors in other workflow files are
-              # still caught.
+              # so a global -ignore pattern is the only mechanism that works here.
+              # `-ignore` matches the message text only (not the file path), so the
+              # pattern cannot be narrowed to ci.yaml by prefixing the regex with a
+              # filename. The risk is bounded: any step genuinely missing run:/uses:
+              # would fail immediately at GitHub Actions runtime.
               "-ignore"
               ''unexpected key "background" for step''
               "-ignore"
-              "ci.yaml.*step must run script with .run. section or run action with .uses. section"
+              "step must run script with .run. section or run action with .uses. section"
             ];
             includes = [
               ".github/workflows/*.yaml"

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -97,6 +97,10 @@ in
               ''unknown permission scope "code-quality"''
               "-ignore"
               "shellcheck reported issue in this script: SC2016:info:"
+              # `background:` is a new parallel-step key (GitHub Actions 2026-06-25)
+              # that actionlint does not yet recognise.
+              "-ignore"
+              ''unexpected key "background" for step''
             ];
             includes = [
               ".github/workflows/*.yaml"

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -97,12 +97,12 @@ in
               ''unknown permission scope "code-quality"''
               "-ignore"
               "shellcheck reported issue in this script: SC2016:info:"
-              # `background:` and `wait-all:` are new parallel-step keys
-              # (GitHub Actions 2026-06-25) that actionlint does not yet recognize.
+              # `background:` is a new parallel-step key (GitHub Actions 2026-06-25)
+              # that actionlint does not yet recognize.
+              # `wait-all:` is suppressed with an inline actionlint:ignore comment
+              # in the workflow file itself, keeping the global ignore narrow.
               "-ignore"
               ''unexpected key "background" for step''
-              "-ignore"
-              "step must run script with .run. section or run action with .uses. section"
             ];
             includes = [
               ".github/workflows/*.yaml"

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -97,10 +97,12 @@ in
               ''unknown permission scope "code-quality"''
               "-ignore"
               "shellcheck reported issue in this script: SC2016:info:"
-              # `background:` is a new parallel-step key (GitHub Actions 2026-06-25)
-              # that actionlint does not yet recognise.
+              # `background:` and `wait-all:` are new parallel-step keys
+              # (GitHub Actions 2026-06-25) that actionlint does not yet recognise.
               "-ignore"
               ''unexpected key "background" for step''
+              "-ignore"
+              "step must run script with .run. section or run action with .uses. section"
             ];
             includes = [
               ".github/workflows/*.yaml"


### PR DESCRIPTION
## What

Apply the new [GitHub Actions parallel steps](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) feature (`background: true` + `wait-all`) to the CI workflow to cut wall time and a duplicated runner.

This is an **experiment to observe** — the feature shipped 2026-06-25 and isn't in the official workflow-syntax reference yet, and our heavy jobs run on Blacksmith runners whose agent support for it is unverified. The `action-timeline` job will show whether it actually helps.

## Changes

1. **`test` job: run Node and Rust tests in parallel** (`d065a10`)
   - `just test-node` (mostly single-threaded) and `nix build .#ccusage-tests` (CPU-heavy) are independent with different resource profiles, so they overlap well on one runner instead of running back-to-back.

2. **Fold `nix flake check` into the `test` job** (`8d132f3`)
   - The standalone `check` job only re-paid the checkout + Nix cache restore on a second runner to run one command. It now runs as an early background step in `test`, overlapping the JS toolchain install and the test runs.
   - ⚠️ **Removes the `check` status check** — `test` now covers it. Branch-protection required-checks may need updating.

## Deliberately NOT done

- **`ccusage-perf-comment` left as a matrix.** Parallelizing the js/rust legs on one runner would make them contend for CPU and **corrupt the hyperfine benchmark numbers**; serializing them on one runner would be slower than the current two-machine matrix. Separate machines are correct here.
- **`npm publish` / release untouched** (per request) and other jobs with strictly sequential dependencies.

## What to observe

- Does Blacksmith accept the `background:` / `wait-all:` syntax at all?
- `action-timeline`: is the merged `test` job faster than the old `check` + `test`, or does CPU/memory contention (flake check + node + rust on one 32-vCPU box) eat the saving?
- Are the parallel step logs cleanly separated in the Actions UI?

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized the `test` job and folded `nix flake check` into it to cut CI wall time and remove a duplicated runner. Added global `actionlint` ignores for the new parallel-step keys so checks stay green with `background`/`wait-all`.

- **Refactors**
  - Run `nix flake check` as an early background step in `test`; removed the `check` job and its `action-timeline` dependency.
  - Run `just test-node` and `nix build .#ccusage-tests` in parallel, start the Rust build before JS setup, then join with `wait-all`.
  - Add global `actionlint` ignores for `background` and the `wait-all` syntax-check message; inline/file-scoped suppression isn’t supported for this error, and the risk is bounded by runtime failures.

- **Migration**
  - Update branch protection required checks: replace `check` with `test`.

<sup>Written for commit d0975d66b4c7659802b4441ebcbb055bf3609426. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the CI workflow by removing the standalone checks job and running `nix flake check` within the main test job.
  * Improved CI throughput by running related validations/builds concurrently and synchronizing completion.
  * Updated workflow job dependencies to match the simplified pipeline.
  * Adjusted formatting/lint settings to suppress `actionlint` false warnings for newly used parallel-step keys (`background` / `wait-all`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->