### PR TITLE
fix(progress): keep the spinner status on a single row

### DIFF
--- a/rust/crates/ccusage-core/src/progress.rs
+++ b/rust/crates/ccusage-core/src/progress.rs
@@ -6,8 +6,13 @@ use std::{
     time::Duration,
 };
 
+use ccusage_terminal::{terminal_width, truncate_to_width};
+
 const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const SPINNER_INTERVAL: Duration = Duration::from_millis(80);
+
+/// Display columns the spinner frame and the space after it take up.
+const SPINNER_PREFIX_WIDTH: usize = 2;
 
 thread_local! {
     static ACTIVE_PROGRESS: RefCell<Option<ProgressController>> = const { RefCell::new(None) };
@@ -70,6 +75,20 @@ fn format_usage_load_progress_text(
         Some(status) => format!("{status} :: {base}"),
         None => base,
     }
+}
+
+/// Shorten the status text so the spinner line always occupies a single row.
+///
+/// Each frame clears its own line with `\r\x1b[K`, which only erases the row the
+/// cursor sits on. A status wide enough to wrap therefore leaves the overflow
+/// row on screen and the redraw reads as flicker. One column is left free on top
+/// of the spinner prefix so the cursor never ends a frame in the wrap-pending
+/// state some terminals enter at the last column.
+fn fit_status_to_width(text: &str, terminal_width: usize) -> String {
+    truncate_to_width(
+        text,
+        terminal_width.saturating_sub(SPINNER_PREFIX_WIDTH + 1),
+    )
 }
 
 pub fn usage_load_output_is_tty() -> bool {
@@ -253,7 +272,10 @@ impl ProgressState {
         if !self.has_content() {
             return;
         }
-        let text = format_usage_load_progress_text(&self.states, self.status.as_deref());
+        let text = fit_status_to_width(
+            &format_usage_load_progress_text(&self.states, self.status.as_deref()),
+            terminal_width(),
+        );
         let frame = SPINNER_FRAMES[self.frame % SPINNER_FRAMES.len()];
         self.frame = self.frame.wrapping_add(1);
         let _ = write!(
@@ -336,6 +358,37 @@ mod tests {
             format_usage_load_progress_text(&[], Some("Refreshing model pricing from LiteLLM...")),
             "Refreshing model pricing from LiteLLM..."
         );
+    }
+
+    #[test]
+    fn fits_the_status_within_a_narrow_terminal() {
+        let text = format_usage_load_progress_text(
+            &[
+                (UsageLoadAgent("Claude"), LoadProgressState::Loading),
+                (UsageLoadAgent("Codex"), LoadProgressState::Loading),
+            ],
+            Some("Refreshing model pricing from LiteLLM..."),
+        );
+
+        let fitted = fit_status_to_width(&text, 80);
+
+        assert_eq!(
+            fitted,
+            "Refreshing model pricing from LiteLLM... :: Loading usage logs (0/2) :: Clau…"
+        );
+        assert_eq!(fitted.chars().count() + SPINNER_PREFIX_WIDTH, 79);
+    }
+
+    #[test]
+    fn keeps_the_status_intact_on_a_wide_terminal() {
+        let text = format_usage_load_progress_text(&[], Some("Refreshing model pricing"));
+
+        assert_eq!(fit_status_to_width(&text, 120), "Refreshing model pricing");
+    }
+
+    #[test]
+    fn fits_the_status_when_the_terminal_has_no_room_at_all() {
+        assert_eq!(fit_status_to_width("Loading usage logs", 2), "…");
     }
 
     #[test]

--- a/rust/crates/ccusage-core/src/progress.rs
+++ b/rust/crates/ccusage-core/src/progress.rs
@@ -387,8 +387,9 @@ mod tests {
     }
 
     #[test]
-    fn fits_the_status_when_the_terminal_has_no_room_at_all() {
-        assert_eq!(fit_status_to_width("Loading usage logs", 2), "…");
+    fn drops_the_status_when_the_terminal_has_no_room_at_all() {
+        assert_eq!(fit_status_to_width("Loading usage logs", 3), "");
+        assert_eq!(fit_status_to_width("Loading usage logs", 4), "…");
     }
 
     #[test]

--- a/rust/crates/ccusage-terminal/README.md
+++ b/rust/crates/ccusage-terminal/README.md
@@ -10,6 +10,7 @@ the table writer every report uses.
 - `style.rs` — `TerminalStyle`, color selection, and `NO_COLOR` handling.
 - `terminal.rs` — terminal width detection.
 - `title.rs` — the boxed report titles.
+- `width.rs` — ANSI-aware display width measurement and truncation.
 
 `ccusage-core` re-exports this crate's types, so adapters reach them through
 `ccusage_core` rather than depending on it directly.
@@ -23,6 +24,7 @@ the table writer every report uses.
 - `table::SimpleTable`
 - `terminal::terminal_width`
 - `title::print_box_title`
+- `width::truncate_to_width`
 
 ## Depends on
 

--- a/rust/crates/ccusage-terminal/src/lib.rs
+++ b/rust/crates/ccusage-terminal/src/lib.rs
@@ -8,3 +8,4 @@ pub use style::{Color, TerminalStyle, color};
 pub use table::{Align, SimpleTable};
 pub use terminal::terminal_width;
 pub use title::print_box_title;
+pub use width::truncate_to_width;

--- a/rust/crates/ccusage-terminal/src/snapshots/ccusage_terminal__table__tests__snapshots_ansi_truncation_boundary.snap
+++ b/rust/crates/ccusage-terminal/src/snapshots/ccusage_terminal__table__tests__snapshots_ansi_truncation_boundary.snap
@@ -1,6 +1,0 @@
----
-source: crates/ccusage-terminal/src/table.rs
-assertion_line: 506
-expression: "truncate_visible(\"\\x1b[33mvery-long-value\\x1b[0m\", 8)"
----
-[33mvery-lo[0m…

--- a/rust/crates/ccusage-terminal/src/snapshots/ccusage_terminal__width__tests__snapshots_ansi_truncation_boundary.snap
+++ b/rust/crates/ccusage-terminal/src/snapshots/ccusage_terminal__width__tests__snapshots_ansi_truncation_boundary.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ccusage-terminal/src/width.rs
+expression: "truncate_to_width(\"\\x1b[33mvery-long-value\\x1b[0m\", 8)"
+---
+[33mvery-lo[0m…

--- a/rust/crates/ccusage-terminal/src/table.rs
+++ b/rust/crates/ccusage-terminal/src/table.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 use crate::{
     style::{Color, TerminalStyle, color},
     terminal::DEFAULT_TERMINAL_WIDTH,
-    width::{char_display_width, contains_ansi, visible_width, visible_width_max_line},
+    width::{truncate_to_width, visible_width, visible_width_max_line},
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -245,7 +245,7 @@ fn wrap_cell_lines(cell: &str, width: usize) -> Vec<String> {
 
 fn wrap_cell_line(line: &str, width: usize) -> Vec<String> {
     if line.split_whitespace().count() <= 1 {
-        return vec![truncate_visible(line, width)];
+        return vec![truncate_to_width(line, width)];
     }
 
     let mut lines = Vec::new();
@@ -266,7 +266,7 @@ fn wrap_cell_line(line: &str, width: usize) -> Vec<String> {
                 lines.push(current);
             }
             current = if visible_width(word) > width {
-                truncate_visible(word, width)
+                truncate_to_width(word, width)
             } else {
                 word.to_string()
             };
@@ -276,51 +276,6 @@ fn wrap_cell_line(line: &str, width: usize) -> Vec<String> {
         lines.push(current);
     }
     lines
-}
-
-fn truncate_visible(value: &str, width: usize) -> String {
-    if visible_width(value) <= width {
-        return value.to_string();
-    }
-    if width <= 1 {
-        return "…".to_string();
-    }
-    let mut output = String::new();
-    let mut current_width = 0;
-    let mut index = 0;
-    let bytes = value.as_bytes();
-    while index < bytes.len() {
-        if bytes[index] == 0x1b {
-            let start = index;
-            index += 1;
-            if index < bytes.len() && bytes[index] == b'[' {
-                index += 1;
-                while index < bytes.len() && !(bytes[index] as char).is_ascii_alphabetic() {
-                    index += 1;
-                }
-                if index < bytes.len() {
-                    index += 1;
-                }
-            }
-            output.push_str(&value[start..index]);
-            continue;
-        }
-        let Some(ch) = value[index..].chars().next() else {
-            break;
-        };
-        let char_width = char_display_width(ch);
-        if current_width + char_width >= width {
-            break;
-        }
-        output.push(ch);
-        current_width += char_width;
-        index += ch.len_utf8();
-    }
-    if contains_ansi(value) && !output.ends_with("\x1b[0m") {
-        output.push_str("\x1b[0m");
-    }
-    output.push('…');
-    output
 }
 
 fn compact_date_cell(value: &str) -> Option<String> {
@@ -476,18 +431,6 @@ mod tests {
         ]);
 
         insta::assert_snapshot!(table.render_lines().join("\n"));
-    }
-
-    #[test]
-    fn truncate_visible_preserves_ansi_reset() {
-        let truncated = truncate_visible("\x1b[33mvery-long-value\x1b[0m", 8);
-
-        assert!(truncated.ends_with("\x1b[0m…"));
-    }
-
-    #[test]
-    fn snapshots_ansi_truncation_boundary() {
-        insta::assert_snapshot!(truncate_visible("\x1b[33mvery-long-value\x1b[0m", 8));
     }
 
     #[test]

--- a/rust/crates/ccusage-terminal/src/width.rs
+++ b/rust/crates/ccusage-terminal/src/width.rs
@@ -25,16 +25,77 @@ pub(crate) fn visible_width(value: &str) -> usize {
     width
 }
 
-pub(crate) fn contains_ansi(value: &str) -> bool {
+fn contains_ansi(value: &str) -> bool {
     value.as_bytes().contains(&0x1b)
 }
 
-pub(crate) fn char_display_width(ch: char) -> usize {
+fn char_display_width(ch: char) -> usize {
     UnicodeWidthChar::width(ch).unwrap_or(0)
 }
 
 pub(crate) fn visible_width_max_line(value: &str) -> usize {
     value.lines().map(visible_width).max().unwrap_or_default()
+}
+
+/// Shorten `value` to at most `width` display columns, marking the cut with `…`.
+///
+/// Values that already fit are returned unchanged. ANSI escapes are copied
+/// through without spending width, and a reset is appended before the ellipsis
+/// so a cut inside a colored run cannot leak its style into the rest of the
+/// line.
+///
+/// # Examples
+///
+/// ```
+/// use ccusage_terminal::truncate_to_width;
+///
+/// assert_eq!(truncate_to_width("fits", 10), "fits");
+/// assert_eq!(truncate_to_width("Loading usage logs", 10), "Loading u…");
+/// ```
+pub fn truncate_to_width(value: &str, width: usize) -> String {
+    if visible_width(value) <= width {
+        return value.to_string();
+    }
+    if width <= 1 {
+        return "…".to_string();
+    }
+    let mut output = String::new();
+    let mut current_width = 0;
+    let mut index = 0;
+    let bytes = value.as_bytes();
+    while index < bytes.len() {
+        if bytes[index] == 0x1b {
+            let start = index;
+            index += 1;
+            if index < bytes.len() && bytes[index] == b'[' {
+                index += 1;
+                while index < bytes.len() && !(bytes[index] as char).is_ascii_alphabetic() {
+                    index += 1;
+                }
+                if index < bytes.len() {
+                    index += 1;
+                }
+            }
+            output.push_str(&value[start..index]);
+            continue;
+        }
+        let Some(ch) = value[index..].chars().next() else {
+            break;
+        };
+        let char_width = char_display_width(ch);
+        // Stop one column early so the ellipsis itself stays inside `width`.
+        if current_width + char_width >= width {
+            break;
+        }
+        output.push(ch);
+        current_width += char_width;
+        index += ch.len_utf8();
+    }
+    if contains_ansi(value) && !output.ends_with("\x1b[0m") {
+        output.push_str("\x1b[0m");
+    }
+    output.push('…');
+    output
 }
 
 #[cfg(test)]
@@ -45,6 +106,36 @@ mod tests {
     fn visible_width_handles_combining_marks_and_cjk() {
         assert_eq!(visible_width("e\u{0301}"), 1);
         assert_eq!(visible_width("表"), 2);
+    }
+
+    #[test]
+    fn truncate_to_width_keeps_values_that_already_fit() {
+        assert_eq!(
+            truncate_to_width("Loading usage logs", 40),
+            "Loading usage logs"
+        );
+    }
+
+    #[test]
+    fn truncate_to_width_stays_within_the_requested_width() {
+        assert_eq!(truncate_to_width("Loading usage logs", 10), "Loading u…");
+    }
+
+    #[test]
+    fn truncate_to_width_never_splits_a_wide_char_across_the_boundary() {
+        assert_eq!(truncate_to_width("表表表表", 5), "表表…");
+    }
+
+    #[test]
+    fn truncate_to_width_preserves_ansi_reset() {
+        let truncated = truncate_to_width("\x1b[33mvery-long-value\x1b[0m", 8);
+
+        assert!(truncated.ends_with("\x1b[0m…"));
+    }
+
+    #[test]
+    fn snapshots_ansi_truncation_boundary() {
+        insta::assert_snapshot!(truncate_to_width("\x1b[33mvery-long-value\x1b[0m", 8));
     }
 
     #[test]

--- a/rust/crates/ccusage-terminal/src/width.rs
+++ b/rust/crates/ccusage-terminal/src/width.rs
@@ -1,19 +1,28 @@
 use unicode_width::UnicodeWidthChar;
 
+/// Index of the first byte after the escape sequence starting at `index`.
+///
+/// Only CSI sequences carry parameters, so a bare `\x1b` advances by one and a
+/// `\x1b[` run consumes bytes up to and including its alphabetic final byte.
+fn skip_ansi_escape(bytes: &[u8], index: usize) -> usize {
+    let mut index = index + 1;
+    if index < bytes.len() && bytes[index] == b'[' {
+        index += 1;
+        while index < bytes.len() && !(bytes[index] as char).is_ascii_alphabetic() {
+            index += 1;
+        }
+        index += usize::from(index < bytes.len());
+    }
+    index
+}
+
 pub(crate) fn visible_width(value: &str) -> usize {
     let bytes = value.as_bytes();
     let mut width = 0;
     let mut index = 0;
     while index < bytes.len() {
         if bytes[index] == 0x1b {
-            index += 1;
-            if index < bytes.len() && bytes[index] == b'[' {
-                index += 1;
-                while index < bytes.len() && !(bytes[index] as char).is_ascii_alphabetic() {
-                    index += 1;
-                }
-                index += usize::from(index < bytes.len());
-            }
+            index = skip_ansi_escape(bytes, index);
             continue;
         }
         let Some(ch) = value[index..].chars().next() else {
@@ -39,10 +48,11 @@ pub(crate) fn visible_width_max_line(value: &str) -> usize {
 
 /// Shorten `value` to at most `width` display columns, marking the cut with `…`.
 ///
-/// Values that already fit are returned unchanged. ANSI escapes are copied
-/// through without spending width, and a reset is appended before the ellipsis
-/// so a cut inside a colored run cannot leak its style into the rest of the
-/// line.
+/// The result never exceeds `width`, so a `width` of zero yields an empty
+/// string. Values that already fit are returned unchanged. ANSI escapes are
+/// copied through without spending width, and a reset is appended before the
+/// ellipsis so a cut inside a colored run cannot leak its style into the rest of
+/// the line.
 ///
 /// # Examples
 ///
@@ -51,12 +61,17 @@ pub(crate) fn visible_width_max_line(value: &str) -> usize {
 ///
 /// assert_eq!(truncate_to_width("fits", 10), "fits");
 /// assert_eq!(truncate_to_width("Loading usage logs", 10), "Loading u…");
+/// assert_eq!(truncate_to_width("Loading usage logs", 0), "");
 /// ```
 pub fn truncate_to_width(value: &str, width: usize) -> String {
     if visible_width(value) <= width {
         return value.to_string();
     }
-    if width <= 1 {
+    // The ellipsis itself needs a column, so a zero budget can only stay silent.
+    if width == 0 {
+        return String::new();
+    }
+    if width == 1 {
         return "…".to_string();
     }
     let mut output = String::new();
@@ -66,16 +81,7 @@ pub fn truncate_to_width(value: &str, width: usize) -> String {
     while index < bytes.len() {
         if bytes[index] == 0x1b {
             let start = index;
-            index += 1;
-            if index < bytes.len() && bytes[index] == b'[' {
-                index += 1;
-                while index < bytes.len() && !(bytes[index] as char).is_ascii_alphabetic() {
-                    index += 1;
-                }
-                if index < bytes.len() {
-                    index += 1;
-                }
-            }
+            index = skip_ansi_escape(bytes, index);
             output.push_str(&value[start..index]);
             continue;
         }
@@ -119,6 +125,12 @@ mod tests {
     #[test]
     fn truncate_to_width_stays_within_the_requested_width() {
         assert_eq!(truncate_to_width("Loading usage logs", 10), "Loading u…");
+    }
+
+    #[test]
+    fn truncate_to_width_writes_nothing_when_no_column_is_available() {
+        assert_eq!(truncate_to_width("Loading usage logs", 0), "");
+        assert_eq!(truncate_to_width("Loading usage logs", 1), "…");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the flickering progress spinner on narrow terminals (#1411). Each frame clears its line with `\r\x1b[K`, which only erases the row the cursor sits on, so a status wider than the terminal wraps and every redraw leaves the overflow row behind.

## What changed

- `ccusage-core::progress` truncates the status to the terminal width minus the spinner prefix and one spare column before writing it, so the line always occupies a single row and the single-line clear stays correct.
- `table.rs` already had ANSI- and CJK-aware truncation for table cells, so that helper moves to `ccusage-terminal::width` as the public `truncate_to_width` rather than being duplicated. Its tests and insta snapshot move with it.

## Why

On an 80-column terminal the combined status is ~85 columns:

```
⠏ Refreshing model pricing from LiteLLM... :: Loading usage logs (0/2) :: Claude, Codex
```

so it wrapped on every online run. `-O` skips the pricing status, which is why it avoided the flicker.

## Testing

- `just rust::test`, clippy (`--all-targets`), `just hawk`, and `just fmt` are clean.
- New unit tests cover the narrow, wide, and no-room-at-all cases, plus width/CJK/ANSI truncation behaviour.
- Verified end to end under a pty: at `COLUMNS=40` all 284 spinner frames stay within 39 columns (83 of them truncated, none wrapping); at `COLUMNS=80` nothing is truncated.

Closes #1411

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes spinner flicker on narrow terminals by keeping the spinner line on a single row. Also makes truncation ANSI/CJK-aware in `ccusage-terminal` and treats zero-width truncation as empty to avoid overflow.

- **Bug Fixes**
  - Truncate spinner status to terminal width minus the spinner prefix and one spare column using `truncate_to_width` and `terminal_width` to prevent wrapping and flicker.
  - Make `truncate_to_width(..., 0)` return "" (not "…") to avoid overrunning the width on ultra-narrow terminals.

- **Refactors**
  - Move ANSI/CJK-aware truncation from `table.rs` to `ccusage-terminal::width` as public `truncate_to_width`, share ANSI escape scanning via `skip_ansi_escape`, and re-export in `ccusage-terminal`; update table code and snapshots.

<sup>Written for commit 7f130ed1f6ac1d4f5472b30f4c030d2a58773518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public `truncate_to_width` helper for ANSI-aware, Unicode column–based truncation.
  * Re-exported the truncation helper from the terminal crate for easier access.

* **Bug Fixes**
  * Reduced spinner/status flicker when terminal line wrapping occurs.
  * Improved status rendering in narrow terminals by truncating text to available width.
  * Enhanced table truncation to preserve ANSI styling correctly and handle wide characters.

* **Documentation**
  * Updated terminal crate documentation to reflect its width/truncation responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->