### PR TITLE
refactor(nix): split out the git wt module and auto-install JS deps on shell entry

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,6 +31,10 @@ install:
         toolDir="$(dirname "$tsconfig")"
         (cd "$toolDir" && bun install --frozen-lockfile)
     done
+    # The dev shell re-installs when a lockfile is newer than this stamp. It
+    # cannot compare against node_modules itself, because an install that
+    # changes nothing leaves those directory mtimes untouched.
+    touch node_modules/.install-stamp
 
 # Build every workspace package
 build: ccusage::build docs::build

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -15,6 +15,7 @@ in
         overlays = [ inputs.rust-overlay.overlays.default ];
       };
       rustToolchain = pkgs.rust-bin.fromRustupToolchainFile (root + /rust-toolchain.toml);
+      gitWtHook = import ./git-wt.nix { inherit pkgs; };
     in
     {
       devShells.default = pkgs.mkShell {
@@ -83,18 +84,8 @@ in
           fi
           ${lib.getExe config.packages.syncAgentSkills}
           ${config.pre-commit.shellHook}
-
-          # Set up direnv and JS dependencies whenever `git wt` creates a new
-          # worktree, so worktrees are usable without a manual step.
-          git config --replace-all wt.hook "direnv allow || true; just install || true"
-
-          # Move deleted worktree directories to the trash instead of `rm -rf`,
-          # which is noticeably slower on large node_modules and target trees.
-          git config --replace-all wt.remover "${pkgs.trash-cli}/bin/trash"
-
-          # Free the worktree's direnv/nix state before it's deleted.
-          git config --replace-all wt.deletehook "direnv revoke .envrc || true; ${pkgs.trash-cli}/bin/trash .direnv || true; nix store gc || true"
-        '';
+        ''
+        + gitWtHook;
       };
     };
 }

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -82,6 +82,28 @@ in
               *) export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-fuse-ld=mold" ;;
             esac
           fi
+
+          # Install whenever a lockfile is newer than the last `just install`, so
+          # a `git pull` that bumps dependencies does not leave a stale tree. The
+          # `.envrc` watches pnpm-lock.yaml and the whole nix/ tree, so direnv
+          # re-enters the shell — and re-runs this check — as soon as one changes.
+          # The tool dirs under nix/tools are outside the pnpm workspace, hence
+          # the extra lockfiles.
+          needsInstall=false
+          if [ ! -e node_modules/.install-stamp ]; then
+            needsInstall=true
+          else
+            for lock in pnpm-lock.yaml nix/tools/*/bun.lock; do
+              if [ "$lock" -nt node_modules/.install-stamp ]; then
+                needsInstall=true
+              fi
+            done
+          fi
+          if [ "$needsInstall" = true ]; then
+            echo "Installing dependencies..."
+            just install
+          fi
+
           ${lib.getExe config.packages.syncAgentSkills}
           ${config.pre-commit.shellHook}
         ''

--- a/nix/git-wt.nix
+++ b/nix/git-wt.nix
@@ -1,0 +1,23 @@
+# `git wt` worktree wiring for the dev shell.
+#
+# These live in the repo's git config rather than a derivation because `git wt`
+# reads them from the checkout it runs in, so entering the shell is the only
+# moment we can (re)write them for the current worktree.
+{
+  pkgs,
+  # Command that installs JS dependencies in a freshly created worktree.
+  installCommand ? "just install",
+}:
+
+''
+  # Set up direnv and JS dependencies whenever `git wt` creates a new
+  # worktree, so worktrees are usable without a manual step.
+  git config --replace-all wt.hook "direnv allow || true; ${installCommand} || true"
+
+  # Move deleted worktree directories to the trash instead of `rm -rf`,
+  # which is noticeably slower on large node_modules and target trees.
+  git config --replace-all wt.remover "${pkgs.trash-cli}/bin/trash"
+
+  # Free the worktree's direnv/nix state before it's deleted.
+  git config --replace-all wt.deletehook "direnv revoke .envrc || true; ${pkgs.trash-cli}/bin/trash .direnv || true; nix store gc || true"
+''


### PR DESCRIPTION
## Summary

Two dev-shell changes. First, the `git wt` repo config moves out of `nix/dev-shell.nix` into its own `nix/git-wt.nix` module, matching the layout `rorkai/rork-local` already uses. Second, the dev shell now installs JS dependencies itself when a lockfile is newer than the last install.

## What Changed

- Add `nix/git-wt.nix`: takes `pkgs` and an `installCommand` (default `just install`) and returns the `wt.hook` / `wt.remover` / `wt.deletehook` shellHook fragment. The expanded hook is byte-identical to before.
- `nix/dev-shell.nix`: imports that module and appends it to `shellHook`; adds a guarded auto-install ahead of the agent-skill sync.
- `justfile`: `just install` now writes `node_modules/.install-stamp`, which is what the dev shell checks.

## Why

Entering the shell after a `git pull` that bumped a lockfile left a stale `node_modules` until someone remembered to run `just install` — usually surfacing as a confusing type or resolution error rather than as a missing dependency.

The stamp file, rather than the `node_modules` mtimes, is what makes the check reliable: an install that changes nothing leaves those directory mtimes untouched, so comparing against the tree itself would re-install on every shell entry. Because `just install` owns the stamp, the `git wt` worktree hook already satisfies the check and a fresh worktree does not install twice.

The check also covers `nix/tools/*/bun.lock`, since those tool directories sit outside the pnpm workspace and `.envrc` already watches the whole `nix/` tree.

## Testing

- `nix fmt` — no changes
- `nix eval .#devShells.aarch64-darwin.default.shellHook` — the `git wt` config expands identically to the pre-refactor shellHook
- Live direnv reloads on macOS covering each guard branch:
  - stamp missing → installs, stamp created
  - stamp fresh → skipped, no output
  - `touch nix/tools/publint/bun.lock` → direnv re-enters and installs, then settles back to skipping

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the `git wt` worktree wiring into its own Nix module and added auto-install of JS dependencies on dev shell entry when lockfiles change. This prevents stale `node_modules` after pulls and keeps the shell hook easier to read.

- **Refactors**
  - Moved `git wt` wiring to `nix/git-wt.nix`; imported from `nix/dev-shell.nix`. The module accepts an `installCommand` (default `just install`) and emits the same `wt.hook/remover/deletehook` as before.

- **New Features**
  - Dev shell installs JS deps when any lockfile is newer than `node_modules/.install-stamp`. `just install` now writes the stamp and covers `pnpm-lock.yaml` and `nix/tools/*/bun.lock`.

<sup>Written for commit 02891ee6967dfa9b5a70f2aecd5d38bf688222df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development environments now automatically install JavaScript dependencies when lockfiles change.
  * New worktree hooks streamline environment setup and cleanup, including dependency installation and safer removal of worktree directories.

* **Improvements**
  * Worktree cleanup now also refreshes local environment settings and performs garbage collection.
  * Hook failures no longer interrupt worktree operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->