### PR TITLE
ci: add tirith security scan and fail-fast preflight gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,106 @@ jobs:
       - id: detect
         uses: ./.github/actions/detect-code-changes
 
+  # Security gate: scan the repository with tirith (https://tirith.sh/docs/ci/)
+  # before any of the real CI work runs. This is wired on `pull_request` (not
+  # `pull_request_target`), so fork PRs only ever get a read-only token and
+  # cannot leak secrets while we scan their code. The downstream jobs `needs`
+  # this job, so they are skipped unless tirith passes. tirith is installed from
+  # the flake's pinned nixpkgs so CI matches the dev shell.
+  tirith-scan:
+    name: tirith security scan
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # Publish SARIF to the Security tab. Only effective for same-repo PRs and
+      # pushes to main; fork PRs get a read-only token, so the upload is gated
+      # to non-fork events below (the scan and gate still run for forks).
+      security-events: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix-cache
+      - name: Install tirith
+        run: nix profile install --inputs-from . nixpkgs#tirith
+      # One pass produces the SARIF report and sets the gate exit code. tirith's
+      # `--ci` exit code is: 0 = no findings, 1 = findings at/above --fail-on,
+      # 2 = findings present but all below it. We capture it (rather than letting
+      # it abort the step) so the SARIF still uploads before the gate decides.
+      #
+      # `*.snap` are excluded: they are terminal snapshot test fixtures that
+      # intentionally contain ANSI escape sequences, so the `ansi_escapes` rule
+      # (High) fires on them as a false positive. The rule stays active for real
+      # source files; we only skip the test data.
+      - name: Scan repository with tirith
+        id: scan
+        run: |
+          set +e
+          tirith scan --ci --fail-on high --exclude '*.snap' --format sarif ./ > results.sarif
+          code=$?
+          set -e
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          echo "tirith exited ${code}"
+      - name: Summarize findings
+        if: always()
+        run: |
+          count="$(jq '[.runs[].results[]?] | length' results.sarif 2>/dev/null || echo 0)"
+          echo "tirith reported ${count} finding(s)" | tee -a "$GITHUB_STEP_SUMMARY"
+          jq -r '.runs[].results[]? | "- [\(.level // "warning")] \(.ruleId): \(.locations[0].physicalLocation.artifactLocation.uri)"' \
+            results.sarif 2>/dev/null | tee -a "$GITHUB_STEP_SUMMARY" || true
+      - name: Upload SARIF to the Security tab
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif
+          category: tirith
+      - name: Gate CI on tirith findings
+        if: always()
+        env:
+          SCAN_EXIT: ${{ steps.scan.outputs.exit_code }}
+        run: |
+          case "$SCAN_EXIT" in
+            0 | 2)
+              echo "tirith gate passed (exit ${SCAN_EXIT}: no findings, or all below 'high')"
+              ;;
+            1)
+              echo "::error::tirith found findings at or above the 'high' threshold; blocking downstream CI"
+              exit 1
+              ;;
+            *)
+              echo "::error::tirith scan errored (exit ${SCAN_EXIT}); blocking downstream CI"
+              exit 1
+              ;;
+          esac
+
+  # Fast, unconditional fail-fast gate for the cheap-but-high-signal checks:
+  # secret detection (gitleaks) and workflow/format lint (the treefmt check,
+  # which runs actionlint + zizmor with the repo's exact ignore config). Runs in
+  # parallel with tirith-scan and is NOT gated on `changes`, so secrets and
+  # workflow regressions are caught even on docs-only PRs and on fork PRs (where
+  # local git hooks never run). Both are existing flake checks, so this reuses
+  # their exact behavior instead of re-specifying flags here. The heavy test job
+  # re-runs them inside `nix flake check`; that is intentional duplication so the
+  # gate can fail fast before any build/test work starts.
+  preflight:
+    name: security & lint preflight
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix-cache
+      - name: Secret scan and workflow lint
+        run: nix build --print-build-logs .#checks.x86_64-linux.gitleaks .#checks.x86_64-linux.treefmt
+
   test:
-    needs: changes
+    needs: [changes, tirith-scan, preflight]
     if: needs.changes.outputs.code-changed == 'true'
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
@@ -50,7 +148,7 @@ jobs:
               just test-node
 
   build-native-packages:
-    needs: changes
+    needs: [changes, tirith-scan, preflight]
     if: needs.changes.outputs.code-changed == 'true'
     name: ${{ matrix.name }}
     permissions:
@@ -394,6 +492,8 @@ jobs:
   action-timeline:
     needs:
       - changes
+      - tirith-scan
+      - preflight
       - test
       - build-native-packages
       - npm-publish-dry-run-and-upload-pkg-pr-now

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,12 +31,12 @@ jobs:
     name: tirith security scan
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
+    # Read-only: this job executes PR-controlled code (the local action, the PR
+    # flake, the installed tirith), so it must hold no write scopes. The SARIF
+    # is published from the separate `tirith-sarif-upload` job, which never runs
+    # PR code, keeping the elevated `security-events: write` away from the scan.
     permissions:
       contents: read
-      # Publish SARIF to the Security tab. Only effective for same-repo PRs and
-      # pushes to main; fork PRs get a read-only token, so the upload is gated
-      # to non-fork events below (the scan and gate still run for forks).
-      security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -70,12 +70,16 @@ jobs:
           echo "tirith reported ${count} finding(s)" | tee -a "$GITHUB_STEP_SUMMARY"
           jq -r '.runs[].results[]? | "- [\(.level // "warning")] \(.ruleId): \(.locations[0].physicalLocation.artifactLocation.uri)"' \
             results.sarif 2>/dev/null | tee -a "$GITHUB_STEP_SUMMARY" || true
-      - name: Upload SARIF to the Security tab
-        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      # Hand the SARIF to the privileged upload job as an artifact. Uploaded
+      # before the gate step so findings reach the Security tab even when the
+      # gate then blocks the PR.
+      - name: Upload SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          sarif_file: results.sarif
-          category: tirith
+          name: tirith-sarif
+          path: results.sarif
+          if-no-files-found: error
       - name: Gate CI on tirith findings
         if: always()
         env:
@@ -94,6 +98,35 @@ jobs:
               exit 1
               ;;
           esac
+
+  # Publish the tirith SARIF to the Security tab. Split from the scan so the
+  # `security-events: write` scope lives in a job that never executes
+  # PR-controlled code: it only downloads the artifact and runs trusted, pinned
+  # actions. `always()` so findings are published even when the gate blocked the
+  # PR; skipped for fork PRs, whose token is read-only and cannot upload.
+  tirith-sarif-upload:
+    name: tirith SARIF upload
+    needs: tirith-scan
+    if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      # Checkout only places files for path mapping; no PR code is executed in
+      # this privileged job.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tirith-sarif
+      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif
+          category: tirith
 
   # Fast, unconditional fail-fast gate for the cheap-but-high-signal checks:
   # secret detection (gitleaks) and workflow/format lint (the treefmt check,
@@ -493,6 +526,7 @@ jobs:
     needs:
       - changes
       - tirith-scan
+      - tirith-sarif-upload
       - preflight
       - test
       - build-native-packages


### PR DESCRIPTION
## Summary

Adds a security gate to the CI workflow ([tirith](https://tirith.sh/docs/ci/)) plus a fail-fast preflight, so the expensive build/test work runs only after the cheap, high-signal security checks pass.

## What changed

Two new jobs run **unconditionally and in parallel** at the front of `ci.yaml` (not gated on `changes`, so they also cover docs-only PRs and fork PRs, where local git hooks never run):

- **`tirith-scan`** — scans the whole checkout with tirith, uploads SARIF to the Security tab, and gates downstream CI.
  - Wired on `pull_request` (not `pull_request_target`): fork PRs only get a read-only token and cannot leak secrets while their code is scanned. The SARIF upload is therefore skipped for forks (the scan + gate still run); pushes to `main` and same-repo PRs populate the Security tab.
  - tirith is installed from the flake's pinned `nixpkgs` so CI matches the dev shell.
  - `--fail-on high` blocks on high/critical findings. tirith's `--ci` exit code is `0` = clean, `1` = at/above threshold, `2` = findings below threshold; the gate treats `0`/`2` as pass and `1` (or any other code) as a block. The exit code is passed via `env` to avoid template injection.
  - `*.snap` is excluded: terminal snapshot test fixtures intentionally contain ANSI escapes that trip the `ansi_escapes` rule. The rule stays active for real source files.
- **`preflight`** — runs the existing `gitleaks` and `treefmt` flake checks (treefmt carries `actionlint` + `zizmor` with the repo's exact ignore config) as an early fail-fast gate.

`test` and `build-native-packages` now `needs` both gates, so the heavy pipeline is skipped unless the gates pass. Heavy gate jobs run on blacksmith runners, consistent with the rest of the nix-based CI.

## Why

- **Fail-fast**: secret/malware/lint regressions stop the pipeline before any build/test compute.
- **Coverage gaps closed**: the unconditional gates catch issues on docs-only PRs and fork PRs that previously bypassed the `code-changed`-gated checks and local hooks.

## Testing

Validated locally against a CI-equivalent tree (`git archive HEAD`):

- `nix build .#checks.<sys>.gitleaks .#checks.<sys>.treefmt` → pass (`no leaks found`, `0 changed`).
- `actionlint` on `ci.yaml` → clean (only the pre-existing `parallel:` extension ignored).
- `zizmor --offline --min-severity high --min-confidence high .github/workflows/` → no findings.
- tirith on the clean tree with `--fail-on high --exclude '*.snap'` → exit 2 (pass, 0 high findings); a planted high/critical finding → blocks. The 8 remaining warnings (emoji variation selectors, instructional-comment `config_injection`) are below threshold and surface in the Security tab only.

> Note: committing/pushing a workflow-only change trips a pre-existing single-file `zizmor` quirk in the git hooks (`ci.yaml`'s `parallel:` extension is rejected as a lone input — "no inputs collected"). The whole-tree check CI runs passes, so this is a hook-invocation issue, not a content one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI security gate with `tirith` and a fast preflight so build/test only run after cheap, high-signal checks pass. Runs on all PRs (including docs-only and forks); SARIF publishing is isolated in a least-privilege job and uploads for same-repo PRs and pushes.

- **New Features**
  - Added `tirith-scan`: repo-wide `tirith --fail-on high`; treats exit 0/2 as pass and 1 as block; excludes `*.snap`; installed from pinned `nixpkgs`; runs read-only and emits a SARIF artifact.
  - Added `tirith-sarif-upload`: separate job with `security-events: write` that never executes PR code; runs always and publishes SARIF (skipped for forks).
  - Added `preflight`: runs `gitleaks` and `treefmt` (`actionlint` + `zizmor`) as an early gate.
  - Gated `test`, `build-native-packages`, and `action-timeline` on the gates; `action-timeline` also needs `tirith-sarif-upload`.

<sup>Written for commit 8ff5cb84e1c2e7c46ad3d7830822c5bee66da068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added an automated security scanning gate that fails CI for high-severity findings.
  * Security findings are summarized in CI and uploaded to the GitHub Security view when available (SARIF).
* **CI Improvements**
  * Added a fast preflight stage for secret detection plus formatting/lint checks.
  * Updated downstream CI requirements so tests and builds wait for the new security and preflight gates to pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->