### PR TITLE
feat(pricing): add Kimi K3 pricing

### DIFF
--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -948,6 +948,23 @@ impl PricingMap {
                 fast_multiplier: 1.0,
             },
         );
+        // Source: https://platform.kimi.ai/docs/pricing/chat-k3
+        self.entries.insert(
+            "moonshot/kimi-k3".to_string(),
+            Pricing {
+                input: 3e-6,
+                output: 15e-6,
+                cache_create: 0.0,
+                cache_read: 0.3e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                long_context_threshold: None,
+                fast_multiplier: 1.0,
+            },
+        );
         let gpt_5_1_pricing = Pricing {
             input: 1.25e-6,
             output: 10e-6,
@@ -1156,6 +1173,8 @@ impl PricingMap {
             .insert("moonshot/kimi-k2.5".to_string(), 262_144);
         self.context_limits
             .insert("moonshot/kimi-k2.6".to_string(), 262_144);
+        self.context_limits
+            .insert("moonshot/kimi-k3".to_string(), 1_048_576);
 
         for model in [
             "claude-opus-4-5",
@@ -1520,6 +1539,7 @@ mod tests {
         let pricing = PricingMap::load_embedded();
         let kimi_k25 = pricing.find("moonshot/kimi-k2.5").unwrap();
         let kimi_k26 = pricing.find("moonshot/kimi-k2.6").unwrap();
+        let kimi_k3 = pricing.find("moonshot/kimi-k3").unwrap();
 
         assert_eq!(kimi_k25.input, 0.6e-6);
         assert_eq!(kimi_k25.output, 3e-6);
@@ -1529,8 +1549,13 @@ mod tests {
         assert_eq!(kimi_k26.output, 4e-6);
         assert_eq!(kimi_k26.cache_read, 0.16e-6);
         assert!(kimi_k26.cache_read_explicit);
+        assert_eq!(kimi_k3.input, 3e-6);
+        assert_eq!(kimi_k3.output, 15e-6);
+        assert_eq!(kimi_k3.cache_read, 0.3e-6);
+        assert!(kimi_k3.cache_read_explicit);
         assert_eq!(pricing.context_limit("moonshot/kimi-k2.5"), Some(262_144));
         assert_eq!(pricing.context_limit("moonshot/kimi-k2.6"), Some(262_144));
+        assert_eq!(pricing.context_limit("moonshot/kimi-k3"), Some(1_048_576));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add embedded pricing for the `moonshot/kimi-k3` model, released by Moonshot AI in July 2026. K3 is a 2.8T-parameter model with significantly different pricing from the existing K2.x models.

## Changes

- Add `moonshot/kimi-k3` pricing entry: input $3.00/M, output $15.00/M, cache read $0.30/M
- Add context window entry: 1,048,576 tokens (1M)
- Extend the existing Kimi pricing test to cover K3

## Pricing source

Official Moonshot platform: https://platform.kimi.ai/docs/pricing/chat-k3

## Notes

- K3 does not charge a separate cache creation fee (unlike K2.5/K2.6 which have 1.25× input), so `cache_create` is set to `0.0`.
- The `kimi-for-coding` → K3 timestamp mapping is intentionally left unchanged; that cutoff should be added separately once Kimi Code's K3 rollout date is confirmed.

Closes #1462
Supersedes #1461

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add embedded pricing and context window for `moonshot/kimi-k3` to ensure accurate cost calculations and token budgeting. Also adds unit tests for the new model.

- New Features
  - Pricing: input $3.00/M tokens, output $15.00/M tokens.
  - Caching: cache read $0.30/M tokens; no cache creation fee; explicit cache read.
  - Context: 1,048,576-token window with tests covering pricing and limits.

<sup>Written for commit 024ab28969efdc66c676b9f2d2c2c0b3a8182b87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in pricing support for the Moonshot Kimi K3 model.
  * Added context-window information and cache-read pricing for Kimi K3.

* **Tests**
  * Expanded offline pricing validation to cover the new model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->