### PR TITLE
ci(pricing): land pricing updates on main instead of opening PRs

### DIFF
--- a/.github/actions/commit-and-push-main/action.yaml
+++ b/.github/actions/commit-and-push-main/action.yaml
@@ -1,0 +1,38 @@
+name: Commit and push to main
+description: >
+  Commit the given paths as github-actions[bot] and push them to main, rebasing
+  onto whatever main has become while the caller was validating. Callers must
+  check out with fetch-depth: 0, because a shallow clone has no merge base to
+  rebase onto, and must only run this when the paths actually changed.
+inputs:
+  message:
+    description: Commit message
+    required: true
+  paths:
+    description: Whitespace-separated list of paths to commit
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Commit and push to main
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        MESSAGE: ${{ inputs.message }}
+        PATHS: ${{ inputs.paths }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        gh auth setup-git
+
+        # PATHS is word-split on purpose: it carries a list of paths.
+        # shellcheck disable=SC2086
+        git commit --message "$MESSAGE" -- $PATHS
+
+        git fetch origin main
+        if ! git rebase origin/main; then
+          git rebase --abort
+          echo 'main moved with a conflicting change; the next run will retry.'
+          exit 1
+        fi
+        git push origin HEAD:main

--- a/.github/scripts/update-litellm-lock.nu
+++ b/.github/scripts/update-litellm-lock.nu
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from ../.. nixpkgs#nushell nixpkgs#git --command nu
+
+# Bump the pinned LiteLLM input and report whether it moved the pricing JSON that
+# the build embeds, so the workflow can skip validating lock-only churn.
+def main [] {
+    let before = (locked-pricing)
+    ^nix flake update litellm
+
+    let changed = match ((locked-pricing) == $before) {
+        false => true
+        true => {
+            print 'LiteLLM pricing JSON is unchanged; dropping the lock-only bump.'
+            ^git checkout -- flake.lock
+            false
+        }
+    }
+
+    $"changed=($changed)(char nl)" | save --append $env.GITHUB_OUTPUT
+}
+
+# Fetch model_prices_and_context_window.json at the revision flake.lock pins.
+def locked-pricing []: nothing -> record {
+    let rev = open --raw flake.lock | from json | get nodes.litellm.locked.rev
+    http get $"https://raw.githubusercontent.com/BerriAI/litellm/($rev)/model_prices_and_context_window.json"
+}

--- a/.github/scripts/update-models-dev-lock.nu
+++ b/.github/scripts/update-models-dev-lock.nu
@@ -1,0 +1,35 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from ../.. nixpkgs#nushell nixpkgs#git --command nu
+
+const SNAPSHOTS = [
+    'rust/crates/ccusage-core/src/models-dev-pricing.json'
+    'rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json'
+]
+
+# Bump the pinned models.dev input, regenerate the committed snapshots, and report
+# whether anything the build embeds actually moved.
+def main [] {
+    ^nix flake update models-dev
+    ^nix develop --command just gen-models-dev-pricing
+
+    let state = {
+        snapshots: (dirty ...$SNAPSHOTS)
+        lock: (dirty flake.lock)
+    }
+    let changed = match $state {
+        {snapshots: true} => true
+        {snapshots: false, lock: true} => {
+            print 'models.dev pricing snapshots are unchanged; dropping the lock-only bump.'
+            ^git checkout -- flake.lock ...$SNAPSHOTS
+            false
+        }
+        _ => false
+    }
+
+    $"changed=($changed)(char nl)" | save --append $env.GITHUB_OUTPUT
+}
+
+# Whether git reports tracked changes for the given paths.
+def dirty [...paths: string]: nothing -> bool {
+    (^git diff --quiet -- ...$paths | complete).exit_code != 0
+}

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -7,15 +7,22 @@ on:
 
 permissions: {}
 
+# Both jobs push to main, so a manual dispatch landing on top of the hourly
+# schedule would otherwise race the other run's push.
+concurrency:
+  group: update-pricing
+  cancel-in-progress: false
+
 jobs:
   update-pricing:
     runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 60
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-nix-cache
       - name: Capture current LiteLLM pricing JSON
@@ -28,6 +35,7 @@ jobs:
         run: |
           nix flake update litellm
       - name: Skip lock-only LiteLLM updates
+        id: litellm
         run: |
           rev="$(jq -r '.nodes.litellm.locked.rev' flake.lock)"
           curl --fail --location --silent --show-error \
@@ -35,57 +43,53 @@ jobs:
             --output /tmp/litellm-pricing-after.json
 
           if cmp --silent /tmp/litellm-pricing-before.json /tmp/litellm-pricing-after.json; then
-            echo "LiteLLM pricing JSON is unchanged; skipping PR."
+            echo "LiteLLM pricing JSON is unchanged; skipping the update."
             git checkout -- flake.lock
           fi
-      - name: Validate updated pricing snapshot
-        run: |
+
           if git diff --quiet; then
-            echo "Pricing snapshot is already up to date."
-            exit 0
-          fi
-          nix develop --command just check
-      - name: Create pull request
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if git diff --quiet; then
-            echo "Pricing snapshot is already up to date."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          gh auth setup-git
-
-          branch="automation/litellm-pricing"
-          git checkout -B "$branch"
-          git add flake.lock
-          git commit -m "chore(pricing): update LiteLLM snapshot"
-          git push --force origin "$branch"
-
-          body="$(printf '%s\n' \
-            'Updates the locked LiteLLM pricing input used by Nix builds.' \
-            '' \
-            'Validation:' \
-            '- just check')"
-
-          if gh pr view "$branch" >/dev/null 2>&1; then
-            printf '%s\n' "$body" | gh pr edit "$branch" --title "chore(pricing): update LiteLLM snapshot" --body-file -
+            echo 'Pricing snapshot is already up to date.'
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
           else
-            printf '%s\n' "$body" | gh pr create --base main --head "$branch" --title "chore(pricing): update LiteLLM snapshot" --body-file -
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
           fi
+      # The push below cannot trigger ci.yaml, so the checks that would have run
+      # on a pull request run here instead. Each leg no-ops when the snapshot was
+      # already up to date.
+      - parallel:
+          - name: Run nix flake check
+            run: |
+              git diff --quiet && exit 0
+              nix flake check --print-build-logs
+          - name: Run Rust tests
+            run: |
+              git diff --quiet && exit 0
+              nix build .#ccusage-tests --no-link --print-build-logs
+          - name: JS test
+            run: |
+              git diff --quiet && exit 0
+              nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#just
+              pnpm install --frozen-lockfile
+              mkdir -p "$HOME/.claude/projects"
+              mkdir -p "$HOME/.config/claude/projects"
+              just test-node
+      - uses: ./.github/actions/commit-and-push-main
+        if: steps.litellm.outputs.changed == 'true'
+        with:
+          message: 'chore(pricing): update LiteLLM snapshot'
+          paths: flake.lock
 
   update-models-dev-pricing:
     needs: update-pricing
     if: ${{ always() }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 60
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-nix-cache
       - name: Update models.dev input
@@ -95,47 +99,43 @@ jobs:
         run: |
           nix develop --command just gen-models-dev-pricing
       - name: Skip lock-only models.dev updates
+        id: models-dev
         run: |
           # Only the compacted snapshot affects the build; if a models.dev bump
           # leaves embedded pricing unchanged, drop the lock-only churn.
           if git diff --quiet -- rust/crates/ccusage-core/src/models-dev-pricing.json rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json; then
-            echo "models.dev pricing snapshots are unchanged; skipping PR."
+            echo "models.dev pricing snapshots are unchanged; skipping the update."
             git checkout -- flake.lock rust/crates/ccusage-core/src/models-dev-pricing.json rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json
           fi
-      - name: Validate updated pricing snapshot
-        run: |
+
           if git diff --quiet; then
-            echo "Pricing snapshot is already up to date."
-            exit 0
-          fi
-          nix develop --command just check
-      - name: Create pull request
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if git diff --quiet; then
-            echo "Pricing snapshot is already up to date."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          gh auth setup-git
-
-          branch="automation/models-dev-pricing"
-          git checkout -B "$branch"
-          git add flake.lock rust/crates/ccusage-core/src/models-dev-pricing.json rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json
-          git commit -m "chore(pricing): update models.dev snapshot"
-          git push --force origin "$branch"
-
-          body="$(printf '%s\n' \
-            'Updates the pinned models.dev input and its committed pricing snapshot.' \
-            '' \
-            'Validation:' \
-            '- just check')"
-
-          if gh pr view "$branch" >/dev/null 2>&1; then
-            printf '%s\n' "$body" | gh pr edit "$branch" --title "chore(pricing): update models.dev snapshot" --body-file -
+            echo 'Pricing snapshot is already up to date.'
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
           else
-            printf '%s\n' "$body" | gh pr create --base main --head "$branch" --title "chore(pricing): update models.dev snapshot" --body-file -
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
           fi
+      - parallel:
+          - name: Run nix flake check
+            run: |
+              git diff --quiet && exit 0
+              nix flake check --print-build-logs
+          - name: Run Rust tests
+            run: |
+              git diff --quiet && exit 0
+              nix build .#ccusage-tests --no-link --print-build-logs
+          - name: JS test
+            run: |
+              git diff --quiet && exit 0
+              nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#just
+              pnpm install --frozen-lockfile
+              mkdir -p "$HOME/.claude/projects"
+              mkdir -p "$HOME/.config/claude/projects"
+              just test-node
+      - uses: ./.github/actions/commit-and-push-main
+        if: steps.models-dev.outputs.changed == 'true'
+        with:
+          message: 'chore(pricing): update models.dev snapshot'
+          paths: >-
+            flake.lock
+            rust/crates/ccusage-core/src/models-dev-pricing.json
+            rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -7,7 +7,7 @@ on:
 
 permissions: {}
 
-# Both jobs push to main, so a manual dispatch landing on top of the hourly
+# Both legs push to main, so a manual dispatch landing on top of the hourly
 # schedule would otherwise race the other run's push.
 concurrency:
   group: update-pricing
@@ -15,22 +15,46 @@ concurrency:
 
 jobs:
   update-pricing:
+    name: ${{ matrix.name }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 60
     permissions:
       contents: write
+    strategy:
+      fail-fast: false
+      # The legs push to the same branch, so they must not race each other's
+      # rebase onto main.
+      max-parallel: 1
+      matrix:
+        include:
+          - name: litellm
+            script: .github/scripts/update-litellm-lock.nu
+            message: 'chore(pricing): update LiteLLM snapshot'
+            paths: flake.lock
+          - name: models-dev
+            script: .github/scripts/update-models-dev-lock.nu
+            message: 'chore(pricing): update models.dev snapshot'
+            paths: >-
+              flake.lock
+              rust/crates/ccusage-core/src/models-dev-pricing.json
+              rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-nix-cache
-      - name: Update LiteLLM pricing input
-        id: litellm
-        run: .github/scripts/update-litellm-lock.nu
-      # The push below cannot trigger ci.yaml, so the checks that would have run
-      # on a pull request run here instead. Each leg no-ops when the snapshot was
-      # already up to date.
+        with:
+          cache-scope: ${{ matrix.name }}
+      - name: Update pricing input
+        id: update
+        env:
+          SCRIPT: ${{ matrix.script }}
+        run: $SCRIPT
+      # The push below cannot trigger ci.yaml, so the checks a pull request would
+      # have run happen here instead: `nix flake check` covers the preflight job's
+      # treefmt and gitleaks checks, and the remaining legs mirror the test job.
+      # Each leg no-ops when the update turned out to be lock-only churn.
       - parallel:
           - name: Run nix flake check
             run: |
@@ -48,50 +72,12 @@ jobs:
               mkdir -p "$HOME/.claude/projects"
               mkdir -p "$HOME/.config/claude/projects"
               just test-node
+          - name: Babashka performance harness test
+            run: |
+              git diff --quiet && exit 0
+              apps/ccusage/scripts/compare-pr-performance_test.clj
       - uses: ./.github/actions/commit-and-push-main
-        if: steps.litellm.outputs.changed == 'true'
+        if: steps.update.outputs.changed == 'true'
         with:
-          message: 'chore(pricing): update LiteLLM snapshot'
-          paths: flake.lock
-
-  update-models-dev-pricing:
-    needs: update-pricing
-    if: ${{ always() }}
-    runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 60
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: ./.github/actions/setup-nix-cache
-      - name: Update models.dev pricing input
-        id: models-dev
-        run: .github/scripts/update-models-dev-lock.nu
-      - parallel:
-          - name: Run nix flake check
-            run: |
-              git diff --quiet && exit 0
-              nix flake check --print-build-logs
-          - name: Run Rust tests
-            run: |
-              git diff --quiet && exit 0
-              nix build .#ccusage-tests --no-link --print-build-logs
-          - name: JS test
-            run: |
-              git diff --quiet && exit 0
-              nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#just
-              pnpm install --frozen-lockfile
-              mkdir -p "$HOME/.claude/projects"
-              mkdir -p "$HOME/.config/claude/projects"
-              just test-node
-      - uses: ./.github/actions/commit-and-push-main
-        if: steps.models-dev.outputs.changed == 'true'
-        with:
-          message: 'chore(pricing): update models.dev snapshot'
-          paths: >-
-            flake.lock
-            rust/crates/ccusage-core/src/models-dev-pricing.json
-            rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json
+          message: ${{ matrix.message }}
+          paths: ${{ matrix.paths }}

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -25,34 +25,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-nix-cache
-      - name: Capture current LiteLLM pricing JSON
-        run: |
-          rev="$(jq -r '.nodes.litellm.locked.rev' flake.lock)"
-          curl --fail --location --silent --show-error \
-            "https://raw.githubusercontent.com/BerriAI/litellm/${rev}/model_prices_and_context_window.json" \
-            --output /tmp/litellm-pricing-before.json
       - name: Update LiteLLM pricing input
-        run: |
-          nix flake update litellm
-      - name: Skip lock-only LiteLLM updates
         id: litellm
-        run: |
-          rev="$(jq -r '.nodes.litellm.locked.rev' flake.lock)"
-          curl --fail --location --silent --show-error \
-            "https://raw.githubusercontent.com/BerriAI/litellm/${rev}/model_prices_and_context_window.json" \
-            --output /tmp/litellm-pricing-after.json
-
-          if cmp --silent /tmp/litellm-pricing-before.json /tmp/litellm-pricing-after.json; then
-            echo "LiteLLM pricing JSON is unchanged; skipping the update."
-            git checkout -- flake.lock
-          fi
-
-          if git diff --quiet; then
-            echo 'Pricing snapshot is already up to date.'
-            echo 'changed=false' >> "$GITHUB_OUTPUT"
-          else
-            echo 'changed=true' >> "$GITHUB_OUTPUT"
-          fi
+        run: .github/scripts/update-litellm-lock.nu
       # The push below cannot trigger ci.yaml, so the checks that would have run
       # on a pull request run here instead. Each leg no-ops when the snapshot was
       # already up to date.
@@ -92,28 +67,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-nix-cache
-      - name: Update models.dev input
-        run: |
-          nix flake update models-dev
-      - name: Regenerate committed models.dev pricing snapshot
-        run: |
-          nix develop --command just gen-models-dev-pricing
-      - name: Skip lock-only models.dev updates
+      - name: Update models.dev pricing input
         id: models-dev
-        run: |
-          # Only the compacted snapshot affects the build; if a models.dev bump
-          # leaves embedded pricing unchanged, drop the lock-only churn.
-          if git diff --quiet -- rust/crates/ccusage-core/src/models-dev-pricing.json rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json; then
-            echo "models.dev pricing snapshots are unchanged; skipping the update."
-            git checkout -- flake.lock rust/crates/ccusage-core/src/models-dev-pricing.json rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json
-          fi
-
-          if git diff --quiet; then
-            echo 'Pricing snapshot is already up to date.'
-            echo 'changed=false' >> "$GITHUB_OUTPUT"
-          else
-            echo 'changed=true' >> "$GITHUB_OUTPUT"
-          fi
+        run: .github/scripts/update-models-dev-lock.nu
       - parallel:
           - name: Run nix flake check
             run: |


### PR DESCRIPTION
## Summary

`update-pricing.yaml` already runs hourly and already accepts `workflow_dispatch`, but it opened a pull request with `github.token`. Such a PR cannot trigger `ci.yaml`, so it arrived with no checks and nothing merged it — pricing data was only as fresh as the last time someone merged that PR by hand (#1355 for the flake lock sat open for a month for the same reason). Both jobs now validate in place and push straight to `main`, so a dispatch lands the update immediately.

## What Changed

- `.github/workflows/update-pricing.yaml`
  - each job runs the checks a PR would have run — `nix flake check`, `nix build .#ccusage-tests`, `just test-node` — in a `parallel:` step, then pushes to `main`.
  - the existing "skip lock-only update" logic now feeds a step output, so the push step is skipped instead of every later step re-testing `git diff`.
  - added a `concurrency` group: a manual dispatch would otherwise race the hourly run's push.
  - dropped `pull-requests: write`; the jobs only need `contents: write` now.
- `.github/actions/commit-and-push-main/action.yaml`: new composite action shared by both jobs. It commits the given paths as `github-actions[bot]`, rebases onto whatever `main` has become during validation, and fails loudly (so the next run retries) if that rebase conflicts.
- `.github/scripts/update-litellm-lock.nu` and `.github/scripts/update-models-dev-lock.nu`: the two update steps moved out of shell into Nushell. The lock file is read with `open`, the LiteLLM pricing document is fetched with `http get` and compared as a record, so the jq/curl/cmp dance and its `/tmp` JSON files are gone. models.dev decides through a `match` over `{snapshots, lock}`, which names the three states the step can end in — snapshots moved, only the lock moved, nothing moved. Both carry the repository's Nix shebang, so no nushell setup step is needed and they stay runnable by hand.

## Why the checks run inline

A push made with `github.token` cannot trigger `ci.yaml` either, so `main` would otherwise receive the pricing bump with no validation at all. Running the PR's checks inside the workflow keeps the same gate without needing a PR that nobody merges.

`just gen-models-dev-pricing` still runs before validation, so the committed `models-dev-pricing.json` and `codex-auto-review-fallbacks.json` snapshots never lag the locked `models-dev` revision.

## Testing

- Both Nushell scripts were run end to end against this checkout: LiteLLM bumped `34561482` to `f2cda740`, saw the pricing JSON change and reported `changed=true`; models.dev regenerated `models-dev-pricing.json` and reported `changed=true`. The lock and snapshot were restored afterwards.
- `nu-check` passes on both scripts.
- `just fmt` passes, which runs actionlint over the workflow, zizmor over both the workflow and the new composite action, and nufmt over the scripts.
- actionlint with the repo's ignore set reports nothing for the workflow; the only diagnostic anywhere is the `parallel:` step syntax already ignored repo-wide for `ci.yaml`.

## Note

The `parallel:` legs each start with `git diff --quiet && exit 0` so they no-op when the snapshot was already current. `if:` is used for the ordinary steps, but its behaviour on a `parallel:` step is not something this repo exercises yet, so the guard stays inside the legs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pricing updates for LiteLLM and models.dev are now applied automatically to the main branch when relevant pricing changes are detected.
  * Workflows were restructured to use a single change-aware, matrix-driven update flow.
* **Bug Fixes**
  * Reduced unnecessary lockfile/pricing commits by detecting whether the underlying pricing content actually changed.
  * Prevented lock-only churn by reverting lock changes when snapshot outputs remained the same.
  * Improved reliability by serializing runs and handling rebase conflicts to allow safe retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->