### PR TITLE
chore(renovate): unblock automated dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,22 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"],
 	"nix": {
 		"enabled": true
 	},
-	"extends": ["github>ryoppippi/renovate-config:no-group"]
+	"automerge": true,
+	"platformAutomerge": true,
+	"branchConcurrentLimit": 0,
+	"dependencyDashboard": true,
+	"labels": ["dependencies", "renovate"],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": ["at any time"]
+	},
+	"minimumReleaseAge": "3 days",
+	"postUpdateOptions": ["pnpmDedupe"],
+	"rangeStrategy": "bump",
+	"vulnerabilityAlerts": {
+		"labels": ["security"]
+	}
 }

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -30,7 +30,10 @@ in
           hooks = {
             renovate-config-validator = {
               enable = true;
-              entry = "${lib.getExe pkgs.renovate} --strict config-validator";
+              # `renovate config-validator` does not exist as a subcommand, and
+              # `--strict` is only understood by the standalone validator, so the
+              # hook silently failed with "unknown option" whenever it did run.
+              entry = "${pkgs.renovate}/bin/renovate-config-validator --strict";
               files = "renovate\\.json5?$";
               pass_filenames = false;
               stages = [


### PR DESCRIPTION
## Summary

Renovate has not opened a dependency PR since 2026-06-22. Nothing is broken on our side except the schedule: every pending update is gated behind the `schedule:weekly` window (`before 3am on monday`) that came in through the shared preset, and no hosted run has landed inside that window for five weeks.

Evidence, from a local `renovate --dry-run=full --platform=github ccusage/ccusage`:

- unmodified config: `result: "done"`, `onboarded: true`, zero branches — the run is healthy, it just is not allowed to do anything today.
- with the schedule dropped: **25 update branches plus lock file maintenance** pending, i.e. a five-week backlog.

## What Changed

`.github/renovate.json` now inlines the settings that used to come from `github>ryoppippi/renovate-config:no-group`. That preset lives outside this org, and the settings that need to differ here are exactly the ones that caused the outage, so extending it no longer buys anything. Everything else from the preset is carried over verbatim: `config:recommended`, `automerge`, `platformAutomerge`, `branchConcurrentLimit: 0`, `labels`, `minimumReleaseAge: 3 days`, `postUpdateOptions: [pnpmDedupe]`, `rangeStrategy: bump`, and the `security` label on vulnerability alerts.

Differences against the preset:

- no `schedule:weekly`, so any hosted run can act on the backlog.
- `dependencyDashboard: true`. It is the only place the hosted app reports config errors, and the only way to trigger a run by hand — with it disabled this outage was completely invisible.
- `lockFileMaintenance` runs at any time instead of weekly, so `flake.lock`, `pnpm-lock.yaml` and `rust/Cargo.lock` refresh as soon as inputs move rather than once a week.

`nix.enabled` stays on — the manager is off by default, and it is what puts `flake.lock` in the lock file maintenance branch at all.

Also fixes `nix/git-hooks.nix`: the `renovate-config-validator` hook ran `renovate --strict config-validator`, which exits with `unknown option '--strict'` on renovate 43. `config-validator` is not a subcommand, and `--strict` only exists on the standalone `renovate-config-validator` binary. The hook only fires when a renovate config file is staged, so nobody hit it before.

## Testing

- `renovate-config-validator --strict` passes, and the fixed hook ran it on this commit.
- Dry-run with the new settings forced: the backlog is created immediately, the lock file maintenance branch is included, and the Dependency Dashboard issue would be created.

## Notes

- Lock file maintenance rewrites `flake.lock` as a whole, so it also moves the `litellm` and `models-dev` pricing inputs. `update-pricing.yaml` already runs hourly and regenerates the committed pricing snapshots from whatever revision is locked, so a snapshot left behind by a lock maintenance PR is repaired within the hour.
- A `flake.lock` bump that changes a formatter version makes `security & lint preflight` fail on `treefmt-check` and needs a `nix fmt` commit on the branch. That is what kept #1355 red and open for a month. Renovate cannot do that itself: `postUpgradeTasks` commands have to match the global `allowedCommands` allowlist, which only Mend controls on the hosted app.

## Follow-up after merge

Pushing this to `main` triggers a webhook run. If the Dependency Dashboard issue does not appear within ~15 minutes, the hosted app is not processing this repository at all — most likely fallout from the `ryoppippi/ccusage` to `ccusage/ccusage` transfer — and it needs re-onboarding from https://developer.mend.io/github/ccusage/ccusage (or by toggling the app's repository access).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks automated dependency updates by inlining and adjusting `renovate` config to remove the weekly schedule gate and enable the Dependency Dashboard. Also fixes the `nix` git hook to use the standalone `renovate-config-validator`.

- **Refactors**
  - Inline `github>ryoppippi/renovate-config:no-group` and remove `schedule:weekly` so hosted runs can create PRs anytime.
  - Enable `dependencyDashboard` and run lockfile maintenance “at any time” for `flake.lock`, `pnpm-lock.yaml`, and `rust/Cargo.lock`.
  - Preserve previous behavior: `automerge`, `platformAutomerge`, `branchConcurrentLimit: 0`, labels, `minimumReleaseAge: "3 days"`, `postUpdateOptions: ["pnpmDedupe"]`, `rangeStrategy: "bump"`, security labels, and `nix.enabled: true`.

- **Bug Fixes**
  - Update Nix hook to call `${pkgs.renovate}/bin/renovate-config-validator --strict` (previous `renovate --strict config-validator` was invalid and failed).

<sup>Written for commit 4f4ebb8de04ffd92c9a99e347a26014576b8bcff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

