### PR TITLE
feat(pricing): add GPT-5.6 two-stage rates

### DIFF
--- a/rust/crates/ccusage/build.rs
+++ b/rust/crates/ccusage/build.rs
@@ -114,6 +114,13 @@ fn compact_pricing_json(json: &str) -> Option<String> {
             ("output_cost_per_token_above_200k_tokens", "oa"),
             ("cache_creation_input_token_cost_above_200k_tokens", "cca"),
             ("cache_read_input_token_cost_above_200k_tokens", "cra"),
+            ("input_cost_per_token_above_272k_tokens", "ia272"),
+            ("output_cost_per_token_above_272k_tokens", "oa272"),
+            (
+                "cache_creation_input_token_cost_above_272k_tokens",
+                "cca272",
+            ),
+            ("cache_read_input_token_cost_above_272k_tokens", "cra272"),
             ("max_input_tokens", "ctx"),
         ] {
             let Some(value) = pricing.get(source) else {

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -335,6 +335,11 @@ fn accumulate_codex_event_into_group(
     model_usage.output_tokens += event.output_tokens;
     model_usage.reasoning_output_tokens += event.reasoning_output_tokens;
     model_usage.total_tokens += event.total_tokens;
+    if event.input_tokens > crate::pricing::OPENAI_LONG_CONTEXT_THRESHOLD_TOKENS {
+        model_usage.long_context_input_tokens += event.input_tokens;
+        model_usage.long_context_cached_input_tokens += event.cached_input_tokens;
+        model_usage.long_context_output_tokens += event.output_tokens;
+    }
     model_usage.is_fallback |= event.is_fallback_model;
 }
 
@@ -415,6 +420,9 @@ fn merge_groups(target: &mut BTreeMap<String, CodexGroup>, source: BTreeMap<Stri
             target_usage.output_tokens += usage.output_tokens;
             target_usage.reasoning_output_tokens += usage.reasoning_output_tokens;
             target_usage.total_tokens += usage.total_tokens;
+            target_usage.long_context_input_tokens += usage.long_context_input_tokens;
+            target_usage.long_context_cached_input_tokens += usage.long_context_cached_input_tokens;
+            target_usage.long_context_output_tokens += usage.long_context_output_tokens;
             target_usage.is_fallback |= usage.is_fallback;
         }
     }

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -231,6 +231,65 @@ mod tests {
     }
 
     #[test]
+    fn prices_codex_long_context_rates_per_request_before_aggregation() {
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{
+                "gpt-long": {
+                    "input_cost_per_token": 0.000005,
+                    "output_cost_per_token": 0.000030,
+                    "cache_read_input_token_cost": 0.0000005,
+                    "input_cost_per_token_above_272k_tokens": 0.000010,
+                    "output_cost_per_token_above_272k_tokens": 0.000045,
+                    "cache_read_input_token_cost_above_272k_tokens": 0.000001
+                }
+            }"#,
+        );
+        let events = [
+            CodexTokenUsageEvent {
+                session_id: "session-long".to_string(),
+                timestamp: "2026-07-09T08:01:00.000Z".to_string(),
+                model: Some("gpt-long".to_string()),
+                input_tokens: 280_000,
+                cached_input_tokens: 20_000,
+                output_tokens: 500,
+                reasoning_output_tokens: 0,
+                total_tokens: 280_500,
+                is_fallback_model: false,
+            },
+            CodexTokenUsageEvent {
+                session_id: "session-short".to_string(),
+                timestamp: "2026-07-09T09:01:00.000Z".to_string(),
+                model: Some("gpt-long".to_string()),
+                input_tokens: 100_000,
+                cached_input_tokens: 50_000,
+                output_tokens: 300,
+                reasoning_output_tokens: 0,
+                total_tokens: 100_300,
+                is_fallback_model: false,
+            },
+        ];
+
+        let report = report_json(
+            &events,
+            AgentReportKind::Daily,
+            Some("UTC"),
+            &pricing,
+            CodexSpeed::Standard,
+        )
+        .unwrap();
+
+        let expected = 260_000.0 * 10e-6
+            + 20_000.0 * 1e-6
+            + 500.0 * 45e-6
+            + 50_000.0 * 5e-6
+            + 50_000.0 * 0.5e-6
+            + 300.0 * 30e-6;
+        let cost = report["daily"][0]["costUSD"].as_f64().unwrap();
+        assert!((cost - expected).abs() < 1e-9);
+    }
+
+    #[test]
     fn applies_speed_option_to_codex_cost() {
         let mut pricing = PricingMap::default();
         pricing.load_json(

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -222,7 +222,7 @@ mod tests {
             output_tokens: 5,
             reasoning_output_tokens: 0,
             total_tokens: 105,
-            is_fallback: false,
+            ..CodexModelUsage::default()
         };
 
         let cost = calculate_codex_model_cost("gpt-test", &usage, &pricing, CodexSpeed::Standard);
@@ -307,7 +307,7 @@ mod tests {
             output_tokens: 5,
             reasoning_output_tokens: 0,
             total_tokens: 105,
-            is_fallback: false,
+            ..CodexModelUsage::default()
         };
 
         let standard =

--- a/rust/crates/ccusage/src/adapter/codex/report.rs
+++ b/rust/crates/ccusage/src/adapter/codex/report.rs
@@ -134,7 +134,6 @@ pub(crate) fn calculate_codex_model_cost(
     let Some(pricing) = pricing.find(model) else {
         return 0.0;
     };
-    let non_cached_input = usage.input_tokens.saturating_sub(usage.cached_input_tokens);
     let multiplier = if matches!(speed, CodexSpeed::Fast) {
         if pricing.fast_multiplier == 1.0 {
             2.0
@@ -149,9 +148,36 @@ pub(crate) fn calculate_codex_model_cost(
     } else {
         pricing.input
     };
-    (non_cached_input as f64 * pricing.input
-        + usage.cached_input_tokens as f64 * cache_read
-        + usage.output_tokens as f64 * pricing.output)
+    let long_input_rate = pricing.input_above_200k.unwrap_or(pricing.input);
+    let long_output_rate = pricing.output_above_200k.unwrap_or(pricing.output);
+    let long_cache_read = if pricing.cache_read_explicit {
+        pricing.cache_read_above_200k.unwrap_or(cache_read)
+    } else {
+        long_input_rate
+    };
+    let long_input = pricing.full_request_threshold.map_or(0, |_| {
+        usage.long_context_input_tokens.min(usage.input_tokens)
+    });
+    let long_cached = if long_input == 0 {
+        0
+    } else {
+        usage
+            .long_context_cached_input_tokens
+            .min(usage.cached_input_tokens)
+            .min(long_input)
+    };
+    let long_output = pricing.full_request_threshold.map_or(0, |_| {
+        usage.long_context_output_tokens.min(usage.output_tokens)
+    });
+    let short_non_cached =
+        (usage.input_tokens - long_input).saturating_sub(usage.cached_input_tokens - long_cached);
+    let long_non_cached = long_input - long_cached;
+    (short_non_cached as f64 * pricing.input
+        + (usage.cached_input_tokens - long_cached) as f64 * cache_read
+        + (usage.output_tokens - long_output) as f64 * pricing.output
+        + long_non_cached as f64 * long_input_rate
+        + long_cached as f64 * long_cache_read
+        + long_output as f64 * long_output_rate)
         * multiplier
 }
 

--- a/rust/crates/ccusage/src/cost.rs
+++ b/rust/crates/ccusage/src/cost.rs
@@ -177,6 +177,65 @@ mod tests {
         pricing
     }
 
+    fn openai_long_context_pricing() -> PricingMap {
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{
+                "gpt-long": {
+                    "input_cost_per_token": 1.0,
+                    "output_cost_per_token": 10.0,
+                    "cache_read_input_token_cost": 0.1,
+                    "input_cost_per_token_above_272k_tokens": 2.0,
+                    "output_cost_per_token_above_272k_tokens": 15.0,
+                    "cache_read_input_token_cost_above_272k_tokens": 0.2
+                }
+            }"#,
+        );
+        pricing
+    }
+
+    #[test]
+    fn prices_entire_openai_request_at_long_context_rates() {
+        let usage = TokenUsageRaw {
+            input_tokens: 250_000,
+            output_tokens: 1_000,
+            cache_read_input_tokens: 30_000,
+            ..TokenUsageRaw::default()
+        };
+
+        let cost = calculate_cost_for_usage(
+            Some("gpt-long"),
+            usage,
+            None,
+            CostMode::Calculate,
+            Some(&openai_long_context_pricing()),
+        );
+
+        let expected = 250_000.0 * 2.0 + 30_000.0 * 0.2 + 1_000.0 * 15.0;
+        assert!((cost - expected).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn keeps_openai_request_at_short_rates_at_272k_input_tokens() {
+        let usage = TokenUsageRaw {
+            input_tokens: 242_000,
+            output_tokens: 1_000,
+            cache_read_input_tokens: 30_000,
+            ..TokenUsageRaw::default()
+        };
+
+        let cost = calculate_cost_for_usage(
+            Some("gpt-long"),
+            usage,
+            None,
+            CostMode::Calculate,
+            Some(&openai_long_context_pricing()),
+        );
+
+        let expected = 242_000.0 + 30_000.0 * 0.1 + 1_000.0 * 10.0;
+        assert!((cost - expected).abs() < f64::EPSILON);
+    }
+
     #[test]
     fn prices_cache_creation_breakdown_by_duration() {
         let usage = TokenUsageRaw {

--- a/rust/crates/ccusage/src/cost.rs
+++ b/rust/crates/ccusage/src/cost.rs
@@ -114,6 +114,29 @@ pub(crate) fn calculate_cost_from_pricing(usage: crate::TokenUsageRaw, pricing: 
     let cache_create_1h_cost_above_200k = pricing
         .input_above_200k
         .map(|c| c * CACHE_CREATE_1H_INPUT_MULTIPLIER);
+    if let Some(threshold) = pricing.full_request_threshold {
+        let request_input_tokens = usage
+            .input_tokens
+            .saturating_add(cache_create_5m_tokens)
+            .saturating_add(cache_create_1h_tokens)
+            .saturating_add(usage.cache_read_input_tokens);
+        let uses_long_context_rates = request_input_tokens > threshold;
+        let request_rate = |base: f64, long_context: Option<f64>| {
+            if uses_long_context_rates {
+                long_context.unwrap_or(base)
+            } else {
+                base
+            }
+        };
+        return usage.input_tokens as f64 * request_rate(pricing.input, pricing.input_above_200k)
+            + usage.output_tokens as f64 * request_rate(pricing.output, pricing.output_above_200k)
+            + cache_create_5m_tokens as f64
+                * request_rate(pricing.cache_create, pricing.cache_create_above_200k)
+            + cache_create_1h_tokens as f64
+                * request_rate(cache_create_1h_cost, cache_create_1h_cost_above_200k)
+            + usage.cache_read_input_tokens as f64
+                * request_rate(pricing.cache_read, pricing.cache_read_above_200k);
+    }
     tiered_cost(usage.input_tokens, pricing.input, pricing.input_above_200k)
         + tiered_cost(
             usage.output_tokens,

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -24,6 +24,7 @@ const MODELS_DEV_FAILURE_RETRY_AFTER: Duration = Duration::from_secs(60);
 // Anthropic date-suffixed model aliases use YYYYMMDD, while other numeric
 // suffixes are treated as distinct model versions.
 const MODEL_DATE_SUFFIX_DIGITS: usize = 8;
+pub(crate) const OPENAI_LONG_CONTEXT_THRESHOLD_TOKENS: u64 = 272_000;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Pricing {
@@ -36,6 +37,9 @@ pub(crate) struct Pricing {
     pub(crate) output_above_200k: Option<f64>,
     pub(crate) cache_create_above_200k: Option<f64>,
     pub(crate) cache_read_above_200k: Option<f64>,
+    /// When set, the request's combined input decides whether every token uses
+    /// the long-context rates. `None` preserves LiteLLM's marginal 200K tier.
+    pub(crate) full_request_threshold: Option<u64>,
     pub(crate) fast_multiplier: f64,
 }
 
@@ -51,6 +55,7 @@ impl Pricing {
             output_above_200k: None,
             cache_create_above_200k: None,
             cache_read_above_200k: None,
+            full_request_threshold: None,
             fast_multiplier: 1.0,
         }
     }
@@ -87,6 +92,10 @@ struct LiteLlmPricing {
     output_cost_per_token_above_200k_tokens: Option<f64>,
     cache_creation_input_token_cost_above_200k_tokens: Option<f64>,
     cache_read_input_token_cost_above_200k_tokens: Option<f64>,
+    input_cost_per_token_above_272k_tokens: Option<f64>,
+    output_cost_per_token_above_272k_tokens: Option<f64>,
+    cache_creation_input_token_cost_above_272k_tokens: Option<f64>,
+    cache_read_input_token_cost_above_272k_tokens: Option<f64>,
     max_input_tokens: Option<u64>,
     provider_specific_entry: Option<ProviderSpecificEntry>,
 }
@@ -106,6 +115,10 @@ struct CompactLiteLlmPricing {
     oa: Option<f64>,
     cca: Option<f64>,
     cra: Option<f64>,
+    ia272: Option<f64>,
+    oa272: Option<f64>,
+    cca272: Option<f64>,
+    cra272: Option<f64>,
     ctx: Option<u64>,
     fast: Option<f64>,
 }
@@ -283,6 +296,15 @@ impl PricingMap {
             };
             let context_limit = pricing.max_input_tokens;
             let cache_read_explicit = pricing.cache_read_input_token_cost.is_some();
+            let full_request_threshold = [
+                pricing.input_cost_per_token_above_272k_tokens,
+                pricing.output_cost_per_token_above_272k_tokens,
+                pricing.cache_creation_input_token_cost_above_272k_tokens,
+                pricing.cache_read_input_token_cost_above_272k_tokens,
+            ]
+            .iter()
+            .any(Option::is_some)
+            .then_some(OPENAI_LONG_CONTEXT_THRESHOLD_TOKENS);
             let fast_multiplier = pricing
                 .provider_specific_entry
                 .and_then(|entry| entry.fast)
@@ -298,11 +320,19 @@ impl PricingMap {
                         .unwrap_or(input * 1.25),
                     cache_read: pricing.cache_read_input_token_cost.unwrap_or(input * 0.1),
                     cache_read_explicit,
-                    input_above_200k: pricing.input_cost_per_token_above_200k_tokens,
-                    output_above_200k: pricing.output_cost_per_token_above_200k_tokens,
+                    input_above_200k: pricing
+                        .input_cost_per_token_above_272k_tokens
+                        .or(pricing.input_cost_per_token_above_200k_tokens),
+                    output_above_200k: pricing
+                        .output_cost_per_token_above_272k_tokens
+                        .or(pricing.output_cost_per_token_above_200k_tokens),
                     cache_create_above_200k: pricing
-                        .cache_creation_input_token_cost_above_200k_tokens,
-                    cache_read_above_200k: pricing.cache_read_input_token_cost_above_200k_tokens,
+                        .cache_creation_input_token_cost_above_272k_tokens
+                        .or(pricing.cache_creation_input_token_cost_above_200k_tokens),
+                    cache_read_above_200k: pricing
+                        .cache_read_input_token_cost_above_272k_tokens
+                        .or(pricing.cache_read_input_token_cost_above_200k_tokens),
+                    full_request_threshold,
                     fast_multiplier,
                 },
             );
@@ -363,6 +393,7 @@ impl PricingMap {
                     output_above_200k: None,
                     cache_create_above_200k: None,
                     cache_read_above_200k: None,
+                    full_request_threshold: None,
                     fast_multiplier: 1.0,
                 },
             );
@@ -585,6 +616,7 @@ impl PricingMap {
                 .or(base.output_above_200k),
             cache_create_above_200k,
             cache_read_above_200k,
+            full_request_threshold: base.full_request_threshold,
             fast_multiplier: override_value
                 .fast_multiplier
                 .unwrap_or(base.fast_multiplier),
@@ -626,6 +658,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -641,6 +674,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: fast_multiplier_overrides
                     .multiplier_for("claude-opus-4-6")
                     .unwrap_or(1.0),
@@ -658,6 +692,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: fast_multiplier_overrides
                     .multiplier_for("claude-opus-4-7")
                     .unwrap_or(1.0),
@@ -675,6 +710,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: fast_multiplier_overrides
                     .multiplier_for("claude-opus-4-8")
                     .unwrap_or(1.0),
@@ -692,6 +728,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -707,6 +744,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -722,6 +760,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -737,6 +776,7 @@ impl PricingMap {
                 output_above_200k: Some(22.5e-6),
                 cache_create_above_200k: Some(7.5e-6),
                 cache_read_above_200k: Some(0.6e-6),
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -750,6 +790,7 @@ impl PricingMap {
             output_above_200k: None,
             cache_create_above_200k: None,
             cache_read_above_200k: None,
+            full_request_threshold: None,
             fast_multiplier: 1.0,
         };
         self.entries
@@ -768,6 +809,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -783,6 +825,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -798,6 +841,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -813,6 +857,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -824,10 +869,11 @@ impl PricingMap {
                 cache_create: 5e-6,
                 cache_read: 0.5e-6,
                 cache_read_explicit: true,
-                input_above_200k: None,
-                output_above_200k: None,
-                cache_create_above_200k: None,
-                cache_read_above_200k: None,
+                input_above_200k: Some(10e-6),
+                output_above_200k: Some(45e-6),
+                cache_create_above_200k: Some(10e-6),
+                cache_read_above_200k: Some(1e-6),
+                full_request_threshold: Some(OPENAI_LONG_CONTEXT_THRESHOLD_TOKENS),
                 fast_multiplier: fast_multiplier_overrides
                     .multiplier_for("gpt-5.5")
                     .unwrap_or(1.0),
@@ -845,6 +891,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -861,6 +908,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -877,6 +925,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -890,6 +939,7 @@ impl PricingMap {
             output_above_200k: None,
             cache_create_above_200k: None,
             cache_read_above_200k: None,
+            full_request_threshold: None,
             fast_multiplier: 1.0,
         };
         self.entries.insert("gpt-5.1".to_string(), gpt_5_1_pricing);
@@ -905,6 +955,7 @@ impl PricingMap {
             output_above_200k: None,
             cache_create_above_200k: None,
             cache_read_above_200k: None,
+            full_request_threshold: None,
             fast_multiplier: 1.0,
         };
         self.entries
@@ -928,10 +979,11 @@ impl PricingMap {
                 cache_create: 2.5e-6,
                 cache_read: 0.25e-6,
                 cache_read_explicit: true,
-                input_above_200k: None,
-                output_above_200k: None,
-                cache_create_above_200k: None,
-                cache_read_above_200k: None,
+                input_above_200k: Some(5e-6),
+                output_above_200k: Some(22.5e-6),
+                cache_create_above_200k: Some(5e-6),
+                cache_read_above_200k: Some(0.5e-6),
+                full_request_threshold: Some(OPENAI_LONG_CONTEXT_THRESHOLD_TOKENS),
                 fast_multiplier: fast_multiplier_overrides
                     .multiplier_for("gpt-5.4")
                     .unwrap_or(1.0),
@@ -949,6 +1001,7 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -964,9 +1017,33 @@ impl PricingMap {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
+        // Source: https://developers.openai.com/api/docs/pricing (Standard).
+        for (model, input, output, cache_create, cache_read) in [
+            ("gpt-5.6-sol", 5e-6, 30e-6, 6.25e-6, 0.5e-6),
+            ("gpt-5.6-terra", 2.5e-6, 15e-6, 3.125e-6, 0.25e-6),
+            ("gpt-5.6-luna", 1e-6, 6e-6, 1.25e-6, 0.1e-6),
+        ] {
+            self.entries.insert(
+                model.to_string(),
+                Pricing {
+                    input,
+                    output,
+                    cache_create,
+                    cache_read,
+                    cache_read_explicit: true,
+                    input_above_200k: Some(input * 2.0),
+                    output_above_200k: Some(output * 1.5),
+                    cache_create_above_200k: Some(cache_create * 2.0),
+                    cache_read_above_200k: Some(cache_read * 2.0),
+                    full_request_threshold: Some(OPENAI_LONG_CONTEXT_THRESHOLD_TOKENS),
+                    fast_multiplier: 1.0,
+                },
+            );
+        }
         // Source: https://docs.z.ai/guides/overview/pricing
         let glm_pricing = |input: f64, output: f64, cache_read: f64| Pricing {
             input,
@@ -978,6 +1055,7 @@ impl PricingMap {
             output_above_200k: None,
             cache_create_above_200k: None,
             cache_read_above_200k: None,
+            full_request_threshold: None,
             fast_multiplier: 1.0,
         };
         let glm_base = glm_pricing(0.6e-6, 2.2e-6, 0.11e-6);
@@ -1038,6 +1116,9 @@ impl PricingMap {
         self.context_limits
             .insert("grok-4.3".to_string(), 1_000_000);
         self.context_limits.insert("gpt-5.4".to_string(), 1_050_000);
+        for model in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            self.context_limits.insert(model.to_string(), 1_050_000);
+        }
         for model in [
             "claude-opus-4-8",
             "claude-opus-4-7",
@@ -1082,6 +1163,10 @@ fn parse_litellm_pricing(value: Value) -> Option<LiteLlmPricing> {
             output_cost_per_token_above_200k_tokens: compact.oa,
             cache_creation_input_token_cost_above_200k_tokens: compact.cca,
             cache_read_input_token_cost_above_200k_tokens: compact.cra,
+            input_cost_per_token_above_272k_tokens: compact.ia272,
+            output_cost_per_token_above_272k_tokens: compact.oa272,
+            cache_creation_input_token_cost_above_272k_tokens: compact.cca272,
+            cache_read_input_token_cost_above_272k_tokens: compact.cra272,
             max_input_tokens: compact.ctx,
             provider_specific_entry: compact
                 .fast
@@ -2060,6 +2145,7 @@ mod tests {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -2075,6 +2161,7 @@ mod tests {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -2097,6 +2184,7 @@ mod tests {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -2236,6 +2324,7 @@ mod tests {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -2251,6 +2340,7 @@ mod tests {
                 output_above_200k: None,
                 cache_create_above_200k: None,
                 cache_read_above_200k: None,
+                full_request_threshold: None,
                 fast_multiplier: 1.0,
             },
         );
@@ -2317,6 +2407,7 @@ mod tests {
                     output_above_200k: None,
                     cache_create_above_200k: None,
                     cache_read_above_200k: None,
+                    full_request_threshold: None,
                     fast_multiplier: 1.5,
                 },
             );
@@ -2401,6 +2492,7 @@ mod tests {
                     output_above_200k: None,
                     cache_create_above_200k: Some(4.6875e-6),
                     cache_read_above_200k: Some(3.75e-7),
+                    full_request_threshold: None,
                     fast_multiplier: 1.0,
                 },
             );
@@ -2439,6 +2531,7 @@ mod tests {
                     output_above_200k: None,
                     cache_create_above_200k: None,
                     cache_read_above_200k: None,
+                    full_request_threshold: None,
                     fast_multiplier: 1.0,
                 },
             );
@@ -2469,6 +2562,7 @@ mod tests {
                     output_above_200k: None,
                     cache_create_above_200k: None,
                     cache_read_above_200k: None,
+                    full_request_threshold: None,
                     fast_multiplier: 1.0,
                 },
             );

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1853,8 +1853,53 @@ mod tests {
         assert_eq!(gpt_55.output, 30e-6);
         assert_eq!(gpt_55.cache_read, 0.5e-6);
         assert!(gpt_55.cache_read_explicit);
+        assert_eq!(gpt_55.input_above_200k, Some(10e-6));
+        assert_eq!(gpt_55.output_above_200k, Some(45e-6));
+        assert_eq!(gpt_55.cache_read_above_200k, Some(1e-6));
         assert_eq!(gpt_55.fast_multiplier, 2.5);
         assert_eq!(pricing.context_limit("gpt-5.5"), Some(1_050_000));
+    }
+
+    #[test]
+    fn embedded_pricing_includes_gpt_5_6_family_for_offline_reports() {
+        let pricing = PricingMap::load_embedded();
+
+        let sol = pricing.find("gpt-5.6-sol").unwrap();
+        assert_eq!(sol.input, 5e-6);
+        assert_eq!(sol.output, 30e-6);
+        assert_eq!(sol.cache_create, 6.25e-6);
+        assert_eq!(sol.cache_read, 0.5e-6);
+        assert_eq!(sol.input_above_200k, Some(10e-6));
+        assert_eq!(sol.output_above_200k, Some(45e-6));
+        assert_eq!(sol.cache_create_above_200k, Some(12.5e-6));
+        assert_eq!(sol.cache_read_above_200k, Some(1e-6));
+        assert_eq!(pricing.context_limit("gpt-5.6-sol"), Some(1_050_000));
+
+        let terra = pricing.find("gpt-5.6-terra").unwrap();
+        assert_eq!(terra.input, 2.5e-6);
+        assert_eq!(terra.output, 15e-6);
+        assert_eq!(terra.input_above_200k, Some(5e-6));
+        assert_eq!(terra.output_above_200k, Some(22.5e-6));
+
+        let luna = pricing.find("gpt-5.6-luna").unwrap();
+        assert_eq!(luna.input, 1e-6);
+        assert_eq!(luna.output, 6e-6);
+        assert_eq!(luna.input_above_200k, Some(2e-6));
+        assert_eq!(luna.output_above_200k, Some(9e-6));
+    }
+
+    #[test]
+    fn embedded_litellm_pricing_keeps_openai_272k_rates() {
+        let pricing = PricingMap::load_embedded();
+        let dated_gpt_55 = pricing.find_exact("gpt-5.5-2026-04-23").unwrap();
+        let dated_gpt_54 = pricing.find_exact("gpt-5.4-2026-03-05").unwrap();
+
+        assert_eq!(dated_gpt_55.input_above_200k, Some(10e-6));
+        assert_eq!(dated_gpt_55.output_above_200k, Some(45e-6));
+        assert_eq!(dated_gpt_55.cache_read_above_200k, Some(1e-6));
+        assert_eq!(dated_gpt_54.input_above_200k, Some(5e-6));
+        assert_eq!(dated_gpt_54.output_above_200k, Some(22.5e-6));
+        assert_eq!(dated_gpt_54.cache_read_above_200k, Some(0.5e-6));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/types.rs
+++ b/rust/crates/ccusage/src/types.rs
@@ -157,6 +157,11 @@ pub(crate) struct CodexModelUsage {
     pub(crate) output_tokens: u64,
     pub(crate) reasoning_output_tokens: u64,
     pub(crate) total_tokens: u64,
+    /// Portions of the totals produced by requests above OpenAI's 272K input
+    /// cutoff. The request split cannot be reconstructed after aggregation.
+    pub(crate) long_context_input_tokens: u64,
+    pub(crate) long_context_cached_input_tokens: u64,
+    pub(crate) long_context_output_tokens: u64,
     pub(crate) is_fallback: bool,
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds standard pricing for GPT-5.6 Sol, Terra, and Luna and preserves LiteLLM’s OpenAI-specific rates above 272K input tokens. Applies those long-context rates to the full request while retaining existing marginal 200K behavior for other providers. Codex now retains the short/long request split during aggregation so mixed reports are priced correctly.

Testing:
- `cargo test --manifest-path rust/Cargo.toml --workspace`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cb499b0-4d43-4e65-9b6d-d699daa84104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cb499b0-4d43-4e65-9b6d-d699daa84104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786213338&installation_id=139163553&pr_number=1415&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1415&signature=dbf10d2bac8afb3edc6109a26f6a2857e7b1474a02af9de8a1029b2c4b73cff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two-stage pricing for the GPT-5.6 family and applies OpenAI’s 272k long-context rates to the whole request when combined input exceeds 272k tokens. Codex now preserves per-request tiers by tracking long-context portions before aggregation.

- **New Features**
  - Embedded pricing for `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, including above-200k rates, cache costs, and a 1.05M context limit.
  - Preserves two-stage and 272k long-context rates for GPT-5.5 and GPT-5.4 (including dated variants), and supports LiteLLM’s 272k fields in both JSON and compact formats.

- **Bug Fixes**
  - Codex aggregation keeps per-request tiers by tracking long-context input/output/cache portions, so mixed short/long requests are billed correctly.

<sup>Written for commit df2fd7c57072f910a52c9cf8b9ab60330a3561df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

