### PR TITLE
fix(pi): align unified session date filtering

### DIFF
--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -374,9 +374,8 @@ fn load_session_capable_summary_agent_rows(
     let mut entries = load_entries(shared, None, Some(pricing))?;
     let detected = !entries.is_empty();
     let summaries = if kind == AgentReportKind::Session {
-        let mut summaries = summarize_entry_sessions(&entries)?;
-        filter_session_summaries(&mut summaries, shared);
-        summaries
+        filter_loaded_entries_by_date(&mut entries, shared);
+        summarize_entry_sessions(&entries)?
     } else {
         filter_loaded_entries_by_date(&mut entries, shared);
         summarize_entries(&entries, kind)?
@@ -642,6 +641,7 @@ pub(super) fn aggregate_rows(rows: Vec<AllRow>, kind: AgentReportKind) -> Vec<Al
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
 
     fn usage_summary(date: &str, input_tokens: u64) -> UsageSummary {
         UsageSummary {
@@ -685,5 +685,69 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].date.as_deref(), Some("2026-01-02"));
         assert_eq!(rows[0].input_tokens, 20);
+    }
+
+    fn usage_fingerprint(rows: &[AllRow]) -> Vec<(String, u64, u64, u64, u64, u64)> {
+        rows.iter()
+            .map(|row| {
+                (
+                    row.period.clone(),
+                    row.input_tokens,
+                    row.output_tokens,
+                    row.cache_creation_tokens,
+                    row.cache_read_tokens,
+                    row.total_tokens,
+                )
+            })
+            .collect()
+    }
+
+    fn pi_path_subcommand_rows(
+        store_path: &str,
+        shared: &SharedArgs,
+        pricing: &PricingMap,
+    ) -> Result<Vec<AllRow>> {
+        let mut entries = pi::load_entries(shared, Some(store_path), Some(pricing))?;
+        filter_loaded_entries_by_date(&mut entries, shared);
+        let summaries = pi::summarize_entries(&entries, AgentReportKind::Session)?;
+        Ok(summary_rows("pi", summaries))
+    }
+
+    #[test]
+    fn default_pi_unified_session_window_keeps_until_day_like_pi_path() {
+        let fixture = fs_fixture!({
+            "pi/sessions/project-a/agent_until-day.jsonl": r#"{"type":"message","timestamp":"2026-07-04T18:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":10,"output":1}}}"#,
+            "pi/sessions/project-a/agent_after-day.jsonl": r#"{"type":"message","timestamp":"2026-07-05T18:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":20,"output":2}}}"#,
+        });
+        let _pi_agent_dir = EnvVarGuard::set("PI_AGENT_DIR", fixture.path("pi/sessions"));
+        let shared = SharedArgs {
+            json: true,
+            mode: crate::cli::CostMode::Display,
+            offline: true,
+            timezone: Some("America/Boise".to_string()),
+            since: Some("20260704".to_string()),
+            until: Some("20260704".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let result = load_rows(AgentReportKind::Session, &shared).unwrap();
+        let pi_rows = result
+            .rows
+            .iter()
+            .filter(|row| row.agent == "pi")
+            .cloned()
+            .collect::<Vec<_>>();
+        let pi_path_rows = pi_path_subcommand_rows(
+            fixture.path("pi/sessions").to_str().unwrap(),
+            &shared,
+            &PricingMap::default(),
+        )
+        .unwrap();
+
+        assert_eq!(usage_fingerprint(&pi_rows), usage_fingerprint(&pi_path_rows));
+        assert_eq!(
+            usage_fingerprint(&pi_rows),
+            vec![("until-day".to_string(), 10, 1, 0, 0, 11)]
+        );
     }
 }

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -744,7 +744,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(usage_fingerprint(&pi_rows), usage_fingerprint(&pi_path_rows));
+        assert_eq!(
+            usage_fingerprint(&pi_rows),
+            usage_fingerprint(&pi_path_rows)
+        );
         assert_eq!(
             usage_fingerprint(&pi_rows),
             vec![("until-day".to_string(), 10, 1, 0, 0, 11)]


### PR DESCRIPTION
Fixes #1390

The unified all-agent loader's pi session path summarized entries first and then filtered `UsageSummary.last_activity` as if it were a compact `YYYYMMDD` date. That `lastActivity` value is RFC3339, so an inclusive `--until` date such as `20260704` rejected rows like `2026-07-04T18:00:00.000Z` after dash removal, because `20260704T...` sorts after `20260704`.

Result: `ccusage session -u <today>` silently drops pi sessions whose last activity falls ON the inclusive until day, while the equivalent `ccusage pi session --pi-path` invocation keeps them (it applies the normal timezone-normalized entry date window via `filter_loaded_entries_by_date` before summarizing).

**Fix:** filter default pi unified session entries by date before summarizing (`filter_loaded_entries_by_date` then `summarize_entry_sessions`), matching the `pi session --pi-path` behavior.

### Test

`default_pi_unified_session_window_keeps_until_day_like_pi_path`: fixture with one session on the inclusive until day and one after it; asserts the unified pi rows fingerprint-match the `--pi-path` subcommand rows, and that exactly the until-day session survives. Fails red on unpatched main.

### Behavior change note

This is a user-visible fix: sessions previously (incorrectly) dropped on the until day now appear.

### Verification

`cargo test --workspace`, `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` all pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785766926&installation_id=139163553&pr_number=1394&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1394&signature=fd064c5ce5ac1a40c851865d0d339aac850368349f4e8092adee768e392007ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the unified PI session date window so inclusive --until days are respected. Sessions on the until day now appear, matching the `pi session --pi-path` behavior.

- **Bug Fixes**
  - Filter PI entries by date before summarizing sessions to align with per-path flow.
  - Add a regression test to ensure the until-day session is included and the next day is excluded.

- **Refactors**
  - Apply `treefmt` formatting (no behavior change).

<sup>Written for commit 74793a9483acae76550deb33ba4b29a683d35787. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

### Note for review ordering

#1397 (named pi stores) deliberately preserves this bug to stay byte-identical to main, pinning it with an explicit test. If this fix merges first, I'll flip that pinned test when rebasing #1397; if #1397 merges first, I'll regenerate this fix against the restructured loader.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session-based usage reports now apply the selected date window before computing summaries, improving accuracy for time-range views.
  * Session reporting is now more consistent across different loading paths, reducing mismatches for “until day” style ranges.

* **Tests**
  * Added deterministic comparison coverage to verify session report output remains stable for the expected window (including PI session scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->