### PR TITLE
refactor(scripts): use match and functional pipelines in Nushell scripts

### DIFF
--- a/.github/scripts/upsert-pr-comment.nu
+++ b/.github/scripts/upsert-pr-comment.nu
@@ -38,7 +38,12 @@ def comment_body [comment: record] {
         _ => ''
     }
 }
-def update_or_recreate_comment [repository: string, pr_number: string, comment_id: int, body: string] {
+def update_or_recreate_comment [
+    repository: string
+    pr_number: string
+    comment_id: int
+    body: string
+] {
     let update = (try_update_comment $repository $comment_id $body)
     match $update.status {
         'ok' => null
@@ -46,7 +51,9 @@ def update_or_recreate_comment [repository: string, pr_number: string, comment_i
             print --stderr 'Existing PR comment was missing; creating a new comment instead.'
             create_comment $repository $pr_number $body
         }
-        'auth' => (print --stderr $"Skipping PR comment because GitHub token cannot update comments: ($update.stderr | str trim)")
+        'auth' => (
+            print --stderr $"Skipping PR comment because GitHub token cannot update comments: ($update.stderr | str trim)"
+        )
         _ => (error make {
             msg: (format_gh_error ['update comment'] $update.result)
         })
@@ -78,7 +85,9 @@ def create_comment [repository: string, pr_number: string, body: string] {
     )
     match $result.exit_code {
         0 => null
-        _ if (is_comment_write_auth_failure $result.stderr) => (print --stderr $"Skipping PR comment because GitHub token cannot write comments: ($result.stderr | str trim)")
+        _ if (is_comment_write_auth_failure $result.stderr) => (
+            print --stderr $"Skipping PR comment because GitHub token cannot write comments: ($result.stderr | str trim)"
+        )
         _ => (error make {
             msg: (format_gh_error ['create comment'] $result)
         })

--- a/.github/scripts/upsert-pr-comment.nu
+++ b/.github/scripts/upsert-pr-comment.nu
@@ -18,7 +18,9 @@ def find_existing_comment [repository: string, pr_number: string, marker: string
     ]
     | flatten
     | where {|comment|
-        ((comment_login $comment) == 'github-actions[bot]') and ((comment_body $comment) | str contains $marker)
+        let login = comment_login $comment
+        let body = comment_body $comment
+        $login == 'github-actions[bot]' and ($body | str contains $marker)
     }
     | sort-by created_at
     | reverse

--- a/.github/scripts/upsert-pr-comment.nu
+++ b/.github/scripts/upsert-pr-comment.nu
@@ -5,60 +5,66 @@ def main [] {
     let pr_number = (required_env PR_NUMBER)
     let marker = (required_env COMMENT_MARKER)
     let body = (open --raw (required_env COMMENT_FILE))
-    let comments = (gh_api_json [
+    match (find_existing_comment $repository $pr_number $marker) {
+        null => (create_comment $repository $pr_number $body)
+        $existing => (update_or_recreate_comment $repository $pr_number $existing.id $body)
+    }
+}
+def find_existing_comment [repository: string, pr_number: string, marker: string] {
+    gh_api_json [
         --paginate
         --slurp
         $"repos/($repository)/issues/($pr_number)/comments?per_page=100"
-    ] | flatten)
-    let existing = (
-        $comments | where {|comment|
-			let login = if (($comment.user? | describe) =~ '^record') {
-				$comment.user.login?
-			} else {
-				null
-			}
-			let comment_body = if (($comment.body? | describe) =~ '^string') {
-				$comment.body
-			} else {
-				''
-			}
-			$login == 'github-actions[bot]' and ($comment_body | str contains $marker)
-		} | sort-by created_at | reverse | get --optional 0
-    )
-    if $existing == null {
-        create_comment $repository $pr_number $body
-    } else {
-        let update = (try_update_comment $repository $existing.id $body)
-        if $update.status == 'ok' {
-            return
-        }
-        if $update.status == 'missing' {
+    ]
+    | flatten
+    | where {|comment|
+        ((comment_login $comment) == 'github-actions[bot]') and ((comment_body $comment) | str contains $marker)
+    }
+    | sort-by created_at
+    | reverse
+    | get --optional 0
+}
+def comment_login [comment: record] {
+    match ($comment | get --optional user) {
+        {login: $login} => $login
+        _ => null
+    }
+}
+def comment_body [comment: record] {
+    match ($comment | get --optional body) {
+        $body if ($body | describe) == 'string' => $body
+        _ => ''
+    }
+}
+def update_or_recreate_comment [repository: string, pr_number: string, comment_id: int, body: string] {
+    let update = (try_update_comment $repository $comment_id $body)
+    match $update.status {
+        'ok' => null
+        'missing' => {
             print --stderr 'Existing PR comment was missing; creating a new comment instead.'
             create_comment $repository $pr_number $body
-        } else if $update.status == 'auth' {
-            print --stderr $"Skipping PR comment because GitHub token cannot update comments: ($update.stderr | str trim)"
-        } else {
-            error make {
-                msg: (format_gh_error ['update comment'] $update.result)
-            }
         }
+        'auth' => (print --stderr $"Skipping PR comment because GitHub token cannot update comments: ($update.stderr | str trim)")
+        _ => (error make {
+            msg: (format_gh_error ['update comment'] $update.result)
+        })
     }
 }
 def required_env [name: string] {
-    let value = $env | get --optional $name
-    if $value == null or ($value | is-empty) {
-        error make {msg: $"($name) is required"}
+    match ($env | get --optional $name) {
+        null => (error make {msg: $"($name) is required"})
+        $value if ($value | is-empty) => (error make {msg: $"($name) is required"})
+        $value => $value
     }
-    $value
 }
 def gh_api_json [args: list<string>] {
     let result = (gh_api_complete $args)
-    if $result.exit_code != 0 {
-        error make {
+    match $result.exit_code {
+        0 => ($result.stdout | from json)
+        _ => (error make {
             msg: (format_gh_error $args $result)
-        }
+        })
     }
-    $result.stdout | from json
 }
 def create_comment [repository: string, pr_number: string, body: string] {
     let result = (
@@ -68,14 +74,12 @@ def create_comment [repository: string, pr_number: string, body: string] {
             $body
         )
     )
-    if $result.exit_code != 0 {
-        if (is_comment_write_auth_failure $result.stderr) {
-            print --stderr $"Skipping PR comment because GitHub token cannot write comments: ($result.stderr | str trim)"
-        } else {
-            error make {
-                msg: (format_gh_error ['create comment'] $result)
-            }
-        }
+    match $result.exit_code {
+        0 => null
+        _ if (is_comment_write_auth_failure $result.stderr) => (print --stderr $"Skipping PR comment because GitHub token cannot write comments: ($result.stderr | str trim)")
+        _ => (error make {
+            msg: (format_gh_error ['create comment'] $result)
+        })
     }
 }
 def try_update_comment [repository: string, comment_id: int, body: string] {
@@ -86,16 +90,13 @@ def try_update_comment [repository: string, comment_id: int, body: string] {
             $body
         )
     )
-    if $result.exit_code == 0 {
-        return {status: 'ok', result: $result, stderr: $result.stderr}
-    }
-    if $result.stderr =~ 'HTTP 404' {
-        return {status: 'missing', result: $result, stderr: $result.stderr}
-    }
-    if (is_comment_write_auth_failure $result.stderr) {
-        return {status: 'auth', result: $result, stderr: $result.stderr}
-    }
-    {status: 'error', result: $result, stderr: $result.stderr}
+    let status = (match $result.exit_code {
+        0 => 'ok'
+        _ if $result.stderr =~ 'HTTP 404' => 'missing'
+        _ if (is_comment_write_auth_failure $result.stderr) => 'auth'
+        _ => 'error'
+    })
+    {status: $status, result: $result, stderr: $result.stderr}
 }
 def gh_api_with_body [method: string, endpoint: string, body: string] {
     let payload = mktemp -t ccusage-pr-comment.XXXXXX | str trim

--- a/apps/ccusage/scripts/ensure-native-binary.nu
+++ b/apps/ccusage/scripts/ensure-native-binary.nu
@@ -7,13 +7,12 @@ def main [] {
     )
     let target_platform = (node_platform)
     let target_arch = (node_arch)
-    let binary_name = if $target_platform == 'win32' { 'ccusage.exe' } else { 'ccusage' }
+    let binary_name = (binary_name $target_platform)
     let native_package_root = (matching_native_package_root $repo_root $target_platform $target_arch)
-    let native_binary = if $native_package_root == null {
-        null
-    } else {
-        $native_package_root | path join bin $binary_name
-    }
+    let native_binary = (match $native_package_root {
+        null => null
+        $package_root => ($package_root | path join bin $binary_name)
+    })
     let cargo_binary = $repo_root | path join rust target release $binary_name
     let version = (expected_version $repo_root)
     if (native_package_includes_binary $native_package_root $binary_name) and (has_expected_version $native_binary $version) {
@@ -42,85 +41,72 @@ def node_arch [] {
         $other => $other
     }
 }
+def binary_name [platform: string] {
+    match $platform {
+        'win32' => 'ccusage.exe'
+        _ => 'ccusage'
+    }
+}
 def matching_native_package_root [repo_root: path, target_platform: string, target_arch: string] {
-    let candidates = (glob ($repo_root | path join packages 'ccusage-*' package.json) | each {|package_json_path|
-			let package_json = (open $package_json_path)
-			let os = $package_json.os?
-			let cpu = $package_json.cpu?
-			if (list_contains $os $target_platform) and (list_contains $cpu $target_arch) {
-				$package_json_path | path dirname
-			} else {
-				null
-			}
-		} | where {|package_root| $package_root != null })
-    $candidates | get --optional 0
+    glob ($repo_root | path join packages 'ccusage-*' package.json)
+    | where {|package_json_path|
+        let package_json = (open $package_json_path)
+        (list_contains $package_json.os? $target_platform) and (list_contains $package_json.cpu? $target_arch)
+    }
+    | each {|package_json_path| $package_json_path | path dirname }
+    | get --optional 0
 }
 def list_contains [value, needle: string] { (($value | describe) =~ '^list') and ($value | any {|item| $item == $needle }) }
 def expected_version [repo_root: path] {
-    let package_json = open ($repo_root | path join apps ccusage package.json)
-    if ($package_json.version? | describe) != 'string' {
-        error make {msg: 'apps/ccusage/package.json version is not configured'}
+    let version = open ($repo_root | path join apps ccusage package.json) | get --optional version
+    match ($version | describe) {
+        'string' => $version
+        _ => (error make {msg: 'apps/ccusage/package.json version is not configured'})
     }
-    $package_json.version
 }
 def native_package_includes_binary [package_root, binary_name: string] {
-    if $package_root == null {
-        false
-    } else {
-        let package_json_path = $package_root | path join package.json
-        if not ($package_json_path | path exists) {
-            false
-        } else {
-            let package_json = (open $package_json_path)
-            let files = $package_json.files?
-            (($files | describe) =~ '^list') and ($files | any {|file| $file == $"bin/($binary_name)" })
-        }
+    match $package_root {
+        null => false
+        $root => (manifest_lists_binary ($root | path join package.json) $binary_name)
     }
 }
+def manifest_lists_binary [package_json_path: path, binary_name: string] {
+    ($package_json_path | path exists) and (list_contains (open $package_json_path | get --optional files) $"bin/($binary_name)")
+}
 def is_portable_binary [target_platform: string, binary] {
-    if $binary == null {
-        false
-    } else if $target_platform == 'linux' {
-        let result = (^ldd $binary | complete)
-        let output = $"($result.stdout)($result.stderr)"
-        $output =~ '(?i)not a dynamic executable|statically linked'
-    } else if $target_platform == 'darwin' {
-        let result = (^otool -L $binary | complete)
-        if $result.exit_code != 0 {
-            false
-        } else {
-            let dylibs = (
-                $result.stdout
-                | lines
-                | skip 1
-                | each {|line| $line | str trim }
-                | where {|line| ($line | is-not-empty) }
-                | each {|line| $line | split row --regex '\s+' | get --optional 0 }
-                | where {|dylib| $dylib != null and ($dylib | is-not-empty) }
-            )
-            $dylibs | all {|dylib|
-				$system_dylib_prefixes | any {|prefix| $dylib | str starts-with $prefix }
-			}
-        }
-    } else {
-        true
+    match [$target_platform, $binary] {
+        [_, null] => false
+        ['linux', _] => (linux_binary_is_static $binary)
+        ['darwin', _] => (darwin_binary_links_only_system_dylibs $binary)
+        _ => true
+    }
+}
+def linux_binary_is_static [binary: path] {
+    let result = ^ldd $binary | complete
+    $"($result.stdout)($result.stderr)" =~ '(?i)not a dynamic executable|statically linked'
+}
+def darwin_binary_links_only_system_dylibs [binary: path] {
+    let result = ^otool -L $binary | complete
+    match $result.exit_code {
+        0 => (
+            $result.stdout
+            | lines
+            | skip 1
+            | each {|line| $line | str trim }
+            | where {|line| $line | is-not-empty }
+            | each {|line| $line | split row --regex '\s+' | first }
+            | all {|dylib| $system_dylib_prefixes | any {|prefix| $dylib | str starts-with $prefix } }
+        )
+        _ => false
     }
 }
 def has_expected_version [binary, version: string] {
-    if $binary == null or not ($binary | path exists) {
-        false
-    } else {
-        let result = run-external $binary '--version' | complete
-        if $result.exit_code != 0 {
-            false
-        } else {
-            let actual_version = (
-                $result.stdout
-                | str trim
-                | split row --regex '\s+'
-                | last
-            )
-            $actual_version == $version
-        }
+    ($binary != null) and ($binary | path exists) and ((reported_version $binary) == $version)
+}
+def reported_version [binary: path] {
+    let result = run-external $binary '--version' | complete
+    match $result.exit_code {
+        0 => ($result.stdout | str trim | split row --regex '\s+' | last)
+        _ => null
     }
 }

--- a/apps/ccusage/scripts/ensure-native-binary.nu
+++ b/apps/ccusage/scripts/ensure-native-binary.nu
@@ -71,7 +71,9 @@ def native_package_includes_binary [package_root, binary_name: string] {
     }
 }
 def manifest_lists_binary [package_json_path: path, binary_name: string] {
-    ($package_json_path | path exists) and (list_contains (open $package_json_path | get --optional files) $"bin/($binary_name)")
+    ($package_json_path | path exists) and (
+        list_contains (open $package_json_path | get --optional files) $"bin/($binary_name)"
+    )
 }
 def is_portable_binary [target_platform: string, binary] {
     match [$target_platform, $binary] {
@@ -106,7 +108,12 @@ def has_expected_version [binary, version: string] {
 def reported_version [binary: path] {
     let result = run-external $binary '--version' | complete
     match $result.exit_code {
-        0 => ($result.stdout | str trim | split row --regex '\s+' | last)
+        0 => (
+            $result.stdout
+            | str trim
+            | split row --regex '\s+'
+            | last
+        )
         _ => null
     }
 }

--- a/apps/ccusage/scripts/stage-native-package.nu
+++ b/apps/ccusage/scripts/stage-native-package.nu
@@ -18,7 +18,10 @@ def main [--platform: string, --arch: string, --binary: string] {
     let repo_root = [$script_dir, '..', '..', '..'] | path join | path expand
     let source = $binary | path expand
     let target_dir = [$repo_root, 'packages', $package_dir, 'bin'] | path join
-    let target = [$target_dir, (binary_name $platform)] | path join
+    let target = [
+        $target_dir
+        (binary_name $platform)
+    ] | path join
     mkdir $target_dir
     cp -f $source $target
     finalize_target $platform $target
@@ -59,6 +62,8 @@ def rewrite_darwin_system_libraries [binary_path: string] {
     )
     match $failed_rewrite {
         null => null
-        $attempt => (error make {msg: $"install_name_tool failed for ($attempt.library)\n($attempt.rewrite.stderr)"})
+        $attempt => (
+            error make {msg: $"install_name_tool failed for ($attempt.library)\n($attempt.rewrite.stderr)"}
+        )
     }
 }

--- a/apps/ccusage/scripts/stage-native-package.nu
+++ b/apps/ccusage/scripts/stage-native-package.nu
@@ -10,43 +10,55 @@ const package_dirs = {
 }
 def main [--platform: string, --arch: string, --binary: string] {
     let key = $"($platform)-($arch)"
-    let package_dir = $package_dirs | get -o $key
-    if $package_dir == null {
-        error make {msg: $"Unsupported native package target: ($key)"}
-    }
+    let package_dir = (match ($package_dirs | get --optional $key) {
+        null => (error make {msg: $"Unsupported native package target: ($key)"})
+        $dir => $dir
+    })
     let script_dir = $env.CURRENT_FILE | path dirname
     let repo_root = [$script_dir, '..', '..', '..'] | path join | path expand
-    let binary_name = if $platform == 'win32' { 'ccusage.exe' } else { 'ccusage' }
     let source = $binary | path expand
     let target_dir = [$repo_root, 'packages', $package_dir, 'bin'] | path join
-    let target = [$target_dir, $binary_name] | path join
+    let target = [$target_dir, (binary_name $platform)] | path join
     mkdir $target_dir
     cp -f $source $target
-    if $platform != 'win32' {
-        chmod 755 $target
-    }
-    if $platform == 'darwin' {
-        rewrite_darwin_system_libraries $target
-    }
+    finalize_target $platform $target
     print $target
+}
+def binary_name [platform: string] {
+    match $platform {
+        'win32' => 'ccusage.exe'
+        _ => 'ccusage'
+    }
+}
+def finalize_target [platform: string, target: path] {
+    match $platform {
+        'win32' => null
+        'darwin' => {
+            chmod 755 $target
+            rewrite_darwin_system_libraries $target
+        }
+        _ => (chmod 755 $target)
+    }
 }
 def rewrite_darwin_system_libraries [binary_path: string] {
     let linked = run-external otool '-L' $binary_path | complete
     if $linked.exit_code != 0 {
         error make {msg: $"otool failed for ($binary_path)\n($linked.stderr)"}
     }
-    for line in ($linked.stdout | lines | skip 1) {
-        let library = (
-            $line | str trim | split row --regex '\s+' | first
-        )
-        if $library =~ '^/nix/store/[^/]+-libiconv-[^/]+/lib/libiconv\.2\.dylib$' {
-            let rewrite = (
-                run-external install_name_tool '-change' $library /usr/lib/libiconv.2.dylib $binary_path
-                | complete
-            )
-            if $rewrite.exit_code != 0 {
-                error make {msg: $"install_name_tool failed for ($library)\n($rewrite.stderr)"}
-            }
+    let failed_rewrite = (
+        $linked.stdout
+        | lines
+        | skip 1
+        | each {|line| $line | str trim | split row --regex '\s+' | first }
+        | where {|library| $library =~ '^/nix/store/[^/]+-libiconv-[^/]+/lib/libiconv\.2\.dylib$' }
+        | each {|library|
+            {library: $library, rewrite: (run-external install_name_tool '-change' $library /usr/lib/libiconv.2.dylib $binary_path | complete)}
         }
+        | where {|attempt| $attempt.rewrite.exit_code != 0 }
+        | get --optional 0
+    )
+    match $failed_rewrite {
+        null => null
+        $attempt => (error make {msg: $"install_name_tool failed for ($attempt.library)\n($attempt.rewrite.stderr)"})
     }
 }

--- a/apps/ccusage/scripts/verify-native-package.nu
+++ b/apps/ccusage/scripts/verify-native-package.nu
@@ -1,27 +1,37 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from ../../.. nixpkgs#nushell --command nu
 def main [] {
-    let package_json = (open package.json)
-    let binary_path = (
-        $package_json.files? | default [] | where {|file| $file | str starts-with 'bin/ccusage' } | first
-    )
-    if ($binary_path | is-empty) {
-        error make {msg: 'Native package binary file is not configured'}
+    let binary_path = (match (configured_binary_path) {
+        null => (error make {msg: 'Native package binary is not configured'})
+        $path => $path
+    })
+    match (binary_issue $binary_path ($binary_path | path expand)) {
+        null => null
+        $issue => (error make {msg: $"Native package binary is not ready: ($issue)"})
     }
-    let resolved_binary_path = $binary_path | path expand
-    try {
-        if not ($resolved_binary_path | path exists) {
-            error make {msg: $"($binary_path) does not exist"}
-        }
-        let entry = ls $resolved_binary_path | first
-        if $entry.type != file {
-            error make {msg: $"($binary_path) is not a file"}
-        }
-        if not ($binary_path | str ends-with '.exe') {
-            let executable = run-external test '-x' $resolved_binary_path | complete
-            if $executable.exit_code != 0 {
-                error make {msg: $"($binary_path) is not executable"}
-            }
-        }
-    } catch {|err| error make {msg: $"Native package binary is not ready: ($err.msg)"} }
+}
+def configured_binary_path [] {
+    open package.json
+    | get --optional files
+    | default []
+    | where {|file| $file | str starts-with 'bin/ccusage' }
+    | get --optional 0
+}
+def binary_issue [binary_path: string, resolved: path] {
+    if not ($resolved | path exists) {
+        return $"($binary_path) does not exist"
+    }
+    match ($resolved | path type) {
+        'file' => (executable_issue $binary_path $resolved)
+        _ => $"($binary_path) is not a file"
+    }
+}
+def executable_issue [binary_path: string, resolved: path] {
+    if ($binary_path | str ends-with '.exe') {
+        return null
+    }
+    match (run-external test '-x' $resolved | complete | get exit_code) {
+        0 => null
+        _ => $"($binary_path) is not executable"
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rewrites the repo Nushell scripts in a more functional style: `match` expressions (including guards, record patterns, and list patterns) replace `if/else` chains and defensive `describe` checks, and pipelines (`where`/`each`/`all`) replace loops and nested conditionals. No behavior changes intended.

- `.github/scripts/upsert-pr-comment.nu`: the update-status dispatch (`ok`/`missing`/`auth`/`error`) is now a `match`; comment author/body extraction uses record patterns and guard patterns instead of `describe =~ '^record'` checks; status classification in `try_update_comment` uses `match` with guards.
- `apps/ccusage/scripts/ensure-native-binary.nu`: nested `if/else` in `is_portable_binary`, `native_package_includes_binary`, and `has_expected_version` split into small functions dispatched via `match` (including a list pattern on `[$target_platform, $binary]`); the package-root scan is a `where`/`each` pipeline.
- `apps/ccusage/scripts/stage-native-package.nu`: package-dir resolution, binary naming, and per-platform finalization dispatch via `match`; the darwin dylib rewrite `for` loop is now a pipeline that collects failed rewrites as values and raises once.
- `apps/ccusage/scripts/verify-native-package.nu`: readiness checks return an issue string or `null` and are dispatched with `match` instead of `try/catch` around imperative checks. Uses `path type`, so a directory at the binary path now correctly reports "is not a file" instead of an incidental `ls` error.

`generate-e2e-fixture.nu` was already pipeline-based and is unchanged.

## CI follow-up

`security & lint preflight` initially failed on `treefmt-check` / nufmt layout. Follow-up commits apply the expected wrapping and rewrite the upsert `where` filter with intermediate `let`s so nufmt does not strip parentheses into invalid syntax. Verified locally with the flake-pinned `nufmt --dry-run` (all five `.nu` scripts already formatted). CI is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f93bd-98a5-7713-948e-5958f5050b7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f93bd-98a5-7713-948e-5958f5050b7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors Nushell scripts to use `match` and pipeline combinators for a clearer, more functional style. Applies `nufmt` layout to satisfy `treefmt-check`; no behavior changes.

- **Refactors**
  - .github/scripts/upsert-pr-comment.nu: extract `find_existing_comment`, `comment_login`, and `comment_body`; dispatch upsert via `match`; centralize `update_or_recreate_comment`; classify update status via `match`; make filter, long signature, and print arms `nufmt`-friendly.
  - apps/ccusage/scripts/ensure-native-binary.nu: add `binary_name`, `manifest_lists_binary`, `linux_binary_is_static`, `darwin_binary_links_only_system_dylibs`, and `reported_version`; use `match` (including list patterns) and pipelines for portability, manifest, and version checks.
  - apps/ccusage/scripts/stage-native-package.nu: select package dir and binary name with `match`; finalize per-platform via `finalize_target`; rewrite darwin dylibs with a pipeline that reports the first failed rewrite.
  - apps/ccusage/scripts/verify-native-package.nu: return readiness issues as values and dispatch with `match`; use `path type` so directories report “is not a file”; skip executability checks for `.exe`.

<sup>Written for commit 07a6cc2d35d4b040fc8ac720a2c11d14eaeede29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native package validation on Linux and macOS, covering binary presence, executability, portability, manifest/bin listing, and `--version` parsing.
  * Enhanced macOS dylib rewriting to surface a single consolidated error when multiple rewrites fail.
  * Increased reliability of automated pull request bot comments by improving how existing comments are detected and updated/recreated, with clearer handling of missing or limited write access.
* **Chores**
  * Streamlined native packaging and release verification logic for clearer, more consistent diagnostics and decision outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->