### PR TITLE
refactor(deps): make Nix the single source for publint and prune dead catalogs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,8 +261,9 @@ jobs:
       # Packing only repackages the native binaries restored from the build
       # matrix below (no Rust build happens here), so the full `nix develop` dev
       # shell is unnecessary. The package checks bring Nu through their Nix
-      # shebangs.
-      - run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs
+      # shebangs; `publint` is the flake's own pinned build, invoked by every
+      # package's prepack script.
+      - run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs .#publint
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,8 +134,9 @@ jobs:
           node-version: lts/*
           package-manager-cache: false
       # node comes from setup-node above (needed for the npm registry auth);
-      # Nushell package checks bring Nu through their Nix shebangs.
-      - run: nix profile install --inputs-from . nixpkgs#pnpm
+      # Nushell package checks bring Nu through their Nix shebangs. `publint` is
+      # the flake's own pinned build, invoked by every package's prepack script.
+      - run: nix profile install --inputs-from . nixpkgs#pnpm .#publint
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/apps/ccusage/package.json
+++ b/apps/ccusage/package.json
@@ -27,8 +27,7 @@
 		"prepack": "pnpm run build"
 	},
 	"devDependencies": {
-		"@types/node": "catalog:types",
-		"publint": "catalog:lint"
+		"@types/node": "catalog:types"
 	},
 	"optionalDependencies": {
 		"@ccusage/ccusage-darwin-arm64": "workspace:*",

--- a/packages/ccusage-darwin-arm64/package.json
+++ b/packages/ccusage-darwin-arm64/package.json
@@ -23,8 +23,5 @@
 	},
 	"scripts": {
 		"prepack": "../../apps/ccusage/scripts/verify-native-package.nu && publint"
-	},
-	"devDependencies": {
-		"publint": "catalog:lint"
 	}
 }

--- a/packages/ccusage-darwin-x64/package.json
+++ b/packages/ccusage-darwin-x64/package.json
@@ -23,8 +23,5 @@
 	},
 	"scripts": {
 		"prepack": "../../apps/ccusage/scripts/verify-native-package.nu && publint"
-	},
-	"devDependencies": {
-		"publint": "catalog:lint"
 	}
 }

--- a/packages/ccusage-linux-arm64/package.json
+++ b/packages/ccusage-linux-arm64/package.json
@@ -23,8 +23,5 @@
 	},
 	"scripts": {
 		"prepack": "../../apps/ccusage/scripts/verify-native-package.nu && publint"
-	},
-	"devDependencies": {
-		"publint": "catalog:lint"
 	}
 }

--- a/packages/ccusage-linux-x64/package.json
+++ b/packages/ccusage-linux-x64/package.json
@@ -23,8 +23,5 @@
 	},
 	"scripts": {
 		"prepack": "../../apps/ccusage/scripts/verify-native-package.nu && publint"
-	},
-	"devDependencies": {
-		"publint": "catalog:lint"
 	}
 }

--- a/packages/ccusage-win32-arm64/package.json
+++ b/packages/ccusage-win32-arm64/package.json
@@ -23,8 +23,5 @@
 	},
 	"scripts": {
 		"prepack": "../../apps/ccusage/scripts/verify-native-package.nu && publint"
-	},
-	"devDependencies": {
-		"publint": "catalog:lint"
 	}
 }

--- a/packages/ccusage-win32-x64/package.json
+++ b/packages/ccusage-win32-x64/package.json
@@ -23,8 +23,5 @@
 	},
 	"scripts": {
 		"prepack": "../../apps/ccusage/scripts/verify-native-package.nu && publint"
-	},
-	"devDependencies": {
-		"publint": "catalog:lint"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,10 +18,6 @@ catalogs:
     vitepress-plugin-llms:
       specifier: ^1.12.2
       version: 1.13.3
-  lint:
-    publint:
-      specifier: ^0.3.12
-      version: 0.3.21
   types:
     '@types/node':
       specifier: ^24.13.2
@@ -39,9 +35,6 @@ importers:
       '@types/node':
         specifier: catalog:types
         version: 24.13.3
-      publint:
-        specifier: catalog:lint
-        version: 0.3.21
     optionalDependencies:
       '@ccusage/ccusage-darwin-arm64':
         specifier: workspace:*
@@ -83,41 +76,17 @@ importers:
         specifier: catalog:docs
         version: 1.13.3
 
-  packages/ccusage-darwin-arm64:
-    devDependencies:
-      publint:
-        specifier: catalog:lint
-        version: 0.3.21
+  packages/ccusage-darwin-arm64: {}
 
-  packages/ccusage-darwin-x64:
-    devDependencies:
-      publint:
-        specifier: catalog:lint
-        version: 0.3.21
+  packages/ccusage-darwin-x64: {}
 
-  packages/ccusage-linux-arm64:
-    devDependencies:
-      publint:
-        specifier: catalog:lint
-        version: 0.3.21
+  packages/ccusage-linux-arm64: {}
 
-  packages/ccusage-linux-x64:
-    devDependencies:
-      publint:
-        specifier: catalog:lint
-        version: 0.3.21
+  packages/ccusage-linux-x64: {}
 
-  packages/ccusage-win32-arm64:
-    devDependencies:
-      publint:
-        specifier: catalog:lint
-        version: 0.3.21
+  packages/ccusage-win32-arm64: {}
 
-  packages/ccusage-win32-x64:
-    devDependencies:
-      publint:
-        specifier: catalog:lint
-        version: 0.3.21
+  packages/ccusage-win32-x64: {}
 
 packages:
 
@@ -323,10 +292,6 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@publint/pack@0.1.5':
-    resolution: {integrity: sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw==}
-    engines: {node: '>=18'}
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
@@ -945,10 +910,6 @@ packages:
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
-  mri@1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -990,11 +951,6 @@ packages:
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
-  publint@0.3.21:
-    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
@@ -1028,10 +984,6 @@ packages:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-
-  sade@1.8.1:
-    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
-    engines: {node: '>=6'}
 
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -1342,10 +1294,6 @@ snapshots:
       import-meta-resolve: 4.2.0
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@publint/pack@0.1.5':
-    dependencies:
-      tinyexec: 1.2.4
 
   '@rolldown/pluginutils@1.0.1': {}
 
@@ -2016,8 +1964,6 @@ snapshots:
 
   minisearch@7.2.0: {}
 
-  mri@1.2.0: {}
-
   ms@2.1.3: {}
 
   nanoid@3.3.16: {}
@@ -2049,13 +1995,6 @@ snapshots:
   pretty-bytes@7.1.1: {}
 
   property-information@7.2.0: {}
-
-  publint@0.3.21:
-    dependencies:
-      '@publint/pack': 0.1.5
-      package-manager-detector: 1.7.0
-      picocolors: 1.1.1
-      sade: 1.8.1
 
   punycode.js@2.3.1: {}
 
@@ -2134,10 +2073,6 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.62.2
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
-
-  sade@1.8.1:
-    dependencies:
-      mri: 1.2.0
 
   section-matter@1.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,19 +11,6 @@ catalogs:
     vitepress: 2.0.0-alpha.17
     vitepress-plugin-group-icons: ^1.7.2
     vitepress-plugin-llms: ^1.12.2
-  llm-docs:
-    '@gunshi/docs': ^0.31.0
-  runtime:
-    '@antfu/utils': ^9.2.1
-    '@praha/byethrow': ^0.11.2
-    ansi-escapes: ^7.3.0
-    arkregex: ^0.0.5
-    get-stdin: ^10.0.0
-    gunshi: ^0.31.0
-    picospinner: ^3.0.0
-    type-fest: ^5.7.0
-    valibot: ^1.4.1
-    xdg-basedir: ^5.1.0
   types:
     '@types/node': ^24.13.2
     '@types/react': ^19.2.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,8 +11,6 @@ catalogs:
     vitepress: 2.0.0-alpha.17
     vitepress-plugin-group-icons: ^1.7.2
     vitepress-plugin-llms: ^1.12.2
-  lint:
-    publint: ^0.3.12
   llm-docs:
     '@gunshi/docs': ^0.31.0
   runtime:


### PR DESCRIPTION
## Summary

`publint` was pinned in two places: the pnpm `lint` catalog (expanded into the devDependencies of `ccusage` and all six native packages) and the bun2nix-built `nix/tools/publint` used by the `publint` flake check and the dev shell. Nothing kept the two pins in sync. This drops the pnpm copies and keeps the Nix build as the only pin.

While auditing `pnpm-workspace.yaml`, two more catalogs turned out to have no consumers at all, so they are removed in a follow-up commit.

## What Changed

- Removed the `lint` catalog and the `publint` devDependency from `apps/ccusage` and `packages/ccusage-*`; regenerated `pnpm-lock.yaml` (4 packages fewer).
- Added `.#publint` to the `nix profile install` line of the two publish jobs (`release.yaml` npm job, `ci.yaml` pkg-pr-new job). These jobs deliberately skip the full dev shell, so they need the tool requested explicitly.
- Removed the `runtime` and `llm-docs` catalogs. `runtime` lost its last reference when the TypeScript CLI was replaced by the Rust binary (#1306) and `llm-docs` when the gunshi docs dependency was dropped; Renovate has been bumping specifiers no package resolves (#1350, #1351). `docs` and `types` are still in use and stay.

## Why

The `build`/`prepack` scripts call bare `publint`, which resolves from PATH — the dev shell and `just ccusage::build-package` already provided the Nix build, so the pnpm copy only mattered inside the publish jobs. Supplying it there from the flake collapses the two pins into one without changing what runs.

Both publint invocations are kept on purpose: `prepack` packs a real tarball, while the flake check runs `--pack false` against stubbed generated files. They cover different failure modes.

Removing the pnpm copy means `pnpm publish` in a bare non-Nix checkout no longer has `publint` on PATH. Releases run through Nix, so that path is not exercised.

## Testing

- `nix build .#checks.aarch64-darwin.publint` — all 7 packages "All good!"
- `nix build .#publint`, `nix eval .#publint.meta.mainProgram` — the attr the CI jobs install resolves
- `pnpm --filter ccusage exec publint --version` → `publint, 0.3.12`, resolved from the Nix store after the devDependency removal
- `pnpm install --frozen-lockfile` — lockfile in sync; dropping the dead catalogs left it untouched, confirming they never reached it
- `just fmt`, `prek run --from-ref main --to-ref HEAD` — clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Nix the single source of `publint` to avoid version drift and simplify the workspace. CI now installs flake `.#publint` so prepack checks keep working.

- **Dependencies**
  - Removed `publint` from `apps/ccusage` and all native package devDependencies; deleted the `lint` catalog; lockfile shrinks by 4 packages.
  - Updated `ci.yaml` and `release.yaml` to install `.#publint` with `nix profile install` (alongside `nixpkgs#pnpm` and, in CI, `nixpkgs#nodejs`).
  - Pruned unused `runtime` and `llm-docs` catalogs; kept `docs` and `types`.

<sup>Written for commit 092ab89a12b5490e593ff700a815c248652f3d2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved package publishing checks to validate package contents before release.
  - Streamlined development tooling used during package creation and publication.
  - Updated platform-specific package preparation workflows for more consistent releases.
  - Cleaned up outdated documentation-related tooling configuration.

- **Bug Fixes**
  - Reduced the risk of publishing incomplete or incorrectly configured packages.

- **User Impact**
  - No changes to application functionality or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->