### PR TITLE
feat: add `--last` to report the most recent N periods

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -142,6 +142,9 @@ bunx ccusage daily --by-agent --json
 
 # Filters and options
 bunx ccusage daily --since 2026-04-25 --until 2026-05-16
+bunx ccusage daily --last 1  # Today
+bunx ccusage weekly --last 1  # This week
+bunx ccusage monthly --last 1  # This month
 bunx ccusage daily --json  # JSON output
 bunx ccusage daily --no-cost  # Hide cost columns and JSON cost fields
 bunx ccusage daily --timezone UTC  # Use UTC timezone
@@ -167,6 +170,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 🤖 **Model Tracking**: See which models are used across supported sources
 - 📊 **Model Breakdown**: View per-model cost breakdown with `--breakdown` flag
 - 📅 **Date Filtering**: Filter reports by date range using `--since` and `--until`
+- ⏱️ **Recent Periods**: Jump to today, this week, or this month with `--last 1` on any daily, weekly, or monthly report
 - 📁 **Custom Paths**: Support for custom local data directory locations
 - 🎨 **Beautiful Output**: Colorful table-formatted display with automatic responsive layout
 - 📱 **Smart Tables**: Automatic compact mode for narrow terminals (< 100 characters) with essential columns

--- a/docs/guide/cli-options.md
+++ b/docs/guide/cli-options.md
@@ -37,7 +37,7 @@ ccusage monthly --last 1
 
 # The last seven days, and the last three months
 ccusage daily --last 7
-ccusage monthly -l 3
+ccusage monthly --last 3
 ```
 
 The count is inclusive of the current period, so `--last 2` on a daily report covers yesterday and today. Weeks start on the same day the report buckets by, which is Monday everywhere except `ccusage claude weekly`, where `--start-of-week` decides.
@@ -333,17 +333,16 @@ LOG_LEVEL=0 ccusage daily --json
 
 Many options have short aliases for convenience:
 
-| Long Option   | Short | Description           |
-| ------------- | ----- | --------------------- |
-| `--json`      | `-j`  | JSON output           |
-| `--breakdown` | `-b`  | Per-model breakdown   |
-| `--offline`   | `-O`  | Offline mode          |
-| `--timezone`  | `-z`  | Set timezone          |
-| `--last`      | `-l`  | Most recent N periods |
-| `--instances` | `-i`  | Group by project      |
-| `--project`   | `-p`  | Filter project        |
-| `--active`    | `-a`  | Active block only     |
-| `--recent`    | `-r`  | Recent blocks         |
+| Long Option   | Short | Description         |
+| ------------- | ----- | ------------------- |
+| `--json`      | `-j`  | JSON output         |
+| `--breakdown` | `-b`  | Per-model breakdown |
+| `--offline`   | `-O`  | Offline mode        |
+| `--timezone`  | `-z`  | Set timezone        |
+| `--instances` | `-i`  | Group by project    |
+| `--project`   | `-p`  | Filter project      |
+| `--active`    | `-a`  | Active block only   |
+| `--recent`    | `-r`  | Recent blocks       |
 
 ## Related Documentation
 

--- a/docs/guide/cli-options.md
+++ b/docs/guide/cli-options.md
@@ -21,6 +21,29 @@ ccusage monthly --since 20260101
 ccusage session --until 20260531
 ```
 
+### Recent Periods
+
+Instead of working out dates, ask for the most recent periods of whatever the report groups by:
+
+```bash
+# Today
+ccusage daily --last 1
+
+# This week
+ccusage weekly --last 1
+
+# This month
+ccusage monthly --last 1
+
+# The last seven days, and the last three months
+ccusage daily --last 7
+ccusage monthly -l 3
+```
+
+The count is inclusive of the current period, so `--last 2` on a daily report covers yesterday and today. Weeks start on the same day the report buckets by, which is Monday everywhere except `ccusage claude weekly`, where `--start-of-week` decides.
+
+`--last` works on every daily, weekly, and monthly report, including the per-agent ones such as `ccusage codex daily --last 1`. It is not available on `session`, `blocks`, or `statusline`, which have no calendar period, and it cannot be combined with `--since`, `--until`, or `--sections`.
+
 ### Output Format
 
 Control how data is displayed:
@@ -310,16 +333,17 @@ LOG_LEVEL=0 ccusage daily --json
 
 Many options have short aliases for convenience:
 
-| Long Option   | Short | Description         |
-| ------------- | ----- | ------------------- |
-| `--json`      | `-j`  | JSON output         |
-| `--breakdown` | `-b`  | Per-model breakdown |
-| `--offline`   | `-O`  | Offline mode        |
-| `--timezone`  | `-z`  | Set timezone        |
-| `--instances` | `-i`  | Group by project    |
-| `--project`   | `-p`  | Filter project      |
-| `--active`    | `-a`  | Active block only   |
-| `--recent`    | `-r`  | Recent blocks       |
+| Long Option   | Short | Description           |
+| ------------- | ----- | --------------------- |
+| `--json`      | `-j`  | JSON output           |
+| `--breakdown` | `-b`  | Per-model breakdown   |
+| `--offline`   | `-O`  | Offline mode          |
+| `--timezone`  | `-z`  | Set timezone          |
+| `--last`      | `-l`  | Most recent N periods |
+| `--instances` | `-i`  | Group by project      |
+| `--project`   | `-p`  | Filter project        |
+| `--active`    | `-a`  | Active block only     |
+| `--recent`    | `-r`  | Recent blocks         |
 
 ## Related Documentation
 

--- a/docs/guide/daily-reports.md
+++ b/docs/guide/daily-reports.md
@@ -67,6 +67,21 @@ ccusage daily --since 20260510 --until 20260516
 ccusage daily --since 20260501
 ```
 
+### Recent Days
+
+Skip the date arithmetic when you only want the days just gone:
+
+```bash
+# Today
+ccusage daily --last 1
+
+# The last seven days, including today
+ccusage daily --last 7
+ccusage daily -l 7
+```
+
+`--last` cannot be combined with `--since` or `--until`. See [Command-Line Options](/guide/cli-options#recent-periods) for how it behaves on the other reports.
+
 ### Sort Order
 
 Control the order of dates:

--- a/docs/guide/daily-reports.md
+++ b/docs/guide/daily-reports.md
@@ -77,7 +77,6 @@ ccusage daily --last 1
 
 # The last seven days, including today
 ccusage daily --last 7
-ccusage daily -l 7
 ```
 
 `--last` cannot be combined with `--since` or `--until`. See [Command-Line Options](/guide/cli-options#recent-periods) for how it behaves on the other reports.

--- a/docs/guide/monthly-reports.md
+++ b/docs/guide/monthly-reports.md
@@ -81,7 +81,6 @@ ccusage monthly --last 1
 
 # This month and the five before it
 ccusage monthly --last 6
-ccusage monthly -l 6
 ```
 
 `--last` cannot be combined with `--since` or `--until`.

--- a/docs/guide/monthly-reports.md
+++ b/docs/guide/monthly-reports.md
@@ -71,6 +71,21 @@ ccusage monthly --since $(date -d '6 months ago' +%Y%m%d)
 Even though you specify full dates (YYYYMMDD), monthly reports group by month. The filters determine which months to include.
 :::
 
+### Recent Months
+
+`--last` counts whole months, so the shell date arithmetic above is not needed:
+
+```bash
+# This month so far
+ccusage monthly --last 1
+
+# This month and the five before it
+ccusage monthly --last 6
+ccusage monthly -l 6
+```
+
+`--last` cannot be combined with `--since` or `--until`.
+
 ### Sort Order
 
 ```bash

--- a/docs/guide/weekly-reports.md
+++ b/docs/guide/weekly-reports.md
@@ -69,6 +69,21 @@ ccusage weekly --since 20260501 --until 20260531
 ccusage weekly --since 20260420
 ```
 
+### Recent Weeks
+
+Count back in whole weeks instead of dates:
+
+```bash
+# This week so far
+ccusage weekly --last 1
+
+# This week and the three before it
+ccusage weekly --last 4
+ccusage weekly -l 4
+```
+
+The window starts on the same weekday the report buckets by, so `ccusage claude weekly --last 1 -w monday` starts on Monday. `--last` cannot be combined with `--since` or `--until`.
+
 ### Sort Order
 
 Control the order of weeks:

--- a/docs/guide/weekly-reports.md
+++ b/docs/guide/weekly-reports.md
@@ -79,7 +79,6 @@ ccusage weekly --last 1
 
 # This week and the three before it
 ccusage weekly --last 4
-ccusage weekly -l 4
 ```
 
 The window starts on the same weekday the report buckets by, so `ccusage claude weekly --last 1 -w monday` starts on Monday. `--last` cannot be combined with `--since` or `--until`.

--- a/rust/crates/ccusage-cli-parser/src/cli-commands.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-commands.json
@@ -1,12 +1,18 @@
 {
 	"combinedOptions": {
+		"agent_period_options": ["agent_options", "last_options"],
+		"all_agent_period_options": ["all_agent_options", "last_options"],
 		"all_agent_session_options": ["all_agent_options", "session_options"],
 		"blocks_combined_options": ["shared_claude_options", "blocks_options"],
-		"claude_daily_options": ["shared_claude_options", "daily_options"],
+		"claude_daily_options": ["shared_claude_options", "daily_options", "last_options"],
+		"claude_monthly_options": ["shared_claude_options", "last_options"],
 		"claude_session_options": ["shared_claude_options", "session_options"],
-		"claude_weekly_options": ["shared_claude_options", "weekly_options"],
+		"claude_weekly_options": ["shared_claude_options", "weekly_options", "last_options"],
+		"codex_period_options": ["codex_options", "last_options"],
 		"openclaw_combined_options": ["agent_options", "openclaw_options"],
-		"pi_combined_options": ["agent_options", "pi_options"]
+		"openclaw_period_options": ["agent_options", "openclaw_options", "last_options"],
+		"pi_combined_options": ["agent_options", "pi_options"],
+		"pi_period_options": ["agent_options", "pi_options", "last_options"]
 	},
 	"root": {
 		"usage": ["ccusage [daily] <OPTIONS>", "ccusage <COMMANDS>"],
@@ -102,19 +108,19 @@
 			"path": ["daily"],
 			"description": "Show all detected coding (agent) CLI usage grouped by date",
 			"usage": "ccusage daily <OPTIONS>",
-			"options": "all_agent_options"
+			"options": "all_agent_period_options"
 		},
 		{
 			"path": ["monthly"],
 			"description": "Show all detected coding (agent) CLI usage grouped by month",
 			"usage": "ccusage monthly <OPTIONS>",
-			"options": "all_agent_options"
+			"options": "all_agent_period_options"
 		},
 		{
 			"path": ["weekly"],
 			"description": "Show all detected coding (agent) CLI usage grouped by week",
 			"usage": "ccusage weekly <OPTIONS>",
-			"options": "all_agent_options"
+			"options": "all_agent_period_options"
 		},
 		{
 			"path": ["session"],
@@ -175,7 +181,7 @@
 			"path": ["claude", "monthly"],
 			"description": "Show usage report grouped by month",
 			"usage": "ccusage claude monthly <OPTIONS>",
-			"options": "shared_claude_options"
+			"options": "claude_monthly_options"
 		},
 		{
 			"path": ["claude", "weekly"],
@@ -224,13 +230,13 @@
 			"path": ["codex", "daily"],
 			"description": "Show Codex token usage grouped by day",
 			"usage": "ccusage codex daily <OPTIONS>",
-			"options": "codex_options"
+			"options": "codex_period_options"
 		},
 		{
 			"path": ["codex", "monthly"],
 			"description": "Show Codex token usage grouped by month",
 			"usage": "ccusage codex monthly <OPTIONS>",
-			"options": "codex_options"
+			"options": "codex_period_options"
 		},
 		{
 			"path": ["codex", "session"],
@@ -265,19 +271,19 @@
 			"path": ["opencode", "daily"],
 			"description": "Show OpenCode token usage grouped by day",
 			"usage": "ccusage opencode daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["opencode", "weekly"],
 			"description": "Show OpenCode token usage grouped by week",
 			"usage": "ccusage opencode weekly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["opencode", "monthly"],
 			"description": "Show OpenCode token usage grouped by month",
 			"usage": "ccusage opencode monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["opencode", "session"],
@@ -308,13 +314,13 @@
 			"path": ["amp", "daily"],
 			"description": "Show Amp token usage grouped by day",
 			"usage": "ccusage amp daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["amp", "monthly"],
 			"description": "Show Amp token usage grouped by month",
 			"usage": "ccusage amp monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["amp", "session"],
@@ -345,13 +351,13 @@
 			"path": ["droid", "daily"],
 			"description": "Show Droid usage grouped by date",
 			"usage": "ccusage droid daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["droid", "monthly"],
 			"description": "Show Droid usage grouped by month",
 			"usage": "ccusage droid monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["droid", "session"],
@@ -382,13 +388,13 @@
 			"path": ["codebuff", "daily"],
 			"description": "Show Codebuff usage grouped by date",
 			"usage": "ccusage codebuff daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["codebuff", "monthly"],
 			"description": "Show Codebuff usage grouped by month",
 			"usage": "ccusage codebuff monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["codebuff", "session"],
@@ -419,13 +425,13 @@
 			"path": ["hermes", "daily"],
 			"description": "Show Hermes usage grouped by date",
 			"usage": "ccusage hermes daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["hermes", "monthly"],
 			"description": "Show Hermes usage grouped by month",
 			"usage": "ccusage hermes monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["hermes", "session"],
@@ -456,13 +462,13 @@
 			"path": ["pi", "daily"],
 			"description": "Show pi-agent usage grouped by date",
 			"usage": "ccusage pi daily <OPTIONS>",
-			"options": "pi_combined_options"
+			"options": "pi_period_options"
 		},
 		{
 			"path": ["pi", "monthly"],
 			"description": "Show pi-agent usage grouped by month",
 			"usage": "ccusage pi monthly <OPTIONS>",
-			"options": "pi_combined_options"
+			"options": "pi_period_options"
 		},
 		{
 			"path": ["pi", "session"],
@@ -493,13 +499,13 @@
 			"path": ["goose", "daily"],
 			"description": "Show Goose usage grouped by date",
 			"usage": "ccusage goose daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["goose", "monthly"],
 			"description": "Show Goose usage grouped by month",
 			"usage": "ccusage goose monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["goose", "session"],
@@ -530,13 +536,13 @@
 			"path": ["kilo", "daily"],
 			"description": "Show Kilo usage grouped by date",
 			"usage": "ccusage kilo daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["kilo", "monthly"],
 			"description": "Show Kilo usage grouped by month",
 			"usage": "ccusage kilo monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["kilo", "session"],
@@ -567,13 +573,13 @@
 			"path": ["copilot", "daily"],
 			"description": "Show GitHub Copilot CLI usage grouped by date",
 			"usage": "ccusage copilot daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["copilot", "monthly"],
 			"description": "Show GitHub Copilot CLI usage grouped by month",
 			"usage": "ccusage copilot monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["copilot", "session"],
@@ -604,13 +610,13 @@
 			"path": ["gemini", "daily"],
 			"description": "Show Gemini CLI usage grouped by date",
 			"usage": "ccusage gemini daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["gemini", "monthly"],
 			"description": "Show Gemini CLI usage grouped by month",
 			"usage": "ccusage gemini monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["gemini", "session"],
@@ -641,13 +647,13 @@
 			"path": ["kimi", "daily"],
 			"description": "Show Kimi usage grouped by date",
 			"usage": "ccusage kimi daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["kimi", "monthly"],
 			"description": "Show Kimi usage grouped by month",
 			"usage": "ccusage kimi monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["kimi", "session"],
@@ -678,13 +684,13 @@
 			"path": ["qwen", "daily"],
 			"description": "Show Qwen usage grouped by date",
 			"usage": "ccusage qwen daily <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["qwen", "monthly"],
 			"description": "Show Qwen usage grouped by month",
 			"usage": "ccusage qwen monthly <OPTIONS>",
-			"options": "agent_options"
+			"options": "agent_period_options"
 		},
 		{
 			"path": ["qwen", "session"],
@@ -715,13 +721,13 @@
 			"path": ["openclaw", "daily"],
 			"description": "Show OpenClaw usage grouped by date",
 			"usage": "ccusage openclaw daily <OPTIONS>",
-			"options": "openclaw_combined_options"
+			"options": "openclaw_period_options"
 		},
 		{
 			"path": ["openclaw", "monthly"],
 			"description": "Show OpenClaw usage grouped by month",
 			"usage": "ccusage openclaw monthly <OPTIONS>",
-			"options": "openclaw_combined_options"
+			"options": "openclaw_period_options"
 		},
 		{
 			"path": ["openclaw", "session"],

--- a/rust/crates/ccusage-cli-parser/src/cli-help.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-help.json
@@ -135,6 +135,12 @@
 			"description": "Display this version"
 		}
 	],
+	"last_options": [
+		{
+			"flags": "-l, --last <last>",
+			"description": "Show only the most recent N periods of the report (1 is today, this week, or this month)"
+		}
+	],
 	"blocks_options": [
 		{
 			"flags": "-a, --active",

--- a/rust/crates/ccusage-cli-parser/src/cli-help.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-help.json
@@ -137,7 +137,7 @@
 	],
 	"last_options": [
 		{
-			"flags": "-l, --last <last>",
+			"flags": "--last <last>",
 			"description": "Show only the most recent N periods of the report (1 is today, this week, or this month)"
 		}
 	],

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -121,6 +121,9 @@ impl Cli {
         if let Some(extra) = parser.next() {
             return Err(format!("Unexpected argument '{extra}'"));
         }
+        if let Some(message) = last_option_error(command.as_ref(), &shared) {
+            return Err(message);
+        }
         Ok(Self { command, shared })
     }
 }
@@ -708,6 +711,7 @@ fn parse_shared_arg(parser: &mut ArgParser, shared: &mut SharedArgs) -> Result<(
         "-u" | "--until" => {
             shared.until = Some(normalize_date_bound(&parser.value_for("--until")?))
         }
+        "-l" | "--last" => shared.last = Some(parse_last_periods(&parser.value_for("--last")?)?),
         "-j" | "--json" => shared.json = true,
         "-m" | "--mode" => shared.mode = parse_cost_mode(&parser.value_for("--mode")?)?,
         "-d" | "--debug" => shared.debug = true,
@@ -864,6 +868,8 @@ fn option_takes_value(arg: &str) -> bool {
         "-s" | "--since"
             | "-u"
             | "--until"
+            | "-l"
+            | "--last"
             | "-m"
             | "--mode"
             | "--debug-samples"
@@ -962,6 +968,8 @@ fn is_shared_flag(arg: &str) -> bool {
         "-s" | "--since"
             | "-u"
             | "--until"
+            | "-l"
+            | "--last"
             | "-j"
             | "--json"
             | "-m"
@@ -987,6 +995,60 @@ fn is_shared_flag(arg: &str) -> bool {
             | "--single-thread"
             | "--no-cost"
     )
+}
+
+fn parse_last_periods(value: &str) -> Result<u32, String> {
+    match value.parse() {
+        Ok(0) | Err(_) => Err(format!(
+            "Invalid value for --last '{value}'. Expected a whole number of periods, 1 or greater."
+        )),
+        Ok(periods) => Ok(periods),
+    }
+}
+
+/// `--last` counts the report's own calendar periods, so it only makes sense on
+/// the reports that group rows by day, week, or month.
+fn last_option_error(command: Option<&Command>, root_shared: &SharedArgs) -> Option<String> {
+    let (shared, supported) = match command {
+        None => (root_shared, true),
+        Some(Command::All(args)) => (&args.shared, args.kind != AgentReportKind::Session),
+        Some(Command::Daily(args)) => (&args.shared, true),
+        Some(Command::Monthly(shared)) => (shared, true),
+        Some(Command::Weekly(args)) => (&args.shared, true),
+        Some(Command::Session(args)) => (&args.shared, false),
+        Some(Command::Blocks(args)) => (&args.shared, false),
+        Some(Command::Statusline(_)) => (root_shared, false),
+        Some(
+            Command::Codex(args)
+            | Command::OpenCode(args)
+            | Command::Amp(args)
+            | Command::Droid(args)
+            | Command::Codebuff(args)
+            | Command::Hermes(args)
+            | Command::Pi(args)
+            | Command::Goose(args)
+            | Command::Kilo(args)
+            | Command::Copilot(args)
+            | Command::Gemini(args)
+            | Command::Kimi(args)
+            | Command::Qwen(args)
+            | Command::OpenClaw(args),
+        ) => (&args.shared, args.kind != AgentReportKind::Session),
+    };
+    shared.last?;
+    if !supported {
+        return Some(
+            "The --last option is only available for the daily, weekly, and monthly reports."
+                .to_string(),
+        );
+    }
+    if shared.since.is_some() || shared.until.is_some() {
+        return Some("The --last option cannot be combined with --since or --until.".to_string());
+    }
+    if matches!(command, Some(Command::All(args)) if args.sections.is_some()) {
+        return Some("The --last option cannot be used with --sections.".to_string());
+    }
+    None
 }
 
 fn parse_cost_mode(value: &str) -> Result<CostMode, String> {

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -711,7 +711,7 @@ fn parse_shared_arg(parser: &mut ArgParser, shared: &mut SharedArgs) -> Result<(
         "-u" | "--until" => {
             shared.until = Some(normalize_date_bound(&parser.value_for("--until")?))
         }
-        "-l" | "--last" => shared.last = Some(parse_last_periods(&parser.value_for("--last")?)?),
+        "--last" => shared.last = Some(parse_last_periods(&parser.value_for("--last")?)?),
         "-j" | "--json" => shared.json = true,
         "-m" | "--mode" => shared.mode = parse_cost_mode(&parser.value_for("--mode")?)?,
         "-d" | "--debug" => shared.debug = true,
@@ -868,7 +868,6 @@ fn option_takes_value(arg: &str) -> bool {
         "-s" | "--since"
             | "-u"
             | "--until"
-            | "-l"
             | "--last"
             | "-m"
             | "--mode"
@@ -968,7 +967,6 @@ fn is_shared_flag(arg: &str) -> bool {
         "-s" | "--since"
             | "-u"
             | "--until"
-            | "-l"
             | "--last"
             | "-j"
             | "--json"

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__codex_daily_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__codex_daily_help.snap
@@ -22,3 +22,4 @@ OPTIONS:
   --config <config>                    Path to configuration file (default: auto-discovery)
   -h, --help                           Display this help message
   -v, --version                        Display this version
+  -l, --last <last>                    Show only the most recent N periods of the report (1 is today, this week, or this month)

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__codex_daily_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__codex_daily_help.snap
@@ -22,4 +22,4 @@ OPTIONS:
   --config <config>                    Path to configuration file (default: auto-discovery)
   -h, --help                           Display this help message
   -v, --version                        Display this version
-  -l, --last <last>                    Show only the most recent N periods of the report (1 is today, this week, or this month)
+  --last <last>                        Show only the most recent N periods of the report (1 is today, this week, or this month)

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -235,6 +235,89 @@ fn parses_root_daily_as_all_agent_report() {
 }
 
 #[test]
+fn parses_last_periods_on_period_reports() {
+    let cli = parse(&["ccusage", "daily", "--last", "1"]);
+    let Some(Command::All(args)) = cli.command else {
+        panic!("expected all-agent command");
+    };
+    assert_eq!(args.shared.last, Some(1));
+
+    let cli = parse(&["ccusage", "claude", "weekly", "-l", "2"]);
+    let Some(Command::Weekly(args)) = cli.command else {
+        panic!("expected weekly command");
+    };
+    assert_eq!(args.shared.last, Some(2));
+
+    let cli = parse(&["ccusage", "codex", "monthly", "--last=3"]);
+    let Some(Command::Codex(args)) = cli.command else {
+        panic!("expected codex command");
+    };
+    assert_eq!(args.shared.last, Some(3));
+}
+
+#[test]
+fn parses_last_periods_before_the_command_name() {
+    let cli = parse(&["ccusage", "--last", "1", "weekly"]);
+    let Some(Command::All(args)) = cli.command else {
+        panic!("expected all-agent command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Weekly);
+    assert_eq!(args.shared.last, Some(1));
+
+    // The bare command is the unified daily report, which the binary resolves
+    // from the root shared options.
+    let cli = parse(&["ccusage", "--last", "1"]);
+    assert!(cli.command.is_none());
+    assert_eq!(cli.shared.last, Some(1));
+}
+
+#[test]
+fn rejects_last_periods_on_reports_without_a_period() {
+    for args in [
+        ["ccusage", "session", "--last", "1"],
+        ["ccusage", "blocks", "--last", "1"],
+        ["ccusage", "codex", "session", "--last=1"],
+    ] {
+        assert_eq!(
+            parse_error(&args),
+            "The --last option is only available for the daily, weekly, and monthly reports."
+        );
+    }
+}
+
+#[test]
+fn rejects_last_periods_alongside_an_explicit_date_window() {
+    assert_eq!(
+        parse_error(&["ccusage", "daily", "--last", "1", "--since", "20260101"]),
+        "The --last option cannot be combined with --since or --until."
+    );
+    assert_eq!(
+        parse_error(&["ccusage", "daily", "--last", "1", "--until", "20260101"]),
+        "The --last option cannot be combined with --since or --until."
+    );
+}
+
+#[test]
+fn rejects_last_periods_with_multi_section_reports() {
+    assert_eq!(
+        parse_error(&["ccusage", "daily", "--last", "1", "--sections", "monthly"]),
+        "The --last option cannot be used with --sections."
+    );
+}
+
+#[test]
+fn rejects_last_periods_that_are_not_positive_whole_numbers() {
+    assert_eq!(
+        parse_error(&["ccusage", "daily", "--last", "0"]),
+        "Invalid value for --last '0'. Expected a whole number of periods, 1 or greater."
+    );
+    assert_eq!(
+        parse_error(&["ccusage", "daily", "--last", "week"]),
+        "Invalid value for --last 'week'. Expected a whole number of periods, 1 or greater."
+    );
+}
+
+#[test]
 fn parses_unified_sections_and_by_agent_flags() {
     let cli = parse(&[
         "ccusage",

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -242,7 +242,7 @@ fn parses_last_periods_on_period_reports() {
     };
     assert_eq!(args.shared.last, Some(1));
 
-    let cli = parse(&["ccusage", "claude", "weekly", "-l", "2"]);
+    let cli = parse(&["ccusage", "claude", "weekly", "--last", "2"]);
     let Some(Command::Weekly(args)) = cli.command else {
         panic!("expected weekly command");
     };
@@ -269,6 +269,14 @@ fn parses_last_periods_before_the_command_name() {
     let cli = parse(&["ccusage", "--last", "1"]);
     assert!(cli.command.is_none());
     assert_eq!(cli.shared.last, Some(1));
+}
+
+#[test]
+fn leaves_the_short_alias_of_the_removed_locale_option_unused() {
+    assert_eq!(
+        parse_error(&["ccusage", "daily", "-l", "1"]),
+        "Unknown option '-l'"
+    );
 }
 
 #[test]

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -31,6 +31,9 @@ pub enum Command {
 pub struct SharedArgs {
     pub since: Option<String>,
     pub until: Option<String>,
+    /// Number of most recent report periods to keep, resolved into `since` by
+    /// the binary once the report's calendar unit is known.
+    pub last: Option<u32>,
     pub json: bool,
     pub mode: CostMode,
     pub debug: bool,

--- a/rust/crates/ccusage-core/src/last_window.rs
+++ b/rust/crates/ccusage-core/src/last_window.rs
@@ -1,0 +1,116 @@
+use jiff::{Span, civil::Date as JiffDate};
+
+use crate::{cli::WeekDay, week_start};
+
+/// The calendar unit a report groups rows by, and therefore the unit `--last`
+/// counts.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PeriodUnit {
+    Day,
+    Week,
+    Month,
+}
+
+/// Compact `YYYYMMDD` start of the window covering the most recent `count`
+/// periods, the last of which is the one `today` falls in.
+///
+/// `today` is a `YYYY-MM-DD` date already resolved in the report timezone, so
+/// the caller decides what "now" means. Weeks start on `start_of_week` to match
+/// the bucketing the report itself uses; months always start on the first.
+pub fn last_periods_since(
+    unit: PeriodUnit,
+    count: u32,
+    today: &str,
+    start_of_week: WeekDay,
+) -> Option<String> {
+    let earlier = i64::from(count.max(1) - 1);
+    let start = match unit {
+        PeriodUnit::Day => parse_date(today)?
+            .checked_sub(Span::new().days(earlier))
+            .ok()?,
+        PeriodUnit::Week => parse_date(&week_start(today, start_of_week)?)?
+            .checked_sub(Span::new().weeks(earlier))
+            .ok()?,
+        PeriodUnit::Month => parse_date(today)?
+            .first_of_month()
+            .checked_sub(Span::new().months(earlier))
+            .ok()?,
+    };
+    Some(format!(
+        "{:04}{:02}{:02}",
+        start.year(),
+        start.month(),
+        start.day()
+    ))
+}
+
+fn parse_date(date: &str) -> Option<JiffDate> {
+    date.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn covers_only_today_for_a_single_day() {
+        assert_eq!(
+            last_periods_since(PeriodUnit::Day, 1, "2026-07-27", WeekDay::Monday).as_deref(),
+            Some("20260727")
+        );
+    }
+
+    #[test]
+    fn counts_days_inclusively_across_a_month_boundary() {
+        assert_eq!(
+            last_periods_since(PeriodUnit::Day, 3, "2026-08-01", WeekDay::Monday).as_deref(),
+            Some("20260730")
+        );
+    }
+
+    #[test]
+    fn starts_a_single_week_at_the_configured_week_start() {
+        // 2026-07-27 is a Monday.
+        assert_eq!(
+            last_periods_since(PeriodUnit::Week, 1, "2026-07-29", WeekDay::Monday).as_deref(),
+            Some("20260727")
+        );
+        assert_eq!(
+            last_periods_since(PeriodUnit::Week, 1, "2026-07-29", WeekDay::Sunday).as_deref(),
+            Some("20260726")
+        );
+    }
+
+    #[test]
+    fn counts_whole_weeks_back_from_the_current_one() {
+        assert_eq!(
+            last_periods_since(PeriodUnit::Week, 2, "2026-07-29", WeekDay::Monday).as_deref(),
+            Some("20260720")
+        );
+    }
+
+    #[test]
+    fn starts_months_on_the_first_and_wraps_the_year() {
+        assert_eq!(
+            last_periods_since(PeriodUnit::Month, 1, "2026-07-27", WeekDay::Monday).as_deref(),
+            Some("20260701")
+        );
+        assert_eq!(
+            last_periods_since(PeriodUnit::Month, 3, "2026-01-15", WeekDay::Monday).as_deref(),
+            Some("20251101")
+        );
+    }
+
+    #[test]
+    fn treats_a_zero_count_as_the_current_period() {
+        assert_eq!(
+            last_periods_since(PeriodUnit::Day, 0, "2026-07-27", WeekDay::Monday).as_deref(),
+            Some("20260727")
+        );
+    }
+
+    #[test]
+    fn rejects_dates_that_are_not_iso_days() {
+        assert!(last_periods_since(PeriodUnit::Day, 1, "not-a-date", WeekDay::Monday).is_none());
+    }
+}

--- a/rust/crates/ccusage-core/src/lib.rs
+++ b/rust/crates/ccusage-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cost;
 pub mod date_utils;
 pub mod fast;
 pub mod home;
+pub mod last_window;
 pub mod logger;
 pub mod model_aliases;
 pub mod output;
@@ -27,6 +28,7 @@ pub use cost::{
     missing_pricing_model_for_usage,
 };
 pub use date_utils::*;
+pub use last_window::{PeriodUnit, last_periods_since};
 pub use logger::{debug_log, log_level};
 pub use output::{
     format_currency, format_models_multiline, format_number, group_project_output, json_float,

--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -1,3 +1,5 @@
+mod last_window;
+
 use std::{env, ffi::OsString, process};
 
 pub(crate) use ccusage_cli::*;
@@ -10,22 +12,26 @@ use crate::DEFAULT_SESSION_DURATION_HOURS;
 pub(crate) fn parse() -> Cli {
     let args = env::args_os().collect::<Vec<_>>();
     let arg_strings = args_to_strings(args.iter().skip(1).cloned()).unwrap_or_else(|message| {
-        eprintln!("{message}");
-        eprintln!("Run 'ccusage --help' for usage.");
-        process::exit(2);
+        exit_with_usage(&message);
     });
     let config = ConfigContext::from_args(&arg_strings);
-    Cli::parse_from_with_config(
+    let mut cli = Cli::parse_from_with_config(
         args,
         &config,
         DEFAULT_SESSION_DURATION_HOURS,
         env!("CCUSAGE_VERSION"),
     )
-    .unwrap_or_else(|message| {
-        eprintln!("{message}");
-        eprintln!("Run 'ccusage --help' for usage.");
-        process::exit(2);
-    })
+    .unwrap_or_else(|message| exit_with_usage(&message));
+    if let Err(message) = last_window::resolve(&mut cli) {
+        exit_with_usage(&message);
+    }
+    cli
+}
+
+fn exit_with_usage(message: &str) -> ! {
+    eprintln!("{message}");
+    eprintln!("Run 'ccusage --help' for usage.");
+    process::exit(2);
 }
 
 fn args_to_strings<I>(args: I) -> Result<Vec<String>, String>

--- a/rust/crates/ccusage/src/cli/last_window.rs
+++ b/rust/crates/ccusage/src/cli/last_window.rs
@@ -1,0 +1,185 @@
+use ccusage_cli::{AgentCommandArgs, AgentReportKind, Command, SharedArgs, WeekDay};
+use ccusage_core::{PeriodUnit, format_date, last_periods_since, utc_now};
+
+use super::Cli;
+
+/// Turns `--last N` into the `--since` bound every loader already understands.
+///
+/// The count means "the most recent N periods of the report's own unit", so it
+/// can only be resolved once the command is known: `daily --last 1` is today,
+/// `weekly --last 1` is the current week, `monthly --last 1` is this month.
+pub(crate) fn resolve(cli: &mut Cli) -> Result<(), String> {
+    let Some((shared, unit, start_of_week)) = window_target(cli) else {
+        return Ok(());
+    };
+    let Some(last) = shared.last else {
+        return Ok(());
+    };
+    let today = format_date(utc_now(), shared.timezone.as_deref());
+    let Some(since) = last_periods_since(unit, last, &today, start_of_week) else {
+        return Err(format!("Could not resolve --last {last} from today's date"));
+    };
+    shared.since = Some(since);
+    Ok(())
+}
+
+fn window_target(cli: &mut Cli) -> Option<(&mut SharedArgs, PeriodUnit, WeekDay)> {
+    match cli.command.as_mut() {
+        // A bare `ccusage` is the unified daily report.
+        None => Some((&mut cli.shared, PeriodUnit::Day, UNIFIED_WEEK_START)),
+        Some(Command::Daily(args)) => Some((&mut args.shared, PeriodUnit::Day, UNIFIED_WEEK_START)),
+        Some(Command::Monthly(shared)) => Some((shared, PeriodUnit::Month, UNIFIED_WEEK_START)),
+        Some(Command::Weekly(args)) => {
+            let start_of_week = args.start_of_week;
+            Some((&mut args.shared, PeriodUnit::Week, start_of_week))
+        }
+        Some(
+            Command::All(args)
+            | Command::Codex(args)
+            | Command::OpenCode(args)
+            | Command::Amp(args)
+            | Command::Droid(args)
+            | Command::Codebuff(args)
+            | Command::Hermes(args)
+            | Command::Pi(args)
+            | Command::Goose(args)
+            | Command::Kilo(args)
+            | Command::Copilot(args)
+            | Command::Gemini(args)
+            | Command::Kimi(args)
+            | Command::Qwen(args)
+            | Command::OpenClaw(args),
+        ) => agent_window_target(args),
+        Some(Command::Session(_) | Command::Blocks(_) | Command::Statusline(_)) => None,
+    }
+}
+
+/// Every report that buckets by week outside of `ccusage claude weekly` starts
+/// the week on Monday, so the window has to as well.
+const UNIFIED_WEEK_START: WeekDay = WeekDay::Monday;
+
+fn agent_window_target(
+    args: &mut AgentCommandArgs,
+) -> Option<(&mut SharedArgs, PeriodUnit, WeekDay)> {
+    let unit = match args.kind {
+        AgentReportKind::Daily => PeriodUnit::Day,
+        AgentReportKind::Weekly => PeriodUnit::Week,
+        AgentReportKind::Monthly => PeriodUnit::Month,
+        AgentReportKind::Session => return None,
+    };
+    Some((&mut args.shared, unit, UNIFIED_WEEK_START))
+}
+
+#[cfg(test)]
+mod tests {
+    use ccusage_cli::{CodexSpeed, SortOrder, WeeklyArgs};
+
+    use super::*;
+
+    fn shared_with_last(last: u32) -> SharedArgs {
+        SharedArgs {
+            last: Some(last),
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::with_defaults()
+        }
+    }
+
+    fn agent_command(kind: AgentReportKind, last: u32) -> AgentCommandArgs {
+        AgentCommandArgs {
+            shared: shared_with_last(last),
+            kind,
+            sections: None,
+            by_agent: false,
+            pi_path: None,
+            open_claw_path: None,
+            codex_speed: CodexSpeed::Auto,
+        }
+    }
+
+    fn resolved_since(command: Command) -> Option<String> {
+        let mut cli = Cli {
+            command: Some(command),
+            shared: SharedArgs::with_defaults(),
+        };
+        resolve(&mut cli).unwrap();
+        match cli.command {
+            Some(Command::All(args)) | Some(Command::Codex(args)) => args.shared.since,
+            Some(Command::Weekly(args)) => args.shared.since,
+            Some(Command::Monthly(shared)) => shared.since,
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn resolves_the_unified_daily_window_to_today() {
+        let today = format_date(utc_now(), Some("UTC")).replace('-', "");
+
+        let since = resolved_since(Command::All(agent_command(AgentReportKind::Daily, 1)));
+
+        assert_eq!(since.as_deref(), Some(today.as_str()));
+    }
+
+    #[test]
+    fn resolves_agent_report_kinds_to_their_own_period() {
+        let weekly = resolved_since(Command::Codex(agent_command(AgentReportKind::Weekly, 1)));
+        let monthly = resolved_since(Command::Codex(agent_command(AgentReportKind::Monthly, 1)));
+
+        let today = format_date(utc_now(), Some("UTC"));
+        assert_eq!(
+            weekly,
+            last_periods_since(PeriodUnit::Week, 1, &today, WeekDay::Monday)
+        );
+        assert_eq!(
+            monthly,
+            last_periods_since(PeriodUnit::Month, 1, &today, WeekDay::Monday)
+        );
+    }
+
+    #[test]
+    fn keeps_the_claude_weekly_start_of_week() {
+        let since = resolved_since(Command::Weekly(WeeklyArgs {
+            shared: shared_with_last(1),
+            start_of_week: WeekDay::Sunday,
+        }));
+
+        let today = format_date(utc_now(), Some("UTC"));
+        assert_eq!(
+            since,
+            last_periods_since(PeriodUnit::Week, 1, &today, WeekDay::Sunday)
+        );
+    }
+
+    #[test]
+    fn leaves_commands_without_last_untouched() {
+        let mut cli = Cli {
+            command: Some(Command::Monthly(SharedArgs {
+                order: SortOrder::Desc,
+                ..SharedArgs::with_defaults()
+            })),
+            shared: SharedArgs::with_defaults(),
+        };
+
+        resolve(&mut cli).unwrap();
+
+        let Some(Command::Monthly(shared)) = cli.command else {
+            panic!("expected monthly command");
+        };
+        assert!(shared.since.is_none());
+    }
+
+    #[test]
+    fn resolves_the_bare_command_as_a_daily_window() {
+        let mut cli = Cli {
+            command: None,
+            shared: shared_with_last(2),
+        };
+
+        resolve(&mut cli).unwrap();
+
+        let today = format_date(utc_now(), Some("UTC"));
+        assert_eq!(
+            cli.shared.since,
+            last_periods_since(PeriodUnit::Day, 2, &today, WeekDay::Monday)
+        );
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1300

## What do you want to change?

Add a `--last <N>` option to the reports that group rows by a calendar period, counting in whatever unit the report already uses:

```bash
ccusage daily --last 1     # today
ccusage weekly --last 1    # this week
ccusage monthly --last 1   # this month
ccusage codex daily --last 7   # the last seven days of Codex usage
```

## Why?

Checking today's or this week's usage currently means working out the dates yourself and passing `--since`. This keeps the command surface as it is — no new subcommands — and maps one option onto the day/week/month granularity each report already has, which is the shape suggested in #1300 and preferred over the `today` / `this-week` commands proposed in #1321.

## How?

- `ccusage-core` gains `last_periods_since`, which turns a unit plus a count into the compact `YYYYMMDD` `--since` bound the loaders already understand. It takes "today" as an argument so it stays deterministic in tests, and reuses `week_start` so the window lines up with the report's own weekly bucketing.
- The parser records only the count, since the unit it counts depends on the command. The binary resolves it into `--since` right after parsing, using the report timezone for "today" and the command's own week start (Monday everywhere except `ccusage claude weekly`, which honors `-w`). Nothing downstream changes.
- `--last` is rejected on `session`, `blocks`, and `statusline`, which have no calendar period, and alongside `--since`, `--until`, or `--sections`, where the intended window would be ambiguous.
- No short alias: `-l` used to be `--locale` until 8792ff5 removed that option, so `--last` deliberately leaves it unclaimed and a test records that.

Covered by unit tests for the date math, the parse and rejection paths, and the resolution of each command shape, plus a manual check against a dated fixture (`daily --last 1` → today only, `weekly --last 2` → the current and previous week, `monthly --last 2` → this month and last).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4dc03ff-c07d-4aa0-b5f9-490542c798d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4dc03ff-c07d-4aa0-b5f9-490542c798d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--last <N>` to daily/weekly/monthly reports to show only the most recent N periods, auto-resolved to `--since`. Works on unified and per‑agent reports to make “today/this week/this month” easy.

- **New Features**
  - Supports `daily`, `weekly`, and `monthly` for unified and per‑agent commands; bare `ccusage --last N` applies to daily.
  - Converts `--last N` to compact `YYYYMMDD` `--since` using the report timezone; weekly windows align to the report’s week start (Monday by default; `ccusage claude weekly` respects `-w`).
  - Rejected on `session`, `blocks`, and `statusline`, and when combined with `--since`, `--until`, or `--sections`; N must be a positive integer.
  - Added `last_periods_since` in `ccusage-core`, resolution logic in the `ccusage` CLI, and updated `ccusage-cli` parser/help; guides and README document “Recent Periods” with examples; tests cover parsing, date math, and rejection paths.

- **Refactors**
  - Dropped the `-l` short alias (formerly `--locale`); `--last` has no short form, and a test locks in that `-l` remains unused.

<sup>Written for commit 834e1d37e8606c591e4cc54da637e56994c6f77d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--last <N>` option for daily, weekly, and monthly reports.
  * Supports viewing the current period or multiple recent periods, including custom week boundaries.
  * Added validation for unsupported commands, conflicting date filters, and invalid values.

* **Documentation**
  * Updated CLI, daily, weekly, monthly, and general usage guides with examples and option details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->