### PR TITLE
fix(codex): follow a rewritten replay burst past a second tick

### DIFF
--- a/rust/adapters/codex/src/loader.rs
+++ b/rust/adapters/codex/src/loader.rs
@@ -1722,6 +1722,58 @@ mod tests {
     }
 
     #[test]
+    fn skips_a_rewritten_burst_that_straddles_a_second_boundary() {
+        let fixture = fs_fixture!({
+            // Codex writes the replayed history in a few milliseconds, so the
+            // burst lands on either side of a second tick whenever the fork
+            // happens late in a second. Measured against real logs, such a burst
+            // spans tens of milliseconds while the child's own first turn follows
+            // seconds later, so the run is what identifies it, not the second it
+            // was stamped with.
+            "child.jsonl": [
+                replay_metadata("2026-07-10T09:00:00.985Z", "child", Some("missing-parent")),
+                replay_token_count("2026-07-10T09:00:00.986Z", 100),
+                replay_token_count("2026-07-10T09:00:00.999Z", 200),
+                replay_token_count("2026-07-10T09:00:01.000Z", 300),
+                replay_token_count("2026-07-10T09:00:01.009Z", 400),
+                // The child's own first turn, after a real pause.
+                replay_token_count("2026-07-10T09:00:08.000Z", 500),
+            ]
+            .join("\n"),
+        });
+
+        assert_eq!(
+            replay_input_tokens_by_session(fixture.root()),
+            [("child".to_string(), 500)]
+        );
+    }
+
+    #[test]
+    fn keeps_fork_local_usage_recorded_after_a_rewritten_burst() {
+        let fixture = fs_fixture!({
+            "child.jsonl": [
+                replay_metadata("2026-07-10T09:00:00.000Z", "child", Some("missing-parent")),
+                replay_token_count("2026-07-10T09:00:00.100Z", 100),
+                replay_token_count("2026-07-10T09:00:00.200Z", 200),
+                // Every later turn is the child's own, however many there are.
+                replay_token_count("2026-07-10T09:00:30.000Z", 300),
+                replay_token_count("2026-07-10T09:01:00.000Z", 400),
+                replay_token_count("2026-07-10T09:01:30.000Z", 500),
+            ]
+            .join("\n"),
+        });
+
+        assert_eq!(
+            replay_input_tokens_by_session(fixture.root()),
+            [
+                ("child".to_string(), 300),
+                ("child".to_string(), 400),
+                ("child".to_string(), 500),
+            ]
+        );
+    }
+
+    #[test]
     fn keeps_child_usage_matching_parent_event_after_fork() {
         let fixture = fs_fixture!({
             "parent.jsonl": [
@@ -1841,9 +1893,11 @@ mod tests {
                     "payload": {"id": "child", "forked_from_id": "missing-parent"},
                 })
                 .to_string(),
+                // The replay repeats a snapshot, which must not end the burst.
                 token_count("2026-07-10T08:00:00.100Z", 100, 100),
                 token_count("2026-07-10T08:00:00.200Z", 100, 100),
-                token_count("2026-07-10T08:00:01.000Z", 50, 50),
+                // The child's own turn, after a real pause.
+                token_count("2026-07-10T08:00:08.000Z", 50, 50),
             ]
             .join("\n"),
         });

--- a/rust/adapters/codex/src/parser.rs
+++ b/rust/adapters/codex/src/parser.rs
@@ -140,8 +140,8 @@ fn detect_rewritten_burst(path: &Path) -> Option<TimestampMs> {
         match first {
             None => first = Some(timestamp),
             Some(first) => {
-                return (timestamp.as_millis() - first.as_millis()
-                    <= CODEX_REWRITTEN_BURST_PAUSE_MS)
+                return (0..=CODEX_REWRITTEN_BURST_PAUSE_MS)
+                    .contains(&(timestamp.as_millis() - first.as_millis()))
                     .then_some(first);
             }
         }
@@ -207,8 +207,8 @@ pub(super) fn visit_codex_session_file(
                 }
                 CodexReplayState::SkippingRewrittenBurst(previous) => {
                     if let Some(timestamp) = parse_ts_timestamp(&event.timestamp)
-                        && timestamp.as_millis() - previous.as_millis()
-                            <= CODEX_REWRITTEN_BURST_PAUSE_MS
+                        && (0..=CODEX_REWRITTEN_BURST_PAUSE_MS)
+                            .contains(&(timestamp.as_millis() - previous.as_millis()))
                     {
                         replay = CodexReplayState::SkippingRewrittenBurst(timestamp);
                         return Ok(());

--- a/rust/adapters/codex/src/parser.rs
+++ b/rust/adapters/codex/src/parser.rs
@@ -10,7 +10,9 @@ use memchr::memmem::Finder;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::{CodexRawUsage, CodexServiceTier, CodexTokenUsageEvent, Result, TimestampMs};
+use crate::{
+    CodexRawUsage, CodexServiceTier, CodexTokenUsageEvent, Result, TimestampMs, parse_ts_timestamp,
+};
 
 use super::types::{
     CodexInfo, CodexLogEntry, CodexModelMetadata, CodexPayload, CodexResultFields,
@@ -72,19 +74,37 @@ enum CodexReplayState<'a> {
         index: usize,
     },
     /// The parent stream could not anchor the replay, so skip the leading burst
-    /// that Codex rewrote into a single second.
-    SkippingSecond([u8; 19]),
+    /// that Codex rewrote to the fork instant. Carries the last skipped event so
+    /// the run can be followed however long it takes to write.
+    SkippingRewrittenBurst(TimestampMs),
     /// Past the replayed history: every remaining event is the child's own usage.
     Done,
 }
 
-fn detect_replay_second(path: &Path) -> Option<[u8; 19]> {
+/// Longest pause tolerated inside a burst of replayed usage.
+///
+/// Codex rewrites a replayed history to the fork instant and writes it in one
+/// go, so the burst is dense while the child's own first turn follows a real
+/// pause. Across the fork logs this was measured against, bursts spanned 10 to
+/// 40ms and the pause that followed ran from 5.8 to 15.3 seconds, so a second
+/// sits two orders of magnitude above the one and well below the other.
+///
+/// Bucketing by the recorded second instead would split any burst written across
+/// a second tick, leaving the remainder counted as the child's own usage.
+const CODEX_REWRITTEN_BURST_PAUSE_MS: i64 = 1_000;
+
+/// Start of the burst of replayed usage at the head of `path`, if it has one.
+///
+/// A session that opens with two usage events written back to back replayed a
+/// history it did not spend; one that pauses between them was recording its own
+/// turns from the start.
+fn detect_rewritten_burst(path: &Path) -> Option<TimestampMs> {
     let Ok(file) = fs::File::open(path) else {
         return None;
     };
     let mut reader = BufReader::new(file);
     let mut line = Vec::new();
-    let mut first_second: Option<[u8; 19]> = None;
+    let mut first: Option<TimestampMs> = None;
 
     loop {
         line.clear();
@@ -111,19 +131,19 @@ fn detect_replay_second(path: &Path) -> Option<[u8; 19]> {
         {
             continue;
         }
-        let Some(timestamp) = codex_session_timestamp(value.timestamp.as_ref()) else {
-            continue;
-        };
-        let Some(second) = timestamp
-            .as_bytes()
-            .get(..19)
-            .and_then(|second| second.try_into().ok())
+        let Some(timestamp) = codex_session_timestamp(value.timestamp.as_ref())
+            .as_deref()
+            .and_then(parse_ts_timestamp)
         else {
             continue;
         };
-        match first_second {
-            None => first_second = Some(second),
-            Some(first) => return (first == second).then_some(first),
+        match first {
+            None => first = Some(timestamp),
+            Some(first) => {
+                return (timestamp.as_millis() - first.as_millis()
+                    <= CODEX_REWRITTEN_BURST_PAUSE_MS)
+                    .then_some(first);
+            }
         }
     }
 }
@@ -176,14 +196,21 @@ pub(super) fn visit_codex_session_file(
                     }
                     // Nothing matched, so the parent stream cannot anchor this
                     // replay: the log is unavailable, or Codex rewrote the copied
-                    // history. Fall back to the same-second burst instead.
+                    // history. Fall back to the rewritten burst instead.
                     replay = (index == 0)
-                        .then(|| detect_replay_second(path))
+                        .then(|| detect_rewritten_burst(path))
                         .flatten()
-                        .map_or(CodexReplayState::Done, CodexReplayState::SkippingSecond);
+                        .map_or(
+                            CodexReplayState::Done,
+                            CodexReplayState::SkippingRewrittenBurst,
+                        );
                 }
-                CodexReplayState::SkippingSecond(second) => {
-                    if event.timestamp.as_bytes().get(..19) == Some(second.as_slice()) {
+                CodexReplayState::SkippingRewrittenBurst(previous) => {
+                    if let Some(timestamp) = parse_ts_timestamp(&event.timestamp)
+                        && timestamp.as_millis() - previous.as_millis()
+                            <= CODEX_REWRITTEN_BURST_PAUSE_MS
+                    {
+                        replay = CodexReplayState::SkippingRewrittenBurst(timestamp);
                         return Ok(());
                     }
                     replay = CodexReplayState::Done;


### PR DESCRIPTION
Closes the gap left by #1457, which I closed as superseded — the one-second heuristic it rewrote no longer exists, but the residual bug it pointed at was real.

## Problem

When a forked session's parent log is in the scanned set, `CodexReplayPlan` subtracts the exact replayed prefix and the accounting is correct. When it is not — the parent was deleted, archived elsewhere, or lives outside the scanned directory — the parser falls back to skipping the burst Codex rewrote to the fork instant.

That fallback bucketed events by their recorded second (`[u8; 19]` prefix compare). Codex writes the replayed history in a few milliseconds, so whenever a fork lands late in a second the burst straddles the tick — and everything after the tick was counted as the child's own usage.

One real subagent log in a local `~/.codex/sessions`:

| Scanned | totalTokens |
| --- | --- |
| Child alone (parent absent, fallback) | 47,175,282 |
| Child + parent (exact prefix subtraction) | 19,820,638 |

A 2.4x over-count, from 315 replayed records that landed in the second after the tick. Its burst is 458 records at `00:36:00` plus 315 at `00:36:01`, all written between `.985` and `.000` — about 15ms of wall clock spread across two second strings.

## Fix

Follow the run rather than the second: skip while successive usage events stay within a second of each other, carrying the last skipped timestamp instead of a fixed second.

The threshold is picked from measurement, not taste. Across the 229 fork sessions in that log directory, the 9 with a leading burst show:

| | Range |
| --- | --- |
| Burst span | 10 – 40 ms |
| Pause before the child's own first turn | 5,789 – 15,252 ms |

One second sits two orders of magnitude above the burst and roughly 6x below the shortest real pause, so the two populations are cleanly separated.

I also checked #1457's own signal — `task_started.started_at` matching the record second — and did not adopt it. Across 1,833 real `task_started` records in fork sessions, 135 have `started_at` differing from their record second, including differences of exactly 1 second on native records that merely crossed a tick. Strict equality there misclassifies them.

## Verification

- 210 real fork sessions whose parent log could be located, each scanned twice, once alone and once beside its parent:

  | | Identical | Mismatched | Excess |
  | --- | --- | --- | --- |
  | Before | 209 / 210 | 1 | 27,354,644 |
  | After | **210 / 210** | 0 | 0 |

  The fallback now agrees with exact prefix subtraction on every one of them.

- A full scan of the same directory is unchanged down to the cost figure: `totalTokens 23,772,515,519`, `costUSD 12927.978162399995` before and after. The normal path is untouched.
- `just test` green, `just fmt` 0 changed, `cargo clippy --all-targets` no warnings.

## Test change to flag

`skips_missing_parent_replay_when_duplicate_snapshot_is_suppressed` placed the child's own turn 800ms after the burst. That only read as the child's own usage under second bucketing — by the measurements above an 800ms gap is inside a burst, not after one. The test's subject is snapshot suppression, so its fixture now uses a pause a real log would show and it keeps testing exactly that.

## Known limits

A fork whose own first turn begins within a second of the replayed burst would still be skipped. The shortest real pause observed is 5.8 seconds, and the previous code carried the same class of exposure, so this narrows the window rather than closing it. The exact path via the parent log has no such limit; this is only the fallback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated token usage when a forked Codex session’s parent log is missing by following the rewritten replay burst across second boundaries and requiring monotonic timestamps. Aligns the fallback with exact-prefix subtraction and prevents counting replayed history as the child’s usage.

- **Bug Fixes**
  - Skip the replayed burst by time continuity: continue skipping while successive events are monotonic and within 1,000ms.
  - Added `CODEX_REWRITTEN_BURST_PAUSE_MS`, `detect_rewritten_burst`, and a new state `SkippingRewrittenBurst`; use `parse_ts_timestamp` and real timestamps instead of `[u8; 19]` second prefixes.
  - Correctly handles bursts that straddle a tick and ignores duplicate snapshots; keeps the child’s own turns after the real pause.
  - Verification: 210/210 fork sessions now match exact subtraction; full scan totals unchanged; adjusted test fixture to use a realistic pause.

<sup>Written for commit afca9d38027447344e1cfac79d8d431d26417507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of replayed and forked Codex sessions, including bursts that cross second boundaries.
  * Prevented duplicate replay snapshots from being counted as new usage.
  * Preserved usage recorded during subsequent fork-local session activity.

* **Tests**
  * Added coverage for rewritten replay bursts and fork-local usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->