### PR TITLE
feat(unified): --sections and --by-agent for single-invocation reporting

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -137,6 +137,8 @@ bunx ccusage pi daily --pi-path /path/to/sessions,/archive/pi/sessions
 
 # Explicit unified report
 bunx ccusage daily --all
+bunx ccusage daily --sections daily,monthly,session --json
+bunx ccusage daily --by-agent --json
 
 # Filters and options
 bunx ccusage daily --since 2026-04-25 --until 2026-05-16

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -23,6 +23,15 @@ The `--all` flag is accepted for compatibility, but it is optional because unifi
 ccusage daily --all
 ```
 
+For automation, unified JSON reports can emit several report sections from one load:
+
+```bash
+ccusage daily --sections daily,monthly,session --json
+ccusage daily --by-agent --json
+```
+
+`--sections` accepts `daily`, `weekly`, `monthly`, and `session`. The invoked report section is always included, and table output prints each requested section as a separate table. `--by-agent` adds an `agents` array to daily, weekly, and monthly JSON rows; session rows are already source-specific.
+
 ## How Unified Views Work
 
 ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:

--- a/docs/guide/cli-options.md
+++ b/docs/guide/cli-options.md
@@ -129,6 +129,20 @@ ccusage monthly --config /path/to/team-config.json
 
 ## Command-Specific Options
 
+### Unified Report Options
+
+These options apply to `ccusage daily`, `ccusage weekly`, `ccusage monthly`, and `ccusage session` when they are aggregating all detected sources:
+
+```bash
+# Emit several JSON report sections from one source load
+ccusage daily --sections daily,monthly,session --json
+
+# Add per-agent breakdowns to daily, weekly, and monthly JSON rows
+ccusage daily --by-agent --json
+```
+
+`--sections` accepts a comma-separated list of `daily`, `weekly`, `monthly`, and `session`. The invoked report section is always included. For table output, each requested section is printed as a separate table. `--by-agent` is JSON-only; session rows are already per-agent.
+
 ### Daily Command
 
 Additional options for daily reports:

--- a/docs/guide/json-output.md
+++ b/docs/guide/json-output.md
@@ -58,9 +58,7 @@ ccusage daily --sections daily,monthly,session --by-agent --json
 							"outputTokens": 100
 						}
 					],
-					"modelsUsed": [
-						"claude-sonnet-4-20250514"
-					],
+					"modelsUsed": ["claude-sonnet-4-20250514"],
 					"outputTokens": 100,
 					"totalCost": 0.02,
 					"totalTokens": 650
@@ -80,9 +78,7 @@ ccusage daily --sections daily,monthly,session --by-agent --json
 							"outputTokens": 200
 						}
 					],
-					"modelsUsed": [
-						"gpt-5"
-					],
+					"modelsUsed": ["gpt-5"],
 					"outputTokens": 200,
 					"totalCost": 0.0031375,
 					"totalTokens": 1200
@@ -92,10 +88,7 @@ ccusage daily --sections daily,monthly,session --by-agent --json
 			"cacheReadTokens": 130,
 			"inputTokens": 1400,
 			"metadata": {
-				"agents": [
-					"claude",
-					"codex"
-				]
+				"agents": ["claude", "codex"]
 			},
 			"modelBreakdowns": [
 				{
@@ -115,10 +108,7 @@ ccusage daily --sections daily,monthly,session --by-agent --json
 					"outputTokens": 200
 				}
 			],
-			"modelsUsed": [
-				"claude-sonnet-4-20250514",
-				"gpt-5"
-			],
+			"modelsUsed": ["claude-sonnet-4-20250514", "gpt-5"],
 			"outputTokens": 300,
 			"period": "2026-01-02",
 			"totalCost": 0.023137500000000002,
@@ -144,9 +134,7 @@ ccusage daily --sections daily,monthly,session --by-agent --json
 							"outputTokens": 100
 						}
 					],
-					"modelsUsed": [
-						"claude-sonnet-4-20250514"
-					],
+					"modelsUsed": ["claude-sonnet-4-20250514"],
 					"outputTokens": 100,
 					"totalCost": 0.02,
 					"totalTokens": 650
@@ -166,9 +154,7 @@ ccusage daily --sections daily,monthly,session --by-agent --json
 							"outputTokens": 200
 						}
 					],
-					"modelsUsed": [
-						"gpt-5"
-					],
+					"modelsUsed": ["gpt-5"],
 					"outputTokens": 200,
 					"totalCost": 0.0031375,
 					"totalTokens": 1200
@@ -178,10 +164,7 @@ ccusage daily --sections daily,monthly,session --by-agent --json
 			"cacheReadTokens": 130,
 			"inputTokens": 1400,
 			"metadata": {
-				"agents": [
-					"claude",
-					"codex"
-				]
+				"agents": ["claude", "codex"]
 			},
 			"modelBreakdowns": [
 				{
@@ -201,10 +184,7 @@ ccusage daily --sections daily,monthly,session --by-agent --json
 					"outputTokens": 200
 				}
 			],
-			"modelsUsed": [
-				"claude-sonnet-4-20250514",
-				"gpt-5"
-			],
+			"modelsUsed": ["claude-sonnet-4-20250514", "gpt-5"],
 			"outputTokens": 300,
 			"period": "2026-01",
 			"totalCost": 0.023137500000000002,
@@ -230,9 +210,7 @@ ccusage daily --sections daily,monthly,session --by-agent --json
 					"outputTokens": 100
 				}
 			],
-			"modelsUsed": [
-				"claude-sonnet-4-20250514"
-			],
+			"modelsUsed": ["claude-sonnet-4-20250514"],
 			"outputTokens": 100,
 			"period": "claude-session",
 			"totalCost": 0.02,
@@ -257,9 +235,7 @@ ccusage daily --sections daily,monthly,session --by-agent --json
 					"outputTokens": 200
 				}
 			],
-			"modelsUsed": [
-				"gpt-5"
-			],
+			"modelsUsed": ["gpt-5"],
 			"outputTokens": 200,
 			"period": "codex-session",
 			"totalCost": 0.0031375,

--- a/docs/guide/json-output.md
+++ b/docs/guide/json-output.md
@@ -29,6 +29,254 @@ ccusage blocks --json --no-cost
 
 This removes cost fields such as `totalCost`, `costUSD`, and nested `cost` values while keeping token, model, date, block, burn-rate, and projection fields.
 
+Unified reports also support JSON-oriented flags for dashboard-style consumers:
+
+```bash
+ccusage daily --sections daily,monthly,session --by-agent --json
+```
+
+`--sections` emits each requested unified section from one load. The invoked command's section is always included, and the top-level `totals` object remains the total for that invoked section. JSON keys are emitted with the invoked section first, then remaining sections in `daily`, `weekly`, `monthly`, `session` order, with `totals` last. `--by-agent` adds an `agents` array to daily, weekly, and monthly rows; session rows are already per-agent.
+
+```json
+{
+	"daily": [
+		{
+			"agent": "all",
+			"agents": [
+				{
+					"agent": "claude",
+					"cacheCreationTokens": 20,
+					"cacheReadTokens": 30,
+					"inputTokens": 500,
+					"modelBreakdowns": [
+						{
+							"cacheCreationTokens": 20,
+							"cacheReadTokens": 30,
+							"cost": 0.02,
+							"inputTokens": 500,
+							"modelName": "claude-sonnet-4-20250514",
+							"outputTokens": 100
+						}
+					],
+					"modelsUsed": [
+						"claude-sonnet-4-20250514"
+					],
+					"outputTokens": 100,
+					"totalCost": 0.02,
+					"totalTokens": 650
+				},
+				{
+					"agent": "codex",
+					"cacheCreationTokens": 0,
+					"cacheReadTokens": 100,
+					"inputTokens": 900,
+					"modelBreakdowns": [
+						{
+							"cacheCreationTokens": 0,
+							"cacheReadTokens": 100,
+							"cost": 0.0031375,
+							"inputTokens": 900,
+							"modelName": "gpt-5",
+							"outputTokens": 200
+						}
+					],
+					"modelsUsed": [
+						"gpt-5"
+					],
+					"outputTokens": 200,
+					"totalCost": 0.0031375,
+					"totalTokens": 1200
+				}
+			],
+			"cacheCreationTokens": 20,
+			"cacheReadTokens": 130,
+			"inputTokens": 1400,
+			"metadata": {
+				"agents": [
+					"claude",
+					"codex"
+				]
+			},
+			"modelBreakdowns": [
+				{
+					"cacheCreationTokens": 20,
+					"cacheReadTokens": 30,
+					"cost": 0.02,
+					"inputTokens": 500,
+					"modelName": "claude-sonnet-4-20250514",
+					"outputTokens": 100
+				},
+				{
+					"cacheCreationTokens": 0,
+					"cacheReadTokens": 100,
+					"cost": 0.0031375,
+					"inputTokens": 900,
+					"modelName": "gpt-5",
+					"outputTokens": 200
+				}
+			],
+			"modelsUsed": [
+				"claude-sonnet-4-20250514",
+				"gpt-5"
+			],
+			"outputTokens": 300,
+			"period": "2026-01-02",
+			"totalCost": 0.023137500000000002,
+			"totalTokens": 1850
+		}
+	],
+	"monthly": [
+		{
+			"agent": "all",
+			"agents": [
+				{
+					"agent": "claude",
+					"cacheCreationTokens": 20,
+					"cacheReadTokens": 30,
+					"inputTokens": 500,
+					"modelBreakdowns": [
+						{
+							"cacheCreationTokens": 20,
+							"cacheReadTokens": 30,
+							"cost": 0.02,
+							"inputTokens": 500,
+							"modelName": "claude-sonnet-4-20250514",
+							"outputTokens": 100
+						}
+					],
+					"modelsUsed": [
+						"claude-sonnet-4-20250514"
+					],
+					"outputTokens": 100,
+					"totalCost": 0.02,
+					"totalTokens": 650
+				},
+				{
+					"agent": "codex",
+					"cacheCreationTokens": 0,
+					"cacheReadTokens": 100,
+					"inputTokens": 900,
+					"modelBreakdowns": [
+						{
+							"cacheCreationTokens": 0,
+							"cacheReadTokens": 100,
+							"cost": 0.0031375,
+							"inputTokens": 900,
+							"modelName": "gpt-5",
+							"outputTokens": 200
+						}
+					],
+					"modelsUsed": [
+						"gpt-5"
+					],
+					"outputTokens": 200,
+					"totalCost": 0.0031375,
+					"totalTokens": 1200
+				}
+			],
+			"cacheCreationTokens": 20,
+			"cacheReadTokens": 130,
+			"inputTokens": 1400,
+			"metadata": {
+				"agents": [
+					"claude",
+					"codex"
+				]
+			},
+			"modelBreakdowns": [
+				{
+					"cacheCreationTokens": 20,
+					"cacheReadTokens": 30,
+					"cost": 0.02,
+					"inputTokens": 500,
+					"modelName": "claude-sonnet-4-20250514",
+					"outputTokens": 100
+				},
+				{
+					"cacheCreationTokens": 0,
+					"cacheReadTokens": 100,
+					"cost": 0.0031375,
+					"inputTokens": 900,
+					"modelName": "gpt-5",
+					"outputTokens": 200
+				}
+			],
+			"modelsUsed": [
+				"claude-sonnet-4-20250514",
+				"gpt-5"
+			],
+			"outputTokens": 300,
+			"period": "2026-01",
+			"totalCost": 0.023137500000000002,
+			"totalTokens": 1850
+		}
+	],
+	"session": [
+		{
+			"agent": "claude",
+			"cacheCreationTokens": 20,
+			"cacheReadTokens": 30,
+			"inputTokens": 500,
+			"metadata": {
+				"lastActivity": "2026-01-02T10:00:00.000Z"
+			},
+			"modelBreakdowns": [
+				{
+					"cacheCreationTokens": 20,
+					"cacheReadTokens": 30,
+					"cost": 0.02,
+					"inputTokens": 500,
+					"modelName": "claude-sonnet-4-20250514",
+					"outputTokens": 100
+				}
+			],
+			"modelsUsed": [
+				"claude-sonnet-4-20250514"
+			],
+			"outputTokens": 100,
+			"period": "claude-session",
+			"totalCost": 0.02,
+			"totalTokens": 650
+		},
+		{
+			"agent": "codex",
+			"cacheCreationTokens": 0,
+			"cacheReadTokens": 100,
+			"inputTokens": 900,
+			"metadata": {
+				"lastActivity": "2026-01-02T11:00:00.000Z",
+				"reasoningOutputTokens": 20
+			},
+			"modelBreakdowns": [
+				{
+					"cacheCreationTokens": 0,
+					"cacheReadTokens": 100,
+					"cost": 0.0031375,
+					"inputTokens": 900,
+					"modelName": "gpt-5",
+					"outputTokens": 200
+				}
+			],
+			"modelsUsed": [
+				"gpt-5"
+			],
+			"outputTokens": 200,
+			"period": "codex-session",
+			"totalCost": 0.0031375,
+			"totalTokens": 1200
+		}
+	],
+	"totals": {
+		"cacheCreationTokens": 20,
+		"cacheReadTokens": 130,
+		"inputTokens": 1400,
+		"outputTokens": 300,
+		"totalCost": 0.023137500000000002,
+		"totalTokens": 1850
+	}
+}
+```
+
 ## JSON Structure
 
 ### Daily Reports (Standard)

--- a/rust/crates/ccusage-cli/src/arg_parser.rs
+++ b/rust/crates/ccusage-cli/src/arg_parser.rs
@@ -26,6 +26,11 @@ impl ArgParser {
         self.args.get(self.index).map(String::as_str)
     }
 
+    pub(crate) fn peek_name(&self) -> Option<&str> {
+        self.peek()
+            .map(|arg| arg.split_once('=').map_or(arg, |(name, _)| name))
+    }
+
     pub(crate) fn next(&mut self) -> Option<String> {
         let value = self.args.get(self.index)?.clone();
         self.index += 1;

--- a/rust/crates/ccusage-cli/src/cli-help.json
+++ b/rust/crates/ccusage-cli/src/cli-help.json
@@ -84,6 +84,15 @@
 			"default": "false"
 		},
 		{
+			"flags": "--sections <sections>",
+			"description": "Emit multiple unified report sections from one load (daily, weekly, monthly, session)"
+		},
+		{
+			"flags": "--by-agent",
+			"description": "Include per-agent JSON breakdowns in unified report rows",
+			"default": "false"
+		},
+		{
 			"flags": "-O, --offline",
 			"description": "Use cached pricing data where supported",
 			"default": "false"

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -342,24 +342,35 @@ fn parse_root_all_arg(
     parser: &mut ArgParser,
     options: &mut RootAllOptions,
 ) -> Result<bool, String> {
-    if matches!(parser.peek(), Some("--all")) {
-        parser.next();
-        options.mark_used("--all");
-        return Ok(true);
-    }
-    if matches!(parser.peek_name(), Some("--sections")) {
-        parser.next_flag()?;
-        options.mark_used("--sections");
-        options.sections = Some(parse_report_sections(&parser.value_for("--sections")?)?);
-        return Ok(true);
-    }
-    if matches!(parser.peek(), Some("--by-agent")) {
-        parser.next();
-        options.mark_used("--by-agent");
-        options.by_agent = true;
+    if let Some(flag) =
+        parse_unified_report_arg(parser, &mut options.sections, &mut options.by_agent)?
+    {
+        options.mark_used(flag);
         return Ok(true);
     }
     Ok(false)
+}
+
+fn parse_unified_report_arg(
+    parser: &mut ArgParser,
+    sections: &mut Option<Vec<AgentReportKind>>,
+    by_agent: &mut bool,
+) -> Result<Option<&'static str>, String> {
+    if matches!(parser.peek(), Some("--all")) {
+        parser.next();
+        return Ok(Some("--all"));
+    }
+    if matches!(parser.peek_name(), Some("--sections")) {
+        parser.next_flag()?;
+        *sections = Some(parse_report_sections(&parser.value_for("--sections")?)?);
+        return Ok(Some("--sections"));
+    }
+    if matches!(parser.peek(), Some("--by-agent")) {
+        parser.next();
+        *by_agent = true;
+        return Ok(Some("--by-agent"));
+    }
+    Ok(None)
 }
 
 fn parse_all_command(
@@ -372,18 +383,7 @@ fn parse_all_command(
     let mut sections = initial_options.sections;
     let mut by_agent = initial_options.by_agent;
     while parser.peek().is_some() {
-        if matches!(parser.peek(), Some("--all")) {
-            parser.next();
-            continue;
-        }
-        if matches!(parser.peek_name(), Some("--sections")) {
-            parser.next_flag()?;
-            sections = Some(parse_report_sections(&parser.value_for("--sections")?)?);
-            continue;
-        }
-        if matches!(parser.peek(), Some("--by-agent")) {
-            parser.next();
-            by_agent = true;
+        if parse_unified_report_arg(parser, &mut sections, &mut by_agent)?.is_some() {
             continue;
         }
         parse_shared_arg(parser, &mut shared)?;
@@ -409,18 +409,7 @@ fn parse_top_level_session_command(
     let mut sections = initial_options.sections;
     let mut by_agent = initial_options.by_agent;
     while parser.peek().is_some() {
-        if matches!(parser.peek(), Some("--all")) {
-            parser.next();
-            continue;
-        }
-        if matches!(parser.peek_name(), Some("--sections")) {
-            parser.next_flag()?;
-            sections = Some(parse_report_sections(&parser.value_for("--sections")?)?);
-            continue;
-        }
-        if matches!(parser.peek(), Some("--by-agent")) {
-            parser.next();
-            by_agent = true;
+        if parse_unified_report_arg(parser, &mut sections, &mut by_agent)?.is_some() {
             continue;
         }
         if parse_shared_arg_for_command(parser, &mut args.shared)? {

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -15,6 +15,39 @@ enum ControlArg {
     Version,
 }
 
+#[derive(Default)]
+struct RootAllOptions {
+    sections: Option<Vec<AgentReportKind>>,
+    by_agent: bool,
+    first_flag: Option<&'static str>,
+}
+
+impl RootAllOptions {
+    fn mark_used(&mut self, flag: &'static str) {
+        self.first_flag.get_or_insert(flag);
+    }
+
+    fn is_used(&self) -> bool {
+        self.first_flag.is_some()
+    }
+
+    fn first_flag(&self) -> &'static str {
+        self.first_flag.unwrap_or("--sections")
+    }
+
+    fn into_agent_args(self, shared: SharedArgs, kind: AgentReportKind) -> AgentCommandArgs {
+        AgentCommandArgs {
+            shared,
+            kind,
+            sections: self.sections,
+            by_agent: self.by_agent,
+            pi_path: None,
+            open_claw_path: None,
+            codex_speed: CodexSpeed::Auto,
+        }
+    }
+}
+
 impl Cli {
     pub fn parse() -> Self {
         Self::parse_from(env::args_os()).unwrap_or_else(|message| {
@@ -58,6 +91,7 @@ impl Cli {
         }
         let mut shared = SharedArgs::with_defaults();
         config.apply_shared(&mut shared);
+        let mut root_all_options = RootAllOptions::default();
         while let Some(arg) = parser.peek() {
             if is_command(arg) {
                 break;
@@ -65,10 +99,16 @@ impl Cli {
             if !arg.starts_with('-') {
                 return Err(format!("Unknown command '{arg}'"));
             }
+            if parse_root_all_arg(&mut parser, &mut root_all_options)? {
+                continue;
+            }
             parse_shared_arg(&mut parser, &mut shared)?;
         }
 
         let command = match parser.next() {
+            None if root_all_options.is_used() => Some(Command::All(
+                root_all_options.into_agent_args(shared.clone(), AgentReportKind::Daily),
+            )),
             None => None,
             Some(command) => Some(parse_command(
                 &command,
@@ -76,6 +116,7 @@ impl Cli {
                 shared.clone(),
                 config,
                 default_session_duration_hours,
+                root_all_options,
             )?),
         };
         if let Some(extra) = parser.next() {
@@ -107,12 +148,37 @@ fn parse_command(
     shared: SharedArgs,
     config: &dyn CliConfig,
     default_session_duration_hours: f64,
+    root_all_options: RootAllOptions,
 ) -> Result<Command, String> {
+    if root_all_options.is_used() && !accepts_root_all_options(command) {
+        return Err(format!(
+            "Unknown option '{}'",
+            root_all_options.first_flag()
+        ));
+    }
     match command {
-        "daily" => parse_all_command(parser, shared, AgentReportKind::Daily, config),
-        "monthly" => parse_all_command(parser, shared, AgentReportKind::Monthly, config),
-        "weekly" => parse_all_command(parser, shared, AgentReportKind::Weekly, config),
-        "session" => parse_top_level_session_command(parser, shared, config),
+        "daily" => parse_all_command(
+            parser,
+            shared,
+            AgentReportKind::Daily,
+            config,
+            root_all_options,
+        ),
+        "monthly" => parse_all_command(
+            parser,
+            shared,
+            AgentReportKind::Monthly,
+            config,
+            root_all_options,
+        ),
+        "weekly" => parse_all_command(
+            parser,
+            shared,
+            AgentReportKind::Weekly,
+            config,
+            root_all_options,
+        ),
+        "session" => parse_top_level_session_command(parser, shared, config, root_all_options),
         "blocks" => {
             let mut args = BlocksArgs {
                 shared,
@@ -268,15 +334,56 @@ fn parse_command(
     }
 }
 
+fn accepts_root_all_options(command: &str) -> bool {
+    matches!(command, "daily" | "monthly" | "weekly" | "session")
+}
+
+fn parse_root_all_arg(
+    parser: &mut ArgParser,
+    options: &mut RootAllOptions,
+) -> Result<bool, String> {
+    if matches!(parser.peek(), Some("--all")) {
+        parser.next();
+        options.mark_used("--all");
+        return Ok(true);
+    }
+    if matches!(parser.peek_name(), Some("--sections")) {
+        parser.next_flag()?;
+        options.mark_used("--sections");
+        options.sections = Some(parse_report_sections(&parser.value_for("--sections")?)?);
+        return Ok(true);
+    }
+    if matches!(parser.peek(), Some("--by-agent")) {
+        parser.next();
+        options.mark_used("--by-agent");
+        options.by_agent = true;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
 fn parse_all_command(
     parser: &mut ArgParser,
     mut shared: SharedArgs,
     kind: AgentReportKind,
     _config: &dyn CliConfig,
+    initial_options: RootAllOptions,
 ) -> Result<Command, String> {
+    let mut sections = initial_options.sections;
+    let mut by_agent = initial_options.by_agent;
     while parser.peek().is_some() {
         if matches!(parser.peek(), Some("--all")) {
             parser.next();
+            continue;
+        }
+        if matches!(parser.peek_name(), Some("--sections")) {
+            parser.next_flag()?;
+            sections = Some(parse_report_sections(&parser.value_for("--sections")?)?);
+            continue;
+        }
+        if matches!(parser.peek(), Some("--by-agent")) {
+            parser.next();
+            by_agent = true;
             continue;
         }
         parse_shared_arg(parser, &mut shared)?;
@@ -284,6 +391,8 @@ fn parse_all_command(
     Ok(Command::All(AgentCommandArgs {
         shared,
         kind,
+        sections,
+        by_agent,
         pi_path: None,
         open_claw_path: None,
         codex_speed: CodexSpeed::Auto,
@@ -294,11 +403,24 @@ fn parse_top_level_session_command(
     parser: &mut ArgParser,
     shared: SharedArgs,
     _config: &dyn CliConfig,
+    initial_options: RootAllOptions,
 ) -> Result<Command, String> {
     let mut args = SessionArgs { shared, id: None };
+    let mut sections = initial_options.sections;
+    let mut by_agent = initial_options.by_agent;
     while parser.peek().is_some() {
         if matches!(parser.peek(), Some("--all")) {
             parser.next();
+            continue;
+        }
+        if matches!(parser.peek_name(), Some("--sections")) {
+            parser.next_flag()?;
+            sections = Some(parse_report_sections(&parser.value_for("--sections")?)?);
+            continue;
+        }
+        if matches!(parser.peek(), Some("--by-agent")) {
+            parser.next();
+            by_agent = true;
             continue;
         }
         if parse_shared_arg_for_command(parser, &mut args.shared)? {
@@ -311,12 +433,20 @@ fn parse_top_level_session_command(
     }
 
     if args.id.is_some() {
+        if sections.is_some() || by_agent {
+            return Err(
+                "The --sections and --by-agent options cannot be used with session --id."
+                    .to_string(),
+            );
+        }
         return Ok(Command::Session(args));
     }
 
     Ok(Command::All(AgentCommandArgs {
         shared: args.shared,
         kind: AgentReportKind::Session,
+        sections,
+        by_agent,
         pi_path: None,
         open_claw_path: None,
         codex_speed: CodexSpeed::Auto,
@@ -432,6 +562,7 @@ fn parse_claude_command(
             shared,
             config,
             default_session_duration_hours,
+            RootAllOptions::default(),
         ),
         _ => unreachable!("claude command is prevalidated"),
     }
@@ -471,6 +602,8 @@ fn parse_codex_command(
     Ok(Command::Codex(AgentCommandArgs {
         shared,
         kind,
+        sections: None,
+        by_agent: false,
         pi_path: None,
         open_claw_path: None,
         codex_speed,
@@ -498,6 +631,8 @@ fn parse_pi_command(
     Ok(Command::Pi(AgentCommandArgs {
         shared,
         kind,
+        sections: None,
+        by_agent: false,
         pi_path,
         open_claw_path: None,
         codex_speed,
@@ -525,6 +660,8 @@ fn parse_openclaw_command(
     Ok(Command::OpenClaw(AgentCommandArgs {
         shared,
         kind,
+        sections: None,
+        by_agent: false,
         pi_path: None,
         open_claw_path,
         codex_speed,
@@ -553,6 +690,8 @@ fn agent_command_args(shared: SharedArgs, kind: AgentReportKind) -> AgentCommand
     AgentCommandArgs {
         shared,
         kind,
+        sections: None,
+        by_agent: false,
         pi_path: None,
         open_claw_path: None,
         codex_speed: CodexSpeed::Auto,
@@ -767,6 +906,7 @@ fn option_takes_value(arg: &str) -> bool {
             | "--speed"
             | "--pi-path"
             | "--open-claw-path"
+            | "--sections"
     )
 }
 
@@ -876,6 +1016,36 @@ fn parse_sort_order(value: &str) -> Result<SortOrder, String> {
         "desc" => Ok(SortOrder::Desc),
         _ => Err(format!("Invalid sort order '{value}'")),
     }
+}
+
+fn parse_report_sections(value: &str) -> Result<Vec<AgentReportKind>, String> {
+    let mut sections = Vec::new();
+    for token in value.split(',') {
+        let token = token.trim();
+        if token.is_empty() {
+            continue;
+        }
+        let kind = match token {
+            "daily" => AgentReportKind::Daily,
+            "weekly" => AgentReportKind::Weekly,
+            "monthly" => AgentReportKind::Monthly,
+            "session" => AgentReportKind::Session,
+            _ => {
+                return Err(format!(
+                    "Invalid --sections value '{token}'. Expected one or more of: daily, weekly, monthly, session."
+                ));
+            }
+        };
+        if !sections.contains(&kind) {
+            sections.push(kind);
+        }
+    }
+    if sections.is_empty() {
+        return Err(format!(
+            "Invalid --sections value '{value}'. Expected one or more of: daily, weekly, monthly, session."
+        ));
+    }
+    Ok(sections)
 }
 
 fn parse_week_day(value: &str) -> Result<WeekDay, String> {

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
@@ -58,6 +58,8 @@ OPTIONS:
   -u, --until <until>                  Filter until date (inclusive)
   -z, --timezone <timezone>            Timezone for date grouping (IANA)
   --all                                Accepted for compatibility; all detected supported agents are included by default (default: false)
+  --sections <sections>                Emit multiple unified report sections from one load (daily, weekly, monthly, session)
+  --by-agent                           Include per-agent JSON breakdowns in unified report rows (default: false)
   -O, --offline                        Use cached pricing data where supported (default: false)
   --no-offline                         Negatable of -O, --offline
   --compact                            Force compact table layout for narrow terminals (default: false)

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__snapshots_representative_cli_parse_shapes.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__snapshots_representative_cli_parse_shapes.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/ccusage/src/cli.rs
+source: crates/ccusage-cli/src/tests.rs
+assertion_line: 752
 expression: cases
 ---
 [
@@ -32,10 +33,12 @@ expression: cases
     "case": "root daily with shared flags",
     "cli": {
       "command": {
+        "byAgent": false,
         "codexSpeed": "Auto",
         "kind": "Daily",
         "openClawPath": null,
         "piPath": null,
+        "sections": null,
         "shared": {
           "breakdown": true,
           "color": true,
@@ -178,10 +181,12 @@ expression: cases
     "case": "codex monthly fast",
     "cli": {
       "command": {
+        "byAgent": false,
         "codexSpeed": "Fast",
         "kind": "Monthly",
         "openClawPath": null,
         "piPath": null,
+        "sections": null,
         "shared": {
           "breakdown": false,
           "color": false,
@@ -228,10 +233,12 @@ expression: cases
     "case": "opencode weekly",
     "cli": {
       "command": {
+        "byAgent": false,
         "codexSpeed": "Auto",
         "kind": "Weekly",
         "openClawPath": null,
         "piPath": null,
+        "sections": null,
         "shared": {
           "breakdown": false,
           "color": false,
@@ -278,10 +285,12 @@ expression: cases
     "case": "pi session path",
     "cli": {
       "command": {
+        "byAgent": false,
         "codexSpeed": "Auto",
         "kind": "Session",
         "openClawPath": null,
         "piPath": "/tmp/pi-sessions",
+        "sections": null,
         "shared": {
           "breakdown": false,
           "color": false,
@@ -328,10 +337,12 @@ expression: cases
     "case": "openclaw session path",
     "cli": {
       "command": {
+        "byAgent": false,
         "codexSpeed": "Auto",
         "kind": "Session",
         "openClawPath": "/tmp/openclaw",
         "piPath": null,
+        "sections": null,
         "shared": {
           "breakdown": false,
           "color": false,

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -210,6 +210,11 @@ fn agent_command_snapshot(agent: &str, args: AgentCommandArgs) -> Value {
         "type": agent,
         "shared": shared_snapshot(&args.shared),
         "kind": format!("{:?}", args.kind),
+        "sections": args.sections.map(|sections| sections
+            .into_iter()
+            .map(|section| format!("{section:?}"))
+            .collect::<Vec<_>>()),
+        "byAgent": args.by_agent,
         "piPath": args.pi_path,
         "openClawPath": args.open_claw_path,
         "codexSpeed": format!("{:?}", args.codex_speed),
@@ -225,6 +230,157 @@ fn parses_root_daily_as_all_agent_report() {
     assert_eq!(args.kind, AgentReportKind::Daily);
     assert!(args.shared.json);
     assert_eq!(args.shared.since.as_deref(), Some("20260102"));
+}
+
+#[test]
+fn parses_unified_sections_and_by_agent_flags() {
+    let cli = parse(&[
+        "ccusage",
+        "daily",
+        "--json",
+        "--sections",
+        "monthly,session",
+        "--by-agent",
+    ]);
+    let Some(Command::All(args)) = cli.command else {
+        panic!("expected all-agent command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Daily);
+    assert_eq!(
+        args.sections.as_deref(),
+        Some(&[AgentReportKind::Monthly, AgentReportKind::Session][..])
+    );
+    assert!(args.by_agent);
+}
+
+#[test]
+fn parses_root_sections_and_by_agent_flags_without_daily_token() {
+    let cli = parse(&[
+        "ccusage",
+        "--json",
+        "--sections",
+        "monthly,session",
+        "--by-agent",
+    ]);
+    let Some(Command::All(args)) = cli.command else {
+        panic!("expected all-agent command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Daily);
+    assert_eq!(
+        args.sections.as_deref(),
+        Some(&[AgentReportKind::Monthly, AgentReportKind::Session][..])
+    );
+    assert!(args.by_agent);
+}
+
+#[test]
+fn parses_inline_unified_sections_value() {
+    let cli = parse(&["ccusage", "daily", "--sections=daily,monthly"]);
+    let Some(Command::All(args)) = cli.command else {
+        panic!("expected all-agent command");
+    };
+    assert_eq!(
+        args.sections.as_deref(),
+        Some(&[AgentReportKind::Daily, AgentReportKind::Monthly][..])
+    );
+}
+
+#[test]
+fn ignores_empty_unified_section_tokens() {
+    let cli = parse(&["ccusage", "daily", "--sections", "daily,,monthly,"]);
+    let Some(Command::All(args)) = cli.command else {
+        panic!("expected all-agent command");
+    };
+    assert_eq!(
+        args.sections.as_deref(),
+        Some(&[AgentReportKind::Daily, AgentReportKind::Monthly][..])
+    );
+}
+
+#[test]
+fn dedupes_unified_section_tokens_preserving_first_occurrence() {
+    let cli = parse(&["ccusage", "daily", "--sections", "daily,daily,monthly"]);
+    let Some(Command::All(args)) = cli.command else {
+        panic!("expected all-agent command");
+    };
+    assert_eq!(
+        args.sections.as_deref(),
+        Some(&[AgentReportKind::Daily, AgentReportKind::Monthly][..])
+    );
+}
+
+#[test]
+fn parses_top_level_session_sections_as_all_agent_report_without_id() {
+    let cli = parse(&[
+        "ccusage",
+        "session",
+        "--sections",
+        "daily,weekly",
+        "--by-agent",
+    ]);
+    let Some(Command::All(args)) = cli.command else {
+        panic!("expected all-agent command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Session);
+    assert_eq!(
+        args.sections.as_deref(),
+        Some(&[AgentReportKind::Daily, AgentReportKind::Weekly][..])
+    );
+    assert!(args.by_agent);
+}
+
+#[test]
+fn rejects_sections_and_by_agent_with_top_level_session_id() {
+    let sections_error = parse_error(&["ccusage", "session", "--id", "abc", "--sections", "daily"]);
+    assert_eq!(
+        sections_error,
+        "The --sections and --by-agent options cannot be used with session --id."
+    );
+
+    let by_agent_error = parse_error(&["ccusage", "session", "--id", "abc", "--by-agent"]);
+    assert_eq!(
+        by_agent_error,
+        "The --sections and --by-agent options cannot be used with session --id."
+    );
+}
+
+#[test]
+fn rejects_unified_only_flags_on_per_agent_subcommands() {
+    let sections_error = parse_error(&["ccusage", "codex", "daily", "--sections", "daily"]);
+    assert_eq!(sections_error, "Unknown codex option '--sections'");
+
+    let by_agent_error = parse_error(&["ccusage", "codex", "daily", "--by-agent"]);
+    assert_eq!(by_agent_error, "Unknown codex option '--by-agent'");
+}
+
+#[test]
+fn rejects_invalid_unified_section_token() {
+    let error = parse_error(&["ccusage", "daily", "--sections", "daily,yearly"]);
+
+    assert_eq!(
+        error,
+        "Invalid --sections value 'yearly'. Expected one or more of: daily, weekly, monthly, session."
+    );
+}
+
+#[test]
+fn preserves_shared_config_defaults_with_unified_sections() {
+    let config = TestConfig {
+        shared_json: Some(true),
+        shared_since: Some("20260102"),
+        ..TestConfig::default()
+    };
+
+    let cli = parse_with_config(&["ccusage", "monthly", "--sections", "daily"], &config);
+    let Some(Command::All(args)) = cli.command else {
+        panic!("expected all-agent command");
+    };
+    assert!(args.shared.json);
+    assert_eq!(args.shared.since.as_deref(), Some("20260102"));
+    assert_eq!(
+        args.sections.as_deref(),
+        Some(&[AgentReportKind::Daily][..])
+    );
 }
 
 #[test]

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -120,6 +120,8 @@ pub struct StatuslineArgs {
 pub struct AgentCommandArgs {
     pub shared: SharedArgs,
     pub kind: AgentReportKind,
+    pub sections: Option<Vec<AgentReportKind>>,
+    pub by_agent: bool,
     pub pi_path: Option<String>,
     pub open_claw_path: Option<String>,
     pub codex_speed: CodexSpeed,

--- a/rust/crates/ccusage-test-support/src/lib.rs
+++ b/rust/crates/ccusage-test-support/src/lib.rs
@@ -13,7 +13,7 @@ use assert_fs::{
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn env_lock() -> MutexGuard<'static, ()> {
-    ENV_LOCK.lock().unwrap()
+    ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner())
 }
 
 pub struct EnvVarGuard {
@@ -40,6 +40,40 @@ impl Drop for EnvVarGuard {
         match self.previous.take() {
             Some(value) => unsafe { std::env::set_var(self.key, value) },
             None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+pub struct EnvVarsGuard {
+    previous: Vec<(&'static str, Option<OsString>)>,
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl EnvVarsGuard {
+    pub fn set_many(vars: impl IntoIterator<Item = (&'static str, Option<OsString>)>) -> Self {
+        let guard = env_lock();
+        let mut previous = Vec::new();
+        for (key, value) in vars {
+            previous.push((key, std::env::var_os(key)));
+            match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+        Self {
+            previous,
+            _guard: guard,
+        }
+    }
+}
+
+impl Drop for EnvVarsGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.previous.drain(..).rev() {
+            match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
         }
     }
 }

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -42,13 +42,14 @@ pub(super) fn load_sections(
         .then(|| load_base_rows(AgentReportKind::Session, shared, &pricing))
         .transpose()?;
 
-    let mut detected_agents = Vec::new();
-    if let Some(base) = daily_base.as_ref() {
-        append_detected_agents(&mut detected_agents, &base.detected_agents);
-    }
-    if let Some(base) = session_base.as_ref() {
-        append_detected_agents(&mut detected_agents, &base.detected_agents);
-    }
+    let daily_detected_agents = daily_base
+        .as_ref()
+        .map(|base| base.detected_agents.clone())
+        .unwrap_or_default();
+    let session_detected_agents = session_base
+        .as_ref()
+        .map(|base| base.detected_agents.clone())
+        .unwrap_or_default();
 
     let mut sections = Vec::with_capacity(kinds.len());
     for kind in kinds {
@@ -68,7 +69,8 @@ pub(super) fn load_sections(
 
     Ok(AllSectionsLoadResult {
         sections,
-        detected_agents,
+        daily_detected_agents,
+        session_detected_agents,
     })
 }
 
@@ -406,17 +408,6 @@ fn append_agent_rows(
         detected_agents.push(agent);
     }
     rows.extend(agent_rows.rows);
-}
-
-fn append_detected_agents(
-    detected_agents: &mut Vec<&'static str>,
-    additional_agents: &[&'static str],
-) {
-    for agent in additional_agents {
-        if !detected_agents.contains(agent) {
-            detected_agents.push(agent);
-        }
-    }
 }
 
 fn load_summary_agent_rows(

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -14,10 +14,86 @@ use crate::{
 
 use super::{
     report::sort_rows,
-    types::{AgentLoadSpec, AgentRows, AllAccumulator, AllLoadResult, AllRow, LoadedAgentRows},
+    types::{
+        AgentLoadSpec, AgentRows, AllAccumulator, AllLoadResult, AllRow, AllSectionsLoadResult,
+        LoadedAgentRows,
+    },
 };
 
 pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AllLoadResult> {
+    let pricing = load_pricing(shared);
+    let load_kind = load_kind_for_report(kind);
+    let loaded = load_base_rows(load_kind, shared, &pricing)?;
+    Ok(AllLoadResult {
+        rows: finish_rows(kind, loaded.rows, shared),
+        detected_agents: loaded.detected_agents,
+    })
+}
+
+pub(super) fn load_sections(
+    kinds: &[AgentReportKind],
+    shared: &SharedArgs,
+) -> Result<AllSectionsLoadResult> {
+    let pricing = load_pricing(shared);
+    let daily_base = needs_daily_family(kinds)
+        .then(|| load_base_rows(AgentReportKind::Daily, shared, &pricing))
+        .transpose()?;
+    let session_base = needs_session(kinds)
+        .then(|| load_base_rows(AgentReportKind::Session, shared, &pricing))
+        .transpose()?;
+
+    let mut detected_agents = Vec::new();
+    if let Some(base) = daily_base.as_ref() {
+        append_detected_agents(&mut detected_agents, &base.detected_agents);
+    }
+    if let Some(base) = session_base.as_ref() {
+        append_detected_agents(&mut detected_agents, &base.detected_agents);
+    }
+
+    let mut sections = Vec::with_capacity(kinds.len());
+    for kind in kinds {
+        let rows = if *kind == AgentReportKind::Session {
+            session_base
+                .as_ref()
+                .map(|base| finish_rows(*kind, base.rows.clone(), shared))
+                .unwrap_or_default()
+        } else {
+            daily_base
+                .as_ref()
+                .map(|base| finish_rows(*kind, base.rows.clone(), shared))
+                .unwrap_or_default()
+        };
+        sections.push((*kind, rows));
+    }
+
+    Ok(AllSectionsLoadResult {
+        sections,
+        detected_agents,
+    })
+}
+
+fn load_pricing(shared: &SharedArgs) -> PricingMap {
+    PricingMap::load_with_overrides(
+        shared.offline,
+        crate::log_level() != Some(0),
+        shared.pricing_overrides.iter(),
+    )
+}
+
+fn load_kind_for_report(kind: AgentReportKind) -> AgentReportKind {
+    match kind {
+        AgentReportKind::Session => AgentReportKind::Session,
+        AgentReportKind::Daily | AgentReportKind::Weekly | AgentReportKind::Monthly => {
+            AgentReportKind::Daily
+        }
+    }
+}
+
+fn load_base_rows(
+    load_kind: AgentReportKind,
+    shared: &SharedArgs,
+    pricing: &PricingMap,
+) -> Result<AllLoadResult> {
     let mut progress = crate::progress::UsageLoadProgress::new(
         crate::log_level() != Some(0)
             && crate::progress::should_show_usage_load_progress(
@@ -25,17 +101,6 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 crate::progress::usage_load_output_is_tty(),
             ),
     );
-    let pricing = PricingMap::load_with_overrides(
-        shared.offline,
-        crate::log_level() != Some(0),
-        shared.pricing_overrides.iter(),
-    );
-    let load_kind = match kind {
-        AgentReportKind::Session => AgentReportKind::Session,
-        AgentReportKind::Daily | AgentReportKind::Weekly | AgentReportKind::Monthly => {
-            AgentReportKind::Daily
-        }
-    };
     let loader_shared = SharedArgs {
         json: true,
         ..shared.clone()
@@ -52,7 +117,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 index: 1,
                 agent: "codex",
                 progress_agent: crate::progress::UsageLoadAgent::Codex,
-                load: Box::new(|| load_codex_rows(load_kind, &loader_shared, &pricing)),
+                load: Box::new(|| load_codex_rows(load_kind, &loader_shared, pricing)),
             },
             AgentLoadSpec {
                 index: 2,
@@ -77,7 +142,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "amp",
                         load_kind,
                         &loader_shared,
-                        &pricing,
+                        pricing,
                         amp::load_entries,
                         amp::summarize_entries,
                     )
@@ -92,7 +157,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "droid",
                         load_kind,
                         &loader_shared,
-                        &pricing,
+                        pricing,
                         droid::load_entries,
                         droid::summarize_entries,
                     )
@@ -107,7 +172,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "codebuff",
                         load_kind,
                         &loader_shared,
-                        &pricing,
+                        pricing,
                         codebuff::load_entries,
                         codebuff::summarize_entries,
                     )
@@ -122,7 +187,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "hermes",
                         load_kind,
                         &loader_shared,
-                        &pricing,
+                        pricing,
                         hermes::load_entries,
                         hermes::summarize_entries,
                     )
@@ -137,7 +202,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "pi",
                         load_kind,
                         &loader_shared,
-                        &pricing,
+                        pricing,
                         pi::load_entries,
                         pi::summarize_entries,
                     )
@@ -152,7 +217,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "goose",
                         load_kind,
                         &loader_shared,
-                        &pricing,
+                        pricing,
                         goose::load_entries,
                         goose::summarize_entries,
                     )
@@ -167,7 +232,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "openclaw",
                         load_kind,
                         &loader_shared,
-                        || openclaw::load_entries(&loader_shared, None, Some(&pricing)),
+                        || openclaw::load_entries(&loader_shared, None, Some(pricing)),
                         openclaw::summarize_entries,
                     )
                 }),
@@ -181,7 +246,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "kilo",
                         load_kind,
                         &loader_shared,
-                        &pricing,
+                        pricing,
                         kilo::load_entries,
                         kilo::summarize_entries,
                     )
@@ -196,7 +261,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "copilot",
                         load_kind,
                         &loader_shared,
-                        &pricing,
+                        pricing,
                         copilot::load_entries,
                         copilot::summarize_entries,
                     )
@@ -211,7 +276,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "gemini",
                         load_kind,
                         &loader_shared,
-                        &pricing,
+                        pricing,
                         gemini::load_entries,
                         gemini::summarize_entries,
                     )
@@ -226,7 +291,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                         "kimi",
                         load_kind,
                         &loader_shared,
-                        &pricing,
+                        pricing,
                         kimi::load_entries,
                         kimi::summarize_entries,
                     )
@@ -251,23 +316,24 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
             loaded.agent_rows,
         );
     }
+    Ok(AllLoadResult {
+        rows,
+        detected_agents,
+    })
+}
+
+fn finish_rows(kind: AgentReportKind, mut rows: Vec<AllRow>, shared: &SharedArgs) -> Vec<AllRow> {
     if kind == AgentReportKind::Session {
         for row in &mut rows {
             row.metadata_agents = None;
         }
         sort_rows(&mut rows, &shared.order);
-        return Ok(AllLoadResult {
-            rows,
-            detected_agents,
-        });
+        return rows;
     }
 
     let mut aggregated = aggregate_rows(rows, kind);
     sort_rows(&mut aggregated, &shared.order);
-    Ok(AllLoadResult {
-        rows: aggregated,
-        detected_agents,
-    })
+    aggregated
 }
 
 pub(super) fn load_agent_rows_parallel(
@@ -340,6 +406,17 @@ fn append_agent_rows(
         detected_agents.push(agent);
     }
     rows.extend(agent_rows.rows);
+}
+
+fn append_detected_agents(
+    detected_agents: &mut Vec<&'static str>,
+    additional_agents: &[&'static str],
+) {
+    for agent in additional_agents {
+        if !detected_agents.contains(agent) {
+            detected_agents.push(agent);
+        }
+    }
 }
 
 fn load_summary_agent_rows(
@@ -499,6 +576,14 @@ fn summarize_entry_sessions(entries: &[LoadedEntry]) -> Result<Vec<UsageSummary>
         .into_values()
         .map(|group| group.into_summary())
         .collect()
+}
+
+fn needs_daily_family(kinds: &[AgentReportKind]) -> bool {
+    kinds.iter().any(|kind| *kind != AgentReportKind::Session)
+}
+
+fn needs_session(kinds: &[AgentReportKind]) -> bool {
+    kinds.contains(&AgentReportKind::Session)
 }
 
 fn filter_session_summaries(rows: &mut Vec<UsageSummary>, shared: &SharedArgs) {

--- a/rust/crates/ccusage/src/adapter/all/mod.rs
+++ b/rust/crates/ccusage/src/adapter/all/mod.rs
@@ -24,8 +24,13 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
                 shared.no_cost,
             );
         }
-        for (section_kind, rows) in result.sections {
-            report::print_table(&rows, section_kind, &shared, &result.detected_agents)?;
+        for (section_kind, rows) in &result.sections {
+            report::print_table(
+                rows,
+                *section_kind,
+                &shared,
+                result.detected_agents_for(*section_kind),
+            )?;
         }
         return Ok(());
     }

--- a/rust/crates/ccusage/src/adapter/all/mod.rs
+++ b/rust/crates/ccusage/src/adapter/all/mod.rs
@@ -2,26 +2,66 @@ mod loader;
 mod report;
 mod types;
 
-use crate::{Result, cli::AgentCommandArgs, print_json_or_jq, wants_json};
+use crate::{
+    Result,
+    cli::{AgentCommandArgs, AgentReportKind},
+    print_json_or_jq, wants_json,
+};
 
 pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     let kind = args.kind;
     let shared = args.shared;
+    let include_agents = args.by_agent;
+    if let Some(sections) = args.sections {
+        let sections = requested_sections(kind, sections);
+        let result = loader::load_sections(&sections, &shared)?;
+        if wants_json(&shared) {
+            return report::print_sections_report_json(
+                &result.sections,
+                kind,
+                include_agents,
+                shared.jq.as_deref(),
+                shared.no_cost,
+            );
+        }
+        for (section_kind, rows) in result.sections {
+            report::print_table(&rows, section_kind, &shared, &result.detected_agents)?;
+        }
+        return Ok(());
+    }
     let result = loader::load_rows(kind, &shared)?;
     if wants_json(&shared) {
-        return print_json_or_jq(
-            report::report_json(&result.rows, kind),
-            shared.jq.as_deref(),
-            shared.no_cost,
-        );
+        let output = report::report_json_with_agents(&result.rows, kind, include_agents);
+        return print_json_or_jq(output, shared.jq.as_deref(), shared.no_cost);
     }
     report::print_table(&result.rows, kind, &shared, &result.detected_agents)
 }
 
+fn requested_sections(
+    command_kind: AgentReportKind,
+    sections: Vec<AgentReportKind>,
+) -> Vec<AgentReportKind> {
+    let mut requested = vec![command_kind];
+    for section in [
+        AgentReportKind::Daily,
+        AgentReportKind::Weekly,
+        AgentReportKind::Monthly,
+        AgentReportKind::Session,
+    ] {
+        if section != command_kind && sections.contains(&section) {
+            requested.push(section);
+        }
+    }
+    requested
+}
+
 #[cfg(test)]
-use loader::{aggregate_rows, codex_group_row, load_agent_rows_parallel};
+use loader::{aggregate_rows, codex_group_row, load_agent_rows_parallel, load_rows, load_sections};
 #[cfg(test)]
-use report::{all_report_title, all_table_columns, all_table_row, report_json};
+use report::{
+    all_report_title, all_table_columns, all_table_row, report_json, report_json_with_agents,
+    sections_report_json,
+};
 #[cfg(test)]
 use types::{AgentLoadSpec, AgentRows, AllRow};
 

--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -1,24 +1,135 @@
-use std::{collections::BTreeSet, io::IsTerminal};
+use std::{
+    collections::BTreeSet,
+    io::{BufWriter, IsTerminal, Write},
+};
 
+use serde::{
+    Serialize,
+    ser::{SerializeMap, Serializer},
+};
 use serde_json::{Value, json};
 
 use crate::{
     Align, Color, ModelBreakdown, Result, SimpleTable, UsageSummary,
     cli::{AgentReportKind, SharedArgs, SortOrder},
-    color, format_currency, format_models_multiline, format_number, json_float, print_box_title,
-    short_model_name, should_use_compact_layout,
+    cli_error, color, format_currency, format_models_multiline, format_number, json_float,
+    output::strip_cost_json,
+    print_box_title, short_model_name, should_use_compact_layout,
 };
 
 use super::types::AllRow;
 
+#[cfg(test)]
 pub(super) fn report_json(rows: &[AllRow], kind: AgentReportKind) -> Value {
+    report_json_with_agents(rows, kind, false)
+}
+
+pub(super) fn report_json_with_agents(
+    rows: &[AllRow],
+    kind: AgentReportKind,
+    include_agents: bool,
+) -> Value {
     json!({
-        rows_key(kind): rows.iter().map(row_json).collect::<Vec<_>>(),
+        rows_key(kind): rows.iter().map(|row| row_json(row, include_agents)).collect::<Vec<_>>(),
         "totals": totals_json(rows),
     })
 }
 
-fn row_json(row: &AllRow) -> Value {
+pub(super) fn sections_report_json(
+    sections: &[(AgentReportKind, Vec<AllRow>)],
+    command_kind: AgentReportKind,
+    include_agents: bool,
+) -> OrderedJsonMap {
+    let mut fields = Vec::with_capacity(sections.len() + 1);
+    for (kind, rows) in sections {
+        fields.push((
+            rows_key(*kind),
+            Value::Array(
+                rows.iter()
+                    .map(|row| row_json(row, include_agents))
+                    .collect(),
+            ),
+        ));
+    }
+    let command_rows = sections
+        .iter()
+        .find_map(|(kind, rows)| (*kind == command_kind).then_some(rows.as_slice()))
+        .unwrap_or(&[]);
+    fields.push(("totals", totals_json(command_rows)));
+    OrderedJsonMap { fields }
+}
+
+pub(super) fn print_sections_report_json(
+    sections: &[(AgentReportKind, Vec<AllRow>)],
+    command_kind: AgentReportKind,
+    include_agents: bool,
+    jq: Option<&str>,
+    no_cost: bool,
+) -> Result<()> {
+    let mut report = sections_report_json(sections, command_kind, include_agents);
+    if no_cost {
+        report.strip_costs();
+    }
+    if let Some(filter) = jq {
+        let mut child = std::process::Command::new("jq")
+            .arg(filter)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::inherit())
+            .spawn()
+            .map_err(|error| cli_error(format!("failed to run jq: {error}")))?;
+        if let Some(stdin) = child.stdin.take() {
+            let mut stdin = BufWriter::new(stdin);
+            serde_json::to_writer(&mut stdin, &report)?;
+            stdin.write_all(b"\n")?;
+            stdin.flush()?;
+        }
+        let status = child.wait()?;
+        if !status.success() {
+            return Err(cli_error("jq failed"));
+        }
+    } else {
+        let stdout = std::io::stdout();
+        let mut stdout = BufWriter::new(stdout.lock());
+        serde_json::to_writer_pretty(&mut stdout, &report)?;
+        stdout.write_all(b"\n")?;
+        stdout.flush()?;
+    }
+    Ok(())
+}
+
+pub(super) struct OrderedJsonMap {
+    fields: Vec<(&'static str, Value)>,
+}
+
+impl OrderedJsonMap {
+    #[cfg(test)]
+    pub(super) fn get(&self, key: &str) -> Option<&Value> {
+        self.fields
+            .iter()
+            .find_map(|(field, value)| (*field == key).then_some(value))
+    }
+
+    fn strip_costs(&mut self) {
+        for (_, value) in &mut self.fields {
+            strip_cost_json(value);
+        }
+    }
+}
+
+impl Serialize for OrderedJsonMap {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.fields.len()))?;
+        for (key, value) in &self.fields {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
+}
+
+fn row_json(row: &AllRow, include_agents: bool) -> Value {
     let mut value = json!({
         "period": row.period,
         "agent": row.agent,
@@ -41,7 +152,30 @@ fn row_json(row: &AllRow) -> Value {
     } else if let (Some(obj), Some(metadata)) = (value.as_object_mut(), row.metadata.as_ref()) {
         obj.insert("metadata".to_string(), metadata.clone());
     }
+    if include_agents
+        && let (Some(obj), Some(agent_breakdowns)) =
+            (value.as_object_mut(), row.agent_breakdowns.as_ref())
+    {
+        obj.insert(
+            "agents".to_string(),
+            Value::Array(agent_breakdowns.iter().map(agent_json).collect()),
+        );
+    }
     value
+}
+
+fn agent_json(row: &AllRow) -> Value {
+    json!({
+        "agent": row.agent,
+        "modelsUsed": row.models_used,
+        "inputTokens": row.input_tokens,
+        "outputTokens": row.output_tokens,
+        "cacheCreationTokens": row.cache_creation_tokens,
+        "cacheReadTokens": row.cache_read_tokens,
+        "totalTokens": row.total_tokens,
+        "totalCost": json_float(row.total_cost),
+        "modelBreakdowns": row.model_breakdowns,
+    })
 }
 
 fn totals_json(rows: &[AllRow]) -> Value {

--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -130,18 +130,10 @@ impl Serialize for OrderedJsonMap {
 }
 
 fn row_json(row: &AllRow, include_agents: bool) -> Value {
-    let mut value = json!({
-        "period": row.period,
-        "agent": row.agent,
-        "modelsUsed": row.models_used,
-        "inputTokens": row.input_tokens,
-        "outputTokens": row.output_tokens,
-        "cacheCreationTokens": row.cache_creation_tokens,
-        "cacheReadTokens": row.cache_read_tokens,
-        "totalTokens": row.total_tokens,
-        "totalCost": json_float(row.total_cost),
-        "modelBreakdowns": row.model_breakdowns,
-    });
+    let mut value = agent_json(row);
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("period".to_string(), json!(row.period));
+    }
     if let (Some(obj), Some(agents)) = (value.as_object_mut(), row.metadata_agents.as_ref()) {
         obj.insert(
             "metadata".to_string(),

--- a/rust/crates/ccusage/src/adapter/all/snapshots/ccusage__adapter__all__tests__renders_multi_section_json_with_command_totals.snap
+++ b/rust/crates/ccusage/src/adapter/all/snapshots/ccusage__adapter__all__tests__renders_multi_section_json_with_command_totals.snap
@@ -1,0 +1,76 @@
+---
+source: crates/ccusage/src/adapter/all/tests.rs
+assertion_line: 466
+expression: "serde_json::to_string_pretty(&report).unwrap()"
+---
+{
+  "daily": [
+    {
+      "agent": "all",
+      "cacheCreationTokens": 0,
+      "cacheReadTokens": 10,
+      "inputTokens": 100,
+      "metadata": {
+        "agents": [
+          "codex"
+        ]
+      },
+      "modelBreakdowns": [],
+      "modelsUsed": [
+        "gpt-5"
+      ],
+      "outputTokens": 20,
+      "period": "2026-01-02",
+      "totalCost": 0.01,
+      "totalTokens": 120
+    }
+  ],
+  "monthly": [
+    {
+      "agent": "all",
+      "cacheCreationTokens": 0,
+      "cacheReadTokens": 10,
+      "inputTokens": 100,
+      "metadata": {
+        "agents": [
+          "codex"
+        ]
+      },
+      "modelBreakdowns": [],
+      "modelsUsed": [
+        "gpt-5"
+      ],
+      "outputTokens": 20,
+      "period": "2026-01",
+      "totalCost": 0.01,
+      "totalTokens": 120
+    }
+  ],
+  "session": [
+    {
+      "agent": "codex",
+      "cacheCreationTokens": 0,
+      "cacheReadTokens": 10,
+      "inputTokens": 100,
+      "metadata": {
+        "lastActivity": "2026-01-02T00:00:00.000Z"
+      },
+      "modelBreakdowns": [],
+      "modelsUsed": [
+        "gpt-5"
+      ],
+      "outputTokens": 20,
+      "period": "session-a",
+      "totalCost": 0.01,
+      "totalTokens": 120
+    }
+  ],
+  "totals": {
+    "cacheCreationTokens": 0,
+    "cacheReadTokens": 10,
+    "inputTokens": 100,
+    "outputTokens": 20,
+    "totalCost": 0.01,
+    "totalTokens": 120
+  }
+}

--- a/rust/crates/ccusage/src/adapter/all/tests.rs
+++ b/rust/crates/ccusage/src/adapter/all/tests.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsString,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -12,8 +13,10 @@ use serde_json::json;
 use super::*;
 use crate::{
     Align, CodexGroup, CodexModelUsage, ModelBreakdown, PricingMap,
-    cli::{AgentReportKind, CodexSpeed},
+    cli::{AgentReportKind, CodexSpeed, SharedArgs},
+    model_aliases::set_model_aliases_for_tests,
 };
+use ccusage_test_support::{EnvVarsGuard, fs_fixture};
 
 fn test_agent_rows(agent: &'static str) -> AgentRows {
     AgentRows {
@@ -227,6 +230,7 @@ fn merges_same_agent_daily_rows_into_one_monthly_breakdown() {
     assert_eq!(claude.output_tokens, 15);
     assert_eq!(claude.cache_creation_tokens, 3);
     assert_eq!(claude.cache_read_tokens, 6);
+    assert!((claude.total_cost - 0.06).abs() < f64::EPSILON);
     assert_eq!(
         claude.models_used,
         vec![
@@ -243,6 +247,8 @@ fn merges_same_agent_daily_rows_into_one_monthly_breakdown() {
             .collect::<Vec<_>>(),
         vec!["claude-opus-4-20250514", "claude-sonnet-4-20250514",]
     );
+    assert_eq!(claude.model_breakdowns[0].cost, 0.05);
+    assert_eq!(claude.model_breakdowns[1].cost, 0.01);
     let codex = breakdowns
         .iter()
         .find(|row| row.agent == "codex")
@@ -274,6 +280,361 @@ fn renders_all_report_json_with_period_and_agent_metadata() {
     assert_eq!(report["daily"][0]["agent"], "all");
     assert_eq!(report["daily"][0]["metadata"]["agents"], json!(["codex"]));
     assert_eq!(report["totals"]["totalTokens"], 130);
+}
+
+#[test]
+fn renders_by_agent_json_breakdowns_when_requested() {
+    let rows = vec![AllRow {
+        period: "2026-01-02".to_string(),
+        agent: "all",
+        models_used: vec!["claude-sonnet-4-20250514".to_string(), "gpt-5".to_string()],
+        input_tokens: 150,
+        output_tokens: 45,
+        cache_creation_tokens: 5,
+        cache_read_tokens: 13,
+        total_tokens: 203,
+        total_cost: 0.03,
+        metadata: None,
+        metadata_agents: Some(vec!["claude", "codex"]),
+        agent_breakdowns: Some(vec![
+            AllRow {
+                period: "2026-01-02".to_string(),
+                agent: "claude",
+                models_used: vec!["claude-sonnet-4-20250514".to_string()],
+                input_tokens: 50,
+                output_tokens: 25,
+                cache_creation_tokens: 5,
+                cache_read_tokens: 3,
+                total_tokens: 83,
+                total_cost: 0.02,
+                metadata: None,
+                metadata_agents: Some(vec!["claude"]),
+                agent_breakdowns: None,
+                model_breakdowns: vec![ModelBreakdown {
+                    model_name: "claude-sonnet-4-20250514".to_string(),
+                    input_tokens: 50,
+                    output_tokens: 25,
+                    cache_creation_tokens: 5,
+                    cache_read_tokens: 3,
+                    cost: 0.02,
+                    ..ModelBreakdown::default()
+                }],
+            },
+            AllRow {
+                period: "2026-01-02".to_string(),
+                agent: "codex",
+                models_used: vec!["gpt-5".to_string()],
+                input_tokens: 100,
+                output_tokens: 20,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 10,
+                total_tokens: 120,
+                total_cost: 0.01,
+                metadata: None,
+                metadata_agents: Some(vec!["codex"]),
+                agent_breakdowns: None,
+                model_breakdowns: vec![ModelBreakdown {
+                    model_name: "gpt-5".to_string(),
+                    input_tokens: 100,
+                    output_tokens: 20,
+                    cache_creation_tokens: 0,
+                    cache_read_tokens: 10,
+                    cost: 0.01,
+                    ..ModelBreakdown::default()
+                }],
+            },
+        ]),
+        model_breakdowns: Vec::new(),
+    }];
+
+    let report = report_json_with_agents(&rows, AgentReportKind::Daily, true);
+
+    assert_eq!(report["daily"][0]["agents"][0]["agent"], "claude");
+    assert_eq!(report["daily"][0]["agents"][0]["inputTokens"], 50);
+    assert_eq!(report["daily"][0]["agents"][1]["agent"], "codex");
+    assert_eq!(report["daily"][0]["agents"][1]["totalCost"], 0.01);
+    assert_eq!(
+        report["daily"][0]["agents"][1]["modelBreakdowns"][0]["modelName"],
+        "gpt-5"
+    );
+    let agents = report["daily"][0]["agents"].as_array().unwrap();
+    assert_eq!(
+        agents
+            .iter()
+            .map(|agent| agent["inputTokens"].as_u64().unwrap())
+            .sum::<u64>(),
+        report["daily"][0]["inputTokens"]
+    );
+    assert_eq!(
+        agents
+            .iter()
+            .map(|agent| agent["outputTokens"].as_u64().unwrap())
+            .sum::<u64>(),
+        report["daily"][0]["outputTokens"]
+    );
+    let agent_cost = agents
+        .iter()
+        .map(|agent| agent["totalCost"].as_f64().unwrap())
+        .sum::<f64>();
+    let row_cost = report["daily"][0]["totalCost"].as_f64().unwrap();
+    assert!((agent_cost - row_cost).abs() < f64::EPSILON);
+}
+
+#[test]
+fn omits_by_agent_json_breakdowns_by_default() {
+    let rows = aggregate_rows(
+        vec![AllRow {
+            period: "2026-01-02".to_string(),
+            agent: "codex",
+            models_used: vec!["gpt-5".to_string()],
+            input_tokens: 100,
+            output_tokens: 20,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 10,
+            total_tokens: 120,
+            total_cost: 0.01,
+            metadata: None,
+            metadata_agents: Some(vec!["codex"]),
+            agent_breakdowns: None,
+            model_breakdowns: Vec::new(),
+        }],
+        AgentReportKind::Daily,
+    );
+
+    let report = report_json(&rows, AgentReportKind::Daily);
+
+    assert!(report["daily"][0].get("agents").is_none());
+}
+
+#[test]
+fn renders_multi_section_json_with_command_totals() {
+    let daily_rows = vec![AllRow {
+        period: "2026-01-02".to_string(),
+        agent: "all",
+        models_used: vec!["gpt-5".to_string()],
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 10,
+        total_tokens: 120,
+        total_cost: 0.01,
+        metadata: None,
+        metadata_agents: Some(vec!["codex"]),
+        agent_breakdowns: None,
+        model_breakdowns: Vec::new(),
+    }];
+    let monthly_rows = aggregate_rows(daily_rows.clone(), AgentReportKind::Monthly);
+    let session_rows = vec![AllRow {
+        period: "session-a".to_string(),
+        agent: "codex",
+        models_used: vec!["gpt-5".to_string()],
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 10,
+        total_tokens: 120,
+        total_cost: 0.01,
+        metadata: Some(json!({ "lastActivity": "2026-01-02T00:00:00.000Z" })),
+        metadata_agents: None,
+        agent_breakdowns: None,
+        model_breakdowns: Vec::new(),
+    }];
+    let sections = vec![
+        (AgentReportKind::Daily, daily_rows.clone()),
+        (AgentReportKind::Monthly, monthly_rows.clone()),
+        (AgentReportKind::Session, session_rows.clone()),
+    ];
+
+    let report = sections_report_json(&sections, AgentReportKind::Daily, false);
+
+    assert_eq!(
+        report.get("daily").unwrap(),
+        &report_json(&daily_rows, AgentReportKind::Daily)["daily"]
+    );
+    assert_eq!(
+        report.get("monthly").unwrap(),
+        &report_json(&monthly_rows, AgentReportKind::Monthly)["monthly"]
+    );
+    assert_eq!(
+        report.get("session").unwrap(),
+        &report_json(&session_rows, AgentReportKind::Session)["session"]
+    );
+    assert_eq!(
+        report.get("totals").unwrap(),
+        &report_json(&daily_rows, AgentReportKind::Daily)["totals"]
+    );
+    insta::assert_snapshot!(serde_json::to_string_pretty(&report).unwrap());
+}
+
+#[test]
+fn renders_multi_section_json_keys_in_invoked_section_order_with_totals_last() {
+    let sections = vec![
+        (AgentReportKind::Weekly, Vec::new()),
+        (AgentReportKind::Daily, Vec::new()),
+        (AgentReportKind::Monthly, Vec::new()),
+        (AgentReportKind::Session, Vec::new()),
+    ];
+
+    let report = sections_report_json(&sections, AgentReportKind::Weekly, false);
+    let serialized = serde_json::to_string(&report).unwrap();
+
+    assert_eq!(
+        serialized,
+        r#"{"weekly":[],"daily":[],"monthly":[],"session":[],"totals":{"cacheCreationTokens":0,"cacheReadTokens":0,"inputTokens":0,"outputTokens":0,"totalCost":0,"totalTokens":0}}"#
+    );
+}
+
+#[test]
+fn multi_section_claude_fixture_matches_standalone_sections_for_daily_and_session_invocations() {
+    let fixture = fs_fixture!({
+        "projects/project-a/session-a.jsonl": [
+            r#"{"timestamp":"2099-01-02T00:00:00.000Z","sessionId":"session-a","requestId":"req-direct","costUSD":0.01,"message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"model":"claude-sonnet-4-20250514","id":"msg-direct"}}"#,
+            r#"{"data":{"message":{"timestamp":"2099-01-02T00:01:00.000Z","requestId":"req-progress","isSidechain":true,"costUSD":0.02,"message":{"usage":{"input_tokens":1000,"output_tokens":500,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"model":"claude-sonnet-4-20250514","id":"msg-progress"}}}}"#,
+        ]
+        .join("\n"),
+    });
+    let _env = isolated_agent_env(
+        &fixture,
+        "CLAUDE_CONFIG_DIR",
+        fixture.root().as_os_str().into(),
+    );
+    let shared = fixture_shared("20990102", "20990102");
+
+    assert_daily_family_and_session_sections_match_standalone(&shared);
+}
+
+#[test]
+fn multi_section_codex_fixture_matches_standalone_sections_for_daily_and_session_invocations() {
+    let _aliases = set_model_aliases_for_tests([("private-alpha", "gpt-5.2")]);
+    let duplicate_session_usage = codex_usage_line("2099-02-01T08:01:00.000Z", "gpt-5.2", 1_000);
+    let alias_usage = codex_usage_line("2099-02-02T08:01:00.000Z", "private-alpha", 2_000);
+    let canonical_usage = codex_usage_line("2099-02-02T08:01:00.000Z", "gpt-5.2", 2_000);
+    let fixture = fs_fixture!({
+        "codex/sessions/session-a.jsonl": &duplicate_session_usage,
+        "codex/sessions/session-b.jsonl": &duplicate_session_usage,
+        "codex/sessions/alias-a.jsonl": &alias_usage,
+        "codex/sessions/alias-b.jsonl": &canonical_usage,
+    });
+    let _env = isolated_agent_env(
+        &fixture,
+        "CODEX_HOME",
+        fixture.path("codex").into_os_string(),
+    );
+    let shared = fixture_shared("20990201", "20990202");
+
+    assert_daily_family_and_session_sections_match_standalone(&shared);
+}
+
+fn fixture_shared(since: &str, until: &str) -> SharedArgs {
+    SharedArgs {
+        since: Some(since.to_string()),
+        until: Some(until.to_string()),
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        single_thread: true,
+        ..SharedArgs::default()
+    }
+}
+
+fn isolated_agent_env(
+    fixture: &ccusage_test_support::Fixture,
+    source_key: &'static str,
+    source_value: OsString,
+) -> EnvVarsGuard {
+    let home = fixture.path("empty-home").into_os_string();
+    let xdg_config = fixture.path("empty-xdg-config").into_os_string();
+    let mut vars = [
+        "CLAUDE_CONFIG_DIR",
+        "CODEX_HOME",
+        "OPENCODE_DATA_DIR",
+        "AMP_DATA_DIR",
+        "DROID_SESSIONS_DIR",
+        "CODEBUFF_DATA_DIR",
+        "HERMES_HOME",
+        "PI_AGENT_DIR",
+        "GOOSE_PATH_ROOT",
+        "OPENCLAW_DIR",
+        "KILO_DATA_DIR",
+        "COPILOT_OTEL_FILE_EXPORTER_PATH",
+        "GEMINI_DATA_DIR",
+        "KIMI_DATA_DIR",
+        "QWEN_DATA_DIR",
+    ]
+    .into_iter()
+    .map(|key| (key, None::<OsString>))
+    .collect::<Vec<_>>();
+    vars.push(("HOME", Some(home)));
+    vars.push((
+        "USERPROFILE",
+        Some(fixture.path("empty-userprofile").into_os_string()),
+    ));
+    vars.push(("XDG_CONFIG_HOME", Some(xdg_config)));
+    vars.push((source_key, Some(source_value)));
+    EnvVarsGuard::set_many(vars)
+}
+
+fn assert_daily_family_and_session_sections_match_standalone(shared: &SharedArgs) {
+    for command_kind in [AgentReportKind::Daily, AgentReportKind::Session] {
+        let sections = match command_kind {
+            AgentReportKind::Daily => vec![
+                AgentReportKind::Daily,
+                AgentReportKind::Weekly,
+                AgentReportKind::Monthly,
+                AgentReportKind::Session,
+            ],
+            AgentReportKind::Session => vec![
+                AgentReportKind::Session,
+                AgentReportKind::Daily,
+                AgentReportKind::Weekly,
+                AgentReportKind::Monthly,
+            ],
+            AgentReportKind::Weekly | AgentReportKind::Monthly => unreachable!(),
+        };
+        let section_rows = load_sections(&sections, shared).unwrap();
+        let report = sections_report_json(&section_rows.sections, command_kind, false);
+
+        for section_kind in [
+            AgentReportKind::Daily,
+            AgentReportKind::Weekly,
+            AgentReportKind::Monthly,
+            AgentReportKind::Session,
+        ] {
+            let standalone = load_rows(section_kind, shared).unwrap();
+            let standalone_report = report_json(&standalone.rows, section_kind);
+            let key = match section_kind {
+                AgentReportKind::Daily => "daily",
+                AgentReportKind::Weekly => "weekly",
+                AgentReportKind::Monthly => "monthly",
+                AgentReportKind::Session => "session",
+            };
+            assert_eq!(
+                report.get(key).unwrap(),
+                &standalone_report[key],
+                "{command_kind:?} invocation should match standalone {section_kind:?}"
+            );
+        }
+    }
+}
+
+fn codex_usage_line(timestamp: &str, model: &str, input_tokens: u64) -> String {
+    json!({
+        "timestamp": timestamp,
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "model": model,
+                "last_token_usage": {
+                    "input_tokens": input_tokens,
+                    "cached_input_tokens": 100,
+                    "output_tokens": 200,
+                    "reasoning_output_tokens": 20,
+                    "total_tokens": input_tokens + 300,
+                },
+            },
+        },
+    })
+    .to_string()
 }
 
 #[test]

--- a/rust/crates/ccusage/src/adapter/all/types.rs
+++ b/rust/crates/ccusage/src/adapter/all/types.rs
@@ -28,7 +28,19 @@ pub(super) struct AllLoadResult {
 
 pub(super) struct AllSectionsLoadResult {
     pub(super) sections: Vec<(AgentReportKind, Vec<AllRow>)>,
-    pub(super) detected_agents: Vec<&'static str>,
+    pub(super) daily_detected_agents: Vec<&'static str>,
+    pub(super) session_detected_agents: Vec<&'static str>,
+}
+
+impl AllSectionsLoadResult {
+    pub(super) fn detected_agents_for(&self, kind: AgentReportKind) -> &[&'static str] {
+        match kind {
+            AgentReportKind::Session => &self.session_detected_agents,
+            AgentReportKind::Daily | AgentReportKind::Weekly | AgentReportKind::Monthly => {
+                &self.daily_detected_agents
+            }
+        }
+    }
 }
 
 pub(super) struct AgentRows {

--- a/rust/crates/ccusage/src/adapter/all/types.rs
+++ b/rust/crates/ccusage/src/adapter/all/types.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use serde_json::Value;
 
-use crate::{ModelBreakdown, fast::FxHashMap};
+use crate::{ModelBreakdown, cli::AgentReportKind, fast::FxHashMap};
 
 #[derive(Debug, Clone)]
 pub(super) struct AllRow {
@@ -23,6 +23,11 @@ pub(super) struct AllRow {
 
 pub(super) struct AllLoadResult {
     pub(super) rows: Vec<AllRow>,
+    pub(super) detected_agents: Vec<&'static str>,
+}
+
+pub(super) struct AllSectionsLoadResult {
+    pub(super) sections: Vec<(AgentReportKind, Vec<AllRow>)>,
     pub(super) detected_agents: Vec<&'static str>,
 }
 

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -150,6 +150,8 @@ fn main() -> Result<()> {
             let args = AgentCommandArgs {
                 shared: cli.shared,
                 kind: AgentReportKind::Daily,
+                sections: None,
+                by_agent: false,
                 pi_path: None,
                 open_claw_path: None,
                 codex_speed: cli::CodexSpeed::Auto,


### PR DESCRIPTION
Proposed in #1392.

An application that wants ccusage's data at more than one granularity has to pay the full pipeline once per granularity. Each invocation re-scans every agent's session store, re-parses every file, re-loads pricing, and re-runs dedupe and aggregation — even though daily, weekly, and monthly are all derived from the same loaded entries. Wanting daily + monthly + session plus per-agent detail today means 3 unified invocations plus one per-agent invocation per detected agent: with a dozen agents, ~15 process launches and ~15 full store scans to answer one question, repeated every poll cycle as stores grow.

There is also a correctness cost, not just an efficiency one: separate invocations read the stores at different moments. Agents append to their stores continuously, so a session total fetched in call N can disagree with the daily total fetched in call N+1 — the consumer sees cross-section drift it cannot distinguish from a bug.

Two additive flags on the unified commands (and the bare root invocation) collapse all of it to a single call over a single point-in-time read:

```bash
ccusage daily --json --sections daily,monthly,session --by-agent
```

**`--sections <csv>`** emits each requested grouping in one envelope from at most TWO store scans (daily/weekly/monthly share one Daily-kind base load; session adds one Session-kind load), one process, one pricing load. Every section is produced by exactly the code path its standalone command uses — `load_sections` delegates to the same `load_rows` machinery, so section output is identical to a standalone invocation *by construction* (covered by fixture equivalence tests including claude agent-progress usage lines and codex cross-session/model-alias dedupe cases). Envelope order is deterministic: invoked section first, remaining sections in canonical order, `totals` last; single-section envelopes use the unchanged existing path.

**`--by-agent`** adds an `"agents"` array to daily/weekly/monthly rows (the internal per-agent breakdowns, now serialized: tokens, cost, and modelBreakdowns per agent). This data is already computed inside every unified run and then discarded at serialization — emitting it is what removes the need for the N per-agent invocations entirely. Session rows are already per-agent, so the flag is a no-op there. Per-agent costs sum exactly to the combined row.

### Backward compatibility

Without the new flags, JSON and table output are byte-identical to before (verified against a 20-invocation golden matrix on real stores). Tables render requested sections sequentially; `--by-agent` is JSON-only.

### Docs

Updated `docs/guide/json-output.md` (real generated example), `docs/guide/all-reports.md`, `docs/guide/cli-options.md`, `apps/ccusage/README.md`.

### Verification

- `cargo test --workspace`, fmt, clippy `-D warnings` all pass.
- Functional parity on real stores: every `--sections` section equals its standalone run exactly (both invocation directions); `--by-agent` sums to the combined row to the last bit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785766929&installation_id=139163553&pr_number=1396&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1396&signature=d65522283a1a52a6c6be85b9bc7efab0cf790f40f6d5b40377e6a18de02a1d80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--sections` and `--by-agent` to unified `ccusage` commands so dashboards can fetch multiple sections and per‑agent breakdowns in one run, cutting repeated scans and eliminating cross‑section drift.

- **New Features**
  - `--sections <daily,weekly,monthly,session>`: emit several sections in one run (invoked section always included). Example: `ccusage daily --sections daily,monthly,session --json`. Tables print sections sequentially.
  - Single read: at most two store scans (daily/weekly/monthly share one; session adds one), one process, one pricing load; replaces many invocations with one.
  - Deterministic JSON: keys ordered as invoked section first, then `daily`, `weekly`, `monthly`, `session`, with `totals` last.
  - `--by-agent`: adds an `agents` array to daily/weekly/monthly JSON rows (per‑agent tokens/cost/modelBreakdowns). Sums match the combined row. No‑op for session. JSON‑only.
  - Works on root invocation too (defaults to `daily` when used without a section verb). Backward compatible; rejects `--sections`/`--by-agent` with `session --id` and on per‑agent subcommands. `jq` and `--no-cost` supported for multi‑section JSON. Docs updated; tests cover parsing, ordering, fixture equivalence, and jq/no‑cost paths.

- **Refactors**
  - JSON serialization now composes a shared agent shape; output is unchanged.
  - Centralized `--sections`/`--by-agent` parsing and validation across root and unified commands.
  - Tracked detected agents separately for daily‑family vs session loads so each `--sections` table shows the same detected list as the equivalent standalone run.

<sup>Written for commit e506ae09b561f0de2b5335ca9fd2d92f274ec95b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

### Note for review ordering

This PR and #1397 both restructure `adapter/all/loader.rs` — whichever lands second needs a rebase over the other; I'll handle it promptly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified report options to emit multiple sections (daily, weekly, monthly, session) in one run, with JSON sectioned output.
  * Added `--by-agent` (JSON-only) to include per-agent breakdowns where applicable.
* **Bug Fixes**
  * Improved CLI parsing and validation, including support for root usage and `--sections=...` syntax.
  * Added stricter flag-combination checks (notably rejecting unified options with `session --id`), plus invalid-token handling.
* **Documentation**
  * Updated guides and README examples for unified JSON reports.
* **Tests**
  * Expanded coverage for sectioned outputs and agent breakdown JSON rendering (including snapshots).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->