### PR TITLE
ci: run pullfrog on Blacksmith and pin action SHAs

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -16,17 +16,17 @@ permissions:
 
 jobs:
   pullfrog:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     permissions:
       id-token: write
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: Run agent
-        uses: pullfrog/pullfrog@v0
+        uses: pullfrog/pullfrog@a809795406487e13f894c681ea09b4f96015284d # v0.1.36
         with:
           prompt: ${{ inputs.prompt }}
         env:


### PR DESCRIPTION
Runs the Pullfrog agent workflow on a Blacksmith runner and pins its actions to commit SHAs, matching the rest of this repo's workflows.

- `runs-on: ubuntu-latest` → `blacksmith-32vcpu-ubuntu-2404`, the label every other job here uses.
- `actions/checkout@v6` → `df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3` (same pin used across the repo).
- `pullfrog/pullfrog@v0` → `a809795406487e13f894c681ea09b4f96015284d # v0.1.36` (the commit the `v0` tag currently resolves to).

```yaml
  pullfrog:
    runs-on: blacksmith-32vcpu-ubuntu-2404
    steps:
      - name: Checkout code
        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
      - name: Run agent
        uses: pullfrog/pullfrog@a809795406487e13f894c681ea09b4f96015284d # v0.1.36
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Pullfrog workflow on the Blacksmith runner and pin its actions to commit SHAs for reproducible CI. Switches to `blacksmith-32vcpu-ubuntu-2404` from `ubuntu-latest` and replaces floating tags.

- **Dependencies**
  - Pin `actions/checkout` to the commit for v6.0.3.
  - Pin `pullfrog/pullfrog` to the commit for v0.1.36.

<sup>Written for commit 38e3a9cd84e6036fbb0fa0a58bfe2b6294116696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow execution to use a dedicated build environment.
  * Pinned workflow actions to specific versions for more consistent and reliable runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->