### PR TITLE
feat(statusline): show reasoning effort level next to model name

### DIFF
--- a/apps/ccusage/justfile
+++ b/apps/ccusage/justfile
@@ -39,6 +39,8 @@ test-statusline-all:
     just test-statusline-opus4
     @echo 'Testing Sonnet 4.1:'
     just test-statusline-sonnet41
+    @echo 'Testing Fable 5:'
+    just test-statusline-fable5
 
 test-statusline-opus4:
     just test-statusline-file test/statusline-test-opus4.json --offline
@@ -48,6 +50,9 @@ test-statusline-sonnet4:
 
 test-statusline-sonnet41:
     just test-statusline-file test/statusline-test-sonnet41.json --offline
+
+test-statusline-fable5:
+    just test-statusline-file test/statusline-test-fable5.json --offline
 
 test-statusline-file file *args:
     cargo run --manifest-path ../../rust/Cargo.toml --bin ccusage -- statusline {{args}} < {{file}}

--- a/apps/ccusage/test/statusline-test-fable5.json
+++ b/apps/ccusage/test/statusline-test-fable5.json
@@ -1,0 +1,33 @@
+{
+	"session_id": "test-session-fable5",
+	"transcript_path": "test/test-transcript.jsonl",
+	"cwd": "/Users/test/project",
+	"model": {
+		"id": "claude-fable-5",
+		"display_name": "Fable 5"
+	},
+	"workspace": {
+		"current_dir": "/Users/test/project",
+		"project_dir": "/Users/test/project"
+	},
+	"version": "2.1.202",
+	"output_style": {
+		"name": "default"
+	},
+	"cost": {
+		"total_cost_usd": 0.0412,
+		"total_duration_ms": 160000,
+		"total_api_duration_ms": 10200,
+		"total_lines_added": 0,
+		"total_lines_removed": 0
+	},
+	"context_window": {
+		"total_input_tokens": 52000,
+		"total_output_tokens": 3800,
+		"context_window_size": 200000
+	},
+	"effort": {
+		"level": "high"
+	},
+	"exceeds_200k_tokens": false
+}

--- a/docs/guide/statusline.md
+++ b/docs/guide/statusline.md
@@ -10,7 +10,7 @@ The `statusline` command provides a compact, real-time view of your Claude Code 
 - 💰 **Today's total cost** - Your cumulative spending for the current day
 - 🚀 **Current session block** - Cost and time remaining in your active 5-hour billing block
 - 🔥 **Burn rate** - Token consumption rate with visual indicators
-- 🤖 **Active model** - The Claude model you're currently using
+- 🤖 **Active model** - The Claude model you're currently using, with its reasoning effort level when available
 
 ## Setup
 
@@ -109,18 +109,24 @@ See [Cost Source Options](#cost-source-options) section for all available modes.
 The statusline displays a compact, single-line summary:
 
 ```text
-🤖 Opus 4.1 | 💰 $0.23 session / $1.23 today / $0.45 block (2h 45m left) | 🔥 $0.12/hr | 🧠 25,000 (12%)
+🤖 Fable 5 (high) | 💰 $0.23 session / $1.23 today / $0.45 block (2h 45m left) | 🔥 $0.12/hr | 🧠 25,000 (12%)
 ```
 
 When using `--cost-source both`, the session cost shows both Claude Code and ccusage calculations:
 
 ```text
-🤖 Opus 4.1 | 💰 ($0.25 cc / $0.23 ccusage) session / $1.23 today / $0.45 block (2h 45m left) | 🔥 $0.12/hr | 🧠 25,000 (12%)
+🤖 Fable 5 (high) | 💰 ($0.25 cc / $0.23 ccusage) session / $1.23 today / $0.45 block (2h 45m left) | 🔥 $0.12/hr | 🧠 25,000 (12%)
+```
+
+The reasoning effort level next to the model name comes from Claude Code (2.1.119+). All current Claude models report it; for older Claude Code versions or models without the effort parameter, the statusline shows just the model name:
+
+```text
+🤖 Opus 4.1 | 💰 $0.23 session / $1.23 today / $0.45 block (2h 45m left) | 🔥 $0.12/hr | 🧠 25,000 (12%)
 ```
 
 ### Components Explained
 
-- **Model** (`🤖 Opus 4.1`): Currently active Claude model
+- **Model** (`🤖 Fable 5 (high)`): Currently active Claude model, followed by the reasoning effort level in parentheses (`low`, `medium`, `high`, `xhigh`, or `max`) when Claude Code provides it
 - **Session Cost** (`💰 $0.23 session`): Cost for the current conversation session (see [Cost Source Options](#cost-source-options) for different calculation modes)
 - **Today's Cost** (`$1.23 today`): Total cost for the current day across all sessions
 - **Session Block** (`$0.45 block (2h 45m left)`): Current 5-hour block cost with remaining time
@@ -138,7 +144,7 @@ When using `--cost-source both`, the session cost shows both Claude Code and ccu
 When no active block exists:
 
 ```text
-🤖 Opus 4.1 | 💰 $0.00 session / $0.00 today / No active block
+🤖 Fable 5 (high) | 💰 $0.00 session / $0.00 today / No active block
 ```
 
 ## Technical Details

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -402,6 +402,19 @@ fn resolve_model_label<'a>(
         .unwrap_or(display_name)
 }
 
+/// Format the model segment of the statusline.
+///
+/// Appends the reasoning effort level reported by Claude Code (e.g.
+/// `Fable 5 (high)`) when present. Claude Code omits the `effort` field for
+/// models without the effort parameter, so the segment falls back to the bare
+/// model label in that case.
+fn format_model_segment(model_label: &str, effort: Option<&HookEffort>) -> String {
+    match effort {
+        Some(effort) if !effort.level.is_empty() => format!("{model_label} ({})", effort.level),
+        _ => model_label.to_string(),
+    }
+}
+
 fn render_statusline(
     hook: &StatuslineHook,
     args: &StatuslineArgs,
@@ -518,10 +531,11 @@ fn render_statusline(
     };
 
     let model_label = resolve_model_label(&args.model_label_aliases, &hook.model.display_name);
+    let model_segment = format_model_segment(model_label, hook.effort.as_ref());
 
     Ok(format!(
         "🤖 {} | 💰 {} session / {} today / {}{} | 🧠 {}",
-        model_label,
+        model_segment,
         session_display,
         format_currency(today_cost),
         block_info,
@@ -801,12 +815,18 @@ struct StatuslineHook {
     model: HookModel,
     cost: Option<HookCost>,
     context_window: Option<HookContext>,
+    effort: Option<HookEffort>,
 }
 
 #[derive(Debug, Deserialize)]
 struct HookModel {
     id: Option<String>,
     display_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct HookEffort {
+    level: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -993,5 +1013,54 @@ mod tests {
         let aliases = std::collections::HashMap::new();
 
         assert_eq!(resolve_model_label(&aliases, "Opus 4.1"), "Opus 4.1");
+    }
+
+    #[test]
+    fn appends_effort_level_to_model_segment() {
+        let effort = HookEffort {
+            level: "high".to_string(),
+        };
+
+        assert_eq!(
+            format_model_segment("Fable 5", Some(&effort)),
+            "Fable 5 (high)"
+        );
+    }
+
+    #[test]
+    fn omits_effort_from_model_segment_when_absent_or_empty() {
+        let empty = HookEffort {
+            level: String::new(),
+        };
+
+        assert_eq!(format_model_segment("Fable 5", None), "Fable 5");
+        assert_eq!(format_model_segment("Fable 5", Some(&empty)), "Fable 5");
+    }
+
+    #[test]
+    fn parses_statusline_hook_with_and_without_effort() {
+        let with_effort: StatuslineHook = serde_json::from_str(
+            r#"{
+                "session_id": "session",
+                "transcript_path": "/tmp/transcript.jsonl",
+                "model": {"id": "claude-fable-5", "display_name": "Fable 5"},
+                "effort": {"level": "xhigh"}
+            }"#,
+        )
+        .unwrap();
+        let without_effort: StatuslineHook = serde_json::from_str(
+            r#"{
+                "session_id": "session",
+                "transcript_path": "/tmp/transcript.jsonl",
+                "model": {"id": "claude-sonnet-4-20250514", "display_name": "Sonnet 4"}
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            with_effort.effort.map(|effort| effort.level).as_deref(),
+            Some("xhigh")
+        );
+        assert!(without_effort.effort.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Shows the reasoning effort level next to the model name in the statusline, e.g. `🤖 Fable 5 (high)`.

## What Changed

- Parse the optional top-level `effort.level` field from the Claude Code statusline hook JSON (added in Claude Code 2.1.119; values: `low`, `medium`, `high`, `xhigh`, `max`).
- Append the level to the model segment when present; fall back to the bare model label when the field is absent (older Claude Code versions or models without the effort parameter).
- Add a `statusline-test-fable5.json` manual fixture with `effort.level` and a `test-statusline-fable5` just recipe wired into `test-statusline-all`.
- Update the statusline guide examples to the current model display and document the effort level component.

## Testing

- `cargo test -p ccusage` (302 passed, including new unit tests for hook parsing and model-segment formatting)
- `cargo clippy -p ccusage --all-targets`
- Manual: `just test-statusline-fable5` prints `🤖 Fable 5 (high) | ...`; fixtures without `effort` keep the previous output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the model’s reasoning effort next to the model name in the statusline, e.g. "🤖 Fable 5 (high)". Reads the optional `effort.level` from Claude Code 2.1.119+ and falls back to just the model name when missing.

- **New Features**
  - Parse optional top-level `effort.level` (`low`, `medium`, `high`, `xhigh`, `max`) from the statusline hook.
  - Append the level to the model segment when present; otherwise show the bare model label.
  - Add `apps/ccusage/test/statusline-test-fable5.json` and unit tests for parsing/formatting; add `just test-statusline-fable5` and wire it into `test-statusline-all`.
  - Update the statusline guide examples and document the effort level display.

<sup>Written for commit 33ede9c2f44ac6de590351582e0bcfa1ac8b4690. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statusline output now shows the model’s reasoning effort when available, e.g. `Fable 5 (high)`.
  * Added an additional statusline test run covering Fable 5.

* **Bug Fixes**
  * Statusline display now falls back cleanly to the model name alone when effort information isn’t provided.

* **Documentation**
  * Updated the statusline guide and examples to match the new display format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->