### PR TITLE
refactor(scripts): functional pipelines in Nushell scripts

### DIFF
--- a/.github/scripts/generate-e2e-fixture.nu
+++ b/.github/scripts/generate-e2e-fixture.nu
@@ -6,14 +6,17 @@ def main [out_dir: string] {
     }
     let fixture_dir = [$out_dir, projects, preview-e2e-project, preview-e2e-session] | path join
     mkdir $fixture_dir
-    let lines = (0..419 | each {|index|
+    0..419
+    | each {|index|
         let day = ($index mod 28) + 1 | into string | fill --alignment right --character '0' --width 2
         [
-            $"(claude_line $index $day 1 '10:00:00.000Z' 'claude-sonnet-4-20250514' 100 50 25 10 '0.12')"
-            $"(claude_line $index $day 2 '12:30:00.000Z' 'claude-opus-4-20250514' 200 75 50 20 '0.34')"
+            (claude_line $index $day 1 '10:00:00.000Z' 'claude-sonnet-4-20250514' 100 50 25 10 '0.12')
+            (claude_line $index $day 2 '12:30:00.000Z' 'claude-opus-4-20250514' 200 75 50 20 '0.34')
         ]
-    } | flatten)
-    (($lines | str join (char nl)) + (char nl)) | save --force ([$fixture_dir, chat.jsonl] | path join)
+    }
+    | flatten
+    | to text
+    | save --force ([$fixture_dir, chat.jsonl] | path join)
 }
 def claude_line [
     index: int

--- a/.github/scripts/pricing-lock.nu
+++ b/.github/scripts/pricing-lock.nu
@@ -7,6 +7,6 @@ export def report [result: record]: nothing -> nothing {
         $"changed=($result.changed)"
         $"paths=($result.paths | str join ' ')"
     ]
-    | each {|line| $"($line)(char nl)" | save --append $env.GITHUB_OUTPUT }
-    | ignore
+    | to text
+    | save --append $env.GITHUB_OUTPUT
 }

--- a/.github/scripts/upsert-pr-comment.nu
+++ b/.github/scripts/upsert-pr-comment.nu
@@ -110,23 +110,22 @@ def try_update_comment [repository: string, comment_id: int, body: string] {
     {status: $status, result: $result, stderr: $result.stderr}
 }
 def gh_api_with_body [method: string, endpoint: string, body: string] {
-    let payload = mktemp -t ccusage-pr-comment.XXXXXX | str trim
-    {body: $body} | to json | save --force $payload
-    let args = [
+    {body: $body}
+    | to json
+    | gh_api_complete [
         --method
         $method
         --header
         'Content-Type: application/json'
         $endpoint
         --input
-        $payload
+        '-'
     ]
-    let result = (gh_api_complete $args)
-    rm --force $payload
-    $result
 }
-def gh_api_complete [args: list<string>] {
-    run-external gh api ...$args | complete
+# Pipeline input becomes the request body, so callers that send one never have to
+# stage a temporary file. Calls without input simply get an empty stdin.
+def gh_api_complete [args: list<string>]: any -> record {
+    $in | run-external gh api ...$args | complete
 }
 def is_comment_write_auth_failure [stderr: string] { ($stderr =~ 'HTTP 401') or ($stderr =~ 'HTTP 403') }
 def format_gh_error [args: list<string>, result: record] { $"gh api ($args | str join ' ') failed with exit code ($result.exit_code): ($result.stderr | str trim)" }

--- a/apps/ccusage/scripts/ensure-native-binary.nu
+++ b/apps/ccusage/scripts/ensure-native-binary.nu
@@ -1,5 +1,8 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from ../../.. nixpkgs#nushell --command nu
+
+use ./native-binary.nu [binary-name, linked-dylibs]
+
 const system_dylib_prefixes = ['/usr/lib/', '/System/Library/']
 def main [] {
     let repo_root = (
@@ -7,7 +10,7 @@ def main [] {
     )
     let target_platform = (node_platform)
     let target_arch = (node_arch)
-    let binary_name = (binary_name $target_platform)
+    let binary_name = (binary-name $target_platform)
     let native_package_root = (matching_native_package_root $repo_root $target_platform $target_arch)
     let native_binary = (match $native_package_root {
         null => null
@@ -39,12 +42,6 @@ def node_arch [] {
         'aarch64' => 'arm64'
         'x86_64' => 'x64'
         $other => $other
-    }
-}
-def binary_name [platform: string] {
-    match $platform {
-        'win32' => 'ccusage.exe'
-        _ => 'ccusage'
     }
 }
 def matching_native_package_root [repo_root: path, target_platform: string, target_arch: string] {
@@ -88,19 +85,11 @@ def linux_binary_is_static [binary: path] {
     $"($result.stdout)($result.stderr)" =~ '(?i)not a dynamic executable|statically linked'
 }
 def darwin_binary_links_only_system_dylibs [binary: path] {
-    let result = ^otool -L $binary | complete
-    match $result.exit_code {
-        0 => (
-            $result.stdout
-            | lines
-            | skip 1
-            | each {|line| $line | str trim }
-            | where {|line| $line | is-not-empty }
-            | each {|line| $line | split row --regex '\s+' | first }
-            | all {|dylib| $system_dylib_prefixes | any {|prefix| $dylib | str starts-with $prefix } }
-        )
-        _ => false
-    }
+    let linked = (linked-dylibs $binary)
+    $linked.ok and (
+        $linked.dylibs
+        | all {|dylib| $system_dylib_prefixes | any {|prefix| $dylib | str starts-with $prefix } }
+    )
 }
 def has_expected_version [binary, version: string] {
     ($binary != null) and ($binary | path exists) and ((reported_version $binary) == $version)

--- a/apps/ccusage/scripts/native-binary.nu
+++ b/apps/ccusage/scripts/native-binary.nu
@@ -1,0 +1,36 @@
+# Shared helpers for the scripts that stage and validate the Rust binary
+# shipped inside packages/ccusage-<platform>-<arch>.
+
+# The file name npm expects for a Node platform identifier.
+export def binary-name [platform: string]: nothing -> string {
+    match $platform {
+        'win32' => 'ccusage.exe'
+        _ => 'ccusage'
+    }
+}
+
+# The dynamic libraries `otool -L` reports for a Mach-O binary.
+#
+# `ok` is false when otool itself failed, so a caller can choose between
+# aborting with the captured stderr and treating the binary as unusable.
+export def linked-dylibs [binary: path]: nothing -> record {
+    let result = run-external otool '-L' $binary | complete
+    {
+        ok: ($result.exit_code == 0)
+        stderr: $result.stderr
+        dylibs: (match $result.exit_code {
+            # Only the `<dylib> (compatibility version ...)` rows are tab
+            # indented. Selecting on that indent rather than skipping a fixed
+            # number of leading rows keeps the unindented `<binary>
+            # (architecture <arch>):` header out of the result for fat binaries,
+            # which repeat that header once per architecture.
+            0 => (
+                $result.stdout
+                | lines
+                | where {|line| $line | str starts-with (char tab) }
+                | each {|line| $line | str trim | split row --regex '\s+' | first }
+            )
+            _ => []
+        })
+    }
+}

--- a/apps/ccusage/scripts/stage-native-package.nu
+++ b/apps/ccusage/scripts/stage-native-package.nu
@@ -1,5 +1,8 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from ../../.. nixpkgs#nushell --command nu
+
+use ./native-binary.nu [binary-name, linked-dylibs]
+
 const package_dirs = {
     darwin-arm64: 'ccusage-darwin-arm64'
     darwin-x64: 'ccusage-darwin-x64'
@@ -20,18 +23,12 @@ def main [--platform: string, --arch: string, --binary: string] {
     let target_dir = [$repo_root, 'packages', $package_dir, 'bin'] | path join
     let target = [
         $target_dir
-        (binary_name $platform)
+        (binary-name $platform)
     ] | path join
     mkdir $target_dir
     cp -f $source $target
     finalize_target $platform $target
     print $target
-}
-def binary_name [platform: string] {
-    match $platform {
-        'win32' => 'ccusage.exe'
-        _ => 'ccusage'
-    }
 }
 def finalize_target [platform: string, target: path] {
     match $platform {
@@ -44,15 +41,12 @@ def finalize_target [platform: string, target: path] {
     }
 }
 def rewrite_darwin_system_libraries [binary_path: string] {
-    let linked = run-external otool '-L' $binary_path | complete
-    if $linked.exit_code != 0 {
+    let linked = (linked-dylibs $binary_path)
+    if not $linked.ok {
         error make {msg: $"otool failed for ($binary_path)\n($linked.stderr)"}
     }
     let failed_rewrite = (
-        $linked.stdout
-        | lines
-        | skip 1
-        | each {|line| $line | str trim | split row --regex '\s+' | first }
+        $linked.dylibs
         | where {|library| $library =~ '^/nix/store/[^/]+-libiconv-[^/]+/lib/libiconv\.2\.dylib$' }
         | each {|library|
             {library: $library, rewrite: (run-external install_name_tool '-change' $library /usr/lib/libiconv.2.dylib $binary_path | complete)}


### PR DESCRIPTION
## Summary

Applies the expression-oriented style from the Nushell book ([Thinking in Nu](https://www.nushell.sh/book/thinking_in_nu.html), [Nu map from functional languages](https://www.nushell.sh/book/nushell_map_functional.html)) to the repo's `.nu` scripts. An earlier pass (#1485) removed the `mut`/`for` accumulators; what was left was side-effecting statement sequences where a pipeline expression says the same thing, plus a duplicated `otool` parse.

Two commits, separately revertable.

### `refactor(scripts): replace side-effecting loops with Nushell pipelines`

- **`pricing-lock.nu`** — `report` called `save --append` once per line inside `each`, then discarded the resulting list of nothings with `ignore`. `to text` already renders a list as newline-terminated lines, so this is one append with no per-iteration side effect.
- **`generate-e2e-fixture.nu`** — dropped a `let lines` binding that existed only to be immediately joined, and removed a redundant `$"(...)"` interpolation wrapping an already-string `claude_line` result.
- **`upsert-pr-comment.nu`** — the request body was staged in a `mktemp` file, passed as `gh api --input <path>`, then removed. `gh api --input -` reads stdin and `$in` forwards pipeline input to an external inside a custom command, so the temp file, its `save`, and its `rm` are gone.

### `refactor(scripts): share otool parsing between native package scripts`

`ensure-native-binary.nu` and `stage-native-package.nu` each defined `binary_name` and each parsed `otool -L` output. The two parses had already drifted — the staging copy kept blank rows the checking copy filtered. Both now come from a new `apps/ccusage/scripts/native-binary.nu` module, following the `pricing-lock.nu` precedent for a shared non-executable module.

`linked-dylibs` returns `{ok, stderr, dylibs}` instead of erroring, because the callers want different failure handling: staging aborts with the captured stderr, the portability check treats an otool failure as not portable.

## Drive-by bug fix

Selecting dylib rows by their tab indent instead of `skip 1` fixes a latent bug. `otool -L` repeats an unindented `<binary> (architecture <arch>):` header **once per architecture**:

```
/bin/ls (architecture x86_64):
	/usr/lib/libutil.dylib (compatibility version 1.0.0, ...)
/bin/ls (architecture arm64e):     <-- skip 1 did not drop this
	/usr/lib/libutil.dylib (compatibility version 1.0.0, ...)
```

`skip 1` dropped only the first header and fed the rest through as linked libraries, so any fat binary was reported as depending on itself — and since a binary path starts with neither `/usr/lib/` nor `/System/Library/`, the portability check failed it. Cargo emits single-architecture binaries, so the shipped path never hit this.

## Verification

- `nu-check` passes on all 9 `.nu` files; `just fmt` (treefmt/nufmt) reports no changes.
- `generate-e2e-fixture.nu` output is **byte-identical** to before (291880 bytes, same sha1).
- `pricing-lock.nu` `report` appends the same `changed=`/`paths=` lines across repeated calls.
- `upsert-pr-comment.nu` driven end to end against a stub `gh` covering create, update, HTTP 404 recreate, and HTTP 403 skip — body arrives as correct JSON on stdin in every write path, and the marker match still picks the `github-actions[bot]` comment over another author's.
- `linked-dylibs` compared against both previous implementations on real Mach-O binaries: identical for single-architecture input; `/bin/ls` now reports its 6 real dylibs and passes the portability check instead of failing it.
- Full darwin staging cycle run over a nix-store binary that links nix-store `libiconv`, confirming the `install_name_tool` rewrite to `/usr/lib/libiconv.2.dylib`, the `chmod 755`, and the `prepack` verification all still pass. Test artefacts removed.

No user-facing behaviour changes, so no docs impact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors Nushell scripts to use functional pipelines and centralizes Mach-O dylib parsing to remove side effects and duplicate code. Fixes dylib parsing for fat binaries on macOS. No user-facing changes.

- **Refactors**
  - Replaced loop-based writes with pipelines in `.github/scripts` and now stream JSON bodies to `gh api` via stdin (no temp files).
  - Extracted `binary-name` and `linked-dylibs` into `apps/ccusage/scripts/native-binary.nu`, used by `ensure-native-binary.nu` and `stage-native-package.nu`.

- **Bug Fixes**
  - Parse `otool -L` output by selecting tab-indented rows, correctly handling fat binaries with repeated headers.
  - Darwin portability check now evaluates actual dylibs; behavior unchanged for single-arch binaries.

<sup>Written for commit 411fded726138cc4f33e80d4f5216b23fa6c79ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native binary packaging checks across supported platforms.
  * Strengthened macOS library validation and error handling.
  * Improved reliability when generating test fixtures and reporting workflow outputs.
  * Streamlined automated pull request comment updates by handling request data more reliably.

* **Refactor**
  * Consolidated native binary naming and dependency inspection into shared tooling for more consistent packaging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->