### PR TITLE
build(lint): prohibit Next.js server actions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,8 +9,12 @@
 		".claude/settings.local.json",
 		"nix/models-dev-gen.ts"
 	],
+	"jsPlugins": ["./nix/oxlint-plugin.js"],
 	"options": {
 		"typeAware": true,
 		"typeCheck": true
+	},
+	"rules": {
+		"ccusage/no-server-actions": "error"
 	}
 }

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ test: rust::test test-node
 
 # Run Node's built-in test runner for TypeScript package and tooling tests
 test-node:
-    TZ=UTC node --test apps/ccusage/src/cli.test.ts nix/models-dev-compact.test.ts
+    TZ=UTC node --test apps/ccusage/src/cli.test.ts nix/models-dev-compact.test.ts nix/oxlint-plugin.test.js
 
 # Generate a large benchmark fixture for PR performance comparisons
 generate-large-fixture output_dir codex_output_dir size_mib="1024":

--- a/nix/oxlint-check.json
+++ b/nix/oxlint-check.json
@@ -8,5 +8,9 @@
 		".git",
 		".claude/settings.local.json",
 		"nix/models-dev-gen.ts"
-	]
+	],
+	"jsPlugins": ["./oxlint-plugin.js"],
+	"rules": {
+		"ccusage/no-server-actions": "error"
+	}
 }

--- a/nix/oxlint-plugin.js
+++ b/nix/oxlint-plugin.js
@@ -1,0 +1,26 @@
+const noServerActions = {
+	create(context) {
+		return {
+			ExpressionStatement(node) {
+				if (node.directive === 'use server') {
+					context.report({
+						message:
+							'Server Actions are not allowed. Remove the "use server" directive.',
+						node,
+					});
+				}
+			},
+		};
+	},
+};
+
+const plugin = {
+	meta: {
+		name: 'ccusage',
+	},
+	rules: {
+		'no-server-actions': noServerActions,
+	},
+};
+
+export default plugin;

--- a/nix/oxlint-plugin.js
+++ b/nix/oxlint-plugin.js
@@ -4,8 +4,7 @@ const noServerActions = {
 			ExpressionStatement(node) {
 				if (node.directive === 'use server') {
 					context.report({
-						message:
-							'Server Actions are not allowed. Remove the "use server" directive.',
+						message: 'Server Actions are not allowed. Remove the "use server" directive.',
 						node,
 					});
 				}

--- a/nix/oxlint-plugin.test.js
+++ b/nix/oxlint-plugin.test.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { it } from 'node:test';
+import plugin from './oxlint-plugin.js';
+
+function lintExpressionStatement(node) {
+	const messages = [];
+	const rule = plugin.rules['no-server-actions'];
+	const visitor = rule.create({
+		report({ message }) {
+			messages.push(message);
+		},
+	});
+
+	visitor.ExpressionStatement(node);
+
+	return messages;
+}
+
+void it('rejects the use server directive', () => {
+	assert.deepEqual(
+		lintExpressionStatement({
+			type: 'ExpressionStatement',
+			directive: 'use server',
+		}),
+		['Server Actions are not allowed. Remove the "use server" directive.'],
+	);
+});
+
+void it('allows the use client directive', () => {
+	assert.deepEqual(
+		lintExpressionStatement({
+			type: 'ExpressionStatement',
+			directive: 'use client',
+		}),
+		[],
+	);
+});
+
+void it('allows a use server string outside a directive prologue', () => {
+	assert.deepEqual(
+		lintExpressionStatement({
+			type: 'ExpressionStatement',
+			expression: {
+				type: 'Literal',
+				value: 'use server',
+			},
+		}),
+		[],
+	);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a repository Oxlint rule that rejects the `use server` directive, preventing Next.js Server Actions from being introduced. The rule is active in both local type-checking and hermetic Nix checks, with focused coverage for allowed and rejected directives.

Testing:
- `node --test nix/oxlint-plugin.test.js`
- `npx --yes oxlint@latest --config nix/oxlint-check.json .`
- Integration fixture confirmed `ccusage(no-server-actions)` rejects `use server`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a426693-df6d-4e9f-b0d1-45be4eff99b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a426693-df6d-4e9f-b0d1-45be4eff99b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786317473&installation_id=139163553&pr_number=1429&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1429&signature=0efbcad33bc0ffb1eb4117d70bcc9429aca8c2c314fd56b1aab9418f8b05a1f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ban Next.js Server Actions by adding a custom `oxlint` rule `ccusage/no-server-actions` that errors on the "use server" directive. The rule is active in both local and Nix lint configs, ignores other directives and plain string expressions, and is covered by tests wired into the Node test task.

<sup>Written for commit 5e04fb74a5916246f61e8475987e743f236d5bbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

