### PR TITLE
chore(renovate): let renovate gate its own automerge on CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
 		"enabled": true
 	},
 	"automerge": true,
-	"platformAutomerge": true,
+	"platformAutomerge": false,
 	"branchConcurrentLimit": 0,
 	"dependencyDashboard": true,
 	"labels": ["dependencies", "renovate"],


### PR DESCRIPTION
## Summary

`main` has no required status checks, so GitHub's auto-merge merges the moment it is enabled — that is how #1509 landed with its CI still running. `platformAutomerge` hands renovate's automerge to that same mechanism, so dependency PRs would merge before their checks report. With it off, renovate merges the branch itself only after it has seen the branch checks pass, which needs no repository rules at all.

## Why not require the `ci gate` check instead

That was the plan, and #1511 added the check for it, but a repository ruleset cannot list the built-in GitHub Actions integration as a bypass actor:

```
422: Actor GitHub Actions integration must be part of the ruleset source or owner organization
```

Required status checks reject direct pushes too, so without that bypass the rule would break `update-pricing.yaml`, which pushes to `main` on purpose. Bypassing by write role does not help either: renovate holds write, so it would bypass the very gate it is meant to obey.

Required checks become workable once a bot app with its own token can open the pricing PRs — then nothing needs to push to `main` directly. `ci gate` stays in place for that.

## Testing

`renovate-config-validator --strict` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `platformAutomerge` in `renovate` so dependency PRs only self-merge after CI passes. This avoids GitHub auto-merge on `main` merging before checks complete.

<sup>Written for commit b879c135a4a461cf8c16471c0f06fb40a62afa91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update handling so changes are no longer merged automatically by the hosting platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->