### PR TITLE
feat(pricing): support OpenAI two-stage pricing and add the gpt-5.6 family

### DIFF
--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -336,8 +336,11 @@ fn accumulate_codex_event_into_group(
     model_usage.reasoning_output_tokens += event.reasoning_output_tokens;
     model_usage.total_tokens += event.total_tokens;
     // Each event is one request, so its input size decides the pricing tier
-    // here; the summed totals cannot recover per-request context sizes.
-    if event.input_tokens > crate::pricing::OPENAI_LONG_CONTEXT_THRESHOLD_TOKENS {
+    // here; the summed totals cannot recover per-request context sizes. The
+    // boundary is per model (OpenAI's 272K models and any future tier with a
+    // different threshold) rather than a single global constant, matching the
+    // threshold used to price the long-context buckets.
+    if event.input_tokens > crate::pricing::long_context_split_threshold(model) {
         model_usage.long_context_input_tokens += event.input_tokens;
         model_usage.long_context_cached_input_tokens += event.cached_input_tokens;
         model_usage.long_context_output_tokens += event.output_tokens;

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -335,6 +335,13 @@ fn accumulate_codex_event_into_group(
     model_usage.output_tokens += event.output_tokens;
     model_usage.reasoning_output_tokens += event.reasoning_output_tokens;
     model_usage.total_tokens += event.total_tokens;
+    // Each event is one request, so its input size decides the pricing tier
+    // here; the summed totals cannot recover per-request context sizes.
+    if event.input_tokens > crate::pricing::OPENAI_LONG_CONTEXT_THRESHOLD_TOKENS {
+        model_usage.long_context_input_tokens += event.input_tokens;
+        model_usage.long_context_cached_input_tokens += event.cached_input_tokens;
+        model_usage.long_context_output_tokens += event.output_tokens;
+    }
     model_usage.is_fallback |= event.is_fallback_model;
 }
 
@@ -415,6 +422,9 @@ fn merge_groups(target: &mut BTreeMap<String, CodexGroup>, source: BTreeMap<Stri
             target_usage.output_tokens += usage.output_tokens;
             target_usage.reasoning_output_tokens += usage.reasoning_output_tokens;
             target_usage.total_tokens += usage.total_tokens;
+            target_usage.long_context_input_tokens += usage.long_context_input_tokens;
+            target_usage.long_context_cached_input_tokens += usage.long_context_cached_input_tokens;
+            target_usage.long_context_output_tokens += usage.long_context_output_tokens;
             target_usage.is_fallback |= usage.is_fallback;
         }
     }
@@ -529,6 +539,53 @@ mod tests {
             assert_eq!(group.reasoning_output_tokens, 20);
             assert_eq!(group.total_tokens, 1_200);
         }
+    }
+
+    #[test]
+    fn tracks_long_context_token_split_per_request() {
+        let usage_line = |input: u64, cached: u64, output: u64| {
+            json!({
+                "timestamp": "2026-07-09T08:01:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "model": "gpt-5.6-sol",
+                        "last_token_usage": {
+                            "input_tokens": input,
+                            "cached_input_tokens": cached,
+                            "output_tokens": output,
+                            "reasoning_output_tokens": 0,
+                            "total_tokens": input + output,
+                        },
+                    },
+                },
+            })
+            .to_string()
+        };
+        // One request above the 272K input threshold and one below it.
+        let long_line = usage_line(280_000, 20_000, 500);
+        let short_line = usage_line(100_000, 50_000, 300);
+        let fixture = fs_fixture!({
+            "sessions/root.jsonl": &format!("{long_line}\n{short_line}"),
+        });
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let groups =
+            load_groups_from_directory(&fixture.path("sessions"), &shared, AgentReportKind::Daily)
+                .unwrap();
+
+        let group = groups.get("2026-07-09").unwrap();
+        let usage = group.models.get("gpt-5.6-sol").unwrap();
+        assert_eq!(usage.input_tokens, 380_000);
+        assert_eq!(usage.cached_input_tokens, 70_000);
+        assert_eq!(usage.output_tokens, 800);
+        assert_eq!(usage.long_context_input_tokens, 280_000);
+        assert_eq!(usage.long_context_cached_input_tokens, 20_000);
+        assert_eq!(usage.long_context_output_tokens, 500);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -222,12 +222,107 @@ mod tests {
             output_tokens: 5,
             reasoning_output_tokens: 0,
             total_tokens: 105,
-            is_fallback: false,
+            ..CodexModelUsage::default()
         };
 
         let cost = calculate_codex_model_cost("gpt-test", &usage, &pricing, CodexSpeed::Standard);
 
         assert!((cost - 0.00015).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn bills_long_context_codex_requests_at_long_context_rates() {
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{
+                "gpt-long": {
+                    "input_cost_per_token": 0.000005,
+                    "output_cost_per_token": 0.00003,
+                    "cache_read_input_token_cost": 0.0000005,
+                    "input_cost_per_token_above_200k_tokens": 0.00001,
+                    "output_cost_per_token_above_200k_tokens": 0.000045,
+                    "cache_read_input_token_cost_above_200k_tokens": 0.000001
+                }
+            }"#,
+        );
+        let usage = CodexModelUsage {
+            input_tokens: 350_000,
+            cached_input_tokens: 50_000,
+            output_tokens: 1_000,
+            total_tokens: 351_000,
+            long_context_input_tokens: 300_000,
+            long_context_cached_input_tokens: 40_000,
+            long_context_output_tokens: 800,
+            ..CodexModelUsage::default()
+        };
+
+        let cost = calculate_codex_model_cost("gpt-long", &usage, &pricing, CodexSpeed::Standard);
+
+        // Short bucket: 40K non-cached input, 10K cached, 200 output tokens.
+        // Long bucket: 260K non-cached input, 40K cached, 800 output tokens.
+        let expected = 40_000.0 * 5e-6
+            + 10_000.0 * 0.5e-6
+            + 200.0 * 30e-6
+            + 260_000.0 * 10e-6
+            + 40_000.0 * 1e-6
+            + 800.0 * 45e-6;
+        assert!((cost - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn long_context_split_without_tier_rates_matches_flat_pricing() {
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{
+                "gpt-test": {
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.00001
+                }
+            }"#,
+        );
+        let flat = CodexModelUsage {
+            input_tokens: 400_000,
+            cached_input_tokens: 100_000,
+            output_tokens: 2_000,
+            total_tokens: 402_000,
+            ..CodexModelUsage::default()
+        };
+        let split = CodexModelUsage {
+            long_context_input_tokens: 300_000,
+            long_context_cached_input_tokens: 80_000,
+            long_context_output_tokens: 1_500,
+            ..flat.clone()
+        };
+
+        let flat_cost =
+            calculate_codex_model_cost("gpt-test", &flat, &pricing, CodexSpeed::Standard);
+        let split_cost =
+            calculate_codex_model_cost("gpt-test", &split, &pricing, CodexSpeed::Standard);
+
+        assert!((flat_cost - split_cost).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn prices_gpt_5_6_long_context_usage_from_embedded_pricing() {
+        let pricing = PricingMap::load_embedded();
+        let usage = CodexModelUsage {
+            input_tokens: 300_000,
+            cached_input_tokens: 100_000,
+            output_tokens: 1_000,
+            total_tokens: 301_000,
+            long_context_input_tokens: 300_000,
+            long_context_cached_input_tokens: 100_000,
+            long_context_output_tokens: 1_000,
+            ..CodexModelUsage::default()
+        };
+
+        let cost =
+            calculate_codex_model_cost("gpt-5.6-sol", &usage, &pricing, CodexSpeed::Standard);
+
+        // The whole request is billed at long-context rates: 200K non-cached
+        // input at $10/M, 100K cached at $1/M, 1K output at $45/M.
+        let expected = 200_000.0 * 10e-6 + 100_000.0 * 1e-6 + 1_000.0 * 45e-6;
+        assert!((cost - expected).abs() < 1e-9);
     }
 
     #[test]
@@ -248,7 +343,7 @@ mod tests {
             output_tokens: 5,
             reasoning_output_tokens: 0,
             total_tokens: 105,
-            is_fallback: false,
+            ..CodexModelUsage::default()
         };
 
         let standard =

--- a/rust/crates/ccusage/src/adapter/codex/report.rs
+++ b/rust/crates/ccusage/src/adapter/codex/report.rs
@@ -134,7 +134,6 @@ pub(crate) fn calculate_codex_model_cost(
     let Some(pricing) = pricing.find(model) else {
         return 0.0;
     };
-    let non_cached_input = usage.input_tokens.saturating_sub(usage.cached_input_tokens);
     let multiplier = if matches!(speed, CodexSpeed::Fast) {
         if pricing.fast_multiplier == 1.0 {
             2.0
@@ -149,9 +148,32 @@ pub(crate) fn calculate_codex_model_cost(
     } else {
         pricing.input
     };
-    (non_cached_input as f64 * pricing.input
-        + usage.cached_input_tokens as f64 * cache_read
-        + usage.output_tokens as f64 * pricing.output)
+    // OpenAI bills every token of a long-context request (input above 272K
+    // tokens) at the long-context rates, so the aggregated usage is priced as
+    // two independent buckets. Models without long-context rates fall back to
+    // the flat rates, which keeps both buckets at the same price.
+    let long_input_rate = pricing.input_above_200k.unwrap_or(pricing.input);
+    let long_output_rate = pricing.output_above_200k.unwrap_or(pricing.output);
+    let long_cache_read = if pricing.cache_read_explicit {
+        pricing.cache_read_above_200k.unwrap_or(cache_read)
+    } else {
+        long_input_rate
+    };
+    let long_input = usage.long_context_input_tokens.min(usage.input_tokens);
+    let long_cached = usage
+        .long_context_cached_input_tokens
+        .min(usage.cached_input_tokens)
+        .min(long_input);
+    let long_output = usage.long_context_output_tokens.min(usage.output_tokens);
+    let short_non_cached =
+        (usage.input_tokens - long_input).saturating_sub(usage.cached_input_tokens - long_cached);
+    let long_non_cached = long_input - long_cached;
+    (short_non_cached as f64 * pricing.input
+        + (usage.cached_input_tokens - long_cached) as f64 * cache_read
+        + (usage.output_tokens - long_output) as f64 * pricing.output
+        + long_non_cached as f64 * long_input_rate
+        + long_cached as f64 * long_cache_read
+        + long_output as f64 * long_output_rate)
         * multiplier
 }
 

--- a/rust/crates/ccusage/src/cost.rs
+++ b/rust/crates/ccusage/src/cost.rs
@@ -114,9 +114,34 @@ pub(crate) fn calculate_cost_from_pricing(usage: crate::TokenUsageRaw, pricing: 
     let cache_create_1h_cost_above_200k = pricing
         .input_above_200k
         .map(|c| c * CACHE_CREATE_1H_INPUT_MULTIPLIER);
-    let threshold = pricing
-        .long_context_threshold
-        .unwrap_or(crate::pricing::DEFAULT_LONG_CONTEXT_THRESHOLD_TOKENS);
+
+    // OpenAI two-stage pricing: a per-model `long_context_threshold` means the
+    // request's input size selects the tier and every bucket is billed entirely
+    // at that tier's rate. The whole request switches once input exceeds the
+    // threshold, so this is not a marginal breakpoint. This mirrors the Codex
+    // per-request tiering in `calculate_codex_model_cost`.
+    if let Some(threshold) = pricing.long_context_threshold {
+        let long_context = usage.input_tokens > threshold;
+        let rate = |base: f64, above: Option<f64>| {
+            if long_context {
+                above.unwrap_or(base)
+            } else {
+                base
+            }
+        };
+        return usage.input_tokens as f64 * rate(pricing.input, pricing.input_above_200k)
+            + usage.output_tokens as f64 * rate(pricing.output, pricing.output_above_200k)
+            + cache_create_5m_tokens as f64
+                * rate(pricing.cache_create, pricing.cache_create_above_200k)
+            + cache_create_1h_tokens as f64
+                * rate(cache_create_1h_cost, cache_create_1h_cost_above_200k)
+            + usage.cache_read_input_tokens as f64
+                * rate(pricing.cache_read, pricing.cache_read_above_200k);
+    }
+
+    // LiteLLM `*_above_200k_tokens` data keeps its marginal above-threshold
+    // semantics at the default 200K boundary.
+    let threshold = crate::pricing::DEFAULT_LONG_CONTEXT_THRESHOLD_TOKENS;
     tiered_cost(
         usage.input_tokens,
         pricing.input,
@@ -223,6 +248,51 @@ mod tests {
         );
 
         assert!((cost - 12.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn prices_two_stage_model_as_whole_request_at_long_context_rates() {
+        let pricing = PricingMap::load_embedded();
+
+        // gpt-5.6-sol has a 272K threshold with long-context rates of
+        // $10/$45 per 1M input/output tokens and a $1 per 1M cache-read rate.
+        let long = TokenUsageRaw {
+            input_tokens: 300_000,
+            output_tokens: 1_000,
+            cache_read_input_tokens: 100,
+            ..TokenUsageRaw::default()
+        };
+        let cost = calculate_cost_for_usage(
+            Some("gpt-5.6-sol"),
+            long,
+            None,
+            CostMode::Calculate,
+            Some(&pricing),
+        );
+        // The whole request switches to long rates once input exceeds 272K,
+        // including the output and cache-read buckets that are individually
+        // far below the threshold: 3.0 + 0.045 + 0.0001.
+        assert!((cost - 3.0451).abs() < 1e-9, "long-context cost was {cost}");
+
+        // Below the threshold every bucket stays on the short-context rates:
+        // 0.5 + 0.03 + 0.00005.
+        let short = TokenUsageRaw {
+            input_tokens: 100_000,
+            output_tokens: 1_000,
+            cache_read_input_tokens: 100,
+            ..TokenUsageRaw::default()
+        };
+        let cost = calculate_cost_for_usage(
+            Some("gpt-5.6-sol"),
+            short,
+            None,
+            CostMode::Calculate,
+            Some(&pricing),
+        );
+        assert!(
+            (cost - 0.53005).abs() < 1e-9,
+            "short-context cost was {cost}"
+        );
     }
 
     #[test]

--- a/rust/crates/ccusage/src/cost.rs
+++ b/rust/crates/ccusage/src/cost.rs
@@ -114,38 +114,45 @@ pub(crate) fn calculate_cost_from_pricing(usage: crate::TokenUsageRaw, pricing: 
     let cache_create_1h_cost_above_200k = pricing
         .input_above_200k
         .map(|c| c * CACHE_CREATE_1H_INPUT_MULTIPLIER);
-    tiered_cost(usage.input_tokens, pricing.input, pricing.input_above_200k)
-        + tiered_cost(
-            usage.output_tokens,
-            pricing.output,
-            pricing.output_above_200k,
-        )
-        + tiered_cost(
-            cache_create_5m_tokens,
-            pricing.cache_create,
-            pricing.cache_create_above_200k,
-        )
-        + tiered_cost(
-            cache_create_1h_tokens,
-            cache_create_1h_cost,
-            cache_create_1h_cost_above_200k,
-        )
-        + tiered_cost(
-            usage.cache_read_input_tokens,
-            pricing.cache_read,
-            pricing.cache_read_above_200k,
-        )
+    let threshold = pricing
+        .long_context_threshold
+        .unwrap_or(crate::pricing::DEFAULT_LONG_CONTEXT_THRESHOLD_TOKENS);
+    tiered_cost(
+        usage.input_tokens,
+        pricing.input,
+        pricing.input_above_200k,
+        threshold,
+    ) + tiered_cost(
+        usage.output_tokens,
+        pricing.output,
+        pricing.output_above_200k,
+        threshold,
+    ) + tiered_cost(
+        cache_create_5m_tokens,
+        pricing.cache_create,
+        pricing.cache_create_above_200k,
+        threshold,
+    ) + tiered_cost(
+        cache_create_1h_tokens,
+        cache_create_1h_cost,
+        cache_create_1h_cost_above_200k,
+        threshold,
+    ) + tiered_cost(
+        usage.cache_read_input_tokens,
+        pricing.cache_read,
+        pricing.cache_read_above_200k,
+        threshold,
+    )
 }
 
-pub(crate) fn tiered_cost(tokens: u64, base: f64, above: Option<f64>) -> f64 {
-    const THRESHOLD: u64 = 200_000;
+pub(crate) fn tiered_cost(tokens: u64, base: f64, above: Option<f64>, threshold: u64) -> f64 {
     if tokens == 0 {
         return 0.0;
     }
     if let Some(above) = above
-        && tokens > THRESHOLD
+        && tokens > threshold
     {
-        return (THRESHOLD as f64 * base) + ((tokens - THRESHOLD) as f64 * above);
+        return (threshold as f64 * base) + ((tokens - threshold) as f64 * above);
     }
     tokens as f64 * base
 }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -183,7 +183,9 @@ mod tests {
 
     #[test]
     fn calculates_tiered_cost() {
-        assert!((tiered_cost(300_000, 3e-6, Some(6e-6)) - 1.2).abs() < f64::EPSILON);
+        assert!((tiered_cost(300_000, 3e-6, Some(6e-6), 200_000) - 1.2).abs() < f64::EPSILON);
+        // A larger threshold keeps more tokens at the base rate.
+        assert!((tiered_cost(300_000, 5e-6, Some(10e-6), 272_000) - 1.64).abs() < 1e-9);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -36,8 +36,21 @@ pub(crate) struct Pricing {
     pub(crate) output_above_200k: Option<f64>,
     pub(crate) cache_create_above_200k: Option<f64>,
     pub(crate) cache_read_above_200k: Option<f64>,
+    // Token count above which the `*_above_200k` rates apply. The field names
+    // keep the LiteLLM `_above_200k_tokens` suffix for JSON compatibility, but
+    // some providers switch tiers at a different point (OpenAI long-context
+    // pricing starts above 272K input tokens), so the threshold is per model.
+    pub(crate) long_context_threshold: Option<u64>,
     pub(crate) fast_multiplier: f64,
 }
+
+/// Default tier boundary for LiteLLM `*_above_200k_tokens` pricing fields.
+pub(crate) const DEFAULT_LONG_CONTEXT_THRESHOLD_TOKENS: u64 = 200_000;
+
+/// OpenAI long-context pricing boundary: requests with more than 272K input
+/// tokens (GPT-5's maximum short-context input size) are billed at
+/// long-context rates.
+pub(crate) const OPENAI_LONG_CONTEXT_THRESHOLD_TOKENS: u64 = 272_000;
 
 impl Pricing {
     pub(crate) const fn empty() -> Self {
@@ -51,6 +64,7 @@ impl Pricing {
             output_above_200k: None,
             cache_create_above_200k: None,
             cache_read_above_200k: None,
+            long_context_threshold: None,
             fast_multiplier: 1.0,
         }
     }
@@ -216,6 +230,7 @@ impl PricingMap {
         let fast_multiplier_overrides = FastMultiplierOverrides::load();
         map.load_json_with_overrides(BUILD_TIME_PRICING_JSON, &fast_multiplier_overrides);
         map.put_builtin_pricing(&fast_multiplier_overrides);
+        map.apply_builtin_long_context_rates();
         // Resolve models that LiteLLM and the built-in table miss from the
         // embedded models.dev snapshot. This works offline, unlike the network
         // source gated by `enable_models_dev_fallback`.
@@ -252,6 +267,10 @@ impl PricingMap {
             }
         }
 
+        // A live LiteLLM refresh replaces whole entries, so re-apply the
+        // built-in long-context rates it does not publish before user
+        // overrides get the final word.
+        map.apply_builtin_long_context_rates();
         map.enable_models_dev_fallback = !offline;
         map.apply_overrides(overrides);
         map
@@ -303,6 +322,7 @@ impl PricingMap {
                     cache_create_above_200k: pricing
                         .cache_creation_input_token_cost_above_200k_tokens,
                     cache_read_above_200k: pricing.cache_read_input_token_cost_above_200k_tokens,
+                    long_context_threshold: None,
                     fast_multiplier,
                 },
             );
@@ -363,6 +383,7 @@ impl PricingMap {
                     output_above_200k: None,
                     cache_create_above_200k: None,
                     cache_read_above_200k: None,
+                    long_context_threshold: None,
                     fast_multiplier: 1.0,
                 },
             );
@@ -585,6 +606,7 @@ impl PricingMap {
                 .or(base.output_above_200k),
             cache_create_above_200k,
             cache_read_above_200k,
+            long_context_threshold: base.long_context_threshold,
             fast_multiplier: override_value
                 .fast_multiplier
                 .unwrap_or(base.fast_multiplier),
@@ -613,6 +635,32 @@ impl PricingMap {
         self.enable_models_dev_fallback
     }
 
+    /// Fills in long-context tier rates for models whose upstream pricing
+    /// entries only carry the flat rates. Runs after every pricing load
+    /// (embedded and live) because LiteLLM refreshes replace whole entries.
+    /// Entries that already carry any tier rate are left untouched so
+    /// upstream data wins once it exists.
+    fn apply_builtin_long_context_rates(&mut self) {
+        for (model, pricing) in &mut self.entries {
+            if pricing.input_above_200k.is_some()
+                || pricing.output_above_200k.is_some()
+                || pricing.cache_create_above_200k.is_some()
+                || pricing.cache_read_above_200k.is_some()
+            {
+                continue;
+            }
+            let Some(rates) = builtin_long_context_rates(model_without_date_suffix(model)) else {
+                continue;
+            };
+            pricing.input_above_200k = rates.input;
+            pricing.output_above_200k = rates.output;
+            pricing.cache_create_above_200k = rates.cache_create;
+            pricing.cache_read_above_200k = rates.cache_read;
+            pricing.long_context_threshold = Some(rates.threshold);
+        }
+        self.clear_find_cache();
+    }
+
     fn put_builtin_pricing(&mut self, fast_multiplier_overrides: &FastMultiplierOverrides) {
         self.entries.insert(
             "claude-opus-4-5".to_string(),
@@ -626,6 +674,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -641,6 +690,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: fast_multiplier_overrides
                     .multiplier_for("claude-opus-4-6")
                     .unwrap_or(1.0),
@@ -658,6 +708,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: fast_multiplier_overrides
                     .multiplier_for("claude-opus-4-7")
                     .unwrap_or(1.0),
@@ -675,6 +726,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: fast_multiplier_overrides
                     .multiplier_for("claude-opus-4-8")
                     .unwrap_or(1.0),
@@ -692,6 +744,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -707,6 +760,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -722,6 +776,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -737,6 +792,7 @@ impl PricingMap {
                 output_above_200k: Some(22.5e-6),
                 cache_create_above_200k: Some(7.5e-6),
                 cache_read_above_200k: Some(0.6e-6),
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -750,6 +806,7 @@ impl PricingMap {
             output_above_200k: None,
             cache_create_above_200k: None,
             cache_read_above_200k: None,
+            long_context_threshold: None,
             fast_multiplier: 1.0,
         };
         self.entries
@@ -768,6 +825,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -783,6 +841,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -798,6 +857,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -813,6 +873,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -828,6 +889,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: fast_multiplier_overrides
                     .multiplier_for("gpt-5.5")
                     .unwrap_or(1.0),
@@ -845,6 +907,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -861,6 +924,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -877,6 +941,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -890,6 +955,7 @@ impl PricingMap {
             output_above_200k: None,
             cache_create_above_200k: None,
             cache_read_above_200k: None,
+            long_context_threshold: None,
             fast_multiplier: 1.0,
         };
         self.entries.insert("gpt-5.1".to_string(), gpt_5_1_pricing);
@@ -905,6 +971,7 @@ impl PricingMap {
             output_above_200k: None,
             cache_create_above_200k: None,
             cache_read_above_200k: None,
+            long_context_threshold: None,
             fast_multiplier: 1.0,
         };
         self.entries
@@ -932,6 +999,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: fast_multiplier_overrides
                     .multiplier_for("gpt-5.4")
                     .unwrap_or(1.0),
@@ -949,6 +1017,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -964,9 +1033,37 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
+        // Source: https://platform.openai.com/docs/pricing (Standard tier,
+        // short context). The long-context tier rates live in
+        // `builtin_long_context_rates`, which runs after every pricing load.
+        for (model, input, output, cache_create, cache_read) in [
+            ("gpt-5.6-sol", 5e-6, 30e-6, 6.25e-6, 0.5e-6),
+            ("gpt-5.6-terra", 2.5e-6, 15e-6, 3.125e-6, 0.25e-6),
+            ("gpt-5.6-luna", 1e-6, 6e-6, 1.25e-6, 0.1e-6),
+        ] {
+            self.entries.insert(
+                model.to_string(),
+                Pricing {
+                    input,
+                    output,
+                    cache_create,
+                    cache_read,
+                    cache_read_explicit: true,
+                    input_above_200k: None,
+                    output_above_200k: None,
+                    cache_create_above_200k: None,
+                    cache_read_above_200k: None,
+                    long_context_threshold: None,
+                    fast_multiplier: fast_multiplier_overrides
+                        .multiplier_for(model)
+                        .unwrap_or(1.0),
+                },
+            );
+        }
         // Source: https://docs.z.ai/guides/overview/pricing
         let glm_pricing = |input: f64, output: f64, cache_read: f64| Pricing {
             input,
@@ -978,6 +1075,7 @@ impl PricingMap {
             output_above_200k: None,
             cache_create_above_200k: None,
             cache_read_above_200k: None,
+            long_context_threshold: None,
             fast_multiplier: 1.0,
         };
         let glm_base = glm_pricing(0.6e-6, 2.2e-6, 0.11e-6);
@@ -1038,6 +1136,11 @@ impl PricingMap {
         self.context_limits
             .insert("grok-4.3".to_string(), 1_000_000);
         self.context_limits.insert("gpt-5.4".to_string(), 1_050_000);
+        // The gpt-5.6 family shares the 1,050,000-token window of the other
+        // long-context GPT-5 flagship models until upstream data lands.
+        for model in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            self.context_limits.insert(model.to_string(), 1_050_000);
+        }
         for model in [
             "claude-opus-4-8",
             "claude-opus-4-7",
@@ -1200,6 +1303,72 @@ fn normalized_pricing_key(value: &str) -> Cow<'_, str> {
     }
 }
 
+/// Long-context tier rates (per token) for a base model, applied on top of
+/// loaded pricing entries by `apply_builtin_long_context_rates`.
+#[derive(Clone, Copy)]
+struct LongContextRates {
+    threshold: u64,
+    input: Option<f64>,
+    output: Option<f64>,
+    cache_create: Option<f64>,
+    cache_read: Option<f64>,
+}
+
+/// Built-in two-stage rates that upstream pricing sources do not publish.
+/// Source: https://platform.openai.com/docs/pricing (Standard tier); OpenAI
+/// bills requests with more than 272K input tokens at long-context rates.
+fn builtin_long_context_rates(base_model: &str) -> Option<LongContextRates> {
+    let openai = |input: f64, output: f64, cache_create: Option<f64>, cache_read: Option<f64>| {
+        LongContextRates {
+            threshold: OPENAI_LONG_CONTEXT_THRESHOLD_TOKENS,
+            input: Some(input),
+            output: Some(output),
+            cache_create,
+            cache_read,
+        }
+    };
+    match base_model {
+        "gpt-5.6-sol" => Some(openai(10e-6, 45e-6, Some(12.5e-6), Some(1e-6))),
+        "gpt-5.6-terra" => Some(openai(5e-6, 22.5e-6, Some(6.25e-6), Some(0.5e-6))),
+        "gpt-5.6-luna" => Some(openai(2e-6, 9e-6, Some(2.5e-6), Some(0.2e-6))),
+        // gpt-5.5 and gpt-5.4 have no separate cache-write price, so cache
+        // writes are billed as regular input in both tiers.
+        "gpt-5.5" => Some(openai(10e-6, 45e-6, Some(10e-6), Some(1e-6))),
+        "gpt-5.4" => Some(openai(5e-6, 22.5e-6, Some(5e-6), Some(0.5e-6))),
+        // The pro models have no prompt-caching prices, so only the input and
+        // output rates change in the long-context tier.
+        "gpt-5.5-pro" | "gpt-5.4-pro" => Some(openai(60e-6, 270e-6, None, None)),
+        _ => None,
+    }
+}
+
+/// Strips a trailing release-date suffix (`-YYYY-MM-DD` or `-YYYYMMDD`) so
+/// date-pinned pricing keys share their base model's long-context rates.
+fn model_without_date_suffix(model: &str) -> &str {
+    let bytes = model.as_bytes();
+    // -YYYY-MM-DD (OpenAI style, e.g. gpt-5.5-2026-04-23)
+    if model.len() > 11 {
+        let suffix = &bytes[model.len() - 11..];
+        if suffix[0] == b'-'
+            && suffix[1..5].iter().all(u8::is_ascii_digit)
+            && suffix[5] == b'-'
+            && suffix[6..8].iter().all(u8::is_ascii_digit)
+            && suffix[8] == b'-'
+            && suffix[9..].iter().all(u8::is_ascii_digit)
+        {
+            return &model[..model.len() - 11];
+        }
+    }
+    // -YYYYMMDD (Anthropic style, e.g. claude-3-5-haiku-20241022)
+    if model.len() > 9 {
+        let suffix = &bytes[model.len() - 9..];
+        if suffix[0] == b'-' && suffix[1..].iter().all(u8::is_ascii_digit) {
+            return &model[..model.len() - 9];
+        }
+    }
+    model
+}
+
 /// Maps Codex log labels that upstream pricing sources do not publish to
 /// canonical pricing keys.
 fn pricing_alias(model: &str) -> Option<&'static str> {
@@ -1302,7 +1471,7 @@ fn fetch_json_url(url: &str) -> std::io::Result<String> {
 mod tests {
     use super::{
         BUILD_TIME_MODELS_DEV_JSON, BUILD_TIME_PRICING_JSON, Pricing, PricingMap,
-        embedded_models_dev_pricing,
+        embedded_models_dev_pricing, model_without_date_suffix,
     };
     use ccusage_test_support::fs_fixture;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1858,6 +2027,116 @@ mod tests {
     }
 
     #[test]
+    fn embedded_pricing_includes_gpt_5_6_family_with_long_context_rates() {
+        let pricing = PricingMap::load_embedded();
+
+        let sol = pricing.find("gpt-5.6-sol").unwrap();
+        assert_eq!(sol.input, 5e-6);
+        assert_eq!(sol.output, 30e-6);
+        assert_eq!(sol.cache_create, 6.25e-6);
+        assert_eq!(sol.cache_read, 0.5e-6);
+        assert!(sol.cache_read_explicit);
+        assert_eq!(sol.input_above_200k, Some(10e-6));
+        assert_eq!(sol.output_above_200k, Some(45e-6));
+        assert_eq!(sol.cache_create_above_200k, Some(12.5e-6));
+        assert_eq!(sol.cache_read_above_200k, Some(1e-6));
+        assert_eq!(sol.long_context_threshold, Some(272_000));
+        assert_eq!(pricing.context_limit("gpt-5.6-sol"), Some(1_050_000));
+
+        let terra = pricing.find("gpt-5.6-terra").unwrap();
+        assert_eq!(terra.input, 2.5e-6);
+        assert_eq!(terra.cache_create, 3.125e-6);
+        assert_eq!(terra.input_above_200k, Some(5e-6));
+        assert_eq!(terra.output_above_200k, Some(22.5e-6));
+
+        let luna = pricing.find("gpt-5.6-luna").unwrap();
+        assert_eq!(luna.input, 1e-6);
+        assert_eq!(luna.output, 6e-6);
+        assert_eq!(luna.input_above_200k, Some(2e-6));
+        assert_eq!(luna.output_above_200k, Some(9e-6));
+    }
+
+    #[test]
+    fn embedded_pricing_fills_gpt_long_context_tier_rates() {
+        let pricing = PricingMap::load_embedded();
+
+        let gpt_55 = pricing.find("gpt-5.5").unwrap();
+        assert_eq!(gpt_55.input_above_200k, Some(10e-6));
+        assert_eq!(gpt_55.output_above_200k, Some(45e-6));
+        assert_eq!(gpt_55.cache_read_above_200k, Some(1e-6));
+        assert_eq!(gpt_55.long_context_threshold, Some(272_000));
+
+        let gpt_54 = pricing.find("gpt-5.4").unwrap();
+        assert_eq!(gpt_54.input_above_200k, Some(5e-6));
+        assert_eq!(gpt_54.output_above_200k, Some(22.5e-6));
+        assert_eq!(gpt_54.long_context_threshold, Some(272_000));
+
+        // Models the pricing page lists without a long-context tier stay flat.
+        let mini = pricing.find("gpt-5.4-mini").unwrap();
+        assert_eq!(mini.input_above_200k, None);
+        assert_eq!(mini.long_context_threshold, None);
+    }
+
+    #[test]
+    fn long_context_overlay_survives_litellm_refresh_and_defers_to_upstream() {
+        let mut pricing = PricingMap::load_embedded();
+        // A live LiteLLM refresh replaces whole entries with flat rates and
+        // may add date-pinned keys.
+        pricing.load_json(
+            r#"{
+                "gpt-5.5": {
+                    "input_cost_per_token": 0.000006,
+                    "output_cost_per_token": 0.000031
+                },
+                "gpt-5.5-2026-04-23": {
+                    "input_cost_per_token": 0.000006,
+                    "output_cost_per_token": 0.000031
+                }
+            }"#,
+        );
+        pricing.apply_builtin_long_context_rates();
+
+        let gpt_55 = pricing.find("gpt-5.5").unwrap();
+        assert_eq!(gpt_55.input, 6e-6);
+        assert_eq!(gpt_55.input_above_200k, Some(10e-6));
+        assert_eq!(gpt_55.long_context_threshold, Some(272_000));
+        // Date-pinned keys share the base model's long-context rates.
+        let dated = pricing.find_exact("gpt-5.5-2026-04-23").unwrap();
+        assert_eq!(dated.input_above_200k, Some(10e-6));
+
+        // Tier rates published upstream win over the built-in overlay.
+        pricing.load_json(
+            r#"{
+                "gpt-5.5": {
+                    "input_cost_per_token": 0.000006,
+                    "output_cost_per_token": 0.000031,
+                    "input_cost_per_token_above_200k_tokens": 0.000012
+                }
+            }"#,
+        );
+        pricing.apply_builtin_long_context_rates();
+
+        let gpt_55 = pricing.find("gpt-5.5").unwrap();
+        assert_eq!(gpt_55.input_above_200k, Some(12e-6));
+        assert_eq!(gpt_55.long_context_threshold, None);
+    }
+
+    #[test]
+    fn strips_model_date_suffixes() {
+        assert_eq!(model_without_date_suffix("gpt-5.5-2026-04-23"), "gpt-5.5");
+        assert_eq!(
+            model_without_date_suffix("gpt-5.5-pro-2026-04-23"),
+            "gpt-5.5-pro"
+        );
+        assert_eq!(
+            model_without_date_suffix("claude-3-5-haiku-20241022"),
+            "claude-3-5-haiku"
+        );
+        assert_eq!(model_without_date_suffix("gpt-5.6-sol"), "gpt-5.6-sol");
+        assert_eq!(model_without_date_suffix("gpt-4-0613"), "gpt-4-0613");
+    }
+
+    #[test]
     fn pricing_lookup_resolves_model_aliases() {
         let _aliases =
             crate::model_aliases::set_model_aliases_for_tests([("private-gpt-55", "gpt-5.5")]);
@@ -2015,6 +2294,7 @@ mod tests {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -2030,6 +2310,7 @@ mod tests {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -2052,6 +2333,7 @@ mod tests {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -2191,6 +2473,7 @@ mod tests {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -2206,6 +2489,7 @@ mod tests {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                long_context_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -2272,6 +2556,7 @@ mod tests {
                     output_above_200k: None,
                     cache_create_above_200k: None,
                     cache_read_above_200k: None,
+                    long_context_threshold: None,
                     fast_multiplier: 1.5,
                 },
             );
@@ -2356,6 +2641,7 @@ mod tests {
                     output_above_200k: None,
                     cache_create_above_200k: Some(4.6875e-6),
                     cache_read_above_200k: Some(3.75e-7),
+                    long_context_threshold: None,
                     fast_multiplier: 1.0,
                 },
             );
@@ -2394,6 +2680,7 @@ mod tests {
                     output_above_200k: None,
                     cache_create_above_200k: None,
                     cache_read_above_200k: None,
+                    long_context_threshold: None,
                     fast_multiplier: 1.0,
                 },
             );
@@ -2424,6 +2711,7 @@ mod tests {
                     output_above_200k: None,
                     cache_create_above_200k: None,
                     cache_read_above_200k: None,
+                    long_context_threshold: None,
                     fast_multiplier: 1.0,
                 },
             );

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -639,7 +639,10 @@ impl PricingMap {
     /// entries only carry the flat rates. Runs after every pricing load
     /// (embedded and live) because LiteLLM refreshes replace whole entries.
     /// Entries that already carry any tier rate are left untouched so
-    /// upstream data wins once it exists.
+    /// upstream data wins once it exists. The check is deliberately
+    /// all-or-nothing rather than per field: upstream `*_above_200k_tokens`
+    /// values assume the 200K boundary, so mixing them with built-in rates
+    /// that assume the OpenAI 272K boundary would price both tiers wrong.
     fn apply_builtin_long_context_rates(&mut self) {
         for (model, pricing) in &mut self.entries {
             if pricing.input_above_200k.is_some()

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1345,6 +1345,19 @@ fn builtin_long_context_rates(base_model: &str) -> Option<LongContextRates> {
     }
 }
 
+/// Input-token boundary above which a request is billed at a model's
+/// long-context tier. Codex aggregates per-model token sums before pricing is
+/// applied, so each request's tier must be decided during aggregation from the
+/// model's own threshold rather than a single global constant. This returns the
+/// same value `apply_builtin_long_context_rates` stamps onto
+/// `Pricing::long_context_threshold`, and falls back to the default 200K
+/// boundary used for LiteLLM `*_above_200k_tokens` data.
+pub(crate) fn long_context_split_threshold(model: &str) -> u64 {
+    builtin_long_context_rates(model_without_date_suffix(model))
+        .map(|rates| rates.threshold)
+        .unwrap_or(DEFAULT_LONG_CONTEXT_THRESHOLD_TOKENS)
+}
+
 /// Strips a trailing release-date suffix (`-YYYY-MM-DD` or `-YYYYMMDD`) so
 /// date-pinned pricing keys share their base model's long-context rates.
 fn model_without_date_suffix(model: &str) -> &str {
@@ -1474,7 +1487,7 @@ fn fetch_json_url(url: &str) -> std::io::Result<String> {
 mod tests {
     use super::{
         BUILD_TIME_MODELS_DEV_JSON, BUILD_TIME_PRICING_JSON, Pricing, PricingMap,
-        embedded_models_dev_pricing, model_without_date_suffix,
+        embedded_models_dev_pricing, long_context_split_threshold, model_without_date_suffix,
     };
     use ccusage_test_support::fs_fixture;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -2122,6 +2135,20 @@ mod tests {
         let gpt_55 = pricing.find("gpt-5.5").unwrap();
         assert_eq!(gpt_55.input_above_200k, Some(12e-6));
         assert_eq!(gpt_55.long_context_threshold, None);
+    }
+
+    #[test]
+    fn long_context_split_threshold_is_per_model() {
+        // OpenAI two-stage models switch tiers above 272K input tokens.
+        assert_eq!(long_context_split_threshold("gpt-5.6-sol"), 272_000);
+        assert_eq!(long_context_split_threshold("gpt-5.5"), 272_000);
+        assert_eq!(long_context_split_threshold("gpt-5.5-pro"), 272_000);
+        // Date-pinned keys share their base model's boundary.
+        assert_eq!(long_context_split_threshold("gpt-5.5-2026-04-23"), 272_000);
+        // Models without a built-in tier fall back to the 200K default used for
+        // LiteLLM `*_above_200k_tokens` data.
+        assert_eq!(long_context_split_threshold("gpt-5"), 200_000);
+        assert_eq!(long_context_split_threshold("gpt-5.4-mini"), 200_000);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/types.rs
+++ b/rust/crates/ccusage/src/types.rs
@@ -157,6 +157,14 @@ pub(crate) struct CodexModelUsage {
     pub(crate) output_tokens: u64,
     pub(crate) reasoning_output_tokens: u64,
     pub(crate) total_tokens: u64,
+    // Portion of the sums above that came from long-context requests (input
+    // above the OpenAI 272K threshold). OpenAI decides the pricing tier per
+    // request and bills the whole request at long-context rates, so the split
+    // has to be tracked while events are aggregated; it cannot be derived
+    // from the summed totals afterwards.
+    pub(crate) long_context_input_tokens: u64,
+    pub(crate) long_context_cached_input_tokens: u64,
+    pub(crate) long_context_output_tokens: u64,
     pub(crate) is_fallback: bool,
 }
 


### PR DESCRIPTION
## Summary

OpenAI introduced two-stage (short/long context) pricing with the gpt-5.6 family: requests with more than 272K input tokens are billed at higher long-context rates. The same tier structure also applies to gpt-5.5, gpt-5.5-pro, gpt-5.4, and gpt-5.4-pro on the current pricing page. This PR adds the gpt-5.6-sol/terra/luna models to the built-in pricing table and makes Codex reports bill long-context requests at the correct rates.

## What Changed

- **Per-model tier threshold**: `Pricing` gains `long_context_threshold`; the previous hardcoded 200K boundary stays the default for LiteLLM `*_above_200k_tokens` data, while the OpenAI models switch tiers above 272K input tokens.
- **New built-in entries**: gpt-5.6-sol ($5/$30, long $10/$45), gpt-5.6-terra ($2.50/$15, long $5/$22.50), and gpt-5.6-luna ($1/$6, long $2/$9) per 1M input/output tokens, including cached-input and cache-write rates for both tiers.
- **Long-context overlay**: tier rates that upstream sources do not publish are re-applied after every pricing load via `builtin_long_context_rates`. A live LiteLLM refresh replaces whole entries (LiteLLM currently lists gpt-5.5/gpt-5.4 with flat rates only), so tier rates set directly on built-in entries would be silently dropped once a refresh succeeds. Upstream tier data wins over the overlay when it exists, and date-pinned keys such as `gpt-5.5-2026-04-23` share their base model's rates.
- **Codex per-request tiering**: OpenAI decides the tier per request and bills the whole request (input, cached input, and output) at long-context rates. Codex costs are computed from per-model sums, so `CodexModelUsage` now tracks the long-context portion while events are aggregated (each `token_count` event is one request), and `calculate_codex_model_cost` prices the short and long buckets independently. Models without tier rates are priced exactly as before.

## Notes

- Report JSON shape and table output are unchanged; only `costUSD` for long-context usage differs.
- The generic cost path (Claude Code, pi, and other non-Codex adapters) now mirrors the Codex per-request tiering: models with a per-model `long_context_threshold` bill the whole request at the long-context rates once input exceeds the threshold, so it is no longer a marginal breakpoint. LiteLLM `*_above_200k_tokens` data (no per-model threshold) keeps its marginal above-threshold semantics at the 200K default.
- Codex aggregation derives each request's tier from the matched model's threshold (`long_context_split_threshold`) instead of a single hardcoded 272K constant, so any model whose long-context boundary is not 272K is split at its own threshold.
- gpt-5.6 context limits mirror the 1,050,000-token window of gpt-5.5/gpt-5.4 until upstream metadata lands.
- `pricingOverrides` cannot override the tier threshold yet; that can be added later if someone needs it.

## Testing

- `just test` (Rust workspace + Node) passes: 343 + 61 + 16 + 11 crate tests, 0 failures.
- New tests: embedded gpt-5.6 rates and 272K threshold, overlay survival across a simulated LiteLLM refresh (and deferring to upstream tier data), date-suffix stripping, per-request long-context split during Codex aggregation (fixture-backed), two-stage Codex cost math, and flat-model equivalence.
- `cargo clippy -p ccusage --tests` and `just fmt` are clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for OpenAI two-stage pricing (short vs. long context) and the gpt-5.6 family. Codex now bills any request with more than 272K input tokens at long-context rates while keeping report shapes unchanged.

- **New Features**
  - Per-model tier threshold in pricing. Default stays 200K; OpenAI models use 272K.
  - Added gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna with embedded short-context and cache rates.
  - Filled long-context tier rates via a built-in overlay applied after every pricing load. Upstream tier data wins, and date-pinned keys inherit their base model’s rates.
  - Codex aggregation tracks long-context usage per request and prices short and long buckets separately. Models without tier rates are unchanged.
  - Set a 1,050,000-token context window for the gpt-5.6 family. Only costUSD changes for long-context usage; reports remain the same.

<sup>Written for commit 7d66785e5a0d0dafadbe15fd117590af0f0d1d62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added long-context token tracking and pricing support, with separate accounting for long-context input/cached input/output.
  * Cost calculations now apply long-context/two-stage rates using model-specific thresholds.

* **Bug Fixes**
  * Improved aggregation to correctly preserve long-context usage when combining multiple requests.
  * Updated billing logic to better match tiered long-context behavior across supported model pricing sources.

* **Tests**
  * Expanded unit coverage for long-context split/threshold handling, tier switching, and aggregation correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
