### PR TITLE
fix(claude): count advisor model usage

### DIFF
--- a/rust/crates/ccusage/src/adapter/claude/README.md
+++ b/rust/crates/ccusage/src/adapter/claude/README.md
@@ -45,5 +45,6 @@ Advisor entries:
 - ccusage counts each advisor record separately under the record's own model.
   The top-level usage remains attributed only to the main model, and other
   iteration types are not added again.
-- Advisor costs are calculated from their token counts because the iteration
-  does not include a precomputed `costUSD`.
+- Advisor iterations do not include a precomputed `costUSD`, so `auto` and
+  `calculate` modes price their tokens separately while `display` mode reports
+  zero cost for them.

--- a/rust/crates/ccusage/src/adapter/claude/README.md
+++ b/rust/crates/ccusage/src/adapter/claude/README.md
@@ -37,3 +37,13 @@ The term `session` has two meanings in this codebase:
 - True Claude Code session ID may also appear in each JSONL entry's `sessionId` field.
 
 Malformed JSONL lines are skipped during parsing.
+
+Advisor entries:
+
+- Advisor usage is stored in `message.usage.iterations` records whose type is
+  `advisor_message`.
+- ccusage counts each advisor record separately under the record's own model.
+  The top-level usage remains attributed only to the main model, and other
+  iteration types are not added again.
+- Advisor costs are calculated from their token counts because the iteration
+  does not include a precomputed `costUSD`.

--- a/rust/crates/ccusage/src/adapter/claude/daily.rs
+++ b/rust/crates/ccusage/src/adapter/claude/daily.rs
@@ -19,7 +19,8 @@ use crate::{
 };
 
 use super::{
-    chunk_file_indexes_by_size, has_unsupported_null_field, is_semver_prefix,
+    advisor_usages_from_line, chunk_file_indexes_by_size, has_unsupported_null_field,
+    is_semver_prefix,
     paths::{claude_paths, extract_project, usage_files},
     usage_dedupe_hash,
 };
@@ -299,8 +300,11 @@ fn read_daily_usage_file(
                 Some(model.clone())
             }
         });
+        let date = format_date_tz(timestamp, tz);
+        let message_id = data.message.id.clone();
+        let request_id = data.request_id.clone();
         loaded_file.entries.push(DailyLoadedEntry {
-            date: format_date_tz(timestamp, tz),
+            date: date.clone(),
             project: Arc::clone(&project),
             usage,
             cost,
@@ -310,6 +314,34 @@ fn read_daily_usage_file(
             request_id: data.request_id,
             is_sidechain: data.is_sidechain,
         });
+        for (index, advisor) in advisor_usages_from_line(line).into_iter().enumerate() {
+            let missing_pricing_model = missing_pricing_model_for_usage(
+                Some(&advisor.model),
+                advisor.usage,
+                None,
+                mode,
+                pricing,
+            );
+            loaded_file.entries.push(DailyLoadedEntry {
+                date: date.clone(),
+                project: Arc::clone(&project),
+                usage: advisor.usage,
+                cost: calculate_cost_for_usage(
+                    Some(&advisor.model),
+                    advisor.usage,
+                    None,
+                    mode,
+                    pricing,
+                ),
+                model: Some(advisor.model),
+                missing_pricing_model,
+                message_id: message_id
+                    .as_ref()
+                    .map(|message_id| format!("{message_id}:advisor:{index}")),
+                request_id: request_id.clone(),
+                is_sidechain: data.is_sidechain,
+            });
+        }
     }
     loaded_file
 }

--- a/rust/crates/ccusage/src/adapter/claude/mod.rs
+++ b/rust/crates/ccusage/src/adapter/claude/mod.rs
@@ -12,10 +12,11 @@ use std::{
 use jiff::tz::TimeZone as JiffTimeZone;
 use memchr::memmem;
 use rustc_hash::FxHasher;
+use serde::Deserialize;
 
 use crate::{
-    LoadedEntry, LoadedFile, PricingMap, Result, Speed, TimestampMs, UsageEntry, UsageSummary,
-    calculate_cost,
+    LoadedEntry, LoadedFile, PricingMap, Result, Speed, TimestampMs, TokenUsageRaw, UsageEntry,
+    UsageSummary, calculate_cost, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
     debug_log,
     fast::{FxHashMap, SmallIndexVec, byte_lines, suffix_string},
@@ -385,7 +386,7 @@ fn read_usage_file(
                 Some(model.clone())
             }
         });
-        loaded_file.entries.push(LoadedEntry {
+        let entry = LoadedEntry {
             data,
             timestamp,
             date,
@@ -399,9 +400,105 @@ fn read_usage_file(
             model,
             usage_limit_reset_time,
             missing_pricing_model,
-        });
+        };
+        let mut advisor_entries = Vec::new();
+        for (index, advisor) in advisor_usages_from_line(line).into_iter().enumerate() {
+            let mut advisor_data = entry.data.clone();
+            advisor_data.message.id = advisor_data
+                .message
+                .id
+                .map(|message_id| format!("{message_id}:advisor:{index}"));
+            advisor_data.message.model = Some(advisor.model.clone());
+            advisor_data.message.usage = advisor.usage;
+            advisor_data.cost_usd = None;
+            let missing_pricing_model = missing_pricing_model_for_usage(
+                Some(&advisor.model),
+                advisor.usage,
+                None,
+                mode,
+                pricing,
+            );
+            advisor_entries.push(LoadedEntry {
+                data: advisor_data,
+                timestamp,
+                date: entry.date.clone(),
+                project: Arc::clone(&project),
+                session_id: Arc::clone(&session_id),
+                project_path: Arc::clone(&project_path),
+                cost: calculate_cost_for_usage(
+                    Some(&advisor.model),
+                    advisor.usage,
+                    None,
+                    mode,
+                    pricing,
+                ),
+                extra_total_tokens: 0,
+                credits: None,
+                message_count: None,
+                model: Some(advisor.model),
+                usage_limit_reset_time,
+                missing_pricing_model,
+            });
+        }
+        loaded_file.entries.push(entry);
+        loaded_file.entries.extend(advisor_entries);
     }
     loaded_file
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageIterationsEnvelope {
+    message: UsageIterationsMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageIterationsMessage {
+    usage: UsageIterations,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageIterations {
+    #[serde(default)]
+    iterations: Vec<UsageIteration>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageIteration {
+    #[serde(rename = "type")]
+    kind: String,
+    model: Option<String>,
+    #[serde(flatten)]
+    usage: TokenUsageRaw,
+}
+
+pub(super) struct AdvisorUsage {
+    pub(super) model: String,
+    pub(super) usage: TokenUsageRaw,
+}
+
+pub(super) fn advisor_usages_from_line(line: &[u8]) -> Vec<AdvisorUsage> {
+    if memmem::find(line, br#""advisor_message""#).is_none() {
+        return Vec::new();
+    }
+    let Ok(envelope) = serde_json::from_slice::<UsageIterationsEnvelope>(line) else {
+        return Vec::new();
+    };
+    envelope
+        .message
+        .usage
+        .iterations
+        .into_iter()
+        .filter_map(|iteration| {
+            (iteration.kind == "advisor_message")
+                .then_some(iteration.model)
+                .flatten()
+                .filter(|model| !model.is_empty())
+                .map(|model| AdvisorUsage {
+                    model,
+                    usage: iteration.usage,
+                })
+        })
+        .collect()
 }
 
 fn update_loaded_file_timestamp(loaded_file: &mut LoadedFile, timestamp: TimestampMs) {
@@ -563,9 +660,12 @@ mod tests {
 
     use super::{
         extract_session_parts, has_unsupported_null_field, paths::is_project_path_segment,
-        push_deduped_entry, usage_files,
+        push_deduped_entry, read_usage_file, usage_files,
     };
-    use crate::{LoadedEntry, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage};
+    use crate::{
+        LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+        cli::CostMode,
+    };
     use ccusage_test_support::fs_fixture;
 
     #[test]
@@ -651,6 +751,38 @@ mod tests {
         assert!(!has_unsupported_null_field(
             br#"{"message":{"content":null,"usage":{"input_tokens":0}}}"#
         ));
+    }
+
+    #[test]
+    fn calculates_advisor_cost_with_the_advisor_model() {
+        let fixture = fs_fixture!({
+            "projects/project-a/session-a/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","version":"1.2.3","sessionId":"session-a","message":{"id":"msg-parent","model":"main-model","usage":{"input_tokens":1,"output_tokens":2,"iterations":[{"type":"advisor_message","model":"advisor-model","input_tokens":10,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}]}},"requestId":"req-parent","costUSD":1.23}"#,
+        });
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{
+                "main-model": {
+                    "input_cost_per_token": 100,
+                    "output_cost_per_token": 100
+                },
+                "advisor-model": {
+                    "input_cost_per_token": 2,
+                    "output_cost_per_token": 3
+                }
+            }"#,
+        );
+
+        let loaded = read_usage_file(
+            &fixture.path("projects/project-a/session-a/chat.jsonl"),
+            None,
+            CostMode::Auto,
+            Some(&pricing),
+        );
+
+        assert_eq!(loaded.entries.len(), 2);
+        assert_eq!(loaded.entries[0].cost, 1.23);
+        assert_eq!(loaded.entries[1].model.as_deref(), Some("advisor-model"));
+        assert_eq!(loaded.entries[1].cost, 26.0);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -364,6 +364,57 @@ mod tests {
     }
 
     #[test]
+    fn loads_advisor_usage_as_a_separate_model_entry() {
+        let fixture = fs_fixture!({
+            "projects/project1/session1/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","version":"1.2.3","sessionId":"session1","advisorModel":"claude-opus-4-20250514","message":{"id":"msg_123","model":"claude-sonnet-4-20250514","usage":{"input_tokens":2,"output_tokens":491,"cache_creation_input_tokens":7853,"cache_read_input_tokens":226584,"iterations":[{"type":"message","input_tokens":1,"output_tokens":45,"cache_creation_input_tokens":7192,"cache_read_input_tokens":109696},{"type":"advisor_message","model":"claude-opus-4-20250514","input_tokens":159419,"output_tokens":7805,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},{"type":"message","input_tokens":1,"output_tokens":446,"cache_creation_input_tokens":661,"cache_read_input_tokens":116888}]}},"requestId":"req_456","costUSD":1.23}"#,
+        });
+
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, None).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries[0].model.as_deref(),
+            Some("claude-sonnet-4-20250514")
+        );
+        assert_eq!(entries[0].data.message.usage.input_tokens, 2);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 491);
+        assert_eq!(entries[1].model.as_deref(), Some("claude-opus-4-20250514"));
+        assert_eq!(entries[1].data.message.usage.input_tokens, 159_419);
+        assert_eq!(entries[1].data.message.usage.output_tokens, 7_805);
+    }
+
+    #[test]
+    fn includes_advisor_usage_in_daily_summaries() {
+        let fixture = fs_fixture!({
+            "projects/project1/session1/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","version":"1.2.3","sessionId":"session1","advisorModel":"claude-opus-4-20250514","message":{"id":"msg_123","model":"claude-sonnet-4-20250514","usage":{"input_tokens":2,"output_tokens":491,"cache_creation_input_tokens":7853,"cache_read_input_tokens":226584,"iterations":[{"type":"message","input_tokens":1,"output_tokens":45,"cache_creation_input_tokens":7192,"cache_read_input_tokens":109696},{"type":"advisor_message","model":"claude-opus-4-20250514","input_tokens":159419,"output_tokens":7805,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},{"type":"message","input_tokens":1,"output_tokens":446,"cache_creation_input_tokens":661,"cache_read_input_tokens":116888}]}},"requestId":"req_456","costUSD":1.23}"#,
+        });
+
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let daily = load_daily_summaries(&shared, None, false).unwrap();
+
+        assert_eq!(daily.len(), 1);
+        assert_eq!(daily[0].input_tokens, 159_421);
+        assert_eq!(daily[0].output_tokens, 8_296);
+        assert_eq!(
+            daily[0].models_used,
+            vec![
+                "claude-sonnet-4-20250514".to_string(),
+                "claude-opus-4-20250514".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn loads_daily_summaries_like_loaded_entry_aggregation() {
         let fixture = fs_fixture!({
             "projects/project-a/session-a/chat.jsonl": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- parse `advisor_message` records from Claude Code usage iterations
- attribute advisor tokens and calculated cost to the advisor model
- keep standard and optimized daily report loaders in sync
- document advisor behavior across cost modes

## Testing
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo test --manifest-path rust/Cargo.toml --workspace`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings`

Fixes #1115
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4b0d-0130-7f75-9e53-a0456286731d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4b0d-0130-7f75-9e53-a0456286731d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Claude usage reports now include advisor-model activity as separate usage entries.
  - Advisor token usage is attributed to the correct model and included in daily summaries.
  - Advisor usage costs are calculated using the advisor model’s pricing when supported.

- **Documentation**
  - Clarified how advisor usage, model attribution, token pricing, and display modes are represented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->