### PR TITLE
refactor(nix): derive package metadata from the npm manifest

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -11,7 +11,13 @@
   apple-sdk_15,
 }:
 let
-  inherit ((builtins.fromJSON (builtins.readFile (root + /package.json)))) version;
+  # The root manifest is the version source of truth: rust/crates/ccusage/build.rs
+  # falls back to reading it when CCUSAGE_VERSION is unset, and a test in main.rs
+  # asserts the compiled version matches it.
+  inherit (lib.importJSON (root + /package.json)) version;
+  # The published npm manifest owns the name and the user-facing metadata, so
+  # `meta` below derives from it instead of restating it in Nix.
+  cliPackageJson = lib.importJSON (root + /apps/ccusage/package.json);
   src = lib.cleanSourceWith {
     src = root + /rust;
     filter =
@@ -30,7 +36,7 @@ let
   # duplicated.
   cargoConfigEnv = (builtins.fromTOML (builtins.readFile (root + /.cargo/config.toml))).env;
   commonArgs = {
-    pname = "ccusage";
+    pname = cliPackageJson.name;
     inherit version src;
     strictDeps = true;
     doCheck = false;
@@ -132,10 +138,9 @@ craneLib.buildPackage (
         ;
     };
     meta = {
-      description = "Analyze coding agent CLI token usage and costs from local data";
-      homepage = "https://github.com/ccusage/ccusage";
-      license = lib.licenses.mit;
-      mainProgram = "ccusage";
+      inherit (cliPackageJson) description homepage;
+      license = lib.getLicenseFromSpdxId cliPackageJson.license;
+      mainProgram = builtins.head (builtins.attrNames cliPackageJson.bin);
     };
   }
 )


### PR DESCRIPTION
`package.nix` restated the name, description, homepage, license, and `mainProgram` that `apps/ccusage/package.json` already declares. The two had already drifted — the manifest says "Analyze coding (agent) CLI token usage and costs from local data" while Nix dropped the parentheses — and nothing tied the Nix `mainProgram` to the manifest's `bin` entry.

## What Changed

- Import `apps/ccusage/package.json` and derive `pname`, `meta.description`, `meta.homepage`, `meta.license` (via `lib.getLicenseFromSpdxId`), and `meta.mainProgram` (the sole `bin` key) from it, following the pattern in [yusukebe/ax](https://github.com/yusukebe/ax/blob/main/package.nix).
- Switch the root manifest read from `builtins.fromJSON (builtins.readFile ...)` to `lib.importJSON`.

`ccusage-static` and `ccusage-darwin-x64` already build their `meta` from `config.packages.ccusage.meta`, so they inherit this with no change.

## Why version stays on the root manifest

`rust/crates/ccusage/build.rs` falls back to reading the root `package.json` when `CCUSAGE_VERSION` is unset, and `compiled_version_matches_release_package` asserts the compiled version matches it. Moving the Nix source would split the version's origin between the Nix build and a plain `cargo build`. tagpr bumps both manifests together.

## Behaviour change

`meta.homepage` gains the `#readme` fragment the manifest carries (`https://github.com/ccusage/ccusage#readme`). Same page; happy to strip it or drop it from `package.json` if preferred.

## Testing

`nix eval` on the resulting derivations:

- `.#ccusage`: `pname` = `ccusage`, `version` = `20.0.19`, `license.spdxId` = `MIT`, `mainProgram` = `ccusage` — all unchanged.
- `.#ccusage-darwin-x64`: still inherits the license and `mainProgram`.
- `nixfmt --check package.nix` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derive `ccusage` Nix package metadata from `apps/ccusage/package.json` to keep name, description, homepage, license, and `mainProgram` in sync. Version still comes from the root `package.json` to match the Rust build.

- **Refactors**
  - Import `apps/ccusage/package.json` via `lib.importJSON` and set `pname`, `meta.description`, `meta.homepage`, `meta.license` (with `lib.getLicenseFromSpdxId`), and `meta.mainProgram` (from the sole `bin` key).
  - Read the root `package.json` with `lib.importJSON` instead of `builtins.fromJSON`.
  - `ccusage-static` and `ccusage-darwin-x64` inherit the updated `meta` without changes.
  - Minor: `meta.homepage` now includes the `#readme` fragment from the manifest.

<sup>Written for commit acf86b774e1d217bc5f6fcab47d0161ce8f01b85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package metadata to stay synchronized with the published application manifest.
  - Improved version, name, description, homepage, license, and executable metadata handling for package consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->