### PR TITLE
feat(json): emit modelBreakdowns in per-agent JSON reports

### DIFF
--- a/rust/crates/ccusage/src/adapter/copilot/loader.rs
+++ b/rust/crates/ccusage/src/adapter/copilot/loader.rs
@@ -269,6 +269,17 @@ mod tests {
         assert_eq!(report["daily"][0]["outputTokens"], 50);
         assert_eq!(report["daily"][0]["totalTokens"], 175);
         assert_eq!(report["daily"][0]["totalCost"], 300.0);
+        assert_eq!(
+            report["daily"][0]["modelBreakdowns"],
+            json!([{
+                "modelName": "test-model",
+                "inputTokens": 90,
+                "outputTokens": 50,
+                "cacheCreationTokens": 20,
+                "cacheReadTokens": 10,
+                "cost": 300.0
+            }])
+        );
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/opencode/report.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/report.rs
@@ -41,6 +41,7 @@ pub(crate) fn agent_summary_json(
         "totalTokens": row.total_tokens(),
         "totalCost": row.total_cost,
         "modelsUsed": row.models_used,
+        "modelBreakdowns": row.model_breakdowns,
     });
     if let (Some(obj), Some(credits)) = (value.as_object_mut(), row.credits) {
         obj.insert("credits".to_string(), json!(credits));

--- a/rust/crates/ccusage/src/adapter/opencode/snapshots/ccusage__adapter__opencode__report__tests__snapshots_agent_summary_json_period_keys_and_session_metadata.snap
+++ b/rust/crates/ccusage/src/adapter/opencode/snapshots/ccusage__adapter__opencode__report__tests__snapshots_agent_summary_json_period_keys_and_session_metadata.snap
@@ -10,6 +10,16 @@ expression: "serde_json::json!({\n    \"daily\": agent_summary_json(&daily, Agen
     "date": "2026-01-02",
     "inputTokens": 100,
     "messageCount": 3,
+    "modelBreakdowns": [
+      {
+        "cacheCreationTokens": 10,
+        "cacheReadTokens": 5,
+        "cost": 0.25,
+        "inputTokens": 100,
+        "modelName": "gpt-5.2-codex",
+        "outputTokens": 50
+      }
+    ],
     "modelsUsed": [
       "gpt-5.2-codex",
       "claude-sonnet-4-20250514"
@@ -27,6 +37,16 @@ expression: "serde_json::json!({\n    \"daily\": agent_summary_json(&daily, Agen
         "date": "2026-01-02",
         "inputTokens": 100,
         "messageCount": 3,
+        "modelBreakdowns": [
+          {
+            "cacheCreationTokens": 10,
+            "cacheReadTokens": 5,
+            "cost": 0.25,
+            "inputTokens": 100,
+            "modelName": "gpt-5.2-codex",
+            "outputTokens": 50
+          }
+        ],
         "modelsUsed": [
           "gpt-5.2-codex",
           "claude-sonnet-4-20250514"
@@ -52,6 +72,16 @@ expression: "serde_json::json!({\n    \"daily\": agent_summary_json(&daily, Agen
     "credits": 1.5,
     "inputTokens": 100,
     "messageCount": 3,
+    "modelBreakdowns": [
+      {
+        "cacheCreationTokens": 10,
+        "cacheReadTokens": 5,
+        "cost": 0.25,
+        "inputTokens": 100,
+        "modelName": "gpt-5.2-codex",
+        "outputTokens": 50
+      }
+    ],
     "modelsUsed": [
       "gpt-5.2-codex",
       "claude-sonnet-4-20250514"
@@ -69,6 +99,16 @@ expression: "serde_json::json!({\n    \"daily\": agent_summary_json(&daily, Agen
     "inputTokens": 100,
     "lastActivity": "2026-01-02T12:34:56.000Z",
     "messageCount": 3,
+    "modelBreakdowns": [
+      {
+        "cacheCreationTokens": 10,
+        "cacheReadTokens": 5,
+        "cost": 0.25,
+        "inputTokens": 100,
+        "modelName": "gpt-5.2-codex",
+        "outputTokens": 50
+      }
+    ],
     "modelsUsed": [
       "gpt-5.2-codex",
       "claude-sonnet-4-20250514"
@@ -87,6 +127,16 @@ expression: "serde_json::json!({\n    \"daily\": agent_summary_json(&daily, Agen
         "credits": 1.5,
         "inputTokens": 100,
         "messageCount": 3,
+        "modelBreakdowns": [
+          {
+            "cacheCreationTokens": 10,
+            "cacheReadTokens": 5,
+            "cost": 0.25,
+            "inputTokens": 100,
+            "modelName": "gpt-5.2-codex",
+            "outputTokens": 50
+          }
+        ],
         "modelsUsed": [
           "gpt-5.2-codex",
           "claude-sonnet-4-20250514"
@@ -113,6 +163,16 @@ expression: "serde_json::json!({\n    \"daily\": agent_summary_json(&daily, Agen
     "credits": 1.5,
     "inputTokens": 100,
     "messageCount": 3,
+    "modelBreakdowns": [
+      {
+        "cacheCreationTokens": 10,
+        "cacheReadTokens": 5,
+        "cost": 0.25,
+        "inputTokens": 100,
+        "modelName": "gpt-5.2-codex",
+        "outputTokens": 50
+      }
+    ],
     "modelsUsed": [
       "gpt-5.2-codex",
       "claude-sonnet-4-20250514"

--- a/rust/crates/ccusage/src/adapter/qwen/mod.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/mod.rs
@@ -126,6 +126,17 @@ mod tests {
             report["daily"][0]["modelsUsed"],
             json!(["qwen3-coder-plus"])
         );
+        assert_eq!(
+            report["daily"][0]["modelBreakdowns"],
+            json!([{
+                "modelName": "qwen3-coder-plus",
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "cacheCreationTokens": 0,
+                "cacheReadTokens": 5,
+                "cost": 0.0
+            }])
+        );
     }
 
     #[test]

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -839,6 +839,17 @@ mod tests {
         assert_eq!(report["daily"][0]["totalTokens"], 180);
         assert_eq!(report["daily"][0]["totalCost"], json!(0.05));
         assert_eq!(report["daily"][0]["modelsUsed"], json!(["[pi] gpt-5.4"]));
+        assert_eq!(
+            report["daily"][0]["modelBreakdowns"],
+            json!([{
+                "modelName": "[pi] gpt-5.4",
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "cacheCreationTokens": 20,
+                "cacheReadTokens": 10,
+                "cost": 0.05
+            }])
+        );
     }
 
     #[test]


### PR DESCRIPTION
Proposed in #1391.

Per-agent subcommands (`ccusage pi|opencode|amp|hermes|... daily/weekly/monthly/session --json`) already compute per-model cost breakdowns for every row — the table view renders them with `--breakdown`, and the unified commands (`ccusage daily` etc.) already emit them as `modelBreakdowns` in JSON. The shared per-agent JSON serializer is the one output path that drops them.

That gap is not recoverable downstream. An application consuming per-agent JSON gets `modelsUsed` and a summed `totalCost`, but per-model attribution depends on ccusage-internal state: pricing lookup (including offline cache and overrides), cache-tier token pricing, and entry dedupe. The only workaround is to re-parse the raw session stores and reimplement the cost pipeline — a full recalculation of work ccusage has already done, that then drifts whenever pricing data or dedupe rules change.

This adds `"modelBreakdowns"` to `agent_summary_json`, mirroring the unified serializers (`summary_json` / `session_summary_json`). The data is already computed on every row, so emitting it has no measurable cost — it closes a parity gap between ccusage's own output modes.

**Purely additive:** every pre-existing key and value is unchanged. The codex-native serializer (`models` object) is deliberately untouched — per-model cost for codex is a separate future PR.

### Tests

- Shared-shape insta snapshot now shows populated breakdowns for all four report kinds.
- `pi daily --json` asserts a full single-element breakdown array with non-zero cost (the motivating case).
- Fixture-driven copilot (real pricing via `read_otel_file`) and qwen (real JSONL fixture line) assertions pin their entire breakdown arrays.

### Verification

- `cargo test --workspace`, `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` all pass.
- Byte-identical check on real stores: branch binary vs main binary — the only diff is the added `modelBreakdowns` key.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785766927&installation_id=139163553&pr_number=1395&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1395&signature=c7db6028f66b22a16331a4fdc49f69c3ad566685dcfcfdf3cb68377787ccad84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-model cost breakdowns to per-agent JSON reports so consumers can attribute costs by model without reprocessing data. This brings per-agent JSON to parity with the unified JSON outputs.

- **New Features**
  - Emit `"modelBreakdowns"` from the per-agent JSON serializer (`agent_summary_json`) for `daily`, `weekly`, `monthly`, and `session`.
  - Matches the unified serializers; all existing keys are unchanged. The codex-native `models` object is untouched.
  - Tests updated to assert full breakdown arrays (shared snapshot, `pi`, Copilot, and Qwen).

<sup>Written for commit fe2003f0ccd83fc101a58c004c41464e291ee53f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily JSON reports now include a `modelBreakdowns` section with per-model token usage and cost details.
  * This new breakdown appears alongside existing totals and models-used information in report output.

* **Bug Fixes**
  * Report output now consistently exposes detailed per-model usage across supported report formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->