### PR TITLE
docs: update Star History chart

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,4 +5,4 @@ useDefault = true
 description = "Global allowlist"
 paths = ['''pnpm-lock\.yaml$''']
 # Star History sealed tokens are public, read-only chart identifiers.
-regexes = ['''sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w''']
+regexes = ['''sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w'''] # spellchecker:disable-line

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,4 +5,8 @@ useDefault = true
 description = "Global allowlist"
 paths = ['''pnpm-lock\.yaml$''']
 # Star History sealed tokens are public, read-only chart identifiers.
-regexes = ['''sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w'''] # spellchecker:disable-line
+# spellchecker:off
+regexes = [
+        '''sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w''',
+]
+# spellchecker:on

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,6 +6,7 @@ description = "Global allowlist"
 paths = ['''pnpm-lock\.yaml$''']
 # Star History sealed tokens are public, read-only chart identifiers.
 # spellchecker:off
+regexTarget = "match"
 regexes = [
 	'''sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,3 +4,5 @@ useDefault = true
 [allowlist]
 description = "Global allowlist"
 paths = ['''pnpm-lock\.yaml$''']
+# Star History sealed tokens are public, read-only chart identifiers.
+regexes = ['''sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,6 +7,6 @@ paths = ['''pnpm-lock\.yaml$''']
 # Star History sealed tokens are public, read-only chart identifiers.
 # spellchecker:off
 regexes = [
-        '''sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w''',
+	'''sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w''',
 ]
 # spellchecker:on

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -244,12 +244,12 @@ The scheduled `update pricing` workflow runs the same update and validation, the
 
 ## Star History
 
-<a href="https://www.star-history.com/#ccusage/ccusage&Date">
-    <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ccusage/ccusage&type=Date&theme=dark" />
-        <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ccusage/ccusage&type=Date" />
-        <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ccusage/ccusage&type=Date" />
-    </picture>
+<a href="https://www.star-history.com/?repos=ccusage%2Fccusage&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=ccusage/ccusage&type=date&theme=dark&legend=top-left&sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=ccusage/ccusage&type=date&legend=top-left&sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=ccusage/ccusage&type=date&legend=top-left&sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w" />
+ </picture>
 </a>
 
 ## License

--- a/docs/guide/sponsors.md
+++ b/docs/guide/sponsors.md
@@ -38,10 +38,10 @@ Visit [GitHub Sponsors - @ryoppippi](https://github.com/sponsors/ryoppippi) to s
 
 ## Star History
 
-<a href="https://www.star-history.com/#ccusage/ccusage&Date">
-    <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ccusage/ccusage&type=Date&theme=dark" />
-        <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ccusage/ccusage&type=Date" />
-        <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ccusage/ccusage&type=Date" />
-    </picture>
+<a href="https://www.star-history.com/?repos=ccusage%2Fccusage&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=ccusage/ccusage&type=date&theme=dark&legend=top-left&sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=ccusage/ccusage&type=date&legend=top-left&sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=ccusage/ccusage&type=date&legend=top-left&sealed_token=bC4-7Zs63nsOam9kdlCTUCbyCn7QuItb4yy4h8Ot0SrOeDlb5y2saMUc1CAOskhB1fl3RSZZuUmFyjAOICGnniL5wqbvTmHrbqqiIH5mpn8spRFPfjLK_w" />
+ </picture>
 </a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the Star History chart in the package README and sponsorship guide to use the new date chart with light and dark variants. The sealed chart token is public and read-only, so its exact URL parameter is narrowly allowlisted against the full Gitleaks match to avoid false-positive secret findings.

Testing:
- Verified both light and dark chart URLs return successfully
- Parsed `.gitleaks.toml` with Python `tomllib`
- CI security and formatting checks validate the allowlist
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc551e4f-be0e-473d-80cc-4b42fd403024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc551e4f-be0e-473d-80cc-4b42fd403024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Star History charts in the README and Sponsors guide to use the `chart` endpoint with date view, light/dark themes, and a top-left legend. Add the public read-only sealed token and allowlist it in `.gitleaks.toml` with spellcheck bracketing, repo TOML formatting, and `regexTarget="match"` to suppress false positives across all six chart URLs.

<sup>Written for commit 853fb704737c5bf440c22d3dbc11c8aa23b37c32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History charts in the ccusage README and sponsor guide.
  * Charts now use the latest Star History format with improved theme support for light and dark modes.
  * Updated chart links and rendering to provide a more consistent viewing experience across supported contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->