### PR TITLE
fix(pricing): stop asserting which models upstream has not shipped yet

### DIFF
--- a/rust/crates/ccusage-core/src/pricing.rs
+++ b/rust/crates/ccusage-core/src/pricing.rs
@@ -2441,8 +2441,6 @@ mod tests {
         let pricing = PricingMap::load_embedded();
 
         assert!(pricing.find("claude-opus-4-8-20270898").is_some());
-        assert!(pricing.find("claude-opus-4-9").is_none());
-        assert!(pricing.find("claude-opus-5").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Every hourly `update-pricing` run has been failing its Rust test leg, so the refreshed pricing snapshot cannot reach `main`. The workflow is not at fault — the validation added in #1509 is doing its job and refusing to push a tree whose tests fail:

```
test pricing::tests::fuzzy_match_allows_date_like_suffixes_for_known_numeric_model_versions ... FAILED
```

The test loads the embedded catalogue and then asserted that `claude-opus-4-9` and `claude-opus-5` resolve to nothing. Both litellm and models.dev now ship `claude-opus-5`, so the assertion fails the moment either input is refreshed.

## What Changed

Drops the two absence assertions. What remains is the case the test is named after: a date-like suffix on a version the catalogue really has (`claude-opus-4-8-20270898`).

Which versions must *not* fuzzy match is already covered by `fuzzy_match_requires_model_key_boundaries` and `fuzzy_match_does_not_fall_back_across_numeric_model_versions` — both build their own `PricingMap`, including the exact `claude-opus-4-9` and `claude-opus-5` cases, so they cannot rot when upstream adds a version.

## Testing

Reproduced and verified against the data that breaks it: `nix flake update litellm models-dev` plus `just gen-models-dev-pricing`, after which the snapshot does contain `claude-opus-5`. Then:

```
cargo test -p ccusage-core --lib pricing::tests::fuzzy_match   → 4 passed
nix build .#ccusage-tests                                      → exit 0
```

The lock and snapshots were reverted afterwards; `update-pricing` will land those itself once this is on `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing pricing test by removing brittle absence checks for `claude-opus-4-9` and `claude-opus-5`. This unblocks hourly `update-pricing` snapshots when upstream ships new versions.

- **Bug Fixes**
  - Removed the two absence assertions in `fuzzy_match_allows_date_like_suffixes_for_known_numeric_model_versions`; kept the date-suffix check for a known version.
  - Negative cases remain covered by `fuzzy_match_requires_model_key_boundaries` and `fuzzy_match_does_not_fall_back_across_numeric_model_versions`.

<sup>Written for commit 37d4ebe062732926569535cc2c392cf34aca38b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded pricing validation coverage for date-like suffixes on known numeric model versions.
  * Confirmed that a valid model variant resolves to an existing pricing entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->