### PR TITLE
fix(codex): stop double-counting reasoning in derived token totals

### DIFF
--- a/rust/adapters/codex/src/loader.rs
+++ b/rust/adapters/codex/src/loader.rs
@@ -582,7 +582,7 @@ mod tests {
         assert_eq!(events[2].input_tokens, 9);
         assert_eq!(events[2].output_tokens, 4);
         assert_eq!(events[2].reasoning_output_tokens, 1);
-        assert_eq!(events[2].total_tokens, 14);
+        assert_eq!(events[2].total_tokens, 13);
     }
 
     #[test]

--- a/rust/adapters/codex/src/types.rs
+++ b/rust/adapters/codex/src/types.rs
@@ -294,7 +294,7 @@ impl<'de> Deserialize<'de> for CodexRawUsage {
             total_tokens: fields
                 .total_tokens
                 .filter(|total| *total > 0)
-                .unwrap_or(input + output),
+                .unwrap_or_else(|| input.saturating_add(output)),
         })
     }
 }
@@ -517,17 +517,32 @@ mod tests {
 
     #[test]
     fn keeps_a_recorded_total() {
+        // Deliberately not input plus output, so deriving instead of preserving
+        // the recorded value cannot pass this test.
         let usage: CodexRawUsage = serde_json::from_str(
             r#"{
                 "input_tokens": 100,
                 "output_tokens": 50,
                 "reasoning_output_tokens": 20,
-                "total_tokens": 150
+                "total_tokens": 151
             }"#,
         )
         .expect("usage should deserialize");
 
-        assert_eq!(usage.total_tokens, 150);
+        assert_eq!(usage.total_tokens, 151);
+    }
+
+    #[test]
+    fn saturates_a_derived_total_instead_of_overflowing() {
+        let usage: CodexRawUsage = serde_json::from_str(
+            r#"{
+                "input_tokens": 18446744073709551615,
+                "output_tokens": 5
+            }"#,
+        )
+        .expect("usage should deserialize");
+
+        assert_eq!(usage.total_tokens, u64::MAX);
     }
 
     #[test]

--- a/rust/adapters/codex/src/types.rs
+++ b/rust/adapters/codex/src/types.rs
@@ -288,11 +288,13 @@ impl<'de> Deserialize<'de> for CodexRawUsage {
                 .unwrap_or(0),
             output_tokens: output,
             reasoning_output_tokens: reasoning,
-            total_tokens: match fields.total_tokens {
-                None => input + output,
-                Some(0) => input + output + reasoning,
-                Some(total) => total,
-            },
+            // Codex reports reasoning as a subset of output, so a derived total
+            // must not add it on top. A recorded zero total means the field is
+            // unusable rather than that the turn spent nothing, so derive it too.
+            total_tokens: fields
+                .total_tokens
+                .filter(|total| *total > 0)
+                .unwrap_or(input + output),
         })
     }
 }
@@ -499,7 +501,7 @@ mod tests {
     }
 
     #[test]
-    fn derives_explicit_zero_total_tokens_from_all_nonzero_components() {
+    fn derives_explicit_zero_total_tokens_without_double_counting_reasoning() {
         let usage: CodexRawUsage = serde_json::from_str(
             r#"{
                 "input_tokens": 9,
@@ -510,6 +512,44 @@ mod tests {
         )
         .expect("usage should deserialize");
 
-        assert_eq!(usage.total_tokens, 14);
+        assert_eq!(usage.total_tokens, 13);
+    }
+
+    #[test]
+    fn keeps_a_recorded_total() {
+        let usage: CodexRawUsage = serde_json::from_str(
+            r#"{
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "reasoning_output_tokens": 20,
+                "total_tokens": 150
+            }"#,
+        )
+        .expect("usage should deserialize");
+
+        assert_eq!(usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn derives_total_tokens_from_openai_field_spellings() {
+        let usage: CodexRawUsage = serde_json::from_str(
+            r#"{
+                "prompt_tokens": 50,
+                "cached_tokens": 5,
+                "completion_tokens": 12,
+                "reasoning_tokens": 4
+            }"#,
+        )
+        .expect("usage should deserialize");
+
+        assert_eq!(usage.total_tokens, 62);
+    }
+
+    #[test]
+    fn leaves_an_empty_usage_total_at_zero() {
+        let usage: CodexRawUsage =
+            serde_json::from_str(r#"{"total_tokens": 0}"#).expect("usage should deserialize");
+
+        assert_eq!(usage.total_tokens, 0);
     }
 }

--- a/rust/adapters/codex/src/types.rs
+++ b/rust/adapters/codex/src/types.rs
@@ -288,10 +288,11 @@ impl<'de> Deserialize<'de> for CodexRawUsage {
                 .unwrap_or(0),
             output_tokens: output,
             reasoning_output_tokens: reasoning,
-            total_tokens: fields
-                .total_tokens
-                .filter(|total| *total > 0 || input + output + reasoning == 0)
-                .unwrap_or(input + output + reasoning),
+            total_tokens: match fields.total_tokens {
+                None => input + output,
+                Some(0) => input + output + reasoning,
+                Some(total) => total,
+            },
         })
     }
 }
@@ -477,4 +478,38 @@ where
     }
 
     deserializer.deserialize_any(OptionalU64Visitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_total_tokens_without_double_counting_reasoning() {
+        let usage: CodexRawUsage = serde_json::from_str(
+            r#"{
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "reasoning_output_tokens": 20
+            }"#,
+        )
+        .expect("usage should deserialize");
+
+        assert_eq!(usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn derives_explicit_zero_total_tokens_from_all_nonzero_components() {
+        let usage: CodexRawUsage = serde_json::from_str(
+            r#"{
+                "input_tokens": 9,
+                "output_tokens": 4,
+                "reasoning_output_tokens": 1,
+                "total_tokens": 0
+            }"#,
+        )
+        .expect("usage should deserialize");
+
+        assert_eq!(usage.total_tokens, 14);
+    }
 }


### PR DESCRIPTION
Supersedes #1458, keeping @MaxGhenis's commit intact. Their branch could not be updated in place: `MaxGhenis/ccusage` is a fork of `jackcpku/ccusage` rather than a direct fork of this repository, so GitHub reports `maintainer_can_modify: true` but rejects the push.

## Problem

Codex reports `reasoning_output_tokens` as a subset of `output_tokens`, so `total_tokens` is `input_tokens + output_tokens`. The fallback used when a record omits `total_tokens` added reasoning on top, inflating the reported total.

A saved `codex exec --json` turn with 100 input, 50 output and 20 reasoning tokens reported 170 instead of 150:

```
$ CODEX_HOME=... ccusage codex --json --offline | jq .totals.totalTokens
170     # before
150     # after
```

Costs were never affected, because pricing reads input, cached input and output directly.

## Verification

The semantics were checked against real data rather than assumed. Across 170,429 `token_count` records in a local `~/.codex/sessions`, 21,815 carry a nonzero `reasoning_output_tokens`:

| Invariant | Matching records |
| --- | --- |
| `total_tokens == input_tokens + output_tokens` | 21,815 / 21,815 |
| `total_tokens == input_tokens + output_tokens + reasoning_output_tokens` | 0 / 21,815 |

`docs/guide/codex/index.md` already documents the same rule, noting that reasoning tokens are part of the output charge rather than billed separately, so no documentation change is needed — the code now matches the guide.

Rollout session logs always record a usable total (0 of 170,429 records omit it or report zero alongside nonzero components), so this only affects saved exec JSON usage, where OpenAI-style payloads may omit the field.

## Changes

- `fix(codex): correct legacy token total fallback` (@MaxGhenis) — derive an absent total as input plus output.
- `fix(codex): derive a recorded zero token total the same way` — a recorded `total_tokens` of zero alongside nonzero components means the field is unusable, not that the turn spent nothing, so it takes the same path. Leaving reasoning in that branch kept the inflated sum for exactly the records that cannot be trusted to report a total. Updates the `loader.rs` assertion that encoded the old value (14 to 13) and pins the derivation from every direction: recorded nonzero total, absent total, recorded zero, OpenAI field spellings, empty usage object.

## Testing

- `just test` — full suite green, 0 failures
- `just fmt` — 0 changed
- `cargo clippy -p ccusage-adapter-codex --all-targets` — no warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex token totals by removing double-counting of reasoning tokens and treating zero totals as absent. Derived totals now use saturating input + output, so saved exec JSON reports correct totals; costs were never affected.

- **Bug Fixes**
  - Derive `total_tokens` as `input_tokens + output_tokens` when missing or explicitly zero; do not add reasoning tokens.
  - Preserve recorded nonzero totals; accept OpenAI field spellings; keep empty usage at zero.
  - Saturate and lazily compute the derived sum to avoid overflow or panics; add tests and update one loader assertion.

<sup>Written for commit 6c5c4f6136bf4e7002462544c2a2d6911dec3882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected derived token usage totals to avoid double-counting reasoning tokens when they are already included in output tokens.
  * Improved handling of missing or zero totals by deriving `input + output` (with saturation to prevent overflow) while preserving any explicitly reported non-zero totals.
  * Updated unit test expectations for saved Codex execution usage data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->