### PR TITLE
ci(release): use Conventional Commits title for tagpr release PRs

### DIFF
--- a/.github/tagpr-template.md
+++ b/.github/tagpr-template.md
@@ -1,0 +1,23 @@
+chore: release {{.NextVersion}}
+
+This pull request is for the next release as {{.NextVersion}} created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag {{.NextVersion}} to the merge commit and create a GitHub release.
+
+You can modify this branch "{{.Branch}}" directly before merging if you want to change the next version number or other files for the release.
+
+<details>
+<summary>How to change the next version as you like</summary>
+
+There are two ways to do it.
+
+- Version file
+  - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
+  - If you want to use another version file, edit the configuration file.
+- Labels convention
+  - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
+  - If no conventional labels are added, the patch version is incremented as is.
+
+</details>
+
+---
+
+{{.Changelog}}

--- a/.tagpr
+++ b/.tagpr
@@ -5,3 +5,6 @@
 	release = false
 	versionFile = package.json,apps/ccusage/package.json,docs/package.json,packages/ccusage-darwin-arm64/package.json,packages/ccusage-darwin-x64/package.json,packages/ccusage-linux-arm64/package.json,packages/ccusage-linux-x64/package.json,packages/ccusage-win32-arm64/package.json,packages/ccusage-win32-x64/package.json
 	postVersionCommand = nix develop --command just sync-rust-version
+	# The first line of the template becomes the release PR title; it must stay
+	# a Conventional Commits header so the check-pr-title workflow passes
+	template = .github/tagpr-template.md

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -80,6 +80,10 @@ in
           };
         };
 
+        # The tagpr PR template is a Go text/template, and oxfmt's markdown
+        # rewrites break its <details> block and nested list structure.
+        settings.global.excludes = [ ".github/tagpr-template.md" ];
+
         settings.formatter = {
           deadnix.priority = 1;
           statix.priority = 2;


### PR DESCRIPTION
## Summary

The tagpr release PR title "Release for v20.0.15" fails the check-pr-title workflow because it has no Conventional Commits type prefix (seen on #1408).

## What Changed

- Added `.github/tagpr-template.md`: tagpr uses the first line of the rendered PR template as the PR title, so the template starts with `chore: release {{.NextVersion}}` and otherwise mirrors tagpr's default body. This restores the title style of the previous bumpp-based flow (`chore: release v20.0.14`).
- Pointed `.tagpr` at the template via `template = .github/tagpr-template.md`.
- Excluded the template from treefmt: it is a Go text/template, and oxfmt's markdown rewrites break its `<details>` block and nested list structure.

## Testing

- `just fmt` leaves the template untouched after the exclude.
- Verified against tagpr v1.20.0 source that the first template line becomes the PR title.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `tagpr` release PR titles follow Conventional Commits (chore: release {{.NextVersion}}) so the check-pr-title workflow passes and matches our previous release style.

- **Bug Fixes**
  - Added `.github/tagpr-template.md` and pointed `.tagpr` to it; the first line sets the PR title to "chore: release {{.NextVersion}}".
  - Excluded the template from `treefmt` because `oxfmt` rewrites break its details/list structure.

<sup>Written for commit 230ab2f5566591d4a046781dffed9c6362eb867c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a release note template for GitHub release PRs, including a title, changelog placeholder, and guidance for updating the release version.
  * Added support for version updates through branch-specific workflow labels or version file edits.

* **Chores**
  * Updated release configuration to use the new template.
  * Adjusted formatting rules so the release template is not automatically reformatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->