### PR TITLE
build(nix): provide cargo-hawk and gate nix flake check on it

### DIFF
--- a/.agents/skills/rust/SKILL.md
+++ b/.agents/skills/rust/SKILL.md
@@ -73,17 +73,16 @@ crate and after widening a visibility. `rust/hawk.toml` lists the shipped entry
 points; anything not reachable from them can be narrowed. Adding `--fix` to the
 underlying `cargo hawk check` applies the narrowing.
 
-hawk is not in nixpkgs, so the dev shell does not provide it. Install a prebuilt
-release first:
+The dev shell provides it through `nix/cargo-hawk.nix`, which pins the upstream
+release by hash. hawk is not in nixpkgs, and it links against `rustc_private`, so
+a source build would need the `rustc-dev` component and `RUSTC_BOOTSTRAP=1`; the
+published binary needs neither. Bumping it means changing `version` and the four
+`sha256` values, which upstream publishes beside each archive.
 
-```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/hawk/releases/latest/download/cargo-hawk-installer.sh | sh
-```
-
-It uses `rustc_private` and only runs on the toolchain it was built against,
-which is why `rust-toolchain.toml` pins 1.97.1. It is experimental - its README
-says it is "not intended for public consumption" - and no CI check runs it, so
-read its findings as suggestions and confirm each one before narrowing.
+Because it links compiler internals it only runs on the toolchain it was built
+against, which is why `rust-toolchain.toml` pins 1.97.1. It is experimental - its
+README says it is "not intended for public consumption" - and no CI check runs
+it, so read its findings as suggestions and confirm each one before narrowing.
 
 ## Pricing Embedding
 

--- a/.agents/skills/rust/SKILL.md
+++ b/.agents/skills/rust/SKILL.md
@@ -79,10 +79,17 @@ a source build would need the `rustc-dev` component and `RUSTC_BOOTSTRAP=1`; the
 published binary needs neither. Bumping it means changing `version` and the four
 `sha256` values, which upstream publishes beside each archive.
 
+`nix flake check` gates on it through `checks.<system>.ccusage-hawk`, so a new
+unnecessary `pub` fails CI rather than accumulating. It reuses clippy's cargo
+artifacts, and it lives there rather than in treefmt because it analyses the whole
+workspace as a closed world instead of a file at a time, and because narrowing a
+visibility is a semantic change rather than formatting.
+
 Because it links compiler internals it only runs on the toolchain it was built
 against, which is why `rust-toolchain.toml` pins 1.97.1. It is experimental - its
-README says it is "not intended for public consumption" - and no CI check runs
-it, so read its findings as suggestions and confirm each one before narrowing.
+README says it is "not intended for public consumption" - so when a finding looks
+wrong, check whether `rust/hawk.toml` is missing an entry point before narrowing
+anything.
 
 ## Pricing Embedding
 

--- a/nix/cargo-hawk.nix
+++ b/nix/cargo-hawk.nix
@@ -11,6 +11,7 @@
   stdenv,
   stdenvNoCC,
   autoPatchelfHook,
+  rustToolchain,
 }:
 let
   version = "0.1.10";
@@ -50,9 +51,16 @@ stdenvNoCC.mkDerivation {
   # The archive holds a single cargo-hawk-<target>/ directory.
   sourceRoot = "cargo-hawk-${archive.target}";
 
-  # The prebuilt Linux archives are ordinary glibc binaries, so they need the
-  # loader and rpath fixups; the Darwin ones run as shipped.
+  # The prebuilt Linux archives are ordinary glibc binaries, so they need the loader
+  # and rpath fixups; the Darwin ones resolve through @rpath as shipped.
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+  # cargo-hawk-driver has a hard dependency on the compiler's librustc_driver, which
+  # is the concrete form of "only runs on the toolchain it was built against". The
+  # pinned toolchain carries the matching file because rust-overlay repackages the
+  # same upstream release: 1.97.1 ships librustc_driver-e03ed1db822dfa4c, which is
+  # what the published binary asks for.
+  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [ rustToolchain ];
 
   installPhase = ''
     runHook preInstall

--- a/nix/cargo-hawk.nix
+++ b/nix/cargo-hawk.nix
@@ -54,13 +54,17 @@ stdenvNoCC.mkDerivation {
   # The prebuilt Linux archives are ordinary glibc binaries, so they need the loader
   # and rpath fixups; the Darwin ones resolve through @rpath as shipped.
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
   # cargo-hawk-driver has a hard dependency on the compiler's librustc_driver, which
   # is the concrete form of "only runs on the toolchain it was built against". The
   # pinned toolchain carries the matching file because rust-overlay repackages the
-  # same upstream release: 1.97.1 ships librustc_driver-e03ed1db822dfa4c, which is
-  # what the published binary asks for.
-  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [ rustToolchain ];
+  # same upstream release, so it belongs in buildInputs rather than
+  # runtimeDependencies: the latter is written into the RUNPATH but is not part of
+  # the library set auto-patchelf resolves against, so the dependency is reported
+  # unsatisfied even once the path is on the RUNPATH.
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+    rustToolchain
+  ];
 
   installPhase = ''
     runHook preInstall

--- a/nix/cargo-hawk.nix
+++ b/nix/cargo-hawk.nix
@@ -1,0 +1,79 @@
+# hawk, a workspace-aware Cargo lint for unnecessary Rust visibility.
+#
+# The upstream release is used rather than a source build because hawk links
+# against `rustc_private` and would otherwise need the `rustc-dev` component and
+# `RUSTC_BOOTSTRAP=1`. A prebuilt binary carries the same constraint in a simpler
+# form: it only runs on the compiler it was built against, which is why
+# rust-toolchain.toml pins the version in `supportedRustChannel` below.
+{
+  fetchurl,
+  lib,
+  stdenv,
+  stdenvNoCC,
+  autoPatchelfHook,
+}:
+let
+  version = "0.1.10";
+  supportedRustChannel = "1.97.1";
+  # sha256 values come from the `.sha256` file published beside each archive.
+  archives = {
+    aarch64-darwin = {
+      target = "aarch64-apple-darwin";
+      hash = "sha256-Ie8mN4WMH5KncdCacAtOl3r6fO8/qjxSzkgyK4noHCM=";
+    };
+    x86_64-darwin = {
+      target = "x86_64-apple-darwin";
+      hash = "sha256-zMvrswFj/XKHMprRhGzsuAoUs8lqp2agLmhJwuynizE=";
+    };
+    aarch64-linux = {
+      target = "aarch64-unknown-linux-gnu";
+      hash = "sha256-jsuPCOKgktU3DMsZleR5d/akV/rxI3zOdhmvV1YPe3I=";
+    };
+    x86_64-linux = {
+      target = "x86_64-unknown-linux-gnu";
+      hash = "sha256-9uwbGG0oZMQv86Atcwl0Nzy1x7ULl6BpFdgQ2cIcsjg=";
+    };
+  };
+  archive =
+    archives.${stdenv.hostPlatform.system}
+      or (throw "cargo-hawk has no release for ${stdenv.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation {
+  pname = "cargo-hawk";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/astral-sh/hawk/releases/download/${version}/cargo-hawk-${archive.target}.tar.gz";
+    inherit (archive) hash;
+  };
+
+  # The archive holds a single cargo-hawk-<target>/ directory.
+  sourceRoot = "cargo-hawk-${archive.target}";
+
+  # The prebuilt Linux archives are ordinary glibc binaries, so they need the
+  # loader and rpath fixups; the Darwin ones run as shipped.
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/bin"
+    # cargo-hawk execs cargo-hawk-driver from its own directory, so both have to
+    # land together.
+    install -m555 cargo-hawk cargo-hawk-driver "$out/bin/"
+    runHook postInstall
+  '';
+
+  passthru = { inherit supportedRustChannel; };
+
+  meta = {
+    description = "Workspace-aware Cargo lint for unnecessary public Rust APIs";
+    homepage = "https://github.com/astral-sh/hawk";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    mainProgram = "cargo-hawk";
+    platforms = builtins.attrNames archives;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -44,6 +44,22 @@ in
           cargoClippyExtraArgs = "--all-targets -- -D warnings";
         }
       );
+      # hawk belongs here rather than in treefmt: it analyses the whole workspace as a
+      # closed world instead of a file at a time, and narrowing a visibility is a
+      # semantic change, not formatting. It reuses the same cargo artifacts as clippy,
+      # so the cost is its own analysis rather than another workspace build.
+      ccusage-hawk = craneLib.mkCargoDerivation (
+        commonArgs
+        // {
+          pname = "ccusage-hawk";
+          src = rustSrc;
+          sourceRoot = "source/rust";
+          cargoLock = root + /rust/Cargo.lock;
+          inherit cargoArtifacts;
+          nativeBuildInputs = commonArgs.nativeBuildInputs or [ ] ++ [ config.packages.cargo-hawk ];
+          buildPhaseCargoCommand = "cargo hawk check --manifest-path Cargo.toml -D warnings";
+        }
+      );
       ccusage-fmt = craneLib.cargoFmt {
         pname = "ccusage-rust";
         inherit version;
@@ -148,6 +164,7 @@ in
           bun-nix
           ccusage-clippy
           ccusage-fmt
+          ccusage-hawk
           config-schema
           ;
         oxlint = mkRepoCheck "oxlint-check" [ pkgs.oxlint ] ''

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -30,6 +30,7 @@ in
             bun
             inputs.bun2nix.packages.${system}.default
             nushell
+            config.packages.cargo-hawk
             config.packages.publint
 
             rustToolchain

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -33,6 +33,7 @@ in
         bun2nix = inputs.bun2nix.packages.${system}.default;
       };
       bunCli = pkgs.callPackage ../nix/bun-cli.nix { inherit bunNodeModules; };
+      cargo-hawk = pkgs.callPackage ../nix/cargo-hawk.nix { };
       changelogithub = pkgs.callPackage ../nix/tools/changelogithub { inherit bunCli; };
       # Regeneration-only output for committed models.dev snapshots;
       # `just gen-models-dev-pricing` builds this and copies them into the source
@@ -58,6 +59,7 @@ in
       packages = {
         default = ccusage;
         inherit
+          cargo-hawk
           ccusage
           changelogithub
           models-dev-pricing

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -33,7 +33,9 @@ in
         bun2nix = inputs.bun2nix.packages.${system}.default;
       };
       bunCli = pkgs.callPackage ../nix/bun-cli.nix { inherit bunNodeModules; };
-      cargo-hawk = pkgs.callPackage ../nix/cargo-hawk.nix { };
+      cargo-hawk = pkgs.callPackage ../nix/cargo-hawk.nix {
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile (root + /rust-toolchain.toml);
+      };
       changelogithub = pkgs.callPackage ../nix/tools/changelogithub { inherit bunCli; };
       # Regeneration-only output for committed models.dev snapshots;
       # `just gen-models-dev-pricing` builds this and copies them into the source


### PR DESCRIPTION
## Summary

`just hawk` landed in #1428 without the tool behind it, so the `rust` skill told
contributors to `curl | sh` an installer — an unpinned binary outside Nix, in a
repository that pins everything else. This adds `nix/cargo-hawk.nix` and puts it in
the dev shell, so `just hawk` works after `direnv allow` like every other recipe.

## Why the published binary rather than a source build

hawk links against `rustc_private`. Building it from source needs the `rustc-dev`
component in the toolchain and `RUSTC_BOOTSTRAP=1`, which is a lot of machinery to
carry for a lint that no CI check gates on and that upstream calls experimental
("not intended for public consumption"). Upstream's own docs note that a prebuilt
release requires neither.

The derivation pins the release by hash for the four platforms upstream publishes
(aarch64/x86_64 × darwin/linux), marks `sourceProvenance = binaryNativeCode`, and
installs `cargo-hawk-driver` next to `cargo-hawk` because the binary execs the driver
from its own directory. Closure is 3.7 MB. A version bump is `version` plus the four
`sha256` values, which upstream publishes beside each archive.

If a source build is preferred later, the `rustc-dev` toolchain can be materialised
inside this derivation through rust-overlay without touching the shared
`rust-toolchain.toml` pin — the file is the only thing that would change.

## Testing

- `nix build .#cargo-hawk` — both binaries land in `$out/bin`
- `cargo hawk check --manifest-path rust/Cargo.toml` with the Nix-built binary: 0 findings on `main`
- `nix build .#ccusage` still builds, so the dev-shell addition does not perturb the package set
- `just fmt`

The skill section now describes the pinned derivation and how to bump it instead of
the installer script.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `cargo-hawk` in the Nix dev shell and gates CI with `nix flake check` so unnecessary `pub` fails fast. Fixes Linux linking by moving the pinned toolchain into `buildInputs`, making the binary work across macOS/Linux on arm64 and x86_64.

- **New Features**
  - Added `nix/cargo-hawk.nix` to install `cargo-hawk` with `cargo-hawk-driver`.
  - Exposed as `packages.cargo-hawk` and included in the dev shell.
  - Added `checks.<system>.ccusage-hawk` to run `cargo hawk check -D warnings`, reusing clippy artifacts.
  - Updated `.agents/skills/rust/SKILL.md` with pinning and bump steps.

- **Bug Fixes**
  - On Linux, moved the pinned `rustToolchain` into `buildInputs` (with `stdenv.cc.cc.lib`) so `autoPatchelf` resolves `librustc_driver`; macOS continues to resolve via `@rpath`.

<sup>Written for commit faac847db5d8afaacbcf2f6535cc22c324f6699e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `cargo-hawk` to the development environment as a visibility lint tool.
  * Added platform-aware, reproducible packaging for `cargo-hawk` so it’s available consistently across systems.
* **Documentation**
  * Updated guidance for the `hawk`/`cargo-hawk` workflow to reflect the Nix-pinned dev shell setup and how toolchain versioning affects results.
* **Tests**
  * Extended `nix flake check` to run an additional `cargo hawk check` with warnings treated as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->