### PR TITLE
fix(nix): apply the repository cargo config to Nix builds

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -23,6 +23,12 @@ let
       || lib.hasSuffix "/models-dev-pricing.json" path
       || lib.hasSuffix "/codex-auto-review-fallbacks.json" path;
   };
+  # sqlite3-src's build script turns every SQLITE_* environment variable into a -D
+  # define for the bundled amalgamation, which is how .cargo/config.toml trims it.
+  # Cargo only reads that file when the working directory is the repository root, and
+  # no Nix build has that, so the same values are passed through here rather than
+  # duplicated.
+  cargoConfigEnv = (builtins.fromTOML (builtins.readFile (root + /.cargo/config.toml))).env;
   commonArgs = {
     pname = "ccusage";
     inherit version src;
@@ -54,7 +60,8 @@ let
     buildInputs = lib.optionals stdenv.isDarwin [
       apple-sdk_15
     ];
-  };
+  }
+  // cargoConfigEnv;
   # Keep the dependency artifact keyed only by inputs that affect Cargo deps.
   # Pricing snapshots and the npm release version are embedded by the final
   # package. The Rust workspace packages intentionally stay at 0.0.0, and the


### PR DESCRIPTION
## Summary

`.cargo/config.toml` sets 47 `SQLITE_OMIT_*` values in its `[env]` section, and
`sqlite3-src`'s build script turns every `SQLITE_*` environment variable into a `-D`
define for the bundled amalgamation. That is how this repository trims SQLite down to
what the four SQLite-backed adapters actually use.

Cargo only reads that file when the working directory is the repository root, so it
applied to local `cargo` runs and to nothing else. Every Nix build unpacks a source
tree rooted at `rust/`, so all of them — the artifact layers, the flake checks, and
the binaries the release ships — compiled the full SQLite.

package.nix now reads the same file rather than duplicating the values, so there is
still one source of truth and the two cannot drift.

## Effect

| | bytes |
| --- | --- |
| before | 3,232,896 |
| after | 3,030,272 |

−202,624 bytes, −6.3%, on the aarch64-darwin Nix build. For scale, that is more than
the whole size cost of the crate split in #1428.

## Correctness

The omit flags remove SQLite features, so the risk is a query needing one of them.
These values already applied to every local `cargo test` run, which is what exercises
the adapters' queries, but never to a Nix-built binary — so this is the first time a
shipped binary would carry them. Checked directly by diffing the old and new Nix
binaries against real local data:

- `opencode daily --json --offline` — identical
- `goose daily --json --offline` — identical
- `kilo daily --json --offline` — identical
- `hermes daily --json --offline` — identical
- `daily --json --offline` (unified) — identical

## Testing

- `nix build .#ccusage .#ccusage-tests .#checks.aarch64-darwin.ccusage-clippy .#checks.aarch64-darwin.config-schema`
- `just fmt`
- the five output comparisons above

Found while reviewing the diff of #1428; the condition predates it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply the repository `.cargo/config.toml` `[env]` to Nix builds so `SQLITE_OMIT_*` flags from `sqlite3-src` are honored, matching local cargo builds. Shipped binaries shrink by 202,624 bytes (-6.3% on aarch64-darwin) with identical adapter JSON outputs, and the flags now come from a single source of truth.

<sup>Written for commit e39937543975fc2d269e9d6b0be4ab1b9a3221d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package builds by ensuring required SQLite build settings are applied consistently.
  * Increased reliability when building the bundled SQLite component through Nix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->