### PR TITLE
ci: add a single gate check for main to require

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -544,3 +544,30 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+
+  # Single check for main's branch ruleset to require. Most jobs above are gated
+  # on `changes` and are skipped on docs-only pull requests, so requiring them
+  # individually would leave those pull requests blocked on checks that never
+  # report. A skipped job is fine here; only real failures fail the gate.
+  ci-gate:
+    name: ci gate
+    needs:
+      - changes
+      - tirith-scan
+      - tirith-sarif-upload
+      - preflight
+      - test
+      - build-native-packages
+      - npm-publish-dry-run-and-upload-pkg-pr-now
+      - ccusage-preview-e2e
+      - ccusage-perf-comment
+    if: ${{ always() }}
+    runs-on: ubuntu-slim
+    steps:
+      - name: Report job results
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: echo "$RESULTS"
+      - name: Fail when a job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1


### PR DESCRIPTION
## Summary

`main` has no required status checks, so GitHub auto-merge has nothing to wait for. `gh pr merge --auto --squash` merged #1509 while its CI was still running, and renovate's `platformAutomerge` (now enabled again by #1508) would merge dependency PRs exactly the same way — instantly, unchecked.

Fixing that needs a check the ruleset can require. Requiring the existing ones directly does not work: everything behind the `changes` job is skipped on docs-only pull requests, and a skipped check never satisfies a requirement, so those pull requests would be blocked forever on checks that never report.

## What Changed

Adds the usual aggregator job to `ci.yaml`:

- `needs` the same jobs `action-timeline` already waits for, with `if: always()`.
- Treats skipped as fine; fails only when a job's result is `failure` or `cancelled`, via `contains(needs.*.result, ...)` so it needs no tooling on the runner.
- Reports the joined results first, so the log shows why it failed.

The check is named **`ci gate`** — that single context is what main's ruleset should require.

## Follow-up (repo settings, not in this PR)

Once this is on `main`, a branch ruleset on the default branch requiring `ci gate` makes both auto-merge and renovate's automerge wait for CI.

That ruleset needs a bypass actor for the GitHub Actions app, because required status checks reject direct pushes too, and `update-pricing.yaml` (and tagpr) push to `main` on purpose — a token-created PR gets no CI, which is why they push directly and validate inline.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single CI gate check so auto-merge and Renovate wait for CI on `main`, without blocking docs-only PRs.

- **New Features**
  - Added `ci gate` job in `.github/workflows/ci.yaml`.
  - Aggregates results from key jobs with `if: always()`; skipped is OK.
  - Fails only on `failure` or `cancelled` and outputs the joined results.

- **Migration**
  - In the default branch ruleset, require the `ci gate` status check.
  - Add a bypass for the GitHub Actions app to allow intended direct pushes (e.g., `update-pricing.yaml`, tagpr).

<sup>Written for commit 1feaca5cc7cf510b80e3cd1c1e9a49db67941f05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a unified CI status check that consolidates results from the repository’s major validation and publishing checks.
  * The check now clearly reports failures or cancellations while allowing intentionally skipped checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->