### PR TITLE
fix(pricing): commit the codex fallback snapshot from its real path

### DIFF
--- a/.github/scripts/pricing-lock.nu
+++ b/.github/scripts/pricing-lock.nu
@@ -1,0 +1,12 @@
+# Shared helpers for the pricing lock update scripts driven by update-pricing.yaml.
+
+# Hand the workflow both the verdict and the paths to commit, so the file list
+# lives in one place instead of being repeated in the workflow.
+export def report [result: record]: nothing -> nothing {
+    [
+        $"changed=($result.changed)"
+        $"paths=($result.paths | str join ' ')"
+    ]
+    | each {|line| $"($line)(char nl)" | save --append $env.GITHUB_OUTPUT }
+    | ignore
+}

--- a/.github/scripts/update-litellm-lock.nu
+++ b/.github/scripts/update-litellm-lock.nu
@@ -16,11 +16,25 @@ def main [] {
         }
     }
 
-    $"changed=($changed)(char nl)" | save --append $env.GITHUB_OUTPUT
+    report {
+        changed: $changed
+        paths: [flake.lock]
+    }
 }
 
 # Fetch model_prices_and_context_window.json at the revision flake.lock pins.
 def locked-pricing []: nothing -> record {
     let rev = open --raw flake.lock | from json | get nodes.litellm.locked.rev
     http get $"https://raw.githubusercontent.com/BerriAI/litellm/($rev)/model_prices_and_context_window.json"
+}
+
+# Hand the workflow both the verdict and the paths to commit, so the file list
+# lives in one place instead of being repeated in the workflow.
+def report [result: record]: nothing -> nothing {
+    [
+        $"changed=($result.changed)"
+        $"paths=($result.paths | str join ' ')"
+    ]
+    | each {|line| $"($line)(char nl)" | save --append $env.GITHUB_OUTPUT }
+    | ignore
 }

--- a/.github/scripts/update-litellm-lock.nu
+++ b/.github/scripts/update-litellm-lock.nu
@@ -1,6 +1,8 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from ../.. nixpkgs#nushell nixpkgs#git --command nu
 
+use ./pricing-lock.nu report
+
 # Bump the pinned LiteLLM input and report whether it moved the pricing JSON that
 # the build embeds, so the workflow can skip validating lock-only churn.
 def main [] {
@@ -26,15 +28,4 @@ def main [] {
 def locked-pricing []: nothing -> record {
     let rev = open --raw flake.lock | from json | get nodes.litellm.locked.rev
     http get $"https://raw.githubusercontent.com/BerriAI/litellm/($rev)/model_prices_and_context_window.json"
-}
-
-# Hand the workflow both the verdict and the paths to commit, so the file list
-# lives in one place instead of being repeated in the workflow.
-def report [result: record]: nothing -> nothing {
-    [
-        $"changed=($result.changed)"
-        $"paths=($result.paths | str join ' ')"
-    ]
-    | each {|line| $"($line)(char nl)" | save --append $env.GITHUB_OUTPUT }
-    | ignore
 }

--- a/.github/scripts/update-models-dev-lock.nu
+++ b/.github/scripts/update-models-dev-lock.nu
@@ -3,12 +3,20 @@
 
 const SNAPSHOTS = [
     'rust/crates/ccusage-core/src/models-dev-pricing.json'
-    'rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json'
+    'rust/adapters/codex/src/codex-auto-review-fallbacks.json'
 ]
 
 # Bump the pinned models.dev input, regenerate the committed snapshots, and report
 # whether anything the build embeds actually moved.
 def main [] {
+    # A snapshot that moved in the Rust tree would otherwise only surface as a
+    # `git checkout` pathspec failure after all the regeneration work, which is
+    # how this workflow stayed broken for weeks after the crate split.
+    let missing = $SNAPSHOTS | where {|path| not ($path | path exists) }
+    if ($missing | is-not-empty) {
+        error make {msg: $"snapshot paths no longer exist: ($missing | str join ', ')"}
+    }
+
     ^nix flake update models-dev
     ^nix develop --command just gen-models-dev-pricing
 
@@ -26,10 +34,24 @@ def main [] {
         _ => false
     }
 
-    $"changed=($changed)(char nl)" | save --append $env.GITHUB_OUTPUT
+    report {
+        changed: $changed
+        paths: ($SNAPSHOTS | prepend flake.lock)
+    }
 }
 
 # Whether git reports tracked changes for the given paths.
 def dirty [...paths: string]: nothing -> bool {
     (^git diff --quiet -- ...$paths | complete).exit_code != 0
+}
+
+# Hand the workflow both the verdict and the paths to commit, so the file list
+# lives in one place instead of being repeated in the workflow.
+def report [result: record]: nothing -> nothing {
+    [
+        $"changed=($result.changed)"
+        $"paths=($result.paths | str join ' ')"
+    ]
+    | each {|line| $"($line)(char nl)" | save --append $env.GITHUB_OUTPUT }
+    | ignore
 }

--- a/.github/scripts/update-models-dev-lock.nu
+++ b/.github/scripts/update-models-dev-lock.nu
@@ -1,6 +1,8 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from ../.. nixpkgs#nushell nixpkgs#git --command nu
 
+use ./pricing-lock.nu report
+
 const SNAPSHOTS = [
     'rust/crates/ccusage-core/src/models-dev-pricing.json'
     'rust/adapters/codex/src/codex-auto-review-fallbacks.json'
@@ -43,15 +45,4 @@ def main [] {
 # Whether git reports tracked changes for the given paths.
 def dirty [...paths: string]: nothing -> bool {
     (^git diff --quiet -- ...$paths | complete).exit_code != 0
-}
-
-# Hand the workflow both the verdict and the paths to commit, so the file list
-# lives in one place instead of being repeated in the workflow.
-def report [result: record]: nothing -> nothing {
-    [
-        $"changed=($result.changed)"
-        $"paths=($result.paths | str join ' ')"
-    ]
-    | each {|line| $"($line)(char nl)" | save --append $env.GITHUB_OUTPUT }
-    | ignore
 }

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -30,14 +30,9 @@ jobs:
           - name: litellm
             script: .github/scripts/update-litellm-lock.nu
             message: 'chore(pricing): update LiteLLM snapshot'
-            paths: flake.lock
           - name: models-dev
             script: .github/scripts/update-models-dev-lock.nu
             message: 'chore(pricing): update models.dev snapshot'
-            paths: >-
-              flake.lock
-              rust/crates/ccusage-core/src/models-dev-pricing.json
-              rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -80,4 +75,6 @@ jobs:
         if: steps.update.outputs.changed == 'true'
         with:
           message: ${{ matrix.message }}
-          paths: ${{ matrix.paths }}
+          # The update script reports the files it owns, so the list is not
+          # repeated here where it can drift out of the Rust tree.
+          paths: ${{ steps.update.outputs.paths }}


### PR DESCRIPTION
## Summary

The models.dev half of `update-pricing.yaml` has failed on **every hourly run** since #1428 split the workspace and moved the adapter crates:

```
fatal: pathspec 'rust/crates/ccusage-adapter-codex/src/codex-auto-review-fallbacks.json' did not match any files
```

The tracked file is at `rust/adapters/codex/src/codex-auto-review-fallbacks.json`. So models.dev pricing has not been refreshed since that move — only the LiteLLM half of the workflow still worked. Caught by pullfrog on #1509; the wrong path predates that PR, which carried it over unchanged.

## What Changed

- The path is corrected in `.github/scripts/update-models-dev-lock.nu`.
- The path list is no longer duplicated. It lived in both the script and the workflow's matrix, which is how it drifted from the Rust tree: the script now reports the files it owns via `GITHUB_OUTPUT`, and the workflow passes `steps.update.outputs.paths` straight to the push action.
- The script asserts up front that every snapshot path exists, so the next move fails immediately with a clear message instead of after a full regenerate-and-validate cycle.

## Testing

- `nu-check` passes on both scripts.
- Ran `git checkout -- flake.lock <snapshots>` with the corrected list against a clean tree: the revert arm the job could never reach before is now a no-op instead of a fatal pathspec error.
- Ran `update-litellm-lock.nu` end to end: bumped `34561482` to `f2cda740` and reported `changed=true` / `paths=flake.lock`. Lock restored afterwards.
- `just fmt` (actionlint, zizmor, nufmt) passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the models.dev pricing job by committing the codex fallback snapshot from its real path and removing duplicated path lists, restoring hourly updates.

- **Bug Fixes**
  - Corrected snapshot path to `rust/adapters/codex/src/codex-auto-review-fallbacks.json`.
  - Assert snapshot paths exist before regenerate to fail fast with a clear error.

- **Refactors**
  - Extracted shared `report` helper to `.github/scripts/pricing-lock.nu`; both lock scripts import it to emit `changed` and `paths` via `GITHUB_OUTPUT`.
  - Workflow uses `steps.update.outputs.paths` instead of hardcoded lists to prevent drift.

<sup>Written for commit e138a1e74cf697ee0d0d1752d98be454675cdb37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing update workflows by validating required snapshot files before making changes.
  * Corrected the snapshot location for Codex fallback data.

* **Chores**
  * Automated workflows now commit only files actually changed by update scripts.
  * Standardized reporting of changed files and update status across pricing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->