### PR TITLE
perf: cache PricingMap::find() results and skip redundant opencode pricing checks

### DIFF
--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -130,8 +130,14 @@ pub(crate) fn message_value_to_entry(
     };
     let cost =
         calculate_open_code_cost(&model, &provider, cost_usage, data.cost_usd, mode, pricing);
-    let missing_pricing_model =
-        missing_open_code_pricing(&model, &provider, cost_usage, data.cost_usd, mode, pricing);
+    // If we already have a usable positive cost (calculated or stored), skip
+    // the redundant missing-pricing check — it would iterate through the same
+    // model candidates and find nothing missing.
+    let missing_pricing_model = if cost > 0.0 {
+        None
+    } else {
+        missing_open_code_pricing(&model, &provider, cost_usage, data.cost_usd, mode, pricing)
+    };
     let loaded_session_id = data
         .session_id
         .clone()

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -56,12 +56,25 @@ impl Pricing {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct PricingMap {
     entries: FxHashMap<String, Pricing>,
     context_limits: FxHashMap<String, u64>,
     enable_models_dev_fallback: bool,
     enable_embedded_models_dev_fallback: bool,
+    find_cache: OnceLock<Mutex<FxHashMap<String, Option<Pricing>>>>,
+}
+
+impl Default for PricingMap {
+    fn default() -> Self {
+        Self {
+            entries: FxHashMap::default(),
+            context_limits: FxHashMap::default(),
+            enable_models_dev_fallback: false,
+            enable_embedded_models_dev_fallback: false,
+            find_cache: OnceLock::new(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -298,6 +311,7 @@ impl PricingMap {
             }
             loaded_count += 1;
         }
+        self.clear_find_cache();
         loaded_count
     }
 
@@ -357,13 +371,30 @@ impl PricingMap {
             }
             loaded_count += 1;
         }
+        self.clear_find_cache();
         loaded_count
     }
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
+        // Fast path: check the model-level cache first. When the same model
+        // name is looked up repeatedly (e.g. across thousands of entries with
+        // only a few dozen unique models), the cache avoids re-running the
+        // expensive fuzzy fallback on every call.
+        {
+            let cache = self
+                .find_cache
+                .get_or_init(|| Mutex::new(FxHashMap::default()));
+            let guard = cache.lock().unwrap_or_else(|error| error.into_inner());
+            if let Some(&cached) = guard.get(model) {
+                return cached;
+            }
+        }
+        // Full lookup (dropped the lock above so concurrent callers are not
+        // serialized on the expensive fuzzy path).
         let alias = crate::model_aliases::resolve_model_name(model);
         let resolved_alias = alias.as_ref();
-        self.find_entry_or_alias(model)
+        let result = self
+            .find_entry_or_alias(model)
             .or_else(|| {
                 (resolved_alias != model)
                     .then(|| self.find_entry_or_alias(resolved_alias))
@@ -384,7 +415,16 @@ impl PricingMap {
                 self.enable_embedded_models_dev_fallback
                     .then(|| embedded_models_dev_pricing().find_entry_or_alias(resolved_alias))
                     .flatten()
-            })
+            });
+        // Store the result (including None for misses) so repeated lookups
+        // for the same model that fails to match any pricing entry are also
+        // short-circuited.
+        let cache = self
+            .find_cache
+            .get_or_init(|| Mutex::new(FxHashMap::default()));
+        let mut guard = cache.lock().unwrap_or_else(|error| error.into_inner());
+        guard.insert(model.to_string(), result);
+        result
     }
 
     fn find_entry_or_alias(&self, model: &str) -> Option<Pricing> {
@@ -461,6 +501,7 @@ impl PricingMap {
         for (model, override_value) in overrides {
             self.apply_override(model, override_value);
         }
+        self.clear_find_cache();
     }
 
     fn apply_override(&mut self, model: &str, override_value: &PricingOverride) {
@@ -548,6 +589,13 @@ impl PricingMap {
         self.entries.insert(model.to_string(), pricing);
         if let Some(limit) = override_value.max_input_tokens {
             self.context_limits.insert(model.to_string(), limit);
+        }
+    }
+
+    fn clear_find_cache(&self) {
+        if let Some(cache) = self.find_cache.get() {
+            let mut guard = cache.lock().unwrap_or_else(|error| error.into_inner());
+            guard.clear();
         }
     }
 


### PR DESCRIPTION
Reopens #1358 (the original PR could not be reopened because the fork branch was force-pushed, and GitHub does not allow maintainers to open PRs from a contributor fork).

All commits are authored by @turtton. This branch is the reviewed #1358 change set rebased by the author, plus test timezone fixes (explicit UTC).

- Cache `PricingMap::find()` results to avoid repeated fuzzy matching over ~2,200 entries per message
- Skip the redundant opencode missing-pricing check when the cost is already known

Closes #1358

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Boosts pricing lookup performance by caching `PricingMap::find()` results and skipping redundant opencode missing-pricing checks when cost is already known. This removes repeated fuzzy scans over ~2,200 entries and speeds up per-message processing.

- **Refactors**
  - Memoizes `PricingMap::find(model)` results (including misses) via an internal cache; clears the cache on `load_json_with_overrides()`, `load_models_dev_models()`, and `apply_overrides()`.
  - In `opencode` parsing, skips `missing_open_code_pricing()` when `calculate_open_code_cost` yields a positive cost.

<sup>Written for commit b93c2288d893166b4c1d8ccda663fa34cf3bd34f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing lookups to avoid repeated work, making repeated model checks faster and more responsive.
  * Fixed cases where an available cost could still be treated as missing pricing, reducing incorrect warnings or fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->