### PR TITLE
chore(renovate): ask for full mode from the repository config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,7 @@
 		"schedule": ["at any time"]
 	},
 	"minimumReleaseAge": "3 days",
+	"mode": "full",
 	"postUpdateOptions": ["pnpmDedupe"],
 	"rangeStrategy": "bump",
 	"vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

The Mend dashboard explains the five weeks of silence, and it is not what any of the earlier guesses said. On https://developer.mend.io/github/ccusage:

```
Default Engine Settings
  Dependency Updates (Renovate): Silent
  Renovate plan: Community (Free)

Installed Repositories
  ccusage | Renovate: Enabled | Status: activated | Last Job Run: 1 hours ago
```

The repository is enabled and activated, and its job list shows runs completing every few hours (`DONE`), including webhook-triggered ones from today's merges. But the org's default engine setting is **Silent**, and in silent mode renovate does all the work and then creates no branches, pull requests or issues. That matches everything observed: a config that validates, a local `--dry-run=full` that finds 26 pending updates, and nothing ever appearing on the repo.

## What Changed

Sets `"mode": "full"` in `.github/renovate.json`.

`mode` is not a global-only option, so a repository config is allowed to set it (verified: the validator raises no global-option warning for it in a repo config). If the platform applies silent as an org **default**, this overrides it. If it applies it as **forced** config, only the dashboard toggle helps and this line is inert but harmless.

The reliable fix is still flipping `Dependency Updates` off Silent in the Mend org settings; this is the half that can live in the repo.

## Testing

`renovate-config-validator --strict` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `Renovate` to full mode by adding `"mode": "full"` in `.github/renovate.json`, so it will open update branches and PRs instead of running silently. If Silent is enforced at the org level, this is a safe no-op.

<sup>Written for commit 3f0655aa1fe5da089fe174e52d2271dcb833ce9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance configuration to use its full operating mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->