### PR TITLE
perf(nix): keep dependency cache across releases

### DIFF
--- a/.github/actions/setup-nix-cache/action.yaml
+++ b/.github/actions/setup-nix-cache/action.yaml
@@ -39,8 +39,10 @@ runs:
         # the newest prior entry to warm the deps. The cache backend is
         # effectively unlimited, so one entry per commit is fine and `purge`
         # rolls off the old ones.
-        primary-key: nix-${{ github.workflow }}-${{ github.job }}-${{ inputs.cache-scope }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'package.json', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}-${{ github.sha }}
-        restore-prefixes-first-match: nix-${{ github.workflow }}-${{ github.job }}-${{ inputs.cache-scope }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'package.json', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}-
+        # package.json only supplies the final binary version. It is excluded
+        # because release bumps do not change the deps-only Crane derivation.
+        primary-key: nix-${{ github.workflow }}-${{ github.job }}-${{ inputs.cache-scope }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}-${{ github.sha }}
+        restore-prefixes-first-match: nix-${{ github.workflow }}-${{ github.job }}-${{ inputs.cache-scope }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}-
         purge: true
         purge-prefixes: nix-${{ github.workflow }}-${{ github.job }}-${{ inputs.cache-scope }}-
         purge-created: 172800

--- a/.github/actions/setup-nix-cache/action.yaml
+++ b/.github/actions/setup-nix-cache/action.yaml
@@ -41,8 +41,10 @@ runs:
         # rolls off the old ones.
         # package.json only supplies the final binary version. It is excluded
         # because release bumps do not change the deps-only Crane derivation.
-        primary-key: nix-${{ github.workflow }}-${{ github.job }}-${{ inputs.cache-scope }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}-${{ github.sha }}
-        restore-prefixes-first-match: nix-${{ github.workflow }}-${{ github.job }}-${{ inputs.cache-scope }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'nix/**/*.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}-
+        # Likewise, checks and developer-tooling modules do not affect Cargo
+        # artifacts; only package modules participate in this key.
+        primary-key: nix-${{ github.workflow }}-${{ github.job }}-${{ inputs.cache-scope }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'nix/packages.nix', 'nix/static-package.nix', 'nix/darwin-x64-package.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}-${{ github.sha }}
+        restore-prefixes-first-match: nix-${{ github.workflow }}-${{ github.job }}-${{ inputs.cache-scope }}-${{ hashFiles('flake.lock', 'flake.nix', 'default.nix', 'package.nix', 'nix/packages.nix', 'nix/static-package.nix', 'nix/darwin-x64-package.nix', 'rust-toolchain.toml', 'rust/Cargo.lock', 'rust/**/Cargo.toml') }}-
         purge: true
         purge-prefixes: nix-${{ github.workflow }}-${{ github.job }}-${{ inputs.cache-scope }}-
         purge-created: 172800

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-      # postVersionCommand in .tagpr runs `nix develop`, so the Nix store cache must be ready
-      - uses: ./.github/actions/setup-nix-cache
       - id: tagpr
         uses: Songmu/tagpr@e84001bd5dac8defa0c75b3913937d284a3b3660 # v1.20.0
         env:

--- a/.tagpr
+++ b/.tagpr
@@ -4,7 +4,6 @@
 	changelog = false
 	release = false
 	versionFile = package.json,apps/ccusage/package.json,docs/package.json,packages/ccusage-darwin-arm64/package.json,packages/ccusage-darwin-x64/package.json,packages/ccusage-linux-arm64/package.json,packages/ccusage-linux-x64/package.json,packages/ccusage-win32-arm64/package.json,packages/ccusage-win32-x64/package.json
-	postVersionCommand = nix develop --command just sync-rust-version
 	# The first line of the template becomes the release PR title; it must stay
 	# a Conventional Commits header so the check-pr-title workflow passes
 	template = .github/tagpr-template.md

--- a/justfile
+++ b/justfile
@@ -68,7 +68,3 @@ update-models-dev-pricing:
     nix flake update models-dev
     just gen-models-dev-pricing
     just check
-
-# Sync the Rust workspace version (Cargo.toml + Cargo.lock) to apps/ccusage/package.json; run by tagpr's postVersionCommand
-sync-rust-version:
-    cargo set-version --manifest-path rust/Cargo.toml --workspace "$(jq -r .version apps/ccusage/package.json)"

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -29,14 +29,14 @@ in
       # config edit elsewhere in the repo:
       #   * rust/build.rs           reads ../../../flake.lock
       #   * config_schema.rs tests  include_str! ../../../../ccusage.example.json
-      #   * ccusage-cli tests       include_str! ../../../../apps/ccusage/package.json
+      #   * main.rs tests           include_str! ../../../../package.json
       testSrc = nixFilter {
         inherit root;
         include = [
           "rust"
           "flake.lock"
           "ccusage.example.json"
-          "apps/ccusage/package.json"
+          "package.json"
         ];
       };
     in

--- a/package.nix
+++ b/package.nix
@@ -28,6 +28,7 @@ let
     doCheck = false;
     cargoExtraArgs = "-p ccusage --bin ccusage";
     CCUSAGE_PRICING_JSON_PATH = "${inputs.litellm}/model_prices_and_context_window.json";
+    CCUSAGE_VERSION = version;
     RUSTFLAGS =
       lib.optionalString stdenv.isLinux "-C link-arg=-fuse-ld=mold"
       # The nixpkgs Darwin stdenv injects -liconv even though ccusage uses no
@@ -45,9 +46,26 @@ let
     ];
   };
   # Keep the dependency artifact keyed only by inputs that affect Cargo deps.
-  # Pricing snapshots and release versions are embedded by the final package.
-  depsOnlyArgs = builtins.removeAttrs commonArgs [ "CCUSAGE_PRICING_JSON_PATH" ] // {
+  # Pricing snapshots and the npm release version are embedded by the final
+  # package. The Rust workspace packages intentionally stay at 0.0.0, and the
+  # dummy manifest filter makes that version metadata irrelevant to dependency
+  # resolution too.
+  cargoTomlFilter =
+    path:
+    !lib.lists.hasPrefix [
+      "package"
+      "version"
+    ] path
+    && craneLib.filters.cargoTomlConservative path;
+  depsOnlyArgs = builtins.removeAttrs commonArgs [
+    "CCUSAGE_PRICING_JSON_PATH"
+    "CCUSAGE_VERSION"
+  ] // {
     version = "0.0.0";
+    dummySrc = craneLib.mkDummySrc {
+      inherit src;
+      cleanCargoTomlFilter = cargoTomlFilter;
+    };
   };
   cargoArtifacts = craneLib.buildDepsOnly depsOnlyArgs;
 in

--- a/package.nix
+++ b/package.nix
@@ -57,16 +57,19 @@ let
       "version"
     ] path
     && craneLib.filters.cargoTomlConservative path;
-  depsOnlyArgs = builtins.removeAttrs commonArgs [
-    "CCUSAGE_PRICING_JSON_PATH"
-    "CCUSAGE_VERSION"
-  ] // {
-    version = "0.0.0";
-    dummySrc = craneLib.mkDummySrc {
-      inherit src;
-      cleanCargoTomlFilter = cargoTomlFilter;
+  depsOnlyArgs =
+    builtins.removeAttrs commonArgs [
+      "CCUSAGE_PRICING_JSON_PATH"
+      "CCUSAGE_VERSION"
+      "src"
+    ]
+    // {
+      version = "0.0.0";
+      dummySrc = craneLib.mkDummySrc {
+        inherit src;
+        cleanCargoTomlFilter = cargoTomlFilter;
+      };
     };
-  };
   cargoArtifacts = craneLib.buildDepsOnly depsOnlyArgs;
 in
 craneLib.buildPackage (

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "ccusage"
-version = "20.0.16"
+version = "0.0.0"
 dependencies = [
  "ccusage-cli",
  "ccusage-terminal",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "ccusage-cli"
-version = "20.0.16"
+version = "0.0.0"
 dependencies = [
  "insta",
  "serde_json",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "ccusage-terminal"
-version = "20.0.16"
+version = "0.0.0"
 dependencies = [
  "insta",
  "terminal_size",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "ccusage-test-support"
-version = "20.0.16"
+version = "0.0.0"
 dependencies = [
  "assert_fs",
 ]

--- a/rust/crates/ccusage-cli/Cargo.toml
+++ b/rust/crates/ccusage-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccusage-cli"
-version = "20.0.16"
+version = "0.0.0"
 edition = "2024"
 build = "build.rs"
 

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -794,19 +794,8 @@ fn snapshots_cli_parse_error_guidance() {
 }
 
 #[test]
-fn cargo_version_matches_npm_package_version() {
-    let package_json = serde_json::from_str::<serde_json::Value>(include_str!(
-        "../../../../apps/ccusage/package.json"
-    ))
-    .unwrap();
-
-    assert_eq!(
-        env!("CARGO_PKG_VERSION"),
-        package_json
-            .get("version")
-            .and_then(serde_json::Value::as_str)
-            .unwrap()
-    );
+fn cargo_version_is_independent_from_release_version() {
+    assert_eq!(env!("CARGO_PKG_VERSION"), "0.0.0");
 }
 
 #[test]

--- a/rust/crates/ccusage-terminal/Cargo.toml
+++ b/rust/crates/ccusage-terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccusage-terminal"
-version = "20.0.16"
+version = "0.0.0"
 edition = "2024"
 
 [dependencies]

--- a/rust/crates/ccusage-test-support/Cargo.toml
+++ b/rust/crates/ccusage-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccusage-test-support"
-version = "20.0.16"
+version = "0.0.0"
 edition = "2024"
 publish = false
 

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccusage"
-version = "20.0.16"
+version = "0.0.0"
 edition = "2024"
 build = "build.rs"
 

--- a/rust/crates/ccusage/build.rs
+++ b/rust/crates/ccusage/build.rs
@@ -3,13 +3,25 @@ use std::{env, fs, path::PathBuf};
 use serde_json::{Map, Value};
 
 const FLAKE_LOCK_JSON: &str = "../../../flake.lock";
+const PACKAGE_JSON: &str = "../../../package.json";
 const LITELLM_PRICING_JSON: &str = "model_prices_and_context_window.json";
 const OUT_PRICING_JSON: &str = "litellm-pricing.json";
 const PRICING_JSON_PATH_ENV: &str = "CCUSAGE_PRICING_JSON_PATH";
+const VERSION_ENV: &str = "CCUSAGE_VERSION";
 const PRICING_FETCH_TIMEOUT_SECONDS: u64 = 10;
 
 fn main() {
     println!("cargo:rerun-if-env-changed={PRICING_JSON_PATH_ENV}");
+    println!("cargo:rerun-if-env-changed={VERSION_ENV}");
+    println!("cargo:rerun-if-changed={PACKAGE_JSON}");
+    let version = env::var(VERSION_ENV).unwrap_or_else(|_| {
+        let package_json = fs::read_to_string(PACKAGE_JSON).expect("read root package.json");
+        serde_json::from_str::<Value>(&package_json)
+            .ok()
+            .and_then(|package| package.get("version")?.as_str().map(str::to_owned))
+            .expect("read version from root package.json")
+    });
+    println!("cargo:rustc-env={VERSION_ENV}={version}");
 
     let out_path = out_dir_path(OUT_PRICING_JSON);
     let pricing_json = if let Some(path) = env::var_os(PRICING_JSON_PATH_ENV) {

--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -16,7 +16,7 @@ pub(crate) fn parse() -> Cli {
         args,
         &config,
         DEFAULT_SESSION_DURATION_HOURS,
-        env!("CARGO_PKG_VERSION"),
+        env!("CCUSAGE_VERSION"),
     )
     .unwrap_or_else(|message| {
         eprintln!("{message}");

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -177,6 +177,19 @@ mod tests {
     };
 
     #[test]
+    fn compiled_version_matches_release_package() {
+        let package = serde_json::from_str::<serde_json::Value>(include_str!(
+            "../../../../package.json"
+        ))
+        .unwrap();
+
+        assert_eq!(
+            env!("CCUSAGE_VERSION"),
+            package["version"].as_str().unwrap()
+        );
+    }
+
+    #[test]
     fn formats_numbers_with_commas() {
         assert_eq!(format_number(1_234_567), "1,234,567");
     }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -178,10 +178,9 @@ mod tests {
 
     #[test]
     fn compiled_version_matches_release_package() {
-        let package = serde_json::from_str::<serde_json::Value>(include_str!(
-            "../../../../package.json"
-        ))
-        .unwrap();
+        let package =
+            serde_json::from_str::<serde_json::Value>(include_str!("../../../../package.json"))
+                .unwrap();
 
         assert_eq!(
             env!("CCUSAGE_VERSION"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- decouple internal Cargo package versions from the npm release version
- inject the user-facing version at build time
- configure Crane dummy manifests so release-only bumps preserve dependency artifacts
- narrow CI cache keys to package inputs and remove the obsolete tagpr Rust version synchronization

## Why
Release-only version bumps changed every Rust manifest and `Cargo.lock`, invalidating Crane's deps-only derivation and forcing cold Nix builds. Unrelated checks/tooling Nix files also rotated the action cache key. Adapter crate extraction alone would not improve Nix caching without matching derivation boundaries.

A simulated `package.json` version bump kept the deps-only derivation unchanged at `/nix/store/pyapdwsw0sr37rkp1dmgghag0z59c4pj-ccusage-deps-0.0.0.drv`, while the final package derivation changed to embed the new release version.

## Testing
- `cargo test --manifest-path rust/Cargo.toml --workspace`
- `cargo fmt --all -- --check`
- `nix build .#ccusage --no-link --print-build-logs`
- `nix build .#ccusage-tests --no-link --print-build-logs`
- `nix flake check --print-build-logs`
- `nix build --no-link --print-build-logs .#checks.x86_64-linux.gitleaks .#checks.x86_64-linux.treefmt`
- `nix run .#ccusage -- --version` (`ccusage 20.0.17`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf9d1ee4-1da4-4b36-a3bc-eff52f21f578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf9d1ee4-1da4-4b36-a3bc-eff52f21f578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Nix/Crane dependency cache across release-only bumps and unrelated Nix edits to avoid cold rebuilds. Decouples Cargo workspace versions from the npm release and injects the user-facing version at build time.

- **Refactors**
  - Set all Rust workspace versions to 0.0.0; build injects `CCUSAGE_VERSION` from Nix or falls back to the root `package.json`.
  - In `package.nix`, pass `CCUSAGE_VERSION`; use `craneLib.mkDummySrc` with a `Cargo.toml` filter ignoring `package.version`; drop real `src` when using the dummy source.
  - Narrow CI Nix cache keys to package modules and exclude `package.json` so release bumps and tooling-only Nix edits don’t invalidate dependency artifacts.
  - Remove `postVersionCommand` from `Songmu/tagpr`, delete the `just sync-rust-version` task, and drop the release workflow’s Nix cache setup step.
  - CLI reads `env!("CCUSAGE_VERSION")` for `--version`; tests verify the injected binary version while internal crates stay `0.0.0`; Nix tests include the root `package.json`.

<sup>Written for commit 4ea899a0a1b0358d8b94ceaddafbb8438b7dbf12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The CLI now reports the application release version consistently across packaged builds.

- **Bug Fixes**
  - Fixed version handling so release metadata remains accurate when building through different packaging environments.
  - Improved macOS linking behavior to reduce unnecessary bundled library dependencies.

- **Chores**
  - Simplified the release process by removing an obsolete Rust version synchronization step.
  - Refined build caching and dependency tracking for more reliable, efficient releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->