### PR TITLE
docs: update Lineman affiliate links to CCUsage landing page

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -27,14 +27,14 @@
 
 <div align="center">
 
-<a href="https://linkjolt.io/l/ryotaro-kimura-ryoppippi">
+<a href="https://www.linkjolt.io/redirect?tc=ZRYGKVrY&aff=O8HjtyEN1hpQkXYlalZKT">
     <picture>
         <source media="(prefers-color-scheme: dark)" srcset="https://cdn.lineman.io/logo/lineman-dark.svg">
         <img src="https://cdn.lineman.io/logo/lineman-light.svg" alt="Lineman.io: Teams and Enterprise cost monitoring" width="320">
     </picture>
 </a>
 
-<p align="center"><a href="https://linkjolt.io/l/ryotaro-kimura-ryoppippi">Lineman.io — a Team & Enterprise solution for Claude Code:<br />40% lower token usage, full teams spend visibility, and unauthorized-spend alerts.</a></p>
+<p align="center"><a href="https://www.linkjolt.io/redirect?tc=ZRYGKVrY&aff=O8HjtyEN1hpQkXYlalZKT">Lineman.io — a Team & Enterprise solution for Claude Code:<br />40% lower token usage, full teams spend visibility, and unauthorized-spend alerts.</a></p>
 
 </div>
 

--- a/docs/guide/sponsors.md
+++ b/docs/guide/sponsors.md
@@ -4,13 +4,13 @@ ccusage is sponsored by Lineman.io, CodeRabbit, and Blacksmith.
 
 <div style="display: flex; justify-content: center; margin-top: 1rem;">
     <div style="width: min(360px, 90vw); text-align: center;">
-        <a href="https://linkjolt.io/l/ryotaro-kimura-ryoppippi">
+        <a href="https://www.linkjolt.io/redirect?tc=ZRYGKVrY&aff=O8HjtyEN1hpQkXYlalZKT">
             <picture>
                 <source media="(prefers-color-scheme: dark)" srcset="https://cdn.lineman.io/logo/lineman-dark.svg">
                 <img src="https://cdn.lineman.io/logo/lineman-light.svg" alt="Lineman.io: Teams and Enterprise cost monitoring" style="display: block; width: min(320px, 80vw); height: auto; margin: 0 auto;">
             </picture>
         </a>
-        <p><a href="https://linkjolt.io/l/ryotaro-kimura-ryoppippi">Lineman.io — a Team & Enterprise solution for Claude Code:<br>40% lower token usage, full teams spend visibility, and unauthorized-spend alerts.</a></p>
+        <p><a href="https://www.linkjolt.io/redirect?tc=ZRYGKVrY&aff=O8HjtyEN1hpQkXYlalZKT">Lineman.io — a Team & Enterprise solution for Claude Code:<br>40% lower token usage, full teams spend visibility, and unauthorized-spend alerts.</a></p>
     </div>
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,13 +58,13 @@ features:
 
   <div style="display: flex; justify-content: center; margin-top: 1rem;">
     <div style="width: min(360px, 90vw); text-align: center;">
-      <a href="https://linkjolt.io/l/ryotaro-kimura-ryoppippi" target="_blank">
+      <a href="https://www.linkjolt.io/redirect?tc=ZRYGKVrY&aff=O8HjtyEN1hpQkXYlalZKT" target="_blank">
         <picture>
           <source media="(prefers-color-scheme: dark)" srcset="https://cdn.lineman.io/logo/lineman-dark.svg">
           <img src="https://cdn.lineman.io/logo/lineman-light.svg" alt="Lineman.io: Teams and Enterprise cost monitoring" style="display: block; width: min(320px, 80vw); height: auto; margin: 0 auto;">
         </picture>
       </a>
-      <p><a href="https://linkjolt.io/l/ryotaro-kimura-ryoppippi" target="_blank">Lineman.io — a Team & Enterprise solution for Claude Code:<br>40% lower token usage, full teams spend visibility, and unauthorized-spend alerts.</a></p>
+      <p><a href="https://www.linkjolt.io/redirect?tc=ZRYGKVrY&aff=O8HjtyEN1hpQkXYlalZKT" target="_blank">Lineman.io — a Team & Enterprise solution for Claude Code:<br>40% lower token usage, full teams spend visibility, and unauthorized-spend alerts.</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the Lineman.io sponsor links on GitHub (README) and the docs site to the dedicated CCUsage LinkJolt landing page redirect.

Old: `https://linkjolt.io/l/ryotaro-kimura-ryoppippi`  
New: `https://www.linkjolt.io/redirect?tc=ZRYGKVrY&aff=O8HjtyEN1hpQkXYlalZKT`

Files updated:
- `apps/ccusage/README.md` (also root `README.md` via symlink)
- `docs/index.md`
- `docs/guide/sponsors.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ae58cb6-4a87-48f7-9b9d-9fd528b482be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ae58cb6-4a87-48f7-9b9d-9fd528b482be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Lineman.io sponsor links in the README and docs to the CCUsage-specific LinkJolt redirect for accurate attribution and the free tier + voucher funnel. Replaces https://linkjolt.io/l/ryotaro-kimura-ryoppippi with https://www.linkjolt.io/redirect?tc=ZRYGKVrY&aff=O8HjtyEN1hpQkXYlalZKT.

<sup>Written for commit 1681d3714f52e4c0911e8b9f3b1454d787f441b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sponsor links across the README and docs to use a new redirect URL for Lineman.io.
  * Kept the existing sponsor branding and images intact while changing the destination links.
  * Aligned the “Support ccusage” and “Major Sponsors” sections with the new sponsored link format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->